### PR TITLE
Fixes the Wish Granter

### DIFF
--- a/code/game/machinery/wishgranter.dm
+++ b/code/game/machinery/wishgranter.dm
@@ -29,7 +29,7 @@
 
 	else
 		to_chat(user, "You speak.  [pick("I want the station to disappear","Humanity is corrupt, mankind must be destroyed","I want to be rich", "I want to rule the world","I want immortality.")].  The Wish Granter answers.")
-		to_chat(user, "Your head pounds for a moment, before your vision clears.  You are the avatar of the Wish Granter, and your power is LIMITLESS!  And it's all yours.  You need to make sure no one can take it from you.  No one can know, first.")
+		to_chat(user, "Your head pounds for a moment, before your vision clears. ")
 
 		charges--
 		insisting = 0
@@ -38,16 +38,5 @@
 		user.dna.add_mutation(XRAY)
 		user.dna.add_mutation(COLDRES)
 		user.dna.add_mutation(TK)
-
-		SSticker.mode.traitors += user.mind
-		user.mind.special_role = "Avatar of the Wish Granter"
-
-		var/datum/objective/hijack/hijack = new
-		hijack.owner = user.mind
-		user.mind.objectives += hijack
-
-		user.mind.announce_objectives()
-
 		to_chat(user, "You have a very bad feeling about this.")
-
 	return

--- a/code/modules/awaymissions/mission_code/wildwest.dm
+++ b/code/modules/awaymissions/mission_code/wildwest.dm
@@ -62,16 +62,9 @@
 				user.verbs += /mob/living/carbon/proc/immortality
 				user.set_species(/datum/species/shadow)
 			if("To Kill")
-				to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
-				to_chat(user, "The Wish Granter punishes you for your wickedness, claiming your soul and warping your body to match the darkness in your heart.")
-				SSticker.mode.traitors += user.mind
-				user.mind.special_role = "traitor"
-				var/datum/objective/hijack/hijack = new
-				hijack.owner = user.mind
-				user.mind.objectives += hijack
-				to_chat(user, "<B>Your inhibitions are swept away, the bonds of loyalty broken, you are free to murder as you please!</B>")
-				user.mind.announce_objectives()
-				user.set_species(/datum/species/shadow)
+				to_chat(user, "<B>Your wish is denied, and you are struck down by the Wish Granter</B>")
+				to_chat(user, "The Wish Granter punishes you for your wickedness.")
+				user.dust()
 			if("Peace")
 				to_chat(user, "<B>Whatever alien sentience that the Wish Granter possesses is satisfied with your wish. There is a distant wailing as the last of the Faithless begin to die, then silence.</B>")
 				to_chat(user, "You feel as if you just narrowly avoided a terrible fate...")


### PR DESCRIPTION
Because, to be quite honest, there is literally zero reason that this needs to exist in it's current state. It's only purpose is to let lavaland powergamers selfantag and go on a murderspree.

Is this an i ded? 
Yes, but I still believe it's a valid change.

There exists two wishgranters in the code, one that just makes you an avatar, found in the cube, and one that gives you a choice. I removed the creation of the avatar from the first one, though it still gives hulk/xray/tk/heatresistence so it's still pretty good. The second one dusts the user when they choose "To kill".