### PR TITLE
Syndicate borer added

### DIFF
--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -298,6 +298,7 @@
 obj/item/weapon/antag_spawner/syndi_borer
 	name = "syndicate brain-slug container"
 	desc = "Releases a modified cortical borer to assist the user."
+	icon = 'icons/obj/device.dmi' //Temporary? Doesn't really look like a container for xenofauna... but IDK what else could work.
 	icon_state = "locator"
 	
 obj/item/weapon/antag_spawner/syndi_borer/spawn_antag(client/C, turf/T, mob/owner)
@@ -315,6 +316,7 @@ obj/item/weapon/antag_spawner/syndi_borer/spawn_antag(client/C, turf/T, mob/owne
 		new_objective = new /datum/objective/syndi_borer
 		new_objective.owner = B.mind
 		new_objective.target = owner.mind
+		new_objective.explanation_text = "You are a modified cortical borer. You obey [owner.real_name] and must assist them in completing their objectives."
 		B.mind.objectives += new_objective
 		
 		to_chat(B, "<B>You are awake at last! Seek out whoever released you and aid them as best you can!</B>")

--- a/code/game/gamemodes/antag_spawner.dm
+++ b/code/game/gamemodes/antag_spawner.dm
@@ -292,3 +292,55 @@
 	veil_msg = "<span class='warning'>You sense an adorable presence lurking just beyond the veil...</span>"
 	objective_verb = "Hug and Tickle"
 	demon_type = /mob/living/simple_animal/slaughter/laughter
+
+	
+////////////Syndicate Cortical Borer
+obj/item/weapon/antag_spawner/syndi_borer
+	name = "syndicate brain-slug container"
+	desc = "Releases a modified cortical borer to assist the user."
+	icon_state = "locator"
+	
+obj/item/weapon/antag_spawner/syndi_borer/spawn_antag(client/C, turf/T, mob/owner)
+	var/mob/living/simple_animal/borer/syndi_borer/B = new /mob/living/simple_animal/borer/syndi_borer(T)
+
+	B.key = C.key
+	if (owner)
+		B.owner = owner
+		B.faction = B.faction | owner.faction.Copy()
+		
+		B.mind.assigned_role = B.name
+		B.mind.special_role = B.name
+		ticker.mode.traitors += B.mind
+		var/datum/objective/syndi_borer/new_objective
+		new_objective = new /datum/objective/syndi_borer
+		new_objective.owner = B.mind
+		new_objective.target = owner.mind
+		B.mind.objectives += new_objective
+		
+		to_chat(B, "<B>You are awake at last! Seek out whoever released you and aid them as best you can!</B>")
+		if(new_objective)
+			to_chat(B, "<B>Objective #[1]</B>: [new_objective.explanation_text]")
+		
+/obj/item/weapon/antag_spawner/syndi_borer/proc/check_usability(mob/user)
+	if(used)
+		to_chat(user, "<span class='warning'>[src] appears to be empty!</span>")
+		return 0
+	return 1
+	
+/obj/item/weapon/antag_spawner/syndi_borer/attack_self(mob/user)
+	if(!(check_usability(user)))
+		return
+
+	var/list/borer_candidates = pollCandidatesForMob("Do you want to play as a syndicate cortical borer?", ROLE_BORER, null, ROLE_BORER, 150, src)
+	if(borer_candidates.len)
+		if(!(check_usability(user)))
+			return
+		used = 1
+		var/mob/dead/observer/theghost = pick(borer_candidates)
+		spawn_antag(theghost.client, get_turf(src), user)
+		var/datum/effect_system/spark_spread/S = new /datum/effect_system/spark_spread
+		S.set_up(4, 1, src)
+		S.start()
+		qdel(src)
+	else
+		to_chat(user, "<span class='warning'>Unable to connect to release specimen. Please wait and try again later or use the container on your uplink to get your points refunded.</span>")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -110,10 +110,14 @@ var/total_borer_hosts_needed = 10
 	var/datum/action/innate/borer/punish_victim/punish_victim_action = new
 	var/datum/action/innate/borer/jumpstart_host/jumpstart_host_action = new
 
+	var/is_team_borer = TRUE
+	var/borer_alert = "Become a cortical borer? (Warning, You can no longer be cloned!)"
+
 /mob/living/simple_animal/borer/Initialize(mapload, gen=1)
 	..()
 	generation = gen
-	notify_ghosts("A cortical borer has been created in [get_area(src)]!", enter_link = "<a href=?src=\ref[src];ghostjoin=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK)
+	if(is_team_borer)
+		notify_ghosts("A cortical borer has been created in [get_area(src)]!", enter_link = "<a href=?src=\ref[src];ghostjoin=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK)
 	real_name = "Cortical Borer [rand(1000,9999)]"
 	truename = "[borer_names[min(generation, borer_names.len)]] [rand(1000,9999)]"
 	borer_chems += /datum/borer_chem/epinephrine
@@ -128,8 +132,9 @@ var/total_borer_hosts_needed = 10
 	//borer_chems += /datum/borer_chem/creagent
 	borer_chems += /datum/borer_chem/ethanol
 	borer_chems += /datum/borer_chem/rezadone
-
-	borers += src
+	
+	if(is_team_borer)
+		borers += src
 
 	GrantBorerActions()
 
@@ -146,7 +151,7 @@ var/total_borer_hosts_needed = 10
 		return
 	if(stat != CONSCIOUS)
 		return
-	var/be_borer = alert("Become a cortical borer? (Warning, You can no longer be cloned!)",,"Yes","No")
+	var/be_borer = alert(borer_alert,,"Yes","No")
 	if(be_borer == "No" || !src || QDELETED(src))
 		return
 	if(key)

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -701,7 +701,8 @@ var/total_borer_hosts_needed = 10
 		controlling = TRUE
 
 		victim.verbs += /mob/living/carbon/proc/release_control
-		victim.verbs += /mob/living/carbon/proc/spawn_larvae
+		if(is_team_borer)
+			victim.verbs += /mob/living/carbon/proc/spawn_larvae
 		victim.verbs -= /mob/living/proc/borer_comm
 		victim.verbs += /mob/living/proc/trapped_mind_comm
 		GrantControlActions()
@@ -826,7 +827,8 @@ var/total_borer_hosts_needed = 10
 	controlling = FALSE
 
 	victim.verbs -= /mob/living/carbon/proc/release_control
-	victim.verbs -= /mob/living/carbon/proc/spawn_larvae
+	if(is_team_borer)
+		victim.verbs -= /mob/living/carbon/proc/spawn_larvae
 	victim.verbs += /mob/living/proc/borer_comm
 	victim.verbs -= /mob/living/proc/trapped_mind_comm
 	RemoveControlActions()

--- a/code/game/gamemodes/miniantags/borer/syndi_borer.dm
+++ b/code/game/gamemodes/miniantags/borer/syndi_borer.dm
@@ -1,5 +1,6 @@
 /mob/living/simple_animal/borer/syndi_borer
 	var/mob/owner = null
+	is_team_borer = FALSE
 	borer_alert = "Serve as a syndicate cortical borer? (Warning, You can no longer be cloned!)"
 	
 /mob/living/simple_animal/borer/syndi_borer/Initialize(mapload, gen=1)

--- a/code/game/gamemodes/miniantags/borer/syndi_borer.dm
+++ b/code/game/gamemodes/miniantags/borer/syndi_borer.dm
@@ -1,0 +1,19 @@
+/mob/living/simple_animal/borer/syndi_borer
+	var/mob/owner = null
+	borer_alert = "Serve as a syndicate cortical borer? (Warning, You can no longer be cloned!)"
+	
+/mob/living/simple_animal/borer/syndi_borer/Initialize(mapload, gen=1)
+	..()
+	real_name = "Syndicate Borer [rand(1000,9999)]"
+	truename = "[borer_names[min(generation, borer_names.len)]] [rand(1000,9999)]"
+
+	GrantBorerActions()
+	make_larvae_action.Remove(src)
+
+/mob/living/simple_animal/borer/syndi_borer/GrantControlActions()
+	talk_to_brain_action.Grant(victim)
+	give_back_control_action.Grant(victim)
+
+/mob/living/simple_animal/borer/syndi_borer/RemoveControlActions()
+	talk_to_brain_action.Remove(victim)
+	give_back_control_action.Remove(victim)

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -902,4 +902,16 @@ var/global/list/possible_items_special = list()
 	command_staff_only = TRUE
 
 
+//Syndicate borer objective, relies on their owner getting a greentext, no matter if they themselves did anything really.
+/datum/objective/syndi_borer
+	explanation_text = "You are a modified syndicate cortical borer, assist your owner with their objectives."
+	martyr_compatible = 1
 
+/datum/objective/syndi_borer/check_completion()
+	if(target)
+		for(var/datum/objective/objective in target.objectives)
+			if(!objective.check_completion())
+				return 0
+		return 1
+	else
+		return 1 //Not sure if we should greentext if we somehow don't even have an owner.

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -829,7 +829,9 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 			to assist their host."
 	item = /obj/item/weapon/antag_spawner/syndi_borer
 	refundable = TRUE
-	cost = 5
+	cost = 10
+	surplus = 20 //Let's not have this be too common
+	exclude_modes = list(/datum/game_mode/nuclear)
 
 //Space Suits and Hardsuits
 /datum/uplink_item/suits

--- a/code/modules/uplink/uplink_item.dm
+++ b/code/modules/uplink/uplink_item.dm
@@ -822,6 +822,15 @@ var/list/uplink_items = list() // Global list so we only initialize this once.
 	cost = 1
 	surplus = 1
 
+/datum/uplink_item/stealthy_tools/syndi_borer
+	name = "Syndicate Brain Slug"
+	desc = "A small cortical borer, modified to be completely loyal to the owner. \
+			Genetically infertile, these brain slugs can assist medically in a support role, or take direct action \
+			to assist their host."
+	item = /obj/item/weapon/antag_spawner/syndi_borer
+	refundable = TRUE
+	cost = 5
+
 //Space Suits and Hardsuits
 /datum/uplink_item/suits
 	category = "Space Suits and Hardsuits"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -489,6 +489,7 @@
 #include "code\game\gamemodes\miniantags\borer\borer_event.dm"
 #include "code\game\gamemodes\miniantags\borer\borer_html.dm"
 #include "code\game\gamemodes\miniantags\borer\borer_topic.dm"
+#include "code\game\gamemodes\miniantags\borer\syndi_borer.dm"
 #include "code\game\gamemodes\miniantags\bot_swarm\swarmer.dm"
 #include "code\game\gamemodes\miniantags\bot_swarm\swarmer_event.dm"
 #include "code\game\gamemodes\miniantags\monkey\monkey.dm"


### PR DESCRIPTION
:cl: ktccd
add: Syndicate agents, ~both the nuclear variant and~ **only** traitors, can now purchase our Syndi(tm) brand cortical borers! Nigh-guaranteed to be loyal to you and aid you in your mission, these borers sport all the latest and greatest of borer technology. _Reproductive capabilities may be void in certain states. Seller not responsible for providing souls to be housed in the borer body, please contact your local Syndi(tm) retail outlet for further customer service, refunds are available_
/:cl:

[why]: # 
Because borers are fun and provide some interesting ways to use them as a traitor. The icon for the item itself is a place-holder, as I lack spriting abilities and it looks ok as it is at least.
The borers of this variant are incapable of reproducing and will greentext together with their owner, which is not necessarily the same person as their host. An owner COULD for example buy a borer for their teammates, or send them to take control of a high-value host.
This kind of borer is a subtype of the regular kind, so it allows the possibility for further modifications if that's something we want, such as adding other chemicals to their production, though I want this PR to work as a basic set before I try anything weird.