### PR TITLE
Adds a HUD for borers

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -40,6 +40,7 @@
 #define ANTAG_HUD_SINTOUCHED	16
 #define ANTAG_HUD_SOULLESS		17
 #define ANTAG_HUD_CLOCKWORK		18
+#define ANTAG_HUD_BORER			19
 
 // Notification action types
 #define NOTIFY_JUMP "jump"

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_INIT(huds, list(
 	ANTAG_HUD_SINTOUCHED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_SOULLESS = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_CLOCKWORK = new/datum/atom_hud/antag(),
+	ANTAG_HUD_BORER = new/datum/atom_hud/antag(),
 	))
 
 /datum/atom_hud

--- a/code/game/gamemodes/antag_spawner_cit.dm
+++ b/code/game/gamemodes/antag_spawner_cit.dm
@@ -27,7 +27,7 @@ obj/item/weapon/antag_spawner/syndi_borer/spawn_antag(client/C, turf/T, mob/owne
 		to_chat(B, "<B>You are awake at last! Seek out whoever released you and aid them as best you can!</B>")
 		if(new_objective)
 			to_chat(B, "<B>Objective #[1]</B>: [new_objective.explanation_text]")
-
+		SSticker.mode.update_borer_icons_added(B)
 /obj/item/weapon/antag_spawner/syndi_borer/proc/check_usability(mob/user)
 	if(used)
 		to_chat(user, "<span class='warning'>[src] appears to be empty!</span>")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -413,6 +413,8 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 	victim = C
 	forceMove(victim)
 
+	SSticker.mode.update_borer_icons_added_host(victim.mind)
+
 	RemoveBorerActions()
 	GrantInfestActions()
 
@@ -587,6 +589,7 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 	var/mob/living/V = victim
 	V.verbs -= /mob/living/proc/borer_comm
 	talk_to_borer_action.Remove(victim)
+	SSticker.mode.update_borer_icons_removed_host(victim.mind)
 	victim = null
 	return
 
@@ -842,6 +845,7 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 
 		if(mind)
 			mind.store_memory("You must escape with at least [GLOB.total_borer_hosts_needed] borers with hosts on the shuttle.")
+			SSticker.mode.update_borer_icons_added(mind)
 
 		to_chat(src, "<span class='notice'>You are a cortical borer!</span>")
 		to_chat(src, "You are a brain slug that worms its way into the head of its victim. Use stealth, persuasion and your powers of mind control to keep you, your host and your eventual spawn safe and warm.")
@@ -1076,3 +1080,27 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 /datum/action/innate/borer/jumpstart_host/Activate()
 	var/mob/living/simple_animal/borer/B = owner
 	B.jumpstart()
+
+
+//HUD STUFF
+/datum/game_mode/proc/update_borer_icons_added(datum/mind/borer_mind)
+	var/datum/atom_hud/antag/borerhud = GLOB.huds[ANTAG_HUD_BORER]
+	borerhud.join_hud(borer_mind.current)
+	set_antag_hud(borer_mind.current, "hudbrainworm")
+
+/datum/game_mode/proc/update_borer_icons_removed(datum/mind/borer_mind)
+	var/datum/atom_hud/antag/borerhud = GLOB.huds[ANTAG_HUD_BORER]
+	borerhud.leave_hud(borer_mind.current)
+	set_antag_hud(borer_mind.current, null)
+
+/datum/game_mode/proc/update_borer_icons_added_host(datum/mind/host_mind)
+	var/datum/atom_hud/antag/hosthud = GLOB.huds[ANTAG_HUD_BORER] //Invisible to self
+	hosthud.self_visible = FALSE
+	hosthud.join_hud(host_mind.current)
+	set_antag_hud(host_mind.current, "hudbrainworm")
+
+/datum/game_mode/proc/update_borer_icons_removed_host(datum/mind/host_mind)
+	var/datum/atom_hud/antag/hosthud = GLOB.huds[ANTAG_HUD_BORER] //Invisible to self
+	hosthud.self_visible = FALSE //Probably not needed as we're deleting?
+	hosthud.leave_hud(host_mind.current)
+	set_antag_hud(host_mind.current, null)


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
add: Borers of all kinds now have a HUD element to see other sentient borers and their hosts. (Hosts cannot see this HUD)
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
It's slightly annoying as a borer to not know who is infested with a borer, especially seeing as the borers are supposed to have a hive-mind of a sorts.
This avoids the annoyance of trying to infect someone's host, and also lets borers quickly see if a borer has awoken or not.
Hosts cannot see this HUD, because they're not a telepathic hive-mind. They can always ask their borer to point out people for them if they want to.