### PR TITLE
Enable borer random event

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/borer
 	weight = 10 //Default weight
 	max_occurrences = 1
+	min_players = 20 //10 is MINIMUM needed, but this is not a gamemode that does well in lowpop
 	earliest_start = 24000 //40 min, double default timer
 
 /datum/round_event/borer

--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -1,10 +1,9 @@
 /datum/round_event_control/borer
 	name = "Borer"
 	typepath = /datum/round_event/borer
-	weight = 15
-	max_occurrences = 0
-	min_players = 15
-	earliest_start = 12000
+	weight = 10 //Default weight
+	max_occurrences = 1
+	earliest_start = 24000 //40 min, double default timer
 
 /datum/round_event/borer
 	announceWhen = 2400 //Borers get 4 minutes till the crew tries to murder them.


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
tweak: Enabled random borer event, increased minimum timer before borer event can happen, decreased possibility of borer event, down to default value, increased minimum living, non-AFK players required for event to happen.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Because borers are fun, but lowpop borers are less fun. Also our rounds are expected to last longer than TG rounds, so increased timer and lower weight is required if we don't want borers to happen on every extended round. I don't even know why the weight was HIGHER than the default before....

Final note: I kind of want J to give me his thoughts on this, because I have a vague memory of him changing this at some point so IDK if this was removed because of TG synching or not.
(I know TG disabled it randomly happening before they removed it completely for example, so it might've been a result of a TG-synch)