### PR TITLE
No More Free Parasites

### DIFF
--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -495,6 +495,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if(candidates.len)
 		theghost = pick(candidates)
 		spawn_guardian(user, theghost.key)
+		qdel(src)
 	else
 		to_chat(user, "[failure_message]")
 		used = FALSE

--- a/code/modules/uplink/uplink_item_cit.dm
+++ b/code/modules/uplink/uplink_item_cit.dm
@@ -16,6 +16,7 @@
 		  It requires an organic host as a home base and source of fuel." //This is the description of the actual injector. Feel free to change this for uplink purposes//
 	item = /obj/item/weapon/storage/box/syndie_kit/holoparasite
 	refundable = TRUE
-	cost = 10 //I'm working off the borer. Price subject to change
+	cost = 15 //I'm working off the borer. Price subject to change
 	surplus = 20 //Nobody needs a ton of parasites
 	exclude_modes = list(/datum/game_mode/nuclear)
+	refund_path = /obj/item/weapon/guardiancreator/tech/choose/traitor


### PR DESCRIPTION
Traitors can no longer get free parasites by refunding the box after taking out the injector. Holoparasite injectors (and guardian card decks and holocarp fish sticks) now delete themselves when successfully used. The price for traitor parasites has been increased from 10 to 15