### PR TITLE
Rebalanced pod people so they arnt as weak.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -37,7 +37,7 @@
 		if(H.nutrition > NUTRITION_LEVEL_FULL)
 			H.nutrition = NUTRITION_LEVEL_FULL
 		if(light_amount > 0.2) //if there's enough light, heal
-			H.heal_overall_damage(0.05,0)
+			H.heal_overall_damage(0.75,0)
 			H.adjustOxyLoss(-0.5)
 
 	if(H.nutrition < NUTRITION_LEVEL_STARVING + 55)


### PR DESCRIPTION
This will allow podpeople to regen at a steady pace without them being able to take tool boxes to the head like candy. it takes around 20 seconds to notably heal compared to the 40 it does just for a little bit and the 3 from before it was nerfed.

 :cl: Daniel0Mclovin
tweak: Modify health regeneration from 0.05 to 0.75
/:cl:
[Reason]:
With the way their regen is currently its next to useless, this tweak will make it feel a bit better, considering one laser shot does 25 burn damage, a bit of brute regen could do them justice. Fire royally fucks them which means theyre disadvantaged at most long ranged combat. This change will at least make them viable melee fighters.