### PR TITLE
Increases round time to three hours

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
-	var/auto_call = 72000 //time before in deciseconds in which the shuttle is auto called. Default is 2 hours.
+	var/auto_call = 108000 //time before in deciseconds in which the shuttle is auto called. Default is 3 hours.
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	if(!arrivals)

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -47,7 +47,7 @@ SUBSYSTEM_DEF(shuttle)
 
 	var/lockdown = FALSE	//disallow transit after nuke goes off
 
-	var/auto_call = 108000 //time before in deciseconds in which the shuttle is auto called. Default is 3 hours.
+	var/auto_call = 99000 //time before in deciseconds in which the shuttle is auto called. Default is 2½ hours plus 15 for the shuttle. So total is 3.
 
 /datum/controller/subsystem/shuttle/Initialize(timeofday)
 	if(!arrivals)


### PR DESCRIPTION
:cl: Jay
tweak: Increases round time to a total of three hours. Two and a half before the call then another fifteen for the shuttle to arrive totaling at three.
/:cl:

[why]: # It's been requested a lot and it's large enough that it can have impact without overdoing it.