### PR TITLE
Refactored flavortext to be savable in DNA. (RIP old changeling-meta-hunting)

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -116,6 +116,7 @@
 		"xenohead" 			= "None",
 		"xenotail" 			= "None",
 		"exhibitionist" 	= FALSE,
+		"genitals_use_skintone"	= FALSE,
 		"has_cock"			= FALSE,
 		"cock_shape"		= pick(GLOB.cock_shapes_list),
 		"cock_length"		= 6,
@@ -158,8 +159,9 @@
 		"womb_cum_rate"		= CUM_RATE,
 		"womb_cum_mult"		= CUM_RATE_MULT,
 		"womb_efficiency"	= CUM_EFFICIENCY,
-		"womb_fluid" 		= "femcum"))
-		
+		"womb_fluid" 		= "femcum",
+		"flavor_text"		= ""))
+
 /proc/random_hair_style(gender)
 	switch(gender)
 		if(MALE)

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -32,6 +32,7 @@
 	if(ishuman(destination))
 		var/mob/living/carbon/human/H = destination
 		H.give_genitals(TRUE)//This gives the body the genitals of this DNA. Used for any transformations based on DNA
+	destination.flavor_text = destination.dna.features["flavor_text"] //Update the flavor_text to use new dna text
 
 /datum/dna/proc/copy_dna(datum/dna/new_dna)
 	new_dna.unique_enzymes = unique_enzymes
@@ -231,6 +232,7 @@
 
 	if(newfeatures)
 		dna.features = newfeatures
+		flavor_text = dna.features["flavor_text"] //Update the flavor_text to use new dna text
 
 	if(mrace)
 		set_species(mrace, icon_update=0)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -130,7 +130,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 		"womb_cum_rate"		= CUM_RATE,
 		"womb_cum_mult"		= CUM_RATE_MULT,
 		"womb_efficiency"	= CUM_EFFICIENCY,
-		"womb_fluid" 		= "femcum"
+		"womb_fluid" 		= "femcum",
+		"flavor_text"		= ""
 		)//MAKE SURE TO UPDATE THE LIST IN MOBS.DM IF YOU'RE GOING TO ADD TO THIS LIST, OTHERWISE THINGS MIGHT GET FUCKEY
 
 	var/list/custom_names = list("clown", "mime", "ai", "cyborg", "religion", "deity")
@@ -175,7 +176,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//citadel code
 	var/arousable = TRUE //Allows players to disable arousal from the character creation menu
-	var/flavor_text = ""
 
 /datum/preferences/New(client/C)
 	parent = C
@@ -394,13 +394,13 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<table><tr><td width='340px' height='300px' valign='top'>"
 			dat += "<div class='statusDisplay'><img src=previewicon.png width=[preview_icon.Width()] height=[preview_icon.Height()]></div><br>"
 			dat += "<a href='byond://?src=\ref[user];preference=flavor_text;task=input'><b>Set Flavor Text</b></a><br>"
-			if(lentext(flavor_text) <= 40)
-				if(!lentext(flavor_text))
+			if(lentext(features["flavor_text"]) <= 40)
+				if(!lentext(features["flavor_text"]))
 					dat += "\[...\]"
 				else
-					dat += "[flavor_text]"
+					dat += "[features["flavor_text"]]"
 			else
-				dat += "[TextPreview(flavor_text)]...<BR>"
+				dat += "[TextPreview(features["flavor_text"])]...<BR>"
 			if(config.mutant_races)//really don't need this check, but fuck un-tabbing all those lines
 				dat += "<h2>Body</h2>"
 				dat += "<b>Gender:</b> <a href='?_src_=prefs;preference=gender'>[gender == MALE ? "Male" : "Female"]</a><BR>"
@@ -916,11 +916,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(flavor_text)) as message
+					var/msg = input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(features["flavor_text"])) as message
 					if(msg != null)
 						msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 						msg = html_encode(msg)
-						flavor_text = msg
+						features["flavor_text"] = msg
 
 				if("metadata")
 					var/new_metadata = input(user, "Enter any information you'd like others to see, such as Roleplay-preferences:", "Game Preference" , metadata)  as message|null
@@ -1628,7 +1628,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	character.backbag = backbag
 
-	character.dna.features = features.Copy()
+	character.dna.features = features.Copy() //Flavor text is now a DNA feature
 	character.dna.real_name = character.real_name
 	var/datum/species/chosen_species
 	if(pref_species != /datum/species/human && config.mutant_races)
@@ -1639,7 +1639,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	//citadel code
 	character.give_genitals()
-	character.flavor_text = flavor_text
+	character.flavor_text = features["flavor_text"] //Let's update their flavor_text at least initially
 	character.canbearoused = arousable
 
 	if(icon_updates)

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -342,9 +342,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_med"]		>> job_engsec_med
 	S["job_engsec_low"]		>> job_engsec_low
 
-
 	//Citadel code
-	S["flavor_text"]					>> flavor_text
 	S["feature_exhibitionist"]			>> features["exhibitionist"]
 	S["feature_mcolor2"]				>> features["mcolor2"]
 	S["feature_mcolor3"]				>> features["mcolor3"]
@@ -382,6 +380,13 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_vag_color"]				>> features["vag_color"]
 	//womb features
 	S["feature_has_womb"]				>> features["has_womb"]
