### PR TITLE
Avian 'say' tweak

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -21,6 +21,7 @@ datum/species/mammal
 /datum/species/avian
 	name = "Avian"
 	id = "avian"
+	say_mod = "chirps"
 	default_color = "BCAC9B"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,HAIR)
 	mutant_bodyparts = list("snout", "wings", "taur", "mam_tail", "mam_body_markings")


### PR DESCRIPTION
Added " say_mod = "chirps" " to the avian species entry to allow the say prefix to be "chirps" instead of "says"

:cl: Raeschen
tweak: Changed the avian say prefix of "says" to "chirps"
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Just a silly little fluff tweak. Lizards hiss, humans say, now avians can chirp!