### PR TITLE
Crew Obj & Miscreant system optimizations and tweaks

### DIFF
--- a/code/citadel/cit_crewobjectives.dm
+++ b/code/citadel/cit_crewobjectives.dm
@@ -17,7 +17,6 @@
 	if(!crewMind.assigned_role)
 		return
 	var/list/validobjs = crewobjjobs["[ckey(crewMind.assigned_role)]"]
-	//var/list/validobjs = get_valid_crew_objs(ckey(crewMind.assigned_role))
 	if(!validobjs || !validobjs.len)
 		return
 	var/selectedObj = pick(validobjs)
@@ -28,15 +27,6 @@
 	crewMind.objectives += newObjective
 	to_chat(crewMind, "<B>As a part of Nanotrasen's anti-tide efforts, you have been assigned an optional objective. It will be checked at the end of the shift. <font color=red>Performing traitorous acts in pursuit of your objective may result in termination of your employment.</font></B>")
 	to_chat(crewMind, "<B>Your optional objective:</B> [newObjective.explanation_text]")
-
-/*/datum/controller/subsystem/ticker/proc/get_valid_crew_objs(var/job = "")//taken from old hippie with adjustments
-	var/list/objlist = list()
-	for(var/hoorayhackyshit in crewobjlist)
-		var/datum/objective/crew/obj = hoorayhackyshit //dm is not a sane language in any way, shape, or form.
-		var/list/availableto = splittext(initial(obj.jobs),",")
-		if(job in availableto)
-			objlist += obj
-	return objlist*/
 
 /datum/objective/crew/
 	var/jobs = ""

--- a/code/citadel/cit_crewobjectives.dm
+++ b/code/citadel/cit_crewobjectives.dm
@@ -1,6 +1,6 @@
 /datum/controller/subsystem/ticker/proc/generate_crew_objectives()
 	for(var/datum/mind/crewMind in SSticker.minds)
-		if(prob(2) && !issilicon(crewMind.current) && !jobban_isbanned(crewMind, "Syndicate") && GLOB.miscreants_allowed && ROLE_MISCREANT in crewMind.current.client.prefs.be_special)
+		if(prob(5) && !issilicon(crewMind.current) && !jobban_isbanned(crewMind, "Syndicate") && GLOB.miscreants_allowed && ROLE_MISCREANT in crewMind.current.client.prefs.be_special)
 			generate_miscreant_objectives(crewMind)
 		else
 			if(CONFIG_GET(flag/allow_crew_objectives))
@@ -16,7 +16,8 @@
 		return
 	if(!crewMind.assigned_role)
 		return
-	var/list/validobjs = get_valid_crew_objs(ckey(crewMind.assigned_role))
+	var/list/validobjs = crewobjjobs["[ckey(crewMind.assigned_role)]"]
+	//var/list/validobjs = get_valid_crew_objs(ckey(crewMind.assigned_role))
 	if(!validobjs || !validobjs.len)
 		return
 	var/selectedObj = pick(validobjs)
@@ -28,15 +29,14 @@
 	to_chat(crewMind, "<B>As a part of Nanotrasen's anti-tide efforts, you have been assigned an optional objective. It will be checked at the end of the shift. <font color=red>Performing traitorous acts in pursuit of your objective may result in termination of your employment.</font></B>")
 	to_chat(crewMind, "<B>Your optional objective:</B> [newObjective.explanation_text]")
 
-/datum/controller/subsystem/ticker/proc/get_valid_crew_objs(var/job = "")//taken from old hippie with adjustments
-	var/list/objpaths = typesof(/datum/objective/crew)
+/*/datum/controller/subsystem/ticker/proc/get_valid_crew_objs(var/job = "")//taken from old hippie with adjustments
 	var/list/objlist = list()
-	for(var/hoorayhackyshit in objpaths)
+	for(var/hoorayhackyshit in crewobjlist)
 		var/datum/objective/crew/obj = hoorayhackyshit //dm is not a sane language in any way, shape, or form.
 		var/list/availableto = splittext(initial(obj.jobs),",")
 		if(job in availableto)
 			objlist += obj
-	return objlist
+	return objlist*/
 
 /datum/objective/crew/
 	var/jobs = ""

--- a/code/citadel/cit_miscreants.dm
+++ b/code/citadel/cit_miscreants.dm
@@ -11,7 +11,7 @@
 		return
 	if(jobban_isbanned(crewMind, "Syndicate"))
 		return
-	var/list/objectiveTypes = typesof(/datum/objective/miscreant) - /datum/objective/miscreant
+	var/list/objectiveTypes = miscreantobjlist
 	if(!objectiveTypes.len)
 		return
 	var/selectedType = pick(objectiveTypes)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -128,7 +128,7 @@ SUBSYSTEM_DEF(ticker)
 
 	crewobjlist = typesof(/datum/objective/crew)
 	miscreantobjlist = (typesof(/datum/objective/miscreant) - /datum/objective/miscreant)
-	for(var/hoorayhackyshit in crewobjlist)
+	for(var/hoorayhackyshit in crewobjlist) //taken from old Hippie's "job2obj" proc with adjustments.
 		var/datum/objective/crew/obj = hoorayhackyshit //dm is not a sane language in any way, shape, or form.
 		var/list/availableto = splittext(initial(obj.jobs),",")
 		for(var/job in availableto)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -127,7 +127,7 @@ SUBSYSTEM_DEF(ticker)
 	login_music = pick(music)
 
 	crewobjlist = typesof(/datum/objective/crew)
