### PR TITLE
Adds sanitation to flavor_text

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -170,7 +170,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/parallax
 
 	var/uplink_spawn_loc = UPLINK_PDA
-	
+
 	var/list/exp
 	var/list/menuoptions
 
@@ -922,7 +922,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("flavor_text")
 					var/msg = input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(features["flavor_text"])) as message
 					if(msg != null)
-						msg = copytext(msg, 1, MAX_MESSAGE_LEN)
+						msg = sanitize(copytext(msg, 1, MAX_MESSAGE_LEN))
 						msg = html_encode(msg)
 						features["flavor_text"] = msg
 


### PR DESCRIPTION
[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
No changelog needed really. Just adding a fix I really should've put in when I last touched flavor_text, but I just assumed all input was already sanitized.
Which was kind of silly, so now it is.
Tested inputting various symbols, including the ` (backtick) and was able to examine my character properly.