### PR TITLE
Changes the mining reward katanas to use the regular path

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -145,7 +145,7 @@
 			new /obj/item/weapon/gun/ballistic/automatic/pistol(src)
 			new /obj/item/ammo_box/magazine/m10mm(src)
 		if(98)
-			new /obj/item/weapon/katana/cursed(src)
+			new /obj/item/weapon/katana(src)
 		if(99)
 			new /obj/item/weapon/storage/belt/champion(src)
 			new /obj/item/clothing/mask/luchador(src)

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -20,7 +20,7 @@
 		if(3)
 			new /obj/item/device/soulstone/anybody(src)
 		if(4)
-			new /obj/item/weapon/katana/cursed(src)
+			new /obj/item/weapon/katana(src)
 		if(5)
 			new /obj/item/clothing/glasses/godeye(src)
 		if(6)


### PR DESCRIPTION
item/weapon/katana/cursed was intended to be used for the wizard cursed items event, not for a reward.

:cl: RealDonaldTrump
fix: Changes the mining reward katanas to use the main path, as opposed to the katana intended for the wizard cursed items event
/:cl:
