### PR TITLE
Fixes displaying digestion alert for preys

### DIFF
--- a/code/modules/vore/eating/bellymodes_vr.dm
+++ b/code/modules/vore/eating/bellymodes_vr.dm
@@ -45,7 +45,8 @@
 
 				//Send messages
 				to_chat(owner, "<span class='warning'>[digest_alert_owner]</span>")
-				M.visible_message("<span class='notice'>You watch as [owner]'s form loses its additions.</span>", "<span class='warning'>[digest_alert_prey]</span>")
+				to_chat(M, "<span class='warning'>[digest_alert_prey]</span>")
+				M.visible_message("<span class='notice'>You watch as [owner]'s form loses its additions.</span>")
 
 				owner.nutrition += 400 // so eating dead mobs gives you *something*.
 				M.stop_sound_channel(CHANNEL_PRED)


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)

:cl: ktccd
fix: Preys being digested now get their digestion message
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
It's obviously intended to be shown, but visible_message doesn't work on dead mobs that way it seems.
So I made it use it's own little to_chat for it. Done. 0.5h of testing, topkek.