### PR TITLE
Fix DIR for Waste Loop O2 Gas Filter in Atmo

### DIFF
--- a/_maps/map_files/TgStation/tgstation.2.1.3.dmm
+++ b/_maps/map_files/TgStation/tgstation.2.1.3.dmm
@@ -53120,7 +53120,7 @@
 /area/atmos)
 "cmq" = (
 /obj/machinery/atmospherics/components/trinary/filter{
-	dir = 1;
+	dir = 4;
 	 filter_type = "o2";
 	 on = 1
 	},


### PR DESCRIPTION
Changed DIR of Gas Filter for O2 in Waste Loop from 1 to 4

:cl: Penguaro
fix: Changed DIR of Gas Filter for O2 in Waste Loop from 1 to 4
/:cl:

[]: # Current Default start for TgStation (AKA BoxStation) map has the O2 Gas filter pointing the wrong direction, causing the loop to start broken and inoperable past Nitrogen filtering. Newer players or smaller rounds without an engineer may miss this and a broken loop does not seem canon to the general story.

![atmo](https://cloud.githubusercontent.com/assets/9791590/23575490/b57ef9fa-0052-11e7-9cc9-007adbe85b9f.jpg)
