### PR TITLE
Changes Nar'Sie cult conversion to only need one cultist.

### DIFF
--- a/code/game/gamemodes/cult/runes.dm
+++ b/code/game/gamemodes/cult/runes.dm
@@ -317,7 +317,7 @@ var/list/teleport_runes = list()
 	invocation = "Mah'weyh pleggh at e'ntrath!"
 	icon_state = "3"
 	color = rgb(200, 0, 0)
-	req_cultists = 2
+	req_cultists = 1
 
 /obj/effect/rune/convert/invoke(var/list/invokers)
 	var/list/convertees = list()

--- a/html/changelogs/Roland410-PR-1.yml
+++ b/html/changelogs/Roland410-PR-1.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: "Roland410"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - tweak "Changed Nar'Sie cult conversion to only need one cultist."


### PR DESCRIPTION
Title says it all, I feel like this change is needed, since there was an actual round where the entire round was fucked, because two of the three starter cultists decided to YOLO and got killed/deculted in the first ten minutes, making the round be extended, since two are needed for conversion.