### PR TITLE
Changes Hulk allowed species and fixes SE issues

### DIFF
--- a/code/datums/mutations.dm
+++ b/code/datums/mutations.dm
@@ -117,9 +117,10 @@ GLOBAL_LIST_EMPTY(mutations_list)
 
 	name = "Hulk"
 	quality = POSITIVE
-	dna_block = NON_SCANNABLE
+	get_chance = 15
+	lowest_value = 256 * 12
 	text_gain_indication = "<span class='notice'>Your muscles hurt!</span>"
-	species_allowed = list("human") //no skeleton/lizard hulk
+	species_allowed = list("fly") //no skeleton/lizard hulk
 	health_req = 25
 
 /datum/mutation/human/hulk/on_acquiring(mob/living/carbon/human/owner)


### PR DESCRIPTION
Because this really needs to be nerfed in the absurdly stupid fast time to acquire meme /tg/ is.

The plan on my to-do list is to make equal yet countering effects to all mutation powers that are commonly used and abused. Midget people won't be able to cross reinforced tables (there's a fucking wall in the way)

Cold resist genetics taking *2 burn damage due to lower tolerance. That sort of thing. 

You shouldn't be able to become the god-emperor 15 minutes in for literally no penalty whatsoever. Paradise's autogibbing instability is kinda meh, though instability causing exponential cloneloss damage is a decent alternative as well. something that would require being in cryo or eating clonefixing carpotoxin chems is enough of a hassle to discourage having 8 powers at once.
