### PR TITLE
Fixes cloning and DNA change losing genitals.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -29,6 +29,9 @@
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
 	if(transfer_SE)
 		destination.dna.struc_enzymes = struc_enzymes
+	if(ishuman(destination))
+		var/mob/living/carbon/human/H = destination
+		H.give_genitals(TRUE)//This gives the body the genitals of this DNA. Used for any transformations based on DNA
 
 /datum/dna/proc/copy_dna(datum/dna/new_dna)
 	new_dna.unique_enzymes = unique_enzymes
@@ -246,6 +249,8 @@
 	if(se)
 		dna.struc_enzymes = se
 		domutcheck()
+
+	give_genitals(TRUE)//Give all genitalia that DNA says you should have, remove any pre-existing ones as this is a hardset!
 
 	if(mrace || newfeatures || ui)
 		update_body()


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
fix: Cloning and podding people no longer forgets to put the genitals back in you.
fix: Changeling and other DNA transformations now apply the appropriate genitalia.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Because miners kept losing their penis in lavaland and can't even find it to transplant it back. Also, things in their DNA should really follow with the clone.
And comparing the genitals to find who is a changeling got old really fast. Changelings are powerful enough to fake a dong if they need to...
(Also, this applies to transformation stings! So have fun stinging someone's dick away)