### PR TITLE
Adds kinkmates to Metastation and Deltastation (+Box tweaks)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2281,7 +2281,7 @@
 	name = "Emergency Shuttle Airlock"
 	},
 /obj/docking_port/mobile/emergency{
-	name = "Box emergency shuttle";
+	name = "Box emergency shuttle"
 	},
 /obj/docking_port/stationary{
 	dir = 4;
@@ -42528,14 +42528,14 @@
 	},
 /area/maintenance/port/aft)
 "bTt" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/structure/closet/secure_closet/personal,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
 	},
-/obj/structure/closet/secure_closet/personal,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bTu" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
 	dir = 4
 	},
 /turf/closed/wall,
@@ -42549,9 +42549,9 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bTw" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/light/small,
 /obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/manifold/general/hidden,
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "bTx" = (
@@ -64125,19 +64125,19 @@
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cUq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/machinery/light/small,
 /obj/structure/table/wood,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 5
+	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cUr" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/structure/bed,
 /obj/item/bedsheet,
+/obj/machinery/atmospherics/pipe/simple/general/hidden{
+	dir = 4
+	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
 "cUs" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -97094,8 +97094,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/theatre/abandoned)
 "dHa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/item/twohanded/required/kirbyplants/random,
+/obj/machinery/vending/kink,
 /turf/open/floor/wood,
 /area/crew_quarters/theatre/abandoned)
 "dHb" = (
@@ -113139,6 +113138,14 @@
 "esH" = (
 /turf/closed/wall,
 /area/maintenance/department/medical/morgue)
+"esI" = (
+/obj/machinery/vending/kink,
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"esJ" = (
+/obj/machinery/vending/kink,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 
 (1,1,1) = {"
 aaa
@@ -137474,7 +137481,7 @@ dmb
 dnA
 doK
 dqw
-diJ
+esJ
 aJm
 aHW
 aaf
@@ -143545,7 +143552,7 @@ aib
 asx
 atw
 auQ
-aic
+esI
 awX
 aye
 azn

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -28522,7 +28522,7 @@
 	},
 /area/security/checkpoint/engineering)
 "bcO" = (
-/obj/structure/easel,
+/obj/machinery/vending/kink,
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -64306,10 +64306,10 @@
 /turf/open/space,
 /area/space)
 "ctn" = (
-/obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cto" = (


### PR DESCRIPTION
:cl: deathride58
add: Added kinkmates to Delta in the gambling den (replacing the cigarette vendor), abandoned theatre (replacing a plant), and the abandoned theatre backstage in port bow maintenance.
add: Added kinkmates to Meta in the abandoned bar, maintenance storage room (replacing an easel), and in maintenance right below science (also replacing an easel).
tweak: Made the atmos pipes in maint dorms hidden.
/:cl:
