### PR TITLE
'Give' verb

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/volume_pump.dm
@@ -117,7 +117,7 @@ Thus, the two variables affect pump operation are set in New():
 	if(..())
 		return
 	var/turf/T = get_turf(src)
-	var/area/A = get_area(src)
+	//var/area/A = get_area(src)
 	switch(action)
 		if("power")
 			on = !on
@@ -179,7 +179,7 @@ Thus, the two variables affect pump operation are set in New():
 /obj/machinery/atmospherics/components/binary/volume_pump/can_unwrench(mob/user)
 	if(..())
 		var/turf/T = get_turf(src)
-		var/area/A = get_area(src)
+		//var/area/A = get_area(src)
 		if(!(stat & NOPOWER) && on)
 			user << "<span class='warning'>You cannot unwrench this [src], turn it off first!</span>"
 		else

--- a/code/modules/mob/living/carbon/give.dm
+++ b/code/modules/mob/living/carbon/give.dm
@@ -1,0 +1,58 @@
+/mob/living/verb/give()
+	set category = "IC"
+	set name = "Give"
+	set src in oview(1) //Cannot handle giving shit to mobs on your own tile, but it's a small, small loss
+
+	give_item(usr)
+
+/mob/living/proc/give_item(mob/living/carbon/user)
+
+
+/mob/living/carbon/give_item(mob/living/carbon/user)
+	if(!istype(user))
+		return
+	if(src.stat == 2 || user.stat == 2 || src.client == null)
+		return
+	if(src.handcuffed)
+		user << "<span class='warning'>Those hands are cuffed right now.</span>"
+		return //Can't receive items while cuffed
+	var/obj/item/I
+	if(user.get_active_held_item() == null)
+		user << "You don't have anything in your [get_held_index_name(get_held_index_of_item(I))] to give to [src]."
+		return
+	I = user.get_active_held_item()
+	if(!I)
+		return
+	if(src == user) //Shouldn't happen
+		user << "<span class='warning'>You tried to give yourself \the [I], but you didn't want it.</span>"
+		return
+	if(get_empty_held_index_for_side())
+		switch(alert(src, "[user] wants to give you \a [I]?", , "Yes", "No"))
+			if("Yes")
+				if(!I)
+					return
+				if(!Adjacent(user))
+					user <<"<span class='warning'>You need to stay still while giving an object.</span>"
+					src << "<span class='warning'>[user] moved away.</span>"//What an asshole
+
+					return
+				if(user.get_active_held_item() != I)
+					user << "<span class='warning'>You need to keep the item in your hand.</span>"
+					src << "<span class='warning'>[user] has put \the [I] away!</span>"
+					return
+				if(!get_empty_held_index_for_side())
+					user << "<span class='warning'>Your hands are full.</span>"
+					user << "<span class='warning'>Their hands are full.</span>"
+					return
+				if(!user.drop_item(I))
+					src << "<span class='warning'>[user] can't let go of \the [I]!</span>"
+					user << "<span class='warning'>You can't seem to let go of \the [I].</span>"
+					return
+
+				src.put_in_hands(I)
+				update_inv_hands()
+				src.visible_message("<span class='notice'>[user] handed \the [I] to [src].</span>")
+			if("No")
+				src.visible_message("<span class='warning'>[user] tried to hand \the [I] to [src] but \he didn't want it.</span>")
+	else
+		user << "<span class='warning'>[src]'s hands are full.</span>"

--- a/html/changelogs/Jay-PR-296.yml
+++ b/html/changelogs/Jay-PR-296.yml
@@ -1,0 +1,36 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: "
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
+  - rscdel: "Killed innocent kittens."

--- a/html/changelogs/Jay-PR-296.yml
+++ b/html/changelogs/Jay-PR-296.yml
@@ -21,7 +21,7 @@
 #################################
 
 # Your name.  
-author: "
+author: "Jay"
 
 # Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
 delete-after: True
@@ -32,5 +32,5 @@ delete-after: True
 # Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
 # Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
 changes: 
-  - rscadd: "Added a changelog editing system that should cause fewer conflicts and more accurate timestamps."
-  - rscdel: "Killed innocent kittens."
+  - rscadd: "Added the Give verb in the IC tab."
+ 


### PR DESCRIPTION
:cl: 
add: Adds the 'Give' verb from /vg/ and others. Simply go near a player and click the 'Give' verb (or type it) in the IC tab. The player you are trying to give the item to must have nothing in their hands and a box will appear to confirm if they want the item or not.
/:cl:


Also comments out some unused vars. From #270 