### PR TITLE
Tactical Energy Gun/ERT Sec Officer Change

### DIFF
--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -65,9 +65,8 @@
 	backpack_contents = list(/obj/item/weapon/storage/box/engineer=1,\
 		/obj/item/weapon/storage/box/handcuffs=1,\
 		/obj/item/clothing/mask/gas/sechailer=1,\
-		/obj/item/weapon/gun/energy/e_gun=1,\
-		/obj/item/weapon/melee/baton/loaded=1,\
-		/obj/item/weapon/gun/energy/e_gun/advtaser=1)
+		/obj/item/weapon/gun/energy/e_gun/stun=1,\
+		/obj/item/weapon/melee/baton/loaded=1)
 
 /datum/outfit/ert/security/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()

--- a/code/modules/projectiles/ammunition/energy.dm
+++ b/code/modules/projectiles/ammunition/energy.dm
@@ -78,6 +78,9 @@
 	fire_sound = 'sound/weapons/taser.ogg'
 	e_cost = 200
 
+/obj/item/ammo_casing/energy/electrode/spec
+	e_cost = 100
+
 /obj/item/ammo_casing/energy/electrode/gun
 	fire_sound = 'sound/weapons/gunshot.ogg'
 	e_cost = 100

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -31,6 +31,12 @@
 	if(gun_light && gun_light.on)
 		add_overlay("mini-light")
 
+/obj/item/weapon/gun/energy/e_gun/stun
+	name = "tactical energy gun"
+	desc = "Military issue energy gun, is able to fire stun rounds."
+	ammo_type = list(/obj/item/ammo_casing/energy/electrode/spec, /obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/laser)
+
+
 /obj/item/weapon/gun/energy/e_gun/mini/practice_phaser
 	name = "practice phaser"
 	desc = "A modified version of the basic phaser gun, this one fires less concentrated energy bolts designed for target practice."


### PR DESCRIPTION
This was missed during the PR mirror downtime.

Original PR:

This PR adds a new energy gun variant to the game. The Tactical Energy Gun.

The weapon is identical to a egun in all respects save it has a stun setting which can fire up to ten stun rounds before depleting the gun.

The gun is restricted to the ERT Security Officers only. It serves as an additional perk to the role. In compensation, their additional Adv Taser is removed.

specops egun

🆑 Steelpoint
add: ERT, non-red alert, Security Response Officers spawn with a Tactical Energy Gun. This is a military variant of the Egun that, in addition to laser and disable rounds, has access to stun rounds.
/🆑