### PR TITLE
/me Hotfix

### DIFF
--- a/code/modules/mob/say.dm
+++ b/code/modules/mob/say.dm
@@ -15,7 +15,7 @@
 		return
 	say(message) //only carbons actually whisper, everything else just talks
 
-/mob/verb/me_verb()
+/mob/verb/me_verb(message as message)
 	set name = "Me"
 	set category = "IC"
 
@@ -23,7 +23,7 @@
 		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
 		return
 	var/list/replace_chars = list("\n"=" ","\t"=" ")
-	var/message = copytext(sanitize((input(src,"New lines are handled as spaces","Emote", "") as message|null), replace_chars), 1, (MAX_MESSAGE_LEN*2))
+	message = copytext(sanitize(message, replace_chars), 1, (MAX_MESSAGE_LEN*2))
 	usr.emote("me",1,message)
 
 /mob/proc/say_dead(var/message)


### PR DESCRIPTION
Fixes being unable to type `me` emotes into your command line. 

Who doesn't use hotkeys?