### PR TITLE
Ability to reset personal lockers

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -70,4 +70,4 @@
 			desc = initial(desc)
 			add_fingerprint(usr)
 	else
-		usr << "<span class='danger'>\The [src.name] must be open!</span>"
+		usr << "<span class='danger'>\the [src.name] must be open!</span>"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -61,14 +61,13 @@
 	set name = "Reset Lock"
 
 	if(opened)
-		if(src.broken)
-			usr << "<span class='danger'>It appears to be broken.</span>"
+		if(broken)
+			usr << "<span class='danger'>The lock appears to be broken.</span>"
 			return
 		else
 			registered_name = null
 			usr << "<span class='danger'>You successfully reset the lock.</span>"
-			src.desc = "The lock appears to be reset"
+			desc = initial(desc)
 			add_fingerprint(usr)
-			return
 	else
-		usr << "<span class='danger'>The locker must be open!</span>"
+		usr << "<span class='danger'>The [src.name] must be open!</span>"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -70,4 +70,4 @@
 			desc = initial(desc)
 			add_fingerprint(usr)
 	else
-		usr << "<span class='danger'>The [src.name] must be open!</span>"
+		usr << "<span class='danger'>\The [src.name] must be open!</span>"

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -54,3 +54,21 @@
 			user << "<span class='danger'>Access Denied.</span>"
 	else
 		return ..()
+
+/obj/structure/closet/secure_closet/personal/verb/verb_resetlock()//personal locker ownership reset.
+	set src in oview(1)
+	set category = "Object"
+	set name = "Reset Lock"
+
+	if(opened)
+		if(src.broken)
+			usr << "<span class='danger'>It appears to be broken.</span>"
+			return
+		else
+			registered_name = null
+			usr << "<span class='danger'>You successfully reset the lock.</span>"
+			src.desc = "The lock appears to be reset"
+			add_fingerprint(usr)
+			return
+	else
+		usr << "<span class='danger'>The locker must be open!</span>"


### PR DESCRIPTION
Crow recommended that it be added to port 6, so here ya go

**Description**
Right clicking personal lockers/cabinets will grant you the option to reset the ownership of it, the locker/cabinet has to be open in order for the lock to be reset. 
The description of the locker changes if someone were to examine it and the next person to swipe their ID will have ownership of the locker.