-	miscreantobjlist = typesof(/datum/objective/miscreant)
+	miscreantobjlist = (typesof(/datum/objective/miscreant) - /datum/objective/miscreant)
 	for(var/hoorayhackyshit in crewobjlist)
 		var/datum/objective/crew/obj = hoorayhackyshit //dm is not a sane language in any way, shape, or form.
 		var/list/availableto = splittext(initial(obj.jobs),",")

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -66,6 +66,11 @@ SUBSYSTEM_DEF(ticker)
 
 	var/modevoted = FALSE					//Have we sent a vote for the gamemode?
 
+	//Crew Objective/Miscreant stuff
+	var/list/crewobjlist = list()
+	var/list/crewobjjobs = list()
+	var/list/miscreantobjlist = list()
+
 /datum/controller/subsystem/ticker/Initialize(timeofday)
 	load_mode()
 
@@ -87,7 +92,7 @@ SUBSYSTEM_DEF(ticker)
 	var/list/provisional_title_music = flist("config/title_music/sounds/")
 	var/list/music = list()
 	var/use_rare_music = prob(1)
-	
+
 	for(var/S in provisional_title_music)
 		var/lower = lowertext(S)
 		var/list/L = splittext(lower,"+")
@@ -115,11 +120,19 @@ SUBSYSTEM_DEF(ticker)
 			if(byond_sound_formats[ext])
 				continue
 		music -= S
-				
+
 	if(isemptylist(music))
 		music = world.file2list(ROUND_START_MUSIC_LIST, "\n")
 
 	login_music = pick(music)
+
+	crewobjlist = typesof(/datum/objective/crew)
+	miscreantobjlist = typesof(/datum/objective/miscreant)
+	for(var/hoorayhackyshit in crewobjlist)
+		var/datum/objective/crew/obj = hoorayhackyshit //dm is not a sane language in any way, shape, or form.
+		var/list/availableto = splittext(initial(obj.jobs),",")
+		for(var/job in availableto)
+			crewobjjobs["[job]"] += list(obj)
 
 	if(!GLOB.syndicate_code_phrase)
 		GLOB.syndicate_code_phrase	= generate_code_phrase()
@@ -519,11 +532,11 @@ SUBSYSTEM_DEF(ticker)
 		if(!crewMind.current || !crewMind.objectives.len)
 			continue
 		for(var/datum/objective/miscreant/MO in crewMind.objectives)
-			miscreants += "<B>[crewMind.current.real_name]</B> (Played by: <B>[crewMind.key]</B>)<BR><B>Objective</B>: [MO.explanation_text] <font color='grey'>(Optional)</font><BR>"
+			miscreants += "<B>[crewMind.current.real_name]</B> (Played by: <B>[crewMind.key]</B>)<BR><B>Objective</B>: [MO.explanation_text] <font color='grey'>(Optional)</font>"
 		for(var/datum/objective/crew/CO in crewMind.objectives)
 			if(CO.check_completion())
 				to_chat(crewMind.current, "<br><B>Your optional objective</B>: [CO.explanation_text] <font color='green'><B>Success!</B></font>")
-				successfulCrew += "<B>[crewMind.current.real_name]</B> (Played by: <B>[crewMind.key]</B>)<BR><B>Objective</B>: [CO.explanation_text] <font color='green'><B>Success!</B></font> <font color='grey'>(Optional)</font><BR>"
+				successfulCrew += "<B>[crewMind.current.real_name]</B> (Played by: <B>[crewMind.key]</B>)<BR><B>Objective</B>: [CO.explanation_text] <font color='green'><B>Success!</B></font> <font color='grey'>(Optional)</font>"
 			else
 				to_chat(crewMind.current, "<br><B>Your optional objective</B>: [CO.explanation_text] <font color='red'><B>Failed.</B></font>")
 

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -375,7 +375,7 @@
 		if(GLOB.highlander)
 			to_chat(humanc, "<span class='userdanger'><i>THERE CAN BE ONLY ONE!!!</i></span>")
 			humanc.make_scottish()
-		if(prob(2) && !issilicon(humanc) && !jobban_isbanned(humanc.mind, "Syndicate") && GLOB.miscreants_allowed && ROLE_MISCREANT in humanc.client.prefs.be_special)
+		if(prob(5) && !issilicon(humanc) && !jobban_isbanned(humanc.mind, "Syndicate") && GLOB.miscreants_allowed && ROLE_MISCREANT in humanc.client.prefs.be_special)
 			SSticker.generate_miscreant_objectives(humanc.mind)
 		else
 			if(CONFIG_GET(flag/allow_crew_objectives))


### PR DESCRIPTION
This makes crew and miscreant objectives use a global list automatically generated by the ticker to determine plausible objectives instead of re-generating the list every single time a crew/miscreant objective is generated. I am unable to benchmark the difference in round starting time myself, but the new method of determining plausible objectives should be *far* more efficient than the previous one.

:cl: deathride58
tweak: The game will no longer take 2-3 minutes to start up during highpop. Hooray optimization!
tweak: Miscreants now have a 5% chance of being generated instead of a 2% chance.
tweak: Crew objective display at the end of the round is now a lot more compact.
/:cl: