### PR TITLE
Sprite Accessory Ckey locks

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1067,11 +1067,16 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if(new_tail != "None")
 							features["taur"] = "None"
 				if("mam_tail")
-					var/new_tail
-					new_tail = input(user, "Choose your character's tail:", "Character Preference") as null|anything in GLOB.mam_tails_list
-					if(new_tail)
-						features["mam_tail"] = new_tail
-						if(new_tail != "None")
+					var/list/snowflake_tail_styles = list("Tails")
+					for(var/tpath in subtypesof(/datum/sprite_accessory/mam_tails))
+						var/datum/sprite_accessory/mam_tails/instance = new tpath()
+						if((!instance.ckeys_allowed) || (usr.ckey in instance.ckeys_allowed))
+							snowflake_tail_styles[instance.name] = tpath
+
+					var/selection = input(user, "Choose your character's tail", "Character Preference") as null|anything in snowflake_tail_styles
+					if(selection && selection != "Tails")
+						features["mam_tail"] = snowflake_tail_styles[selection]
+						if(selection != "None")
 							features["taur"] = "None"
 
 				if("taur")
@@ -1082,14 +1087,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						if(new_taur != "None")
 							features["mam_tail"] = "None"
 							features["xenotail"] = "None"
-
-/*	Doesn't exist yet. will include facial overlays to mimic 5th port species heads.
-				if("mam_snout")
-					var/new_snout
-					new_snout = input(user, "Choose your character's snout:", "Character Preference") as null|anything in GLOB.mam_snouts_list
-					if(new_snout)
-						features["snout"] = new_snout
-*/
 
 				if("snout")
 					var/new_snout

--- a/code/modules/mob/dead/new_player/sprite_accessories_Citadel.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories_Citadel.dm
@@ -5,7 +5,7 @@
 	var/extra2 = 0
 	var/extra2_icon = 'icons/mob/mam_bodyparts.dmi'
 	var/extra2_color_src = MUTCOLORS3
-//	var/list/ckeys_allowed = null
+	var/list/ckeys_allowed = null
 
 /* tbi eventually idk
 /datum/sprite_accessory/legs/digitigrade_mam
@@ -367,12 +367,13 @@
 	name = "DataShark"
 	icon_state = "datashark"
 	color_src = 0
-//	ckeys_allowed = list("rubyflamewing")
+	ckeys_allowed = list("rubyflamewing")
 
 /datum/sprite_accessory/mam_tails_animated/shark/datashark
 	name = "DataShark"
 	icon_state = "datashark"
 	color_src = 0
+	ckeys_allowed = list("rubyflamewing")
 
 /datum/sprite_accessory/mam_tails/shepherd
 	name = "Shepherd"


### PR DESCRIPTION
Enables use of ckey-specific tagging for donater and special use sprite accessories such as tails/body markings/etc. Species are unable to be locked, due to the way roundstart_species is stored in the code. It'll have to be an upstream change.

WIP: now to fix it showing the full path, fweeeee