### PR TITLE
Disables Roundstart Aliens

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -99,7 +99,7 @@ datum/species/mammal
 	skinned_type = /obj/item/stack/sheet/animalhide/xeno
 	exotic_bloodtype = "L"
 	damage_overlay_type = "xeno"
-	roundstart = 1
+	roundstart = 0
 
 //Praise the Omnissiah, A challange worthy of my skills - HS
 


### PR DESCRIPTION
This disables the roundstart aliens until they can be more balanced to not have any form of advantage. If anything, a preference to it being purely cosmetic would bet better off.