### PR TITLE
Brings the 10mm Soporific Magazine Uplink Description in line with its nerfed stats

### DIFF
--- a/code/modules/uplink/uplink_item_cit.dm
+++ b/code/modules/uplink/uplink_item_cit.dm
@@ -55,7 +55,7 @@
 /datum/uplink_item/ammo/pistolzzz
 	name = "10mm Soporific Magazine"
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. Loaded with soporific rounds that put the target to sleep. \
-			NOTE: Soporific is not instant acting due to the constraints of the round's scale. Will usually require two shots to take effect."
+			NOTE: Soporific is not instant acting due to the constraints of the round's scale. Will usually require three shots to take effect."
 	item = /obj/item/ammo_box/magazine/m10mm/soporific
 	cost = 2
 


### PR DESCRIPTION
:cl: Toriate
spellcheck: uplink description for soporific magazines now correctly says at least three shots are needed, rather than two
/:cl:

D'oh. Completely forgot about this. Now no one can complain that their rape gun instructions tell them 2 shots is enough when 3 is what you actually need.