### PR TITLE
Fixes traitor holoparasites

### DIFF
--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -305,10 +305,3 @@
 /obj/item/weapon/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/weapon/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/weapon/spellbook/oneuse/mimery_guns(src)
-
-/obj/item/weapon/storage/box/syndie_kit/holoparasite
-	name = "box"
-
-/obj/item/weapon/storage/box/syndie_kit/holoparasite/PopulateContents()
-	new /obj/item/weapon/guardiancreator/tech/choose/traitor(src)
-	new /obj/item/weapon/paper/guardian(src)

--- a/code/game/objects/items/weapons/storage/uplink_kits.dm
+++ b/code/game/objects/items/weapons/storage/uplink_kits.dm
@@ -305,3 +305,10 @@
 /obj/item/weapon/storage/box/syndie_kit/mimery/PopulateContents()
 	new /obj/item/weapon/spellbook/oneuse/mimery_blockade(src)
 	new /obj/item/weapon/spellbook/oneuse/mimery_guns(src)
+
+/obj/item/weapon/storage/box/syndie_kit/holoparasite
+	name = "box"
+
+/obj/item/weapon/storage/box/syndie_kit/holoparasite/PopulateContents()
+	new /obj/item/weapon/guardiancreator/tech/choose/traitor(src)
+	new /obj/item/weapon/paper/guardian(src)

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -467,6 +467,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	var/used_message = "<span class='holoparasite'>All the cards seem to be blank now.</span>"
 	var/failure_message = "<span class='holoparasitebold'>..And draw a card! It's...blank? Maybe you should try again later.</span>"
 	var/ling_failure = "<span class='holoparasitebold'>The deck refuses to respond to a souless creature such as you.</span>"
+	var/activation_message = "<span class='holoparasite'>The rest of the deck rapidly flashes to ash!</span>"
 	var/list/possible_guardians = list("Assassin", "Chaos", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
 	var/random = TRUE
 	var/allowmultiple = FALSE
@@ -495,6 +496,8 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	if(candidates.len)
 		theghost = pick(candidates)
 		spawn_guardian(user, theghost.key)
+		to_chat(user, "[activation_message]")
+  		qdel(src)
 	else
 		to_chat(user, "[failure_message]")
 		used = FALSE
@@ -587,6 +590,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	used_message = "<span class='holoparasite'>The injector has already been used.</span>"
 	failure_message = "<span class='holoparasitebold'>...ERROR. BOOT SEQUENCE ABORTED. AI FAILED TO INTIALIZE. PLEASE CONTACT SUPPORT OR TRY AGAIN LATER.</span>"
 	ling_failure = "<span class='holoparasitebold'>The holoparasites recoil in horror. They want nothing to do with a creature like you.</span>"
+	activation_message = "<span class='holoparasite'>The injector self destructs after you inject yourself with it.</span>"
 
 /obj/item/weapon/guardiancreator/tech/choose/traitor
 	possible_guardians = list("Assassin", "Chaos", "Charger", "Explosive", "Lightning", "Protector", "Ranged", "Standard", "Support")
@@ -599,7 +603,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 
 /obj/item/weapon/paper/guardian
 	name = "Holoparasite Guide"
-	icon_state = "paper_words"
+	icon_state = "alienpaper_words"
 	info = {"<b>A list of Holoparasite Types</b><br>
 
  <br>
@@ -670,6 +674,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 	used_message = "<span class='holoparasite'>Someone's already taken a bite out of these fishsticks! Ew.</span>"
 	failure_message = "<span class='holoparasitebold'>You couldn't catch any carp spirits from the seas of Lake Carp. Maybe there are none, maybe you fucked up.</span>"
 	ling_failure = "<span class='holoparasitebold'>Carp'sie is fine with changelings, so you shouldn't be seeing this message.</span>"
+	activation_message = "<span class='holoparasite'>You finish eating the fishsticks! Delicious!>"
 	allowmultiple = TRUE
 	allowling = TRUE
 	random = TRUE

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -497,7 +497,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		theghost = pick(candidates)
 		spawn_guardian(user, theghost.key)
 		to_chat(user, "[activation_message]")
-  		qdel(src)
+		qdel(src)
 	else
 		to_chat(user, "[failure_message]")
 		used = FALSE

--- a/code/modules/uplink/uplink_item_cit.dm
+++ b/code/modules/uplink/uplink_item_cit.dm
@@ -11,12 +11,12 @@
 
 /datum/uplink_item/stealthy_tools/holoparasite
 	name="Holoparasite Injector"
-	desc="It contains an alien nanoswarm of unknown origin.\
-		  Though capable of near sorcerous feats via use of hardlight holograms and nanomachines.\
-		  It requires an organic host as a home base and source of fuel." //This is the description of the actual injector. Feel free to change this for uplink purposes//
+	desc="An injector containing a swarm of holographic parasites. \
+			They mimic the function of the guardians employed by the Space Wizard Federation, and their form can be selected upon application \
+			NOTE: The precise nature of the symbiosis required by the parasites renders them incompatible with changelings" //updated to actually describe what they do and warn traitorchans not to buy it
 	item = /obj/item/weapon/storage/box/syndie_kit/holoparasite
 	refundable = TRUE
-	cost = 15 //I'm working off the borer. Price subject to change
+	cost = 15
 	surplus = 20 //Nobody needs a ton of parasites
 	exclude_modes = list(/datum/game_mode/nuclear)
 	refund_path = /obj/item/weapon/guardiancreator/tech/choose/traitor


### PR DESCRIPTION
Changes the uplink description to be more descriptive and also warn changelings not to buy it, as it doesn't work on them.

Also fixes the exploit with refunding again, see #1051 and #1066 for more details