### PR TITLE
Nerf to 10mm Soporific Bullets

### DIFF
--- a/code/citadel/cit_guns.dm
+++ b/code/citadel/cit_guns.dm
@@ -596,10 +596,10 @@ obj/item/projectile/bullet/c10mm/soporific
 	if((blocked != 100) && isliving(target))
 		var/mob/living/L = target
 		L.blur_eyes(6)
-		if(L.staminaloss >= 40)
+		if(L.staminaloss >= 60)
 			L.Sleeping(250)
 		else
-			L.adjustStaminaLoss(58)
+			L.adjustStaminaLoss(25)
 	return 1
 
 /obj/item/ammo_casing/c10mm/soporific


### PR DESCRIPTION
:cl: Toriate
balance: 10mm Soporific bullets now have a threshold of 60 stamina damage, up from 40, and deal 25 with each shot, down from 50
/:cl:

This makes rape gun memes less hilarious and require more skill to be used effectively. Also makes a bit more realistic since a 10mm bullet probably won't be able to contain that much chemical agent to the point where two shots is all you need to put your victim to sleep.
