### PR TITLE
Fix for incorrect/missing extra layers

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -67,7 +67,7 @@
 
 	//Eyes
 	var/obj/item/organ/eyes/mutanteyes = /obj/item/organ/eyes
-	
+
 	//Ears
 	var/obj/item/organ/ears/mutantears = /obj/item/organ/ears
 
@@ -497,6 +497,8 @@
 
 	var/g = (H.gender == FEMALE) ? "f" : "m"
 
+	var/image/I
+
 	for(var/layer in relevant_layers)
 		var/layertext = mutant_bodyparts_layertext(layer)
 
@@ -561,9 +563,9 @@
 					S = /datum/sprite_accessory/slimecoon_snout*/
 			if(!S || S.icon_state == "none")
 				continue
-			
-			var/mutable_appearance/accessory_overlay = mutable_appearance(S.icon, layer = -layer)
-			
+
+			var/mutable_appearance/accessory_overlay = mutable_appearance(S.icon, layer =- layer)
+
 			//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 			if(bodypart == "tail_lizard" || bodypart == "tail_human" || bodypart == "mam_tail" || bodypart == "slimecoontail" || bodypart == "xenotail")
 				bodypart = "tail"
@@ -574,10 +576,14 @@
 			if(bodypart == "xenohead")
 				bodypart = "xhead"
 
+			var/icon_string
+
 			if(S.gender_specific)
 				accessory_overlay.icon_state = "[g]_[bodypart]_[S.icon_state]_[layertext]"
 			else
 				accessory_overlay.icon_state = "m_[bodypart]_[S.icon_state]_[layertext]"
+
+			I = image("icon" = S.icon, "icon_state" = icon_string, "layer" =- layer)
 
 			if(S.center)
 				accessory_overlay = center_image(accessory_overlay, S.dimension_x, S.dimension_y)
@@ -614,7 +620,7 @@
 			standing += accessory_overlay
 
 			if(S.hasinner)
-				var/mutable_appearance/inner_accessory_overlay = mutable_appearance(S.icon, layer = -layer)
+				var/mutable_appearance/inner_accessory_overlay = mutable_appearance(S.icon, layer =- layer)
 				if(S.gender_specific)
 					inner_accessory_overlay.icon_state = "[g]_[bodypart]inner_[S.icon_state]_[layertext]"
 				else
@@ -624,86 +630,78 @@
 					inner_accessory_overlay = center_image(inner_accessory_overlay, S.dimension_x, S.dimension_y)
 
 				standing += inner_accessory_overlay
-				
+
 			if(S.extra) //apply the extra overlay, if there is one
-				var/mutable_appearance/extra_accessory_overlay = mutable_appearance(S.icon, layer = -layer)
 				if(S.gender_specific)
-					extra_accessory_overlay.icon_state = "[g]_[bodypart]_extra_[S.icon_state]_[layertext]"
+					icon_string = "[g]_[bodypart]_extra_[S.icon_state]_[layertext]"
 				else
-					extra_accessory_overlay.icon_state = "m_[bodypart]_extra_[S.icon_state]_[layertext]"
+					icon_string = "m_[bodypart]_extra_[S.icon_state]_[layertext]"
+
+				I = image("icon" = S.icon, "icon_state" = icon_string, "layer" =- layer)
 
 				if(S.center)
-					extra_accessory_overlay.icon_state = center_image(extra_accessory_overlay, S.dimension_x, S.dimension_y)
-					
-				if(!forced_colour)
-					switch(S.extra_color_src) //change the color of the extra overlay
-						if(MUTCOLORS)
-							if(fixed_mut_color)
-								extra_accessory_overlay.color = "#[fixed_mut_color]"
-							else
-								extra_accessory_overlay.color = "#[H.dna.features["mcolor"]]"
-						if(MUTCOLORS2)
-							if(fixed_mut_color2)
-								extra_accessory_overlay.color = "#[fixed_mut_color2]"
-							else
-								extra_accessory_overlay.color = "#[H.dna.features["mcolor2"]]"
-						if(MUTCOLORS3)
-							if(fixed_mut_color3)
-								extra_accessory_overlay.color = "#[fixed_mut_color3]"
-							else
-								extra_accessory_overlay.color = "#[H.dna.features["mcolor3"]]"
-						if(HAIR)
-							if(hair_color == "mutcolor")
-								extra_accessory_overlay.color = "#[H.dna.features["mcolor"]]"
-							else
-								extra_accessory_overlay.color = "#[H.hair_color]"
-						if(FACEHAIR)
-							extra_accessory_overlay.color = "#[H.facial_hair_color]"
-						if(EYECOLOR)
-							extra_accessory_overlay.color = "#[H.eye_color]"
-				else
-					extra_accessory_overlay.color = forced_colour
-				standing += extra_accessory_overlay
+					I = center_image(I,S.dimension_x,S.dimension_y)
+
+				switch(S.extra_color_src) //change the color of the extra overlay
+					if(MUTCOLORS)
+						if(fixed_mut_color)
+							I.color = "#[fixed_mut_color]"
+						else
+							I.color = "#[H.dna.features["mcolor"]]"
+					if(MUTCOLORS2)
+						if(fixed_mut_color2)
+							I.color = "#[fixed_mut_color2]"
+						else
+							I.color = "#[H.dna.features["mcolor2"]]"
+					if(MUTCOLORS3)
+						if(fixed_mut_color3)
+							I.color = "#[fixed_mut_color3]"
+						else
+							I.color = "#[H.dna.features["mcolor3"]]"
+					if(HAIR)
+						if(hair_color == "mutcolor")
+							I.color = "#[H.dna.features["mcolor"]]"
+						else
+							I.color = "#[H.hair_color]"
+					if(FACEHAIR)
+						I.color = "#[H.facial_hair_color]"
+					if(EYECOLOR)
+						I.color = "#[H.eye_color]"
+				standing += I
 
 			if(S.extra2) //apply the extra overlay, if there is one
