### PR TITLE
Makes genitals_use_skintone save

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -343,6 +343,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["job_engsec_low"]		>> job_engsec_low
 
 	//Citadel code
+	S["feature_genitals_use_skintone"]	>> features["genitals_use_skintone"]
 	S["feature_exhibitionist"]			>> features["exhibitionist"]
 	S["feature_mcolor2"]				>> features["mcolor2"]
 	S["feature_mcolor3"]				>> features["mcolor3"]
@@ -519,6 +520,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["job_engsec_low"]		, job_engsec_low)
 
 	//Citadel
+	S["feature_genitals_use_skintone"]	<< features["genitals_use_skintone"]
 	S["feature_exhibitionist"]			<< features["exhibitionist"]
 	S["feature_mcolor2"]				<< features["mcolor2"]
 	S["feature_mcolor3"]				<< features["mcolor3"]


### PR DESCRIPTION
[why]: # (Please add a short description [on the next line] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding:) 
Adds a hook or whatever for it to save the setting.
Now, granted, with my previous PR this is probably pointless since humans got custom colours now...
But it's good practice, you know? In case we revert the other PR and all.
No changelog needed, this is a minor fix only.
fixes #1832 
fixes #814
