### PR TITLE
Disables the broken jizz/milk production for the time being.

### DIFF
--- a/code/citadel/organs/breasts.dm
+++ b/code/citadel/organs/breasts.dm
@@ -14,7 +14,7 @@
 
 /obj/item/organ/genital/breasts/Initialize()
 	. = ..()
-	reagents.add_reagent(fluid_id, fluid_max_volume)
+/*	reagents.add_reagent(fluid_id, fluid_max_volume)
 
 /obj/item/organ/genital/breasts/on_life()
 	if(QDELETED(src))
@@ -30,7 +30,7 @@
 		return FALSE
 	reagents.isolate_reagent(fluid_id)
 	reagents.add_reagent(fluid_id, (fluid_mult * fluid_rate))
-
+*/
 /obj/item/organ/genital/breasts/update_appearance()
 	var/string = "breasts_[lowertext(shape)]_[size]"
 	icon_state = sanitize_text(string)

--- a/code/citadel/organs/testicles.dm
+++ b/code/citadel/organs/testicles.dm
@@ -16,7 +16,7 @@
 
 /obj/item/organ/genital/testicles/Initialize()
 	. = ..()
-	reagents.add_reagent(fluid_id, fluid_max_volume)
+/*	reagents.add_reagent(fluid_id, fluid_max_volume)
 
 /obj/item/organ/genital/testicles/on_life()
 	if(QDELETED(src))
@@ -37,7 +37,7 @@
 		return FALSE
 	reagents.isolate_reagent(fluid_id)//remove old reagents if it changed and just clean up generally
 	reagents.add_reagent(fluid_id, (fluid_mult * fluid_rate))//generate the cum
-
+*/
 /obj/item/organ/genital/testicles/update_link()
 	if(owner && !QDELETED(src))
 		linked_penis = (owner.getorganslot("penis"))


### PR DESCRIPTION
-Cactus will fix eventually.
-Hopefully.

:cl: nut/milk production disabled until proper fix to prevent lethal doses of runtime spam.
/:cl:
