### PR TITLE
Fixes flavor_text and changeling genitals

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -28,6 +28,10 @@
 	destination.dna.temporary_mutations = temporary_mutations.Copy()
 	if(transfer_SE)
 		destination.dna.struc_enzymes = struc_enzymes
+	if(ishuman(destination))
+		var/mob/living/carbon/human/H = destination
+		H.give_genitals(TRUE)//This gives the body the genitals of this DNA. Used for any transformations based on DNA
+	destination.flavor_text = destination.dna.features["flavor_text"] //Update the flavor_text to use new dna text
 
 /datum/dna/proc/copy_dna(datum/dna/new_dna)
 	new_dna.unique_enzymes = unique_enzymes
@@ -227,6 +231,7 @@
 
 	if(newfeatures)
 		dna.features = newfeatures
+		flavor_text = dna.features["flavor_text"] //Update the flavor_text to use new dna text
 
 	if(mrace)
 		var/datum/species/newrace = new mrace.type


### PR DESCRIPTION
[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
flavor_text is now, again, set from DNA once cloned/podded/whatever. Changelings should do the same, and also get appropriate genitals.
Thanks TG, for overwriting this code.
But really, thanks Byond, for making extending this functionality so fucking hard.
2h testing memes, yada yada yada. No changelog needed due to being a simple re-add of out-synched fixes.