### PR TITLE
Fixes empty subtle emotes

### DIFF
--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -87,6 +87,8 @@ proc/get_top_level_mob(var/mob/S)
 					alert("Unable to use this emote, must be either hearable or visible.")
 					return
 			message = subtle_emote
+		else
+			return FALSE
 	else
 		message = params
 		if(type_override)


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
fix: The Subtle emote now properly cancels empty or cancelled emotes.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
I forgot to return false when the if statement detects errors, whoops.