### PR TITLE
Makes Taurs not render human legs

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -521,8 +521,21 @@ generate/load female uniform sprites matching all previously decided variables
 
 	. += "-[gender]"
 
+
+	var/is_taur = FALSE
+	var/mob/living/carbon/human/H = src
+	if(("taur" in H.dna.species.mutant_bodyparts) && (H.dna.features["taur"] != "None"))
+		is_taur = TRUE
+
+
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
+
+		if(istype(BP, /obj/item/bodypart/r_leg) || istype(BP, /obj/item/bodypart/l_leg))
+			if(is_taur)
+				continue
+
+
 		. += "-[BP.body_zone]"
 		if(BP.status == BODYPART_ORGANIC)
 			. += "-organic"

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -234,11 +234,22 @@
 	if(limb_icon_cache[icon_render_key])
 		load_limb_from_cache()
 		return
+	//Taur code goes here, since humans just inherit this proc
+	var/is_taur = FALSE
+	if(ishuman(src))
+		var/mob/living/carbon/human/H = src
+		if(("taur" in H.dna.species.mutant_bodyparts) && (H.dna.features["taur"] != "None"))
+			is_taur = TRUE
 
 	//GENERATE NEW LIMBS
 	var/list/new_limbs = list()
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
+
+		if(istype(BP, /obj/item/bodypart/r_leg) || istype(BP, /obj/item/bodypart/l_leg))
+			if(is_taur)
+				continue
+
 		new_limbs += BP.get_limb_icon()
 	if(new_limbs.len)
 		overlays_standing[BODYPARTS_LAYER] = new_limbs


### PR DESCRIPTION
[Changelogs]: # (Please make a changelog if you're adding, removing or changing content that'll affect players. This includes, but is not limited to, new features, sprites, sounds; balance changes; map edits and important fixes)
[]: # (See here for how to easily make a changelog: https://github.com/tgstation/tgstation/wiki/Changelogs. An example changelog has been provided below. Please edit or remove)

:cl: ktccd
fix: Taurs now rely on their taur-sprites to render legs, instead of rendering human legs on top of them. Mostly impacts driders and such uniquely legged individuals.
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Since taurs use their own sprite legs instead, we'll rely on those.
This'll fix some fringe cases with nagas and the problem with driders completely covering their front drider legs.
This will introduce some weirdness with cutting off limbs, since taur sprites have NO support for this, but I would need to completely refactor how we handle taurs to split up their sprites like that... And I'm not THAT good. That problem lies in how taur sprites are one big thing we just render, and there's not "taur leg" bodypart in the code.