### PR TITLE
Ghost-role arousal fix

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -78,6 +78,7 @@
 				MM.objectives += new/datum/objective(objective)
 		special(M)
 		MM.name = M.real_name
+		M.canbearoused = M.client.prefs.arousable
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -67,7 +67,6 @@
 
 	M.adjustOxyLoss(oxy_damage)
 	M.adjustBruteLoss(brute_damage)
-	equip(M)
 
 	if(ckey)
 		M.ckey = ckey
@@ -78,7 +77,7 @@
 				MM.objectives += new/datum/objective(objective)
 		special(M)
 		MM.name = M.real_name
-		M.canbearoused = M.client.prefs.arousable
+	equip(M)
 	if(uses > 0)
 		uses--
 	if(!permanent && !uses)
@@ -116,6 +115,12 @@
 /obj/effect/mob_spawn/human/equip(mob/living/carbon/human/H)
 	if(mob_species)
 		H.set_species(mob_species)
+	else
+		//If we're a human, we still need to handle our snowflake code anyway I guess.
+		if (NOAROUSAL in H.dna.species.species_traits)
+			H.canbearoused = FALSE
+		else
+			H.canbearoused = H.client.prefs.arousable
 	if(husk)
 		H.Drain()
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -158,12 +158,20 @@
 		species_traits += DIGITIGRADE
 	if(DIGITIGRADE in species_traits)
 		C.Digitigrade_Leg_Swap(FALSE)
+	if(NOGENITALS in species_traits)
+		C.canbearoused = FALSE
+	else
+		C.canbearoused = C.client.prefs.arousable
 
 /datum/species/proc/on_species_loss(mob/living/carbon/C)
 	if(C.dna.species.exotic_bloodtype)
 		C.dna.blood_type = random_blood_type()
 	if(DIGITIGRADE in species_traits)
 		C.Digitigrade_Leg_Swap(TRUE)
+	if(NOGENITALS in species_traits)
+		C.canbearoused = FALSE
+	else
+		C.canbearoused = C.client.prefs.arousable
 
 /datum/species/proc/handle_hair(mob/living/carbon/human/H, forced_colour)
 	H.remove_overlay(HAIR_LAYER)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -158,7 +158,7 @@
 		species_traits += DIGITIGRADE
 	if(DIGITIGRADE in species_traits)
 		C.Digitigrade_Leg_Swap(FALSE)
-	if(NOGENITALS in species_traits)
+	if(NOAROUSAL in species_traits)
 		C.canbearoused = FALSE
 	else
 		C.canbearoused = C.client.prefs.arousable
@@ -168,10 +168,6 @@
 		C.dna.blood_type = random_blood_type()
 	if(DIGITIGRADE in species_traits)
 		C.Digitigrade_Leg_Swap(TRUE)
-	if(NOGENITALS in species_traits)
-		C.canbearoused = FALSE
-	else
-		C.canbearoused = C.client.prefs.arousable
 
 /datum/species/proc/handle_hair(mob/living/carbon/human/H, forced_colour)
 	H.remove_overlay(HAIR_LAYER)


### PR DESCRIPTION
[Changelogs]: # Fixes it so ghost role spawners respect arousal preferences of the ghost.

:cl: Ghost-role arousal
fix: Ghost role spawners should now respect your arousal preferences.
/:cl:

[Justification]: # Preferences should be used or not exist, no point in ignoring them.