### PR TITLE
Disables Flight Suits

### DIFF
--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -759,7 +759,7 @@
 	construction_time = 100
 	build_path = /obj/item/device/assembly/flash/handheld
 	category = list("Misc")
-
+/*
 /datum/design/flightsuit		//Multi step build process/redo WIP
 	name = "Flight Suit"
 	desc = "A specialized hardsuit that is able to attach a flightpack and accessories.."
@@ -792,3 +792,4 @@
 	construction_time = 100
 	category = list("Misc")
 	req_tech = list("magnets" = 2, "combat" = 2, "plasmatech" = 3, "materials" = 3, "engineering" = 2, "powerstorage" = 2)
+*/


### PR DESCRIPTION
Still causing lag as far as I can see. Their re-enable was presumably from a port, so by mistake.
:cl: TalkingCactus
del: Flight suit designs have gone missing from the mech fabricator.
/:cl:

