### PR TITLE
Subtle emote fix

### DIFF
--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -115,8 +115,10 @@ proc/get_top_level_mob(var/mob/S)
 	emote_type = EMOTE_VISIBLE
 
 ///////////////// VERB CODE
+/mob/living/verb/subtle()
 	set name = "Subtle"
 	set category = "IC"
 	if(say_disabled)	//This is here to try to identify lag problems
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
+	usr.emote("subtle")

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -2,75 +2,7 @@
 ////////////////////SUBTLE COMMAND////////////////////
 //////////////////////////////////////////////////////
 /mob
-	var/use_me = 1
 	var/flavor_text = "" //tired of fucking double checking this
-
-/mob/verb/me_verb_subtle(message as text) //This would normally go in say.dm
-	set name = "Subtle"
-	set category = "IC"
-	set desc = "Emote to nearby people (and your pred/prey)"
-
-	if(say_disabled)	//This is here to try to identify lag problems
-		usr << "Speech is currently admin-disabled."
-		return
-
-	message = sanitize(message)
-
-	if(use_me)
-		usr.emote_vr("me",4,message)
-	else
-		usr.emote_vr(message)
-
-
-
-/mob/proc/custom_emote_vr(var/m_type=1,var/message = null) //This would normally go in emote.dm
-	if(stat || !use_me && usr == src)
-		src << "You are unable to emote."
-		return
-
-	var/muzzled = is_muzzled()
-	if(m_type == 2 && muzzled) return
-
-	var/input
-	if(!message)
-		input = sanitize(input(src,"Choose an emote to display.") as text|null)
-	else
-		input = message
-
-	if(input)
-		message = "<B>[src]</B> <I>[input]</I>"
-	else
-		return
-
-
-	if (message)
-		log_emote("[name]/[key] : [message]")
-
-		for(var/mob/M in player_list)
-			if (!M.client)
-				continue //skip monkeys and leavers
-			if (istype(M, /mob/dead/new_player))
-				continue
-			if(findtext(message," snores.")) //Because we have so many sleeping people.
-				break
-			if(M.stat == DEAD && !(M in viewers(src,null)))
-				M.show_message(message, m_type)
-		var/list/subtle = hearers(1,src)
-		for(var/I in subtle)
-			/*if(isobj(I)) //micros in hand
-				spawn(0)
-					if(I) //It's possible that it could be deleted in the meantime.
-						var/obj/O = I
-						I.show_message(src, message, 2) */
-			if(ismob(I))
-				var/mob/M = I
-				M.show_message(message, 2)
-
-
-
-/mob/proc/emote_vr(var/act, var/type, var/message) //This would normally go in say.dm
-	if(act == "me")
-		return custom_emote_vr(type, message)
 
 /mob/proc/update_flavor_text()
 	set src in usr
@@ -108,3 +40,83 @@ proc/get_top_level_mob(var/mob/S)
 		var/mob/M=S.loc
 		return M.get_top_level_mob()
 	return S
+
+
+
+
+///////////////// EMOTE CODE
+// Maybe making this as an emote is less messy?
+// It was - ktccd
+/datum/emote/living/subtle
+	key = "subtle"
+	key_third_person = "subtle"
+	message = null
+	mob_type_blacklist_typecache = list(/mob/living/brain)
+
+
+/datum/emote/living/subtle/proc/check_invalid(mob/user, input)
+	. = TRUE
+	if(copytext(input,1,5) == "says")
+		to_chat(user, "<span class='danger'>Invalid emote.</span>")
+	else if(copytext(input,1,9) == "exclaims")
+		to_chat(user, "<span class='danger'>Invalid emote.</span>")
+	else if(copytext(input,1,6) == "yells")
+		to_chat(user, "<span class='danger'>Invalid emote.</span>")
+	else if(copytext(input,1,5) == "asks")
+		to_chat(user, "<span class='danger'>Invalid emote.</span>")
+	else
+		. = FALSE
+
+/datum/emote/living/subtle/run_emote(mob/user, params, type_override = null)
+	if(jobban_isbanned(user, "emote"))
+		to_chat(user, "You cannot send subtle emotes (banned).")
+		return FALSE
+	else if(user.client && user.client.prefs.muted & MUTE_IC)
+		to_chat(user, "You cannot send IC messages (muted).")
+		return FALSE
+	else if(!params)
+		var/subtle_emote = copytext(sanitize(input("Choose an emote to display.") as text|null), 1, MAX_MESSAGE_LEN)
+		if(subtle_emote && !check_invalid(user, subtle_emote))
+			var/type = input("Is this a visible or hearable emote?") as null|anything in list("Visible", "Hearable")
+			switch(type)
+				if("Visible")
+					emote_type = EMOTE_VISIBLE
+				if("Hearable")
+					emote_type = EMOTE_AUDIBLE
+				else
+					alert("Unable to use this emote, must be either hearable or visible.")
+					return
+			message = subtle_emote
+	else
+		message = params
+		if(type_override)
+			emote_type = type_override
+	. = TRUE
+	if(!can_run_emote(user))
+		return FALSE
+
+	user.log_message(message, INDIVIDUAL_EMOTE_LOG)
+	message = "<b>[user]</b> " + message
+
+	for(var/mob/M in dead_mob_list)
+		if(!M.client || isnewplayer(M))
+			continue
+		var/T = get_turf(src)
+		if(M.stat == DEAD && M.client && (M.client.prefs.chat_toggles & CHAT_GHOSTSIGHT) && !(M in viewers(T, null)))
+			M.show_message(message)
+
+	if(emote_type == EMOTE_AUDIBLE)
+		user.audible_message(message=message,hearing_distance=1)
+	else
+		user.visible_message(message=message,self_message=message,vision_distance=1)
+	log_emote("[key_name(user)] : [message]")
+
+	message = null
+	emote_type = EMOTE_VISIBLE
+
+///////////////// VERB CODE
+	set name = "Subtle"
+	set category = "IC"
+	if(say_disabled)	//This is here to try to identify lag problems
+		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
+		return

--- a/html/changelogs/ktccd-PR-350.yml
+++ b/html/changelogs/ktccd-PR-350.yml
@@ -1,0 +1,35 @@
+################################
+# Example Changelog File
+#
+# Note: This file, and files beginning with ".", and files that don't end in ".yml" will not be read. If you change this file, you will look really dumb.
+#
+# Your changelog will be merged with a master changelog. (New stuff added only, and only on the date entry for the day it was merged.)
+# When it is, any changes listed below will disappear.
+#
+# Valid Prefixes: 
+#   bugfix
+#   wip (For works in progress)
+#   tweak
+#   soundadd
+#   sounddel
+#   rscadd (general adding of nice things)
+#   rscdel (general deleting of nice things)
+#   imageadd
+#   imagedel
+#   spellcheck (typo fixes)
+#   experiment
+#################################
+
+# Your name.  
+author: "ktccd"
+
+# Optional: Remove this file after generating master changelog.  Useful for PR changelogs that won't get used again.
+delete-after: True
+
+# Any changes you've made.  See valid prefix list above.
+# INDENT WITH TWO SPACES.  NOT TABS.  SPACES.
+# SCREW THIS UP AND IT WON'T WORK.
+# Also, this gets changed to [] after reading.  Just remove the brackets when you add new shit.
+# Please surround your changes in  double quotes ("). It works without them, but if you use certain characters it screws up compiling. The quotes will not show up in the changelog.
+changes: 
+  - bugfix: The subtle emote now behaves like other emotes and can be used with *subtle or from the IC tab. It also should work for any /mob/living creature(except brains), so simple_mobs should now be able to use it also.


### PR DESCRIPTION
[Changelogs]: 
:cl: ktccd
fix: Remade the subtle proc to be an emote. you can now use *subtle or the verb in the IC tab to use this emote. It works like a normal hearable or visible emote, with a range of 1 tile radius.
/:cl:

[why]: # 
Because the previous proc had issues with simple_mobs using it (at least) and was very difficult to debug because of... code I don't understand. It was NAMED an emote, but wasn't **actually** an emote datum, which is now fixed.