### PR TITLE
Podpeople available as roundstart ft. minor stat changes

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -37,7 +37,7 @@
 		if(H.nutrition > NUTRITION_LEVEL_FULL)
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(1,1)
+			H.heal_overall_damage(0,7)
 			H.adjustOxyLoss(-0.5)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -37,7 +37,7 @@
 		if(H.nutrition > NUTRITION_LEVEL_FULL)
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(0,5)
+			H.heal_overall_damage(0.05,0)
 			H.adjustOxyLoss(-0.5)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -37,12 +37,12 @@
 		if(H.nutrition > NUTRITION_LEVEL_FULL)
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(0.7)
+			H.heal_overall_damage(0,5)
 			H.adjustOxyLoss(-0.5)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)
-		H.adjustOxyLoss(5,5) //can eat to negate this unfortunately
-		H.adjustToxLoss(3,0)
+		H.adjustOxyLoss(5) //can eat to negate this unfortunately
+		H.adjustToxLoss(3)
 
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -37,7 +37,7 @@
 		if(H.nutrition > NUTRITION_LEVEL_FULL)
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(0,7)
+			H.heal_overall_damage(0.7)
 			H.adjustOxyLoss(-0.5)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -8,7 +8,7 @@
 	attack_sound = 'sound/weapons/slice.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	burnmod = 1.25
-	heatmod = 1.5
+	heatmod = 1.55
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
 	disliked_food = NONE
 	liked_food = NONE
@@ -38,11 +38,11 @@
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
 			H.heal_overall_damage(1,1)
-			H.adjustToxLoss(-1)
-			H.adjustOxyLoss(-1)
+			H.adjustOxyLoss(-0.5)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)
-		H.take_overall_damage(2,5)
+		H.adjustOxyLoss(5,5) //can eat to negate this unfortunately
+		H.adjustToxLoss(3,0)
 
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -10,10 +10,10 @@
 	burnmod = 1.25
 	heatmod = 1.5
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
-	disliked_food = MEAT
-	liked_food = VEGETABLES | FRUIT
-	toxic_food = TOXIC | RAW
-	roundstart = 1
+	disliked_food = NONE
+	liked_food = NONE
+	toxic_food = NONE
+	roundstart = TRUE
 
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
@@ -49,8 +49,8 @@
 	if(chem.id == "plantbgone")
 		H.adjustToxLoss(5)
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
-		return 1
 		H.confused = max(H.confused, 1)
+		return TRUE
 
 
 /datum/species/pod/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)

--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -10,8 +10,11 @@
 	burnmod = 1.25
 	heatmod = 1.5
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/plant
-	disliked_food = NONE
-	liked_food = NONE
+	disliked_food = MEAT
+	liked_food = VEGETABLES | FRUIT
+	toxic_food = TOXIC | RAW
+	roundstart = 1
+
 
 /datum/species/pod/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	. = ..()
@@ -38,14 +41,17 @@
 			H.adjustToxLoss(-1)
 			H.adjustOxyLoss(-1)
 
-	if(H.nutrition < NUTRITION_LEVEL_STARVING + 50)
-		H.take_overall_damage(2,0)
+	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)
+		H.take_overall_damage(2,5)
+
 
 /datum/species/pod/handle_chemicals(datum/reagent/chem, mob/living/carbon/human/H)
 	if(chem.id == "plantbgone")
-		H.adjustToxLoss(3)
+		H.adjustToxLoss(5)
 		H.reagents.remove_reagent(chem.id, REAGENTS_METABOLISM)
 		return 1
+		H.confused = max(H.confused, 1)
+
 
 /datum/species/pod/on_hit(obj/item/projectile/P, mob/living/carbon/human/H)
 	switch(P.type)


### PR DESCRIPTION
Essentially it allows podmen to be roundstart along with editing them so they take slightly more fire damage and more damage from plant-b-gone

 :cl: Daniel0Mclovin
add: Podpeople to roundstart
tweak: Modified podpeople heatmod from 1.25 to 1.5
tweak: plant-b-gone now does roughly 7 damage per tick on podpeople
/:cl:

[Reason]:
It'd be nice to see pod people around a bit more. Opens up more roleplay opportunities and another creature to see on board. Only supports basic color changes.
