### PR TITLE
fix for missing area, map should load

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -16,7 +16,9 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 
 /*-----------------------------------------------------------------------------*/
 
-/area/engine
+/area/engine/supermatter
+	name = "Supermatter Engine"
+	icon_state = "engine_sm"
 
 /area/ai_monitored	//stub defined ai_monitored.dm
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -14,8 +14,8 @@
 
 // BEGIN_INCLUDE
 #include "_maps\basemap.dm"
-#include "_maps\citadelstation.dm"
 #include "_maps\loadallmaps.dm"
+#include "_maps\tgstation2.dm"
 #include "code\_compile_options.dm"
 #include "code\world.dm"
 #include "code\__DATASTRUCTURES\heap.dm"


### PR DESCRIPTION
Had to update to /tg/'s latest map build. something broke with the last PR and I don't have a backup.

Only change is the SM engine now has its own specified area.