### PR TITLE
Xeno-pepe is now more rare

### DIFF
--- a/code/modules/events/alien_infestation.dm
+++ b/code/modules/events/alien_infestation.dm
@@ -2,8 +2,9 @@
 	name = "Alien Infestation"
 	typepath = /datum/round_event/ghost_role/alien_infestation
 	weight = 5
+	earliest_start = 24000 //40 min
 
-	min_players = 10
+	min_players = 20 //Avoid lowpop rounds
 	max_occurrences = 1
 
 /datum/round_event/ghost_role/alien_infestation


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
tweak: Increased minimum timer for xenomorph event from 20 to 40min. Also increased minimum living, non-afk players required from 10 to 20.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Xenomorphs have SO many ways to be enabled, especially on as long rounds as we have here that this feels necessary to avoid every round turning into a xenomorph round on 3h rounds.
Also, 10 players? lowpopxenomorphs suck ass, and although I may be biased, I don't think we maxcap- and fire-bomb as much as TG does for 10 people to be able to stop the xeno-hordes, especially since the count only cares aboue NON-afk and in reality every AFK player is actually a resource for the xenos to use against you.