-				var/mutable_appearance/extra2_accessory_overlay = mutable_appearance(S.icon, layer = -layer)
 				if(S.gender_specific)
-					extra2_accessory_overlay.icon_state = "[g]_[bodypart]_extra2_[S.icon_state]_[layertext]"
+					icon_string = "[g]_[bodypart]_extra2_[S.icon_state]_[layertext]"
 				else
-					extra2_accessory_overlay.icon_state = "m_[bodypart]_extra2_[S.icon_state]_[layertext]"
+					icon_string = "m_[bodypart]_extra2_[S.icon_state]_[layertext]"
+
+				I = image("icon" = S.icon, "icon_state" = icon_string, "layer" =- layer)
 
 				if(S.center)
-					extra2_accessory_overlay.icon_state = center_image(extra2_accessory_overlay, S.dimension_x, S.dimension_y)
-					
-				if(!forced_colour)
-					switch(S.extra_color_src) //change the color of the extra overlay
-						if(MUTCOLORS)
-							if(fixed_mut_color)
-								extra2_accessory_overlay.color = "#[fixed_mut_color]"
-							else
-								extra2_accessory_overlay.color = "#[H.dna.features["mcolor"]]"
-						if(MUTCOLORS2)
-							if(fixed_mut_color2)
-								extra2_accessory_overlay.color = "#[fixed_mut_color2]"
-							else
-								extra2_accessory_overlay.color = "#[H.dna.features["mcolor2"]]"
-						if(MUTCOLORS3)
-							if(fixed_mut_color3)
-								extra2_accessory_overlay.color = "#[fixed_mut_color3]"
-							else
-								extra2_accessory_overlay.color = "#[H.dna.features["mcolor3"]]"
-						if(HAIR)
-							if(hair_color == "mutcolor")
-								extra2_accessory_overlay.color = "#[H.dna.features["mcolor"]]"
-							else
-								extra2_accessory_overlay.color = "#[H.hair_color]"
-						if(FACEHAIR)
-							extra2_accessory_overlay.color = "#[H.facial_hair_color]"
-						if(EYECOLOR)
-							extra2_accessory_overlay.color = "#[H.eye_color]"
-				else
-					extra2_accessory_overlay.color = forced_colour
-				standing += extra2_accessory_overlay
+					I = center_image(I,S.dimension_x,S.dimension_y)
+
+				switch(S.extra2_color_src) //change the color of the extra overlay
+					if(MUTCOLORS)
+						if(fixed_mut_color)
+							I.color = "#[fixed_mut_color]"
+						else
+							I.color = "#[H.dna.features["mcolor"]]"
+					if(MUTCOLORS2)
+						if(fixed_mut_color2)
+							I.color = "#[fixed_mut_color2]"
+						else
+							I.color = "#[H.dna.features["mcolor2"]]"
+					if(MUTCOLORS3)
+						if(fixed_mut_color3)
+							I.color = "#[fixed_mut_color3]"
+						else
+							I.color = "#[H.dna.features["mcolor3"]]"
+					if(HAIR)
+						if(hair_color == "mutcolor")
+							I.color = "#[H.dna.features["mcolor"]]"
+						else
+							I.color = "#[H.hair_color]"
+				standing += I
 
 		H.overlays_standing[layer] = standing.Copy()
 		standing = list()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -564,7 +564,7 @@
 			if(!S || S.icon_state == "none")
 				continue
 
-			var/mutable_appearance/accessory_overlay = mutable_appearance(S.icon, layer =- layer)
+			var/mutable_appearance/accessory_overlay = mutable_appearance(S.icon, layer = -layer)
 
 			//A little rename so we don't have to use tail_lizard or tail_human when naming the sprites.
 			if(bodypart == "tail_lizard" || bodypart == "tail_human" || bodypart == "mam_tail" || bodypart == "slimecoontail" || bodypart == "xenotail")
@@ -620,7 +620,7 @@
 			standing += accessory_overlay
 
 			if(S.hasinner)
-				var/mutable_appearance/inner_accessory_overlay = mutable_appearance(S.icon, layer =- layer)
+				var/mutable_appearance/inner_accessory_overlay = mutable_appearance(S.icon, layer = -layer)
 				if(S.gender_specific)
 					inner_accessory_overlay.icon_state = "[g]_[bodypart]inner_[S.icon_state]_[layertext]"
 				else


### PR DESCRIPTION
:cl:
fix: Fixed layers for taurs/nagas not showing correctly.
/:cl:

It uses the old method. While more expensive to render, it actually works. either I'm overlooking something or MA just desn't like to use more than one extra layer.

![Taurs](http://i.imgur.com/IcKfVFs.jpg)

![Nagas](http://i.imgur.com/vRcfidN.jpg)