### PR TITLE
fixes jetpack not having a sprite after being upgraded

### DIFF
--- a/code/game/objects/items/weapons/tanks/jetpack.dm
+++ b/code/game/objects/items/weapons/tanks/jetpack.dm
@@ -127,8 +127,8 @@
 	name = "hardsuit jetpack upgrade"
 	desc = "A modular, compact set of thrusters designed to integrate with a hardsuit. It is fueled by a tank inserted into the suit's storage compartment."
 	origin_tech = "materials=4;magnets=4;engineering=5"
-	icon_state = "jetpack-upgrade"
-	item_state =  "jetpack-black"
+	icon_state = "jetpack-black"
+	item_state = "jetpack-black"
 	w_class = WEIGHT_CLASS_NORMAL
 	actions_types = list(/datum/action/item_action/toggle_jetpack, /datum/action/item_action/jetpack_stabilization)
 	volume = 1


### PR DESCRIPTION
Resolves the issue where if a hardsuit jetpack was upgraded, the sprite was invalid resulting in it becoming invisible. 