### PR TITLE
Adds traitor holoparasites

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -296,3 +296,10 @@
 /obj/item/weapon/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/weapon/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/weapon/spellbook/oneuse/mimery_guns(src)
+
+/obj/item/weapon/storage/box/syndie_kit/holoparasite
+	name = "box"
+
+/obj/item/weapon/storage/box/syndie_kit/holoparasite/PopulateContents()
+	new /obj/item/weapon/guardiancreator/tech/choose/traitor(src)
+	new /obj/item/weapon/paper/guardian(src)

--- a/code/modules/uplink/uplink_item_cit.dm
+++ b/code/modules/uplink/uplink_item_cit.dm
@@ -8,3 +8,14 @@
 	cost = 10
 	surplus = 20 //Let's not have this be too common
 	exclude_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/stealthy_tools/holoparasite
+	name="Holoparasite Injector"
+	desc="It contains an alien nanoswarm of unknown origin.\
+		  Though capable of near sorcerous feats via use of hardlight holograms and nanomachines.\
+		  It requires an organic host as a home base and source of fuel." //This is the description of the actual injector. Feel free to change this for uplink purposes//
+	item = /obj/item/weapon/storage/box/syndie_kit/holoparasite
+	refundable = TRUE
+	cost = 10 //I'm working off the borer. Price subject to change
+	surplus = 20 //Nobody needs a ton of parasites
+	exclude_modes = list(/datum/game_mode/nuclear)


### PR DESCRIPTION



:cl: Cebutris
 rscadd: The Syndicate has found an abandoned storage facility filled with hundreds of holoparasite injectors. While they aren't giving them to their operatives, sleeper operatives can buy them with their uplinks! Get your holographic murder machine buddy today!
/:cl:

[why]:
Because guardians aren't just for wiznerds anymore! If we can have borers, we can have holoparasites, can't we?