+	//flavor text
+	//Let's make our players NOT cry desperately as we wipe their savefiles of their special snowflake texts:
+	if((S["feature_flavor_text"] == "") && (S["flavor_text"] != "")) //If we got no new flavor_text data, but we have old
+		S["flavor_text"]				>> features["flavor_text"]
+	else //Otherwise use new flavor_text data always
+		S["feature_flavor_text"]		>> features["flavor_text"]
+
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -441,7 +446,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	job_engsec_low = sanitize_integer(job_engsec_low, 0, 65535, initial(job_engsec_low))
 
 	//Citadel
-	flavor_text		= sanitize_text(flavor_text, initial(flavor_text))
+	features["flavor_text"]		= sanitize_text(features["flavor_text"], initial(features["flavor_text"]))
 	if(!features["mcolor2"] || features["mcolor"] == "#000")
 		features["mcolor2"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
 	if(!features["mcolor3"] || features["mcolor"] == "#000")
@@ -510,7 +515,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_low"]		<< job_engsec_low
 
 	//Citadel
-	S["flavor_text"]			<< flavor_text
 	S["feature_exhibitionist"]			<< features["exhibitionist"]
 	S["feature_mcolor2"]				<< features["mcolor2"]
 	S["feature_mcolor3"]				<< features["mcolor3"]
@@ -548,7 +552,8 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_vag_color"]				<< features["vag_color"]
 	//womb features
 	S["feature_has_womb"]				<< features["has_womb"]
-
+	//flavor text
+	S["feature_flavor_text"]			<< features["flavor_text"]
 	return 1
 
 #undef SAVEFILE_VERSION_MAX

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -382,11 +382,15 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_has_womb"]				>> features["has_womb"]
 	//flavor text
 	//Let's make our players NOT cry desperately as we wipe their savefiles of their special snowflake texts:
-	if(S["flavor_text"] != "" || S["flavor_text"] != null)
+	if((S["flavor_text"] != "") && (S["flavor_text"] != null) && S["flavor_text"]) //If old text isn't null and isn't "" but still exists.
+		to_chat(world, "DEBUG: OLD TEXT FOUND, MOVING:[S["flavor_text"]]")
 		S["flavor_text"]				>> features["flavor_text"] //Load old flavortext as current dna-based flavortext
-		S["flavor_text"]				>> S["feature_flavor_text"] //Save it in our new type of flavor-text
-		null 							>> S["flavor_text"] //Remove old flavortext, completing the cut-and-paste into the new format.
+
+		S["feature_flavor_text"]		<< features["flavor_text"] //Save it in our new type of flavor-text
+		S["flavor_text"]				<< "" //Remove old flavortext, completing the cut-and-paste into the new format.
+
 	else //We have no old flavortext, default to new
+		to_chat(world, "DEBUG: No old text found.")
 		S["feature_flavor_text"]		>> features["flavor_text"]
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -383,14 +383,12 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//flavor text
 	//Let's make our players NOT cry desperately as we wipe their savefiles of their special snowflake texts:
 	if((S["flavor_text"] != "") && (S["flavor_text"] != null) && S["flavor_text"]) //If old text isn't null and isn't "" but still exists.
-		to_chat(world, "DEBUG: OLD TEXT FOUND, MOVING:[S["flavor_text"]]")
 		S["flavor_text"]				>> features["flavor_text"] //Load old flavortext as current dna-based flavortext
 
 		S["feature_flavor_text"]		<< features["flavor_text"] //Save it in our new type of flavor-text
 		S["flavor_text"]				<< "" //Remove old flavortext, completing the cut-and-paste into the new format.
 
 	else //We have no old flavortext, default to new
-		to_chat(world, "DEBUG: No old text found.")
 		S["feature_flavor_text"]		>> features["flavor_text"]
 
 

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -382,9 +382,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["feature_has_womb"]				>> features["has_womb"]
 	//flavor text
 	//Let's make our players NOT cry desperately as we wipe their savefiles of their special snowflake texts:
-	if((S["feature_flavor_text"] == "") && (S["flavor_text"] != "")) //If we got no new flavor_text data, but we have old
-		S["flavor_text"]				>> features["flavor_text"]
-	else //Otherwise use new flavor_text data always
+	if(S["flavor_text"] != "" || S["flavor_text"] != null)
+		S["flavor_text"]				>> features["flavor_text"] //Load old flavortext as current dna-based flavortext
+		S["flavor_text"]				>> S["feature_flavor_text"] //Save it in our new type of flavor-text
+		null 							>> S["flavor_text"] //Remove old flavortext, completing the cut-and-paste into the new format.
+	else //We have no old flavortext, default to new
 		S["feature_flavor_text"]		>> features["flavor_text"]
 
 


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)


:cl: ktccd
fix: Flavortext is now in the DNA of mobs who has that, meaning changelings, cloners and such things use it properly.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Because changelings got outed by metagamey bullshit and cloners makes miners have to play non-snowflakes.
In all honesty though, this PR **should not be merged** until someone teaches me why the flavortext saving-code I put in doesn't rescue the old flavortext.
I need @kevinz000 or someone to help me with that maybe?
That, or we just remove that piece and let people have some time to back-up their flavortexts?