### PR TITLE
Disables the swarmer events for now

### DIFF
--- a/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
+++ b/code/game/gamemodes/miniantags/bot_swarm/swarmer_event.dm
@@ -1,9 +1,8 @@
-/* 
 /datum/round_event_control/spawn_swarmer
 	name = "Spawn Swarmer Shell"
 	typepath = /datum/round_event/spawn_swarmer
-	weight = 7
-	max_occurrences = 1 //Only once okay fam
+	weight = 0
+	max_occurrences = 0 //Only once okay fam
 	earliest_start = 18000 //30 minutes
 	min_players = 15
 
@@ -26,4 +25,3 @@
 		if(istype(M, /mob/living/simple_animal/hostile/swarmer) && M.client) //If there is a swarmer with an active client, we've found our swarmer
 			return 1
 	return 0
-*/


### PR DESCRIPTION
I feel like it's more proper to disable them via var settings than commenting out the entire file. I also feel it's better to go back and look at these before flatout removing them from the event table.


:cl: Jay
del: Removes swarmers from the event table for the time being.
/:cl:

reverts #2584 
