### PR TITLE
Lets humans use MUTCOLORs [Maximum Heresy]

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -2,10 +2,10 @@
 	name = "Human"
 	id = "human"
 	default_color = "FFFFFF"
-	species_traits = list(MUTCOLORS_PARTSONLY,EYECOLOR,HAIR,FACEHAIR,LIPS)
+	species_traits = list(MUTCOLORS,EYECOLOR,HAIR,FACEHAIR,LIPS)
 	mutant_bodyparts = list("tail_human", "ears", "taur")
 	default_features = list("tail_human" = "None", "ears" = "None", "taur" = "none")
-	use_skintones = 1
+	use_skintones = FALSE
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW
 	liked_food = JUNKFOOD | FRIED


### PR DESCRIPTION
:cl: ktccd
tweak: Heresy has come to the station, humans must now select custom skin colours! Specific RGB values can be enterred in order to get just the right tone of skin your special snowflake needs, just like you can for other humanoids!
/:cl:

[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Exactly what it sounds like. Enables humans to use mutant colours and disables the preset skintones.
Preset skintones are still doable, since mutant colours can be accurately adjusted by putting in RGB values for the colours, but it'd be more manual work. On the other hand, you can now get a more accurate
skin tones. Prepare for the incoming orcs, elves and other special people, the heresy has just begun.