### PR TITLE
[resolved upstream]Makes ashstorms check better

### DIFF
--- a/code/datums/weather/weather_types.dm
+++ b/code/datums/weather/weather_types.dm
@@ -91,14 +91,21 @@
 
 	probability = 90
 
-/datum/weather/ash_storm/impact(mob/living/L)
-	if(istype(L.loc, /obj/mecha))
-		return
-	if(ishuman(L))
+/datum/weather/ash_storm/proc/is_ash_immune(mob/living/L)
+	if(istype(L.loc, /obj/mecha)) //Mechs are immune
+		return TRUE
+	if(ishuman(L)) //Are you immune?
 		var/mob/living/carbon/human/H = L
 		var/thermal_protection = H.get_thermal_protection()
 		if(thermal_protection >= FIRE_IMMUNITY_SUIT_MAX_TEMP_PROTECT)
-			return
+			return TRUE
+	if(istype(L.loc, /mob) && L.loc != L) //Matryoshka check
+		return is_ash_immune(L.loc)
+	return FALSE //RIP you
+
+/datum/weather/ash_storm/impact(mob/living/L)
+	if(is_ash_immune(L))
+		return
 	L.adjustFireLoss(4)
 
 /datum/weather/ash_storm/emberfall //Emberfall: An ash storm passes by, resulting in harmless embers falling like snow. 10% to happen in place of an ash storm.


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
fix: Ashstorms no longer pierces the ash-immune people to kill anyone in them.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Borers would die inside someone in a mech or drake armor. This is silly, they are not expose if their host isn't.
Incidentally, this will also protect anyone inside someone who is immune, so miners doing vore should be protecting the people inside them.
InB4 miners save dying people in ashstorms by voring them.