### PR TITLE
Security department tweaks (Chem dispensers, no more cell windows, and more)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -87719,7 +87719,7 @@ agj
 agj
 agj
 aiX
-agj
+aiX
 anQ
 aov
 cCi

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -658,7 +658,7 @@
 	name = "Armoury Shutter"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "abO" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -683,6 +683,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/security/armory)
 "abR" = (
@@ -838,7 +843,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "acj" = (
 /obj/machinery/light{
@@ -1301,6 +1306,11 @@
 	},
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel{
 	dir = 2
@@ -7574,6 +7584,11 @@
 /area/lawoffice)
 "arc" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "ard" = (
@@ -26761,6 +26776,11 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -60943,19 +60963,70 @@
 	},
 /area/ai_monitored/security/armory)
 "QqW" = (
-/obj/structure/tank_dispenser/oxygen,
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
 "QqX" = (
-/obj/machinery/suit_storage_unit/security,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
 "QqY" = (
-/obj/machinery/suit_storage_unit/security,
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -61021,76 +61092,25 @@
 	req_access_txt = "3"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "Qrh" = (
-/obj/structure/rack,
-/obj/item/gun/energy/e_gun/dragnet,
-/obj/item/gun/energy/e_gun/dragnet,
+/obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
 "Qri" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
 "Qrj" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/structure/tank_dispenser/oxygen,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -61121,22 +61141,33 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
+/obj/structure/cable{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "Qrn" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "Qro" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "Qrp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/ai_monitored/security/armory)
-"Qrq" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -61145,7 +61176,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrr" = (
+"Qrq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -61159,7 +61190,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrs" = (
+"Qrr" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -61171,7 +61202,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrt" = (
+"Qrs" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -61181,26 +61212,31 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qru" = (
+"Qrt" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrv" = (
+"Qru" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/drone,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrw" = (
+"Qrv" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qrx" = (
+"Qrw" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -61210,7 +61246,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qry" = (
+"Qrx" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -61222,7 +61258,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qrz" = (
+"Qry" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
@@ -61231,7 +61267,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrA" = (
+"Qrz" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -61245,26 +61281,26 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrB" = (
+"QrA" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrC" = (
+"QrB" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrD" = (
+"QrC" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrE" = (
+"QrD" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrF" = (
+"QrE" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -61276,7 +61312,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrG" = (
+"QrF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -61296,16 +61332,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrH" = (
+"QrG" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrI" = (
+"QrH" = (
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrJ" = (
+"QrI" = (
 /obj/machinery/flasher{
 	id = "highseccell";
 	pixel_x = 28
@@ -61315,6 +61351,9 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
+"QrJ" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
 "QrK" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
@@ -61322,8 +61361,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
 "QrM" = (
-/turf/open/floor/plasteel/floorgrime,
-/area/security/execution/transfer)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
 "QrN" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -61331,12 +61373,6 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "QrO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"QrP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61348,7 +61384,7 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
-"QrQ" = (
+"QrP" = (
 /obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
@@ -61359,7 +61395,7 @@
 	},
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
-"QrR" = (
+"QrQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61367,7 +61403,7 @@
 	dir = 9
 	},
 /area/security/brig)
-"QrS" = (
+"QrR" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 2";
 	name = "Cell 2"
@@ -61380,7 +61416,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
-"QrT" = (
+"QrS" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
 	name = "Cell 3"
@@ -61393,6 +61429,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
+"QrT" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
 "QrU" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -61401,13 +61444,6 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "QrV" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/security/brig)
-"QrW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -61416,7 +61452,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrX" = (
+"QrW" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -61431,7 +61467,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrY" = (
+"QrX" = (
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 0;
@@ -61445,20 +61481,20 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"QrZ" = (
+"QrY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsa" = (
+"QrZ" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsb" = (
+"Qsa" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
 	pixel_x = -28
@@ -61468,7 +61504,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsc" = (
+"Qsb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -61478,7 +61514,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsd" = (
+"Qsc" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -61490,9 +61526,14 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
-"Qse" = (
+"Qsd" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 8
+	},
+/area/hallway/primary/fore)
+"Qse" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 1
 	},
 /area/hallway/primary/fore)
 "Qsf" = (
@@ -61501,33 +61542,28 @@
 	},
 /area/hallway/primary/fore)
 "Qsg" = (
-/turf/open/floor/plasteel/red/side{
-	dir = 1
-	},
-/area/hallway/primary/fore)
-"Qsh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
 /area/hallway/primary/fore)
-"Qsi" = (
+"Qsh" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/hallway/primary/fore)
-"Qsj" = (
+"Qsi" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
 /area/hallway/primary/fore)
-"Qsk" = (
+"Qsj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsl" = (
+"Qsk" = (
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 28
@@ -61537,7 +61573,7 @@
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsm" = (
+"Qsl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -61556,7 +61592,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
-"Qsn" = (
+"Qsm" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "seclobby";
 	name = "security blast door"
@@ -61568,20 +61604,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"Qso" = (
+"Qsn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsp" = (
+"Qso" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsq" = (
+"Qsp" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
@@ -61589,7 +61625,7 @@
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsr" = (
+"Qsq" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
@@ -61601,31 +61637,31 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"Qss" = (
+"Qsr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
 /area/hallway/primary/fore)
+"Qss" = (
+/turf/open/floor/plasteel/red/side,
+/area/hallway/primary/fore)
 "Qst" = (
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
 "Qsu" = (
-/turf/open/floor/plasteel/red/side,
-/area/hallway/primary/fore)
-"Qsv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/hallway/primary/fore)
-"Qsw" = (
+"Qsv" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsx" = (
+"Qsw" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
@@ -61635,12 +61671,12 @@
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
-"Qsy" = (
+"Qsx" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/hallway/primary/fore)
-"Qsz" = (
+"Qsy" = (
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 0;
@@ -61652,21 +61688,21 @@
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
-"QsA" = (
+"Qsz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"QsB" = (
+"QsA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"QsC" = (
+"QsB" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -84884,10 +84920,10 @@ abc
 aea
 aeH
 aft
+Qrv
 Qrw
 Qrx
-Qry
-QrE
+QrD
 abc
 QmH
 QmH
@@ -85143,8 +85179,8 @@ aeJ
 afw
 abc
 abc
-Qrz
-QrF
+Qry
+QrE
 abc
 QmH
 aaf
@@ -85400,8 +85436,8 @@ aeI
 afv
 agf
 afA
-QrA
-QrG
+Qrz
+QrF
 afA
 aiV
 aiT
@@ -85657,9 +85693,9 @@ aeL
 afy
 agh
 afA
-QrB
-QrH
-QrK
+QrA
+QrG
+QrJ
 aiV
 ajs
 akb
@@ -85914,9 +85950,9 @@ aeK
 afx
 agg
 afA
-QrC
-QrI
-QrL
+QrB
+QrH
+QrK
 aiV
 ajr
 aka
@@ -86171,9 +86207,9 @@ aeN
 afA
 afA
 afA
-QrD
-QrJ
-QrM
+QrC
+QrI
+QrL
 aiV
 aju
 akd
@@ -88234,8 +88270,8 @@ agj
 auj
 akl
 akO
-QrU
-QrZ
+QrT
+QrY
 amg
 aiX
 anw
@@ -88749,7 +88785,7 @@ ajD
 akm
 akP
 aly
-Qsa
+QrZ
 amQ
 aiX
 anw
@@ -89004,8 +89040,8 @@ aiO
 agj
 aja
 akl
-QrS
-QrV
+QrR
+QrU
 amh
 ami
 aiX
@@ -89260,7 +89296,7 @@ agP
 agP
 aiz
 ajg
-QrP
+QrO
 akQ
 agj
 agj
@@ -89520,7 +89556,7 @@ ajb
 ajF
 akN
 alw
-Qsb
+Qsa
 amQ
 aiX
 anw
@@ -89773,10 +89809,10 @@ agn
 agR
 agn
 ajc
-QrN
+QrM
 akv
-QrT
-QrW
+QrS
+QrV
 aww
 amk
 aiX
@@ -90020,7 +90056,7 @@ QqZ
 Qrh
 aaZ
 cpg
-Qru
+Qrt
 acv
 adi
 aaZ
@@ -90031,7 +90067,7 @@ ahQ
 aiI
 aiH
 ajB
-QrQ
+QrP
 akQ
 agj
 agj
@@ -90279,7 +90315,7 @@ aaZ
 acl
 cxA
 acL
-Qrv
+Qru
 aaZ
 agp
 agT
@@ -90287,7 +90323,7 @@ ahx
 ahS
 aiK
 ajc
-QrO
+QrN
 akm
 akT
 alf
@@ -90533,7 +90569,7 @@ QqT
 Qrb
 Qrj
 aaZ
-Qrq
+Qrp
 adk
 adK
 cqG
@@ -90547,8 +90583,8 @@ ajc
 ajI
 akl
 akS
-QrX
-Qsc
+QrW
+Qsb
 amp
 aiX
 anS
@@ -90790,7 +90826,7 @@ QqU
 Qrc
 Qrk
 aaZ
-Qrr
+Qrq
 acM
 adQ
 cwM
@@ -90808,7 +90844,7 @@ agj
 agj
 agj
 aiX
-Qsq
+Qsp
 aoz
 apm
 aqd
@@ -91047,7 +91083,7 @@ QqV
 Qrd
 Qrl
 aaZ
-Qrs
+Qrr
 coS
 aet
 cxA
@@ -91065,8 +91101,8 @@ alz
 aml
 amT
 aiX
-Qsr
-Qsx
+Qsq
+Qsw
 apl
 aqc
 aqc
@@ -91304,7 +91340,7 @@ QqW
 Qre
 Qrm
 abQ
-Qrt
+Qrs
 adj
 arc
 blT
@@ -91321,9 +91357,9 @@ akV
 alB
 amn
 amV
-Qsm
+Qsl
 anB
-Qsy
+Qsx
 aod
 aqf
 ahT
@@ -91576,9 +91612,9 @@ ajI
 akp
 amS
 alA
-Qsd
+Qsc
 amm
-Qsn
+Qsm
 anT
 anT
 aod
@@ -91833,7 +91869,7 @@ ajJ
 akr
 amS
 alC
-Qse
+Qsd
 amX
 amX
 amX
@@ -92073,7 +92109,7 @@ aaf
 aaZ
 aaZ
 Qrg
-Qrp
+avB
 aaZ
 aaZ
 acT
@@ -92087,16 +92123,16 @@ aii
 agn
 ajd
 ajI
-QrR
+QrQ
 akW
 anw
 amo
 amX
 amX
-Qss
+Qsr
+Qsy
 Qsz
-QsA
-QsC
+QsB
 arf
 apY
 ate
@@ -92347,10 +92383,10 @@ ajI
 ahY
 akW
 anA
-Qsf
-Qsi
+Qse
+Qsh
 anB
-Qst
+Qss
 aoD
 aod
 aqe
@@ -92603,11 +92639,11 @@ ajf
 ajK
 aks
 akY
-QrY
-Qsg
-Qsj
+QrX
+Qsf
+Qsi
 amo
-Qsu
+Qst
 aoC
 aod
 aqe
@@ -92861,10 +92897,10 @@ ajB
 akp
 aiX
 akz
-Qsh
-Qsk
-Qso
-Qsv
+Qsg
+Qsj
+Qsn
+Qsu
 aoF
 apo
 aqh
@@ -93119,11 +93155,11 @@ aku
 aiX
 alE
 amq
-Qsl
-Qsp
-Qsw
+Qsk
+Qso
+Qsv
 aoE
-QsB
+QsA
 aqg
 aun
 asf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -6168,6 +6168,10 @@
 /area/hallway/primary/fore)
 "anC" = (
 /obj/effect/spawner/structure/window,
+/obj/machinery/door/poddoor/preopen{
+	id = "seclobby";
+	name = "security lobby blast door"
+	},
 /turf/open/floor/plating,
 /area/security/courtroom)
 "anD" = (
@@ -61591,7 +61595,7 @@
 	cyclelinkeddir = 1;
 	id_tag = "outerbrig";
 	name = "Security Lobby";
-	req_access_txt = "63"
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -61627,7 +61631,7 @@
 	cyclelinkeddir = 1;
 	id_tag = "outerbrig";
 	name = "Security Lobby";
-	req_access_txt = "63"
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -653,7 +653,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "abN" = (
-/obj/structure/closet/secure_closet/lethalshots,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armoury Shutter"
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/security/armory)
 "abO" = (
@@ -664,16 +668,22 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "abQ" = (
-/obj/structure/rack,
-/obj/machinery/airalarm{
-	pixel_y = 23
+/obj/machinery/door/firedoor,
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	dir = 1;
+	icon_state = "right";
+	name = "Armory";
+	req_access_txt = "3"
 	},
-/obj/item/gun/energy/ionrifle,
-/obj/item/gun/energy/temperature/security,
-/obj/item/clothing/suit/armor/laserproof,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
 /area/ai_monitored/security/armory)
 "abR" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -822,7 +832,12 @@
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
 "aci" = (
-/obj/vehicle/secway,
+/obj/machinery/door/poddoor/shutters{
+	id = "armory";
+	name = "Armoury Shutter"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/black,
 /area/ai_monitored/security/armory)
 "acj" = (
@@ -842,6 +857,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "acm" = (
@@ -859,6 +877,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "acn" = (
@@ -1083,6 +1102,7 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel{
 	dir = 2
 	},
@@ -1245,6 +1265,7 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adh" = (
@@ -1253,7 +1274,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "adi" = (
-/obj/machinery/flasher/portable,
+/obj/structure/table,
+/obj/item/storage/box/firingpins,
+/obj/item/storage/box/firingpins,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -1601,6 +1624,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "adR" = (
@@ -1914,12 +1938,18 @@
 	},
 /area/security/prison)
 "aes" = (
+/obj/structure/rack,
+/obj/item/gun/energy/ionrifle,
+/obj/item/gun/energy/temperature/security,
+/obj/item/clothing/suit/armor/laserproof,
 /obj/structure/cable{
 	d1 = 4;
 	d2 = 8;
 	icon_state = "4-8"
 	},
-/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/red/side,
 /area/ai_monitored/security/armory)
 "aet" = (
@@ -1929,12 +1959,24 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "aeu" = (
+/obj/structure/rack,
+/obj/item/storage/box/teargas{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/storage/box/handcuffs,
+/obj/item/storage/box/flashbangs{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
 /turf/open/floor/plasteel/red/side,
 /area/ai_monitored/security/armory)
 "aev" = (
@@ -2262,8 +2304,8 @@
 	d2 = 4
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/security/armory)
@@ -3220,8 +3262,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/iv_drip,
-/obj/item/reagent_containers/blood/empty,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 5
 	},
@@ -3262,8 +3303,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
@@ -3590,13 +3630,6 @@
 	pixel_y = 8;
 	req_access_txt = "2"
 	},
-/obj/machinery/button/door{
-	id = "Secure Gate";
-	name = "Cell Shutters";
-	pixel_x = -27;
-	pixel_y = -2;
-	req_access_txt = "0"
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahS" = (
@@ -3667,6 +3700,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/vehicle/secway,
+/obj/item/key/security,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -4161,6 +4196,9 @@
 /obj/structure/sign/goldenplaque{
 	pixel_y = 32
 	},
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
@@ -4370,7 +4408,7 @@
 	},
 /area/security/brig)
 "ajB" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajC" = (
@@ -4400,7 +4438,7 @@
 "ajF" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/open/floor/plasteel/red/corner{
-	dir = 2
+	dir = 8
 	},
 /area/security/brig)
 "ajG" = (
@@ -4437,14 +4475,14 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4695,16 +4733,21 @@
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "akk" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/door_timer{
+	id = "Cell 1";
+	name = "Cell 1";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
 	},
 /area/security/brig)
 "akl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -4751,28 +4794,24 @@
 	dir = 4
 	},
 /obj/machinery/door_timer{
-	id = "Cell 3";
-	name = "Cell 3";
+	id = "Cell 4";
+	name = "Cell 4";
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/red/side,
+/turf/open/floor/plasteel/red/corner,
 /area/security/brig)
 "akr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/red/side{
-	dir = 9
-	},
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "aks" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/red/corner{
-	dir = 8
-	},
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "akt" = (
 /obj/machinery/light,
@@ -4787,11 +4826,11 @@
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "aku" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
-	dir = 4
+	dir = 6
 	},
 /area/security/brig)
 "akv" = (
@@ -4823,9 +4862,11 @@
 	},
 /area/security/courtroom)
 "akz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
-/area/security/brig)
+/obj/structure/chair,
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/hallway/primary/fore)
 "akA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -4916,10 +4957,6 @@
 /area/maintenance/fore)
 "akM" = (
 /obj/structure/cable{
-	icon_state = "0-2";
-	d2 = 2
-	},
-/obj/structure/cable{
 	icon_state = "0-4";
 	d2 = 4
 	},
@@ -4930,15 +4967,15 @@
 /area/security/brig)
 "akN" = (
 /obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "0-4";
+	d2 = 4
+	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/brig)
 "akO" = (
@@ -4951,6 +4988,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "akP" = (
@@ -4987,6 +5025,19 @@
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "akS" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 4";
+	name = "Cell 4"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/red/side,
+/area/security/brig)
+"akT" = (
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
@@ -4995,21 +5046,9 @@
 	icon_state = "0-4";
 	d2 = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
-/area/security/brig)
-"akT" = (
-/obj/machinery/door/window/brigdoor/security/cell{
-	id = "Cell 3";
-	name = "Cell 3"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "akU" = (
 /obj/machinery/door/airlock/glass_security{
@@ -5041,6 +5080,7 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "akW" = (
+/obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 2;
 	id_tag = "innerbrig";
@@ -5074,17 +5114,11 @@
 /area/security/brig)
 "akY" = (
 /obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/security/brig)
 "akZ" = (
 /obj/structure/cable{
@@ -5263,12 +5297,15 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "alw" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_x = -25;
+	pixel_y = -2;
+	prison_radio = 1
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "alx" = (
@@ -5330,28 +5367,22 @@
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "alC" = (
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
-/area/security/brig)
+/area/hallway/primary/fore)
 "alD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/security/courtroom)
 "alE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/machinery/vending/coffee,
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/machinery/flasher{
-	id = "Cell 4";
-	pixel_x = 28
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plasteel/floorgrime,
-/area/security/brig)
+/area/hallway/primary/fore)
 "alF" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 2
@@ -5522,13 +5553,6 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "amf" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/structure/cable{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/flasher{
 	id = "Cell 1";
 	pixel_x = -28
@@ -5543,11 +5567,8 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "amh" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/machinery/flasher{
-	id = "Cell 2";
-	pixel_x = -28
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
@@ -5624,14 +5645,10 @@
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "amo" = (
-/obj/machinery/flasher{
-	id = "brigentry";
-	pixel_x = 28
-	},
 /turf/open/floor/plasteel/red/side{
-	dir = 5
+	dir = 9
 	},
-/area/security/brig)
+/area/hallway/primary/fore)
 "amp" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 4";
@@ -5640,18 +5657,11 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "amq" = (
-/obj/structure/bed,
-/obj/item/bedsheet,
-/obj/item/device/radio/intercom{
-	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
-	name = "Prison Intercom (General)";
-	pixel_x = 25;
-	pixel_y = -2;
-	prison_radio = 1
+/obj/machinery/vending/snack/random,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/security/brig)
+/area/hallway/primary/fore)
 "amr" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -5831,17 +5841,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "amQ" = (
-/obj/structure/cable{
-	icon_state = "0-4";
-	d2 = 4
-	},
-/obj/structure/cable,
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/bed,
+/obj/item/bedsheet,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "amR" = (
 /obj/structure/cable{
@@ -5868,24 +5870,17 @@
 /turf/closed/wall/r_wall,
 /area/security/brig)
 "amT" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
-/obj/structure/cable{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/cable{
 	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/button/door{
+	id = "seclobby";
+	name = "Security Lobby Lockdown";
+	pixel_x = -26;
+	pixel_y = 8;
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -5902,21 +5897,10 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "amV" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "briggate";
-	name = "security shutters"
-	},
-/obj/machinery/door/window/southleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Brig Desk";
-	req_access_txt = "1"
-	},
 /obj/structure/cable{
-	d1 = 4;
+	d1 = 2;
 	d2 = 8;
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -5933,17 +5917,10 @@
 	},
 /area/security/brig)
 "amX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_security{
-	cyclelinkeddir = 1;
-	id_tag = "outerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /turf/open/floor/plasteel/red/side{
-	dir = 9
+	dir = 8
 	},
-/area/security/brig)
+/area/hallway/primary/fore)
 "amY" = (
 /obj/structure/chair{
 	dir = 1
@@ -6185,14 +6162,8 @@
 	},
 /area/hallway/primary/fore)
 "anB" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/structure/sign/securearea{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
 /area/hallway/primary/fore)
 "anC" = (
@@ -6312,33 +6283,40 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anQ" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 32
-	},
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
 /area/hallway/primary/fore)
 "anR" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
 /area/hallway/primary/fore)
 "anS" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "anT" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/preopen{
+	id = "seclobby";
+	name = "security lobby blast door"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "anU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass{
 	name = "Courtroom"
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "seclobby";
+	name = "security lobby blast door"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/courtroom)
@@ -6605,15 +6583,20 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 2
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
 /area/hallway/primary/fore)
 "aoC" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/red/corner{
-	dir = 2
+/obj/structure/chair{
+	dir = 1
 	},
+/obj/item/device/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
 "aoD" = (
 /obj/machinery/camera{
@@ -6624,21 +6607,22 @@
 	pixel_x = 5;
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/red/corner{
-	dir = 2
+/obj/machinery/light,
+/obj/structure/chair{
+	dir = 1
 	},
+/turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
 "aoE" = (
-/obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/red/corner{
-	dir = 2
-	},
+/obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/bar,
 /area/hallway/primary/fore)
 "aoF" = (
-/obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/red/corner{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
 "aoG" = (
 /obj/structure/table,
@@ -6863,6 +6847,9 @@
 /area/maintenance/fore/secondary)
 "apm" = (
 /obj/machinery/door/firedoor,
+/obj/structure/sign/securearea{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
 	},
@@ -6872,9 +6859,7 @@
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
 "apo" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
 "app" = (
@@ -7197,11 +7182,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "aqg" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
+	},
+/obj/structure/disposalpipe/junction{
+	dir = 8;
+	icon_state = "pipe-j1"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -26769,7 +26755,9 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "blU" = (
@@ -51089,14 +51077,8 @@
 /turf/open/space,
 /area/space)
 "cpg" = (
-/obj/item/grenade/barrier{
-	pixel_x = 4
-	},
-/obj/item/grenade/barrier,
-/obj/item/grenade/barrier{
-	pixel_x = -4
-	},
 /obj/structure/table,
+/obj/item/storage/lockbox/loyalty,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -51282,6 +51264,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "cpC" = (
@@ -54246,15 +54229,13 @@
 /area/shuttle/escape)
 "cwM" = (
 /obj/structure/rack,
-/obj/item/storage/box/teargas{
-	pixel_x = -3;
-	pixel_y = 3
+/obj/item/storage/box/chemimp{
+	pixel_x = 6
 	},
-/obj/item/storage/box/handcuffs,
-/obj/item/storage/box/flashbangs{
-	pixel_x = 3;
-	pixel_y = -3
+/obj/item/storage/box/trackimp{
+	pixel_x = -3
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
@@ -60901,6 +60882,793 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"QqR" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"QqS" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"QqT" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"QqU" = (
+/obj/machinery/flasher/portable,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"QqV" = (
+/obj/structure/table,
+/obj/item/grenade/barrier{
+	pixel_x = 4
+	},
+/obj/item/grenade/barrier,
+/obj/item/grenade/barrier{
+	pixel_x = -4
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"QqW" = (
+/obj/structure/tank_dispenser/oxygen,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"QqX" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"QqY" = (
+/obj/machinery/suit_storage_unit/security,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"QqZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Non-Lethal Armory Motion Sensor";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qra" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qre" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrg" = (
+/obj/machinery/door/poddoor/shutters{
+	id = "lowsecarmory";
+	name = "Non-Lethal Armoury Shutter"
+	},
+/obj/machinery/button/door{
+	id = "lowsecarmory";
+	name = "Non-Lethal Armory Shutters";
+	pixel_y = 26;
+	req_access_txt = "3"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
+"Qrh" = (
+/obj/structure/rack,
+/obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/e_gun/dragnet,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qri" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qrj" = (
+/obj/structure/rack,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/suit/armor/riot,
+/obj/item/clothing/suit/armor/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/head/helmet/riot,
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/shield/riot,
+/obj/item/shield/riot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qrk" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qrl" = (
+/obj/machinery/suit_storage_unit/security,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qrm" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrn" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qro" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrp" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/ai_monitored/security/armory)
+"Qrq" = (
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/camera/motion{
+	c_tag = "Armory Motion Sensor";
+	dir = 2;
+	name = "motion-sensitive security camera"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrs" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qrt" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/security/armory)
+"Qru" = (
+/obj/structure/closet/secure_closet/lethalshots,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qrv" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/drone,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/ai_monitored/security/armory)
+"Qrw" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"Qrx" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner,
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"Qry" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"Qrz" = (
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"QrA" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/brig{
+	id = "highseccell";
+	name = "High Security Cell Locker"
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"QrB" = (
+/obj/effect/decal/cleanable/cobweb,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrC" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrD" = (
+/obj/effect/decal/cleanable/cobweb{
+	icon_state = "cobweb2"
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"QrF" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/obj/machinery/door_timer{
+	id = "highseccell";
+	name = "High Security Cell";
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"QrG" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 4;
+	id = "highseccell";
+	name = "High Security Cell Interior"
+	},
+/obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
+	id = "highseccell";
+	name = "High Security Cell Exterior"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/security/execution/transfer)
+"QrH" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrI" = (
+/obj/structure/bed,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrJ" = (
+/obj/machinery/flasher{
+	id = "highseccell";
+	pixel_x = 28
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrK" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrL" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrM" = (
+/turf/open/floor/plasteel/floorgrime,
+/area/security/execution/transfer)
+"QrN" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"QrO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"QrP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door_timer{
+	id = "Cell 2";
+	name = "Cell 2";
+	pixel_y = -32
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/red/corner,
+/area/security/brig)
+"QrQ" = (
+/obj/machinery/door_timer{
+	id = "Cell 3";
+	name = "Cell 3";
+	pixel_y = -32
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner,
+/area/security/brig)
+"QrR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/security/brig)
+"QrS" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 2";
+	name = "Cell 2"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/red/side,
+/area/security/brig)
+"QrT" = (
+/obj/machinery/door/window/brigdoor/security/cell{
+	id = "Cell 3";
+	name = "Cell 3"
+	},
+/obj/structure/cable{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/red/side,
+/area/security/brig)
+"QrU" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"QrV" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"QrW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"QrX" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/item/device/radio/intercom{
+	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
+	name = "Prison Intercom (General)";
+	pixel_x = 25;
+	pixel_y = -2;
+	prison_radio = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"QrY" = (
+/obj/machinery/flasher{
+	id = "brigentry";
+	pixel_x = 0;
+	pixel_y = 28
+	},
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"QrZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"Qsa" = (
+/obj/machinery/flasher{
+	id = "Cell 2";
+	pixel_x = -28
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"Qsb" = (
+/obj/machinery/flasher{
+	id = "Cell 3";
+	pixel_x = -28
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"Qsc" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/machinery/flasher{
+	id = "Cell 4";
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"Qsd" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/eastright{
+	name = "Brig Desk";
+	req_access_txt = "2"
+	},
+/turf/open/floor/plasteel/black,
+/area/security/brig)
+"Qse" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/hallway/primary/fore)
+"Qsf" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"Qsg" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"Qsh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/red/side{
+	dir = 5
+	},
+/area/hallway/primary/fore)
+"Qsi" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/hallway/primary/fore)
+"Qsj" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/hallway/primary/fore)
+"Qsk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/hallway/primary/fore)
+"Qsl" = (
+/obj/machinery/flasher{
+	id = "brigentry";
+	pixel_x = 28
+	},
+/obj/machinery/vending/cigarette,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/hallway/primary/fore)
+"Qsm" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "briggate";
+	name = "security shutters"
+	},
+/obj/machinery/door/window/southleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Brig Desk";
+	req_access_txt = "1"
+	},
+/obj/structure/cable{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/black,
+/area/security/brig)
+"Qsn" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "seclobby";
+	name = "security blast door"
+	},
+/obj/structure/cable{
+	d2 = 8;
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/brig)
+"Qso" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/hallway/primary/fore)
+"Qsp" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/hallway/primary/fore)
+"Qsq" = (
+/obj/structure/sign/securearea{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/hallway/primary/fore)
+"Qsr" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 1;
+	id_tag = "outerbrig";
+	name = "Security Lobby";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/hallway/primary/fore)
+"Qss" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/hallway/primary/fore)
+"Qst" = (
+/turf/open/floor/plasteel/red/side,
+/area/hallway/primary/fore)
+"Qsu" = (
+/turf/open/floor/plasteel/red/side,
+/area/hallway/primary/fore)
+"Qsv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/hallway/primary/fore)
+"Qsw" = (
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel/red/side{
+	dir = 4
+	},
+/area/hallway/primary/fore)
+"Qsx" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 1;
+	id_tag = "outerbrig";
+	name = "Security Lobby";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/red/side,
+/area/hallway/primary/fore)
+"Qsy" = (
+/turf/open/floor/plasteel/red/side{
+	dir = 6
+	},
+/area/hallway/primary/fore)
+"Qsz" = (
+/obj/machinery/flasher{
+	id = "brigentry";
+	pixel_x = 0;
+	pixel_y = -28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel/red/side,
+/area/hallway/primary/fore)
+"QsA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/fore/secondary)
+"QsB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall,
+/area/maintenance/fore/secondary)
+"QsC" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
 
 (1,1,1) = {"
 aaa
@@ -76993,7 +77761,7 @@ aaa
 aaa
 aaa
 aaa
-Qnh
+Qng
 aaa
 aHr
 aaa
@@ -77250,7 +78018,7 @@ aaa
 aaa
 aaa
 aaa
-Qni
+Qng
 aaa
 aHr
 aaa
@@ -77507,7 +78275,7 @@ aaa
 aaa
 aaa
 aaa
-Qnj
+Qng
 aaa
 aHr
 aaa
@@ -77764,7 +78532,7 @@ aaa
 aaa
 aaa
 aaa
-Qnk
+Qng
 aaa
 aHr
 aaa
@@ -78021,7 +78789,7 @@ aaa
 aaa
 aaa
 aaa
-Qnl
+Qng
 aaa
 aHr
 aaa
@@ -78278,7 +79046,7 @@ aaa
 aaa
 aaa
 aaa
-Qnm
+Qng
 aaa
 aHr
 aaa
@@ -78535,7 +79303,7 @@ aaa
 aaa
 aaa
 aaa
-Qnn
+Qng
 aaa
 aHr
 aaa
@@ -78792,7 +79560,7 @@ aaa
 aaa
 aaa
 aaa
-Qno
+Qng
 aaa
 aHr
 aaa
@@ -79049,7 +79817,7 @@ aaa
 aaa
 aaa
 aaa
-Qnp
+Qng
 aaa
 aHr
 aaa
@@ -79306,8 +80074,8 @@ aaa
 aaa
 aaa
 aaa
-Qnq
-Qnt
+Qng
+QmH
 aHr
 aaa
 apQ
@@ -79563,10 +80331,10 @@ aaa
 aaf
 aaf
 aaf
-Qnr
-Qnu
+Qng
+QmH
 aaf
-Qny
+QmH
 bVx
 caf
 aoV
@@ -80797,7 +81565,7 @@ avY
 axo
 ayB
 Qlm
-Qlt
+Qlr
 QlC
 QlJ
 QlN
@@ -81364,7 +82132,7 @@ aaa
 bCq
 bPV
 bCq
-Qnx
+Qnw
 bTw
 bCq
 bVD
@@ -81570,12 +82338,12 @@ ayC
 azH
 Qlw
 aBS
-aDr
-aDr
-aDr
-aDr
-aDr
-aDr
+QlJ
+QlJ
+QlJ
+QlJ
+QlJ
+QlJ
 aLE
 aLE
 aOl
@@ -81622,7 +82390,7 @@ bCq
 bPW
 Qnv
 bSp
-bTv
+QnB
 bCq
 bVC
 bWx
@@ -82166,7 +82934,7 @@ cqv
 cqL
 bJe
 bLv
-QpX
+QmH
 aaT
 aaT
 aaT
@@ -82338,7 +83106,7 @@ aag
 avY
 axo
 ayB
-Qlq
+Qln
 Qlz
 QlG
 aDv
@@ -82394,19 +83162,19 @@ bPY
 cOw
 bCq
 QnC
-QnJ
-QnR
-Qob
-Qom
+QnC
+QnC
+QnC
+QnC
 Qox
-QoI
-QoS
-cjn
-cjn
-cjn
-cjn
-cjn
-cjn
+QnC
+QnC
+QnC
+QnC
+QnC
+QnC
+QnC
+QnC
 bUs
 bLv
 aaa
@@ -82423,16 +83191,16 @@ bCq
 bCq
 bCq
 bCq
-QpY
-Qqh
-Qql
+QmH
+QmH
+QmH
 aaa
 aaa
-Qqv
+QmH
 aaa
 aaa
 aaa
-QqJ
+QmH
 aaf
 aaf
 aaf
@@ -82650,20 +83418,20 @@ bCq
 bPX
 bRg
 bRg
-QnD
+QnC
 QnK
 bVG
 Qoc
 Qon
-Qoy
+QnK
 QoJ
-QoT
-bcU
+QnC
+QnK
 Qpg
 bVG
-bcU
+QnK
 QpB
-cjn
+QnC
 bUs
 bLv
 aaa
@@ -82691,7 +83459,7 @@ QqA
 btG
 btG
 aaa
-QqP
+QmH
 aaa
 aaa
 aaa
@@ -82828,7 +83596,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+Qqz
 aaa
 aaa
 aaa
@@ -82860,7 +83628,7 @@ QlS
 QlZ
 Qmf
 Qml
-aKx
+Qmm
 aLE
 aMS
 aOi
@@ -82907,20 +83675,20 @@ bLv
 bQa
 bHE
 bHE
-QnE
+QnC
 QnL
 QnS
 Qod
 Qoo
 Qoz
-QoK
+Qoo
 QoU
-Qpa
-Qph
+Qoo
+Qoo
 Qpo
-Qpx
+Qpl
 QpC
-cjn
+QnC
 bUs
 bLv
 aaf
@@ -82947,7 +83715,7 @@ bgN
 QqB
 bgN
 btG
-QqL
+QmH
 aaT
 abY
 abY
@@ -83085,7 +83853,7 @@ aaa
 aaa
 aaa
 aaa
-aae
+aHr
 aaa
 aaa
 aaa
@@ -83172,12 +83940,12 @@ Qop
 QoA
 QoL
 QoV
-Qpb
+QoL
 Qpi
 Qpp
 bdV
-bcU
-cjn
+QnK
+QnC
 bUs
 bLv
 aaa
@@ -83421,20 +84189,20 @@ bLv
 bHE
 bHE
 bSs
-QnG
+QnC
 QnN
 QnU
 Qof
 Qoq
-QoB
-bcU
+QnU
+QnK
 QoW
 Qpc
 cCa
 Qpq
 cCa
 QpD
-cjn
+QnC
 bUs
 bLv
 aaa
@@ -83453,7 +84221,7 @@ QpQ
 btF
 bsc
 Qqj
-Qqo
+Qqn
 bnU
 bgN
 big
@@ -83461,7 +84229,7 @@ bgN
 bkZ
 bgN
 btG
-QqM
+QmH
 aaT
 ctv
 abY
@@ -83678,20 +84446,20 @@ bCq
 bHE
 bRh
 bSr
-QnH
+QnC
 QnO
 QnV
 Qog
 Qor
 QoC
 QoM
-QoX
+QnC
 bdV
 Qpj
-Qpr
+Qpq
 cCa
 QpE
-cjn
+QnC
 bUs
 bLv
 aaf
@@ -83710,7 +84478,7 @@ QpR
 btG
 Qqc
 bsc
-Qqp
+Qqn
 bnV
 bgN
 bii
@@ -83856,11 +84624,11 @@ abc
 abc
 afu
 abc
-aaa
-aaa
-aaa
-aaa
-aaa
+abc
+abc
+abc
+abc
+QmH
 aaa
 akD
 akD
@@ -83935,20 +84703,20 @@ bCq
 bOK
 bCq
 bCq
-QnI
+QnC
 QnP
 QnW
 Qoh
 Qos
 QoD
-QoN
-cjn
+QnC
+QnC
 bdV
 Qpk
-Qps
+Qpq
 Qpy
 bdV
-cjn
+QnC
 bUs
 bLv
 aaa
@@ -83962,9 +84730,9 @@ coz
 cpn
 QpJ
 QpK
-QpN
+QpK
 QpS
-QpW
+QpK
 Qqd
 Qqk
 Qqq
@@ -84112,13 +84880,13 @@ abc
 aea
 aeH
 aft
+Qrw
+Qrx
+Qry
+QrE
 abc
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+QmH
+QmH
 aaa
 aiU
 aln
@@ -84194,18 +84962,18 @@ bLv
 aaa
 bLv
 QnQ
-QnX
-Qoi
-Qot
-QoE
-QoO
-bcU
-bcU
+QnW
+QnC
+QnC
+QnC
+QnC
+QnK
+QnK
 bdV
 Qpt
 bdV
 QpF
-cjn
+QnC
 bUs
 bLv
 aaa
@@ -84232,7 +85000,7 @@ bgO
 QqD
 btG
 btG
-QqN
+QmH
 aaT
 ctv
 abY
@@ -84371,10 +85139,10 @@ aeJ
 afw
 abc
 abc
-aaf
-aaa
-aaf
-aaf
+Qrz
+QrF
+abc
+QmH
 aaf
 aaf
 aiU
@@ -84450,19 +85218,19 @@ bHE
 bLv
 aaf
 bLv
-bUt
-QnY
+QnQ
+QnW
 Qoj
 Qou
 QoF
 QoP
-bcU
+QnK
 Qpd
 Qpl
 Qpu
-bcU
-bcU
-cjn
+QnK
+QnK
+QnC
 bUs
 bLv
 aaf
@@ -84477,17 +85245,17 @@ cjJ
 cjJ
 aaa
 aaa
-QpU
+QpT
 aaf
 aaa
 aaa
 aaa
-Qqs
+QmH
 aaa
 aaa
-Qqw
-QqE
-QqG
+QmH
+QmH
+QmH
 aaa
 aaa
 aaT
@@ -84627,11 +85395,11 @@ aeb
 aeI
 afv
 agf
-abc
-aaf
-aaa
-aaa
-aiT
+afA
+QrA
+QrG
+afA
+aiV
 aiT
 aiV
 akG
@@ -84708,18 +85476,18 @@ bCq
 aaa
 bLv
 bUz
-QnZ
+QnW
 Qok
 Qov
 QoG
-QoQ
+QnC
 QoY
 Qpe
 Qpm
 Qpv
 Qpz
 QpG
-cjn
+QnC
 bUs
 bCq
 aaa
@@ -84734,18 +85502,18 @@ cpo
 cjJ
 aaa
 aaa
-QpV
+QpT
 aaf
-Qqf
+QmH
 aaa
 aaa
-Qqt
+QmH
 aaa
 aaa
-Qqx
-QqF
-QqH
-QqK
+QmH
+QmH
+QmH
+QmH
 aaa
 aaT
 ctv
@@ -84884,11 +85652,11 @@ aee
 aeL
 afy
 agh
-abc
-aaf
-aaa
-aaf
-aiT
+afA
+QrB
+QrH
+QrK
+aiV
 ajs
 akb
 akI
@@ -84967,15 +85735,15 @@ bTB
 bUv
 Qoa
 Qol
-Qow
-QoH
-QoR
-QoZ
-Qpf
-Qpn
-Qpw
-QpA
-QpH
+Qol
+Qol
+Qol
+Qol
+Qol
+Qol
+Qol
+Qol
+Qol
 car
 bUs
 bCq
@@ -84993,17 +85761,17 @@ aaf
 aaf
 cig
 aaf
-Qqg
+QmH
 aaa
 aaa
-Qqu
+QmH
 aaa
 aaa
-Qqy
+QmH
 aaa
-QqI
+QmH
 aaf
-QqO
+QmH
 aaT
 aaT
 aaT
@@ -85141,11 +85909,11 @@ aed
 aeK
 afx
 agg
-abc
-aaf
-aaa
-aaa
-aiU
+afA
+QrC
+QrI
+QrL
+aiV
 ajr
 aka
 akH
@@ -85261,7 +86029,7 @@ aaa
 aaa
 aaa
 aaf
-QqQ
+QmH
 aaa
 aaa
 aaa
@@ -85399,10 +86167,10 @@ aeN
 afA
 afA
 afA
-aaf
-aaa
-aaa
-aiU
+QrD
+QrJ
+QrM
+aiV
 aju
 akd
 akK
@@ -86181,7 +86949,7 @@ afL
 aez
 ahU
 aiX
-anz
+anw
 aov
 cCi
 air
@@ -86438,7 +87206,7 @@ ajc
 afM
 afN
 aiX
-anz
+anw
 aov
 cCi
 aqX
@@ -86695,7 +87463,7 @@ adL
 ahr
 aih
 aiX
-anz
+anw
 aov
 ape
 arT
@@ -86951,7 +87719,7 @@ agj
 agj
 agj
 aiX
-aiX
+agj
 anQ
 aov
 cCi
@@ -87205,11 +87973,11 @@ agj
 ajz
 aki
 akM
-alv
+aly
 amf
 amQ
+aiX
 anw
-anz
 aov
 cCi
 arT
@@ -87462,11 +88230,11 @@ agj
 auj
 akl
 akO
-alx
-alx
-amR
+QrU
+QrZ
+amg
+aiX
 anw
-anz
 aox
 cCi
 cCi
@@ -87718,11 +88486,11 @@ aid
 agj
 aiZ
 akk
-akN
-alw
-amg
-amR
-anw
+akQ
+agj
+agj
+agj
+aiX
 anR
 aow
 apg
@@ -87973,14 +88741,14 @@ ahP
 ahP
 aiF
 agj
-aja
-ajG
-akQ
-agj
-agj
-amS
-anx
-anz
+ajD
+akm
+akP
+aly
+Qsa
+amQ
+aiX
+anw
 aov
 aph
 aph
@@ -88230,14 +88998,14 @@ ahD
 aiw
 aiO
 agj
-ajD
-akm
-akP
-aly
+aja
+akl
+QrS
+QrV
 amh
-amR
+ami
+aiX
 anw
-anz
 aov
 aph
 aob
@@ -88488,13 +89256,13 @@ agP
 agP
 aiz
 ajg
-akl
-akR
-alx
-alx
-amR
+QrP
+akQ
+agj
+agj
+agj
+aiX
 anw
-anz
 aov
 aph
 aoc
@@ -88748,10 +89516,10 @@ ajb
 ajF
 akN
 alw
-ami
-amR
+Qsb
+amQ
+aiX
 anw
-anz
 aov
 api
 ata
@@ -88794,13 +89562,13 @@ aaf
 aaf
 QmH
 aaa
-QmJ
+QmH
 aaa
 QmP
-bsb
-bsb
-bsb
-bsb
+QmP
+QmP
+QmP
+QmP
 aXf
 aJq
 byU
@@ -89001,14 +89769,14 @@ agn
 agR
 agn
 ajc
-ajI
-ako
-akQ
-agj
-agj
-amS
-any
-anz
+QrN
+akv
+QrT
+QrW
+aww
+amk
+aiX
+anQ
 aov
 aph
 aqb
@@ -89053,11 +89821,11 @@ aBb
 aBb
 QmK
 aaa
-bsb
+QmP
 QmR
 QmY
 Qnb
-bsb
+QmP
 aXf
 aJq
 bBi
@@ -89242,14 +90010,14 @@ aaa
 aaf
 aaa
 aaf
-aaf
-aaT
-aaf
 aaZ
-abm
+QqR
+QqZ
+Qrh
+aaZ
 cpg
+Qru
 acv
-adi
 adi
 aaZ
 aeW
@@ -89259,13 +90027,13 @@ ahQ
 aiI
 aiH
 ajB
-akm
-akP
-aly
-amj
-amR
+QrQ
+akQ
+agj
+agj
+agj
+aiX
 anw
-anz
 aov
 aph
 aph
@@ -89302,7 +90070,7 @@ aZR
 aZR
 aZR
 bft
-Qmv
+Qmt
 aBa
 aBT
 bmv
@@ -89310,7 +90078,7 @@ aEN
 aGb
 bpg
 aaa
-bsb
+QmP
 QmS
 buP
 bwm
@@ -89499,15 +90267,15 @@ aaa
 aaf
 aaa
 aaf
-aaf
-aaT
-aaa
 aaZ
-abH
+QqS
+Qra
+Qri
+aaZ
 acl
-ajC
+cxA
 acL
-adi
+Qrv
 aaZ
 agp
 agT
@@ -89515,14 +90283,14 @@ ahx
 ahS
 aiK
 ajc
-ajI
-akl
+QrO
+akm
 akT
-aww
+alf
 alx
-amR
+amQ
+aiX
 anw
-anz
 aov
 apk
 anw
@@ -89559,7 +90327,7 @@ bbm
 bdh
 bee
 bfv
-Qmw
+Qmt
 aBa
 QmF
 aEM
@@ -89756,12 +90524,12 @@ aaa
 aaf
 aaa
 aaf
-aaf
-abY
-aaa
 aaZ
-abn
-ack
+QqT
+Qrb
+Qrj
+aaZ
+Qrq
 adk
 adK
 cqG
@@ -89773,12 +90541,12 @@ ahR
 aiJ
 ajc
 ajI
-akk
+akl
 akS
-alw
-amk
-amR
-anw
+QrX
+Qsc
+amp
+aiX
 anS
 aoy
 apj
@@ -89816,7 +90584,7 @@ bcf
 bdg
 bed
 bfv
-Qmx
+Qmt
 aBa
 aBV
 alu
@@ -90013,12 +90781,12 @@ aaa
 aaf
 aaa
 aaf
-aaf
-aaT
-aaa
 aaZ
-abJ
-ack
+QqU
+Qrc
+Qrk
+aaZ
+Qrr
 acM
 adQ
 cwM
@@ -90034,9 +90802,9 @@ akq
 akQ
 agj
 agj
-amS
-anx
-anz
+agj
+aiX
+Qsq
 aoz
 apm
 aqd
@@ -90073,7 +90841,7 @@ bbm
 bdh
 bef
 bfv
-Qmy
+Qmt
 aBa
 QmG
 aEO
@@ -90270,12 +91038,12 @@ aaa
 aaf
 aaa
 aaf
-aaf
-aaT
-aaa
 aaZ
-abI
-ack
+QqV
+Qrd
+Qrl
+aaZ
+Qrs
 coS
 aet
 cxA
@@ -90292,9 +91060,9 @@ akU
 alz
 aml
 amT
-anw
-anz
-aoz
+aiX
+Qsr
+Qsx
 apl
 aqc
 aqc
@@ -90330,7 +91098,7 @@ aZR
 aZR
 aZR
 bfw
-Qmz
+Qmt
 aBa
 aBW
 bjy
@@ -90338,7 +91106,7 @@ aEP
 aGe
 bpi
 aaa
-bsb
+QmP
 QmW
 buR
 aFM
@@ -90527,12 +91295,12 @@ aaa
 aaf
 aaa
 aaf
-aaf
-abY
-aaa
 aaZ
+QqW
+Qre
+Qrm
 abQ
-ack
+Qrt
 adj
 arc
 blT
@@ -90549,9 +91317,9 @@ akV
 alB
 amn
 amV
-anw
-anz
-aoz
+Qsm
+anB
+Qsy
 aod
 aqf
 ahT
@@ -90595,11 +91363,11 @@ aBc
 aBc
 QmM
 aaa
-bsb
+QmP
 QmX
 Qna
 Qnd
-bsb
+QmP
 aJq
 aJq
 bBu
@@ -90784,10 +91552,10 @@ aaa
 aaf
 aaa
 aaf
-aaf
-abY
-aaa
 aaZ
+QqX
+ack
+Qrn
 abN
 ack
 bkA
@@ -90802,14 +91570,14 @@ aIF
 ajc
 ajI
 akp
-akQ
+amS
 alA
+Qsd
 amm
-amU
-anw
+Qsn
 anT
-aoA
-apn
+anT
+aod
 aqe
 arf
 arf
@@ -90844,19 +91612,19 @@ bcg
 aZU
 beg
 aYB
-QmB
-QmE
+Qmt
+QmD
 aaf
 aaf
-QmI
+QmH
 aaa
-QmN
+QmH
 aaa
-bsb
-bsb
-bsb
-bsb
-bsb
+QmP
+QmP
+QmP
+QmP
+QmP
 aJq
 aJq
 bBt
@@ -91041,10 +91809,10 @@ aaa
 aaf
 aaa
 aaf
-aaf
-aaT
-aaf
 aaZ
+QqY
+Qrf
+Qro
 aci
 acm
 cpA
@@ -91059,12 +91827,12 @@ agn
 aje
 ajJ
 akr
-akX
+amS
 alC
-alC
+Qse
 amX
-anz
-anz
+amX
+amX
 aoB
 aod
 aqe
@@ -91298,10 +92066,10 @@ aaf
 aaf
 aaf
 aaf
-aaa
-adR
-abo
 aaZ
+aaZ
+Qrg
+Qrp
 aaZ
 aaZ
 acT
@@ -91315,16 +92083,16 @@ aii
 agn
 ajd
 ajI
-ahY
+QrR
 akW
-aiG
+anw
 amo
-amW
-anz
-anz
-aoz
-aod
-aqe
+amX
+amX
+Qss
+Qsz
+QsA
+QsC
 arf
 apY
 ate
@@ -91555,10 +92323,10 @@ aaa
 aaa
 aaf
 aaf
-aaa
 abp
-abP
 aco
+abO
+abO
 acO
 abl
 abO
@@ -91572,13 +92340,13 @@ ahZ
 adR
 aiQ
 ajI
-akt
-akQ
-agj
-agj
-aiX
+ahY
+akW
+anA
+Qsf
+Qsi
 anB
-anz
+Qst
 aoD
 aod
 aqe
@@ -91812,8 +92580,8 @@ aaa
 aaa
 aaa
 aaf
-aaa
 abo
+abO
 abO
 abO
 abO
@@ -91831,11 +92599,11 @@ ajf
 ajK
 aks
 akY
-alx
-amp
-aiX
-anA
-anz
+QrY
+Qsg
+Qsj
+amo
+Qsu
 aoC
 aod
 aqe
@@ -92069,9 +92837,9 @@ aaa
 aaa
 aaa
 aaf
-aaa
 abp
 abO
+acq
 acq
 acq
 acq
@@ -92086,13 +92854,13 @@ aia
 aiP
 aiR
 ajB
-akv
-ala
-akz
-alf
+akp
 aiX
-anA
-anz
+akz
+Qsh
+Qsk
+Qso
+Qsv
 aoF
 apo
 aqh
@@ -92326,8 +93094,8 @@ aaa
 aaf
 aaf
 aaf
-aaf
 abo
+abO
 abO
 acp
 acP
@@ -92344,14 +93112,14 @@ adR
 aiG
 ajL
 aku
-akZ
+aiX
 alE
 amq
-aiX
-anA
-anz
+Qsl
+Qsp
+Qsw
 aoE
-aod
+QsB
 aqg
 aun
 asf
@@ -92583,7 +93351,7 @@ aaa
 aaa
 aaa
 aaa
-aaf
+abP
 abp
 abR
 abP
@@ -92840,7 +93608,7 @@ aaf
 aaf
 aaf
 aaf
-aaf
+abp
 abq
 abq
 abq

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -60907,6 +60907,42 @@
 /turf/open/space/basic,
 /area/space)
 "QqR" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqS" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqT" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqU" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqV" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqW" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqX" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqY" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"QqZ" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"Qra" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot{
 	dir = 2
@@ -60916,7 +60952,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"QqS" = (
+"Qrb" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot{
 	dir = 2
@@ -60926,7 +60962,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"QqT" = (
+"Qrc" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot{
 	dir = 2
@@ -60936,7 +60972,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"QqU" = (
+"Qrd" = (
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot{
 	dir = 2
@@ -60946,7 +60982,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"QqV" = (
+"Qre" = (
 /obj/structure/table,
 /obj/item/grenade/barrier{
 	pixel_x = 4
@@ -60962,7 +60998,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"QqW" = (
+"Qrf" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -60970,7 +61006,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"QqX" = (
+"Qrg" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/bulletproof{
 	pixel_x = -3;
@@ -60998,7 +61034,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"QqY" = (
+"Qrh" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = -3;
@@ -61031,7 +61067,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"QqZ" = (
+"Qri" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -61041,30 +61077,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qra" = (
+"Qrj" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrb" = (
+"Qrk" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrc" = (
+"Qrl" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrd" = (
+"Qrm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qre" = (
+"Qrn" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -61073,14 +61109,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrf" = (
+"Qro" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrg" = (
+"Qrp" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "lowsecarmory";
 	name = "Non-Lethal Armoury Shutter"
@@ -61094,19 +61130,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrh" = (
+"Qrq" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qri" = (
+"Qrr" = (
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrj" = (
+"Qrs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -61115,7 +61151,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrk" = (
+"Qrt" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61124,7 +61160,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrl" = (
+"Qru" = (
 /obj/machinery/suit_storage_unit/security,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61133,7 +61169,7 @@
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrm" = (
+"Qrv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -61148,7 +61184,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrn" = (
+"Qrw" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/cable{
 	d1 = 4;
@@ -61157,7 +61193,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qro" = (
+"Qrx" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -61167,7 +61203,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrp" = (
+"Qry" = (
 /obj/machinery/firealarm{
 	pixel_y = 24
 	},
@@ -61176,7 +61212,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrq" = (
+"Qrz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -61190,7 +61226,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrr" = (
+"QrA" = (
 /obj/machinery/light{
 	dir = 1
 	},
@@ -61202,7 +61238,7 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrs" = (
+"QrB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
@@ -61219,24 +61255,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"Qrt" = (
+"QrC" = (
 /obj/structure/closet/secure_closet/lethalshots,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qru" = (
+"QrD" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/drone,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},
 /area/ai_monitored/security/armory)
-"Qrv" = (
+"QrE" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qrw" = (
+"QrF" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -61246,7 +61282,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qrx" = (
+"QrG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -61258,7 +61294,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qry" = (
+"QrH" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
@@ -61267,7 +61303,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"Qrz" = (
+"QrI" = (
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4
@@ -61281,26 +61317,26 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrA" = (
+"QrJ" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrB" = (
+"QrK" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrC" = (
+"QrL" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrD" = (
+"QrM" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrE" = (
+"QrN" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
@@ -61312,7 +61348,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrF" = (
+"QrO" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
@@ -61332,16 +61368,16 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"QrG" = (
+"QrP" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrH" = (
+"QrQ" = (
 /obj/structure/bed,
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrI" = (
+"QrR" = (
 /obj/machinery/flasher{
 	id = "highseccell";
 	pixel_x = 28
@@ -61351,28 +61387,28 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrJ" = (
+"QrS" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrK" = (
+"QrT" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrL" = (
+"QrU" = (
 /turf/open/floor/plasteel/floorgrime,
 /area/security/execution/transfer)
-"QrM" = (
+"QrV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"QrN" = (
+"QrW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"QrO" = (
+"QrX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61384,7 +61420,7 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
-"QrP" = (
+"QrY" = (
 /obj/machinery/door_timer{
 	id = "Cell 3";
 	name = "Cell 3";
@@ -61395,7 +61431,7 @@
 	},
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
-"QrQ" = (
+"QrZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61403,7 +61439,7 @@
 	dir = 9
 	},
 /area/security/brig)
-"QrR" = (
+"Qsa" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 2";
 	name = "Cell 2"
@@ -61416,7 +61452,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
-"QrS" = (
+"Qsb" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	id = "Cell 3";
 	name = "Cell 3"
@@ -61429,21 +61465,21 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
-"QrT" = (
+"Qsc" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrU" = (
+"Qsd" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrV" = (
+"Qse" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
@@ -61452,7 +61488,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrW" = (
+"Qsf" = (
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -61467,7 +61503,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrX" = (
+"Qsg" = (
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 0;
@@ -61481,20 +61517,20 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"QrY" = (
+"Qsh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"QrZ" = (
+"Qsi" = (
 /obj/machinery/flasher{
 	id = "Cell 2";
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsa" = (
+"Qsj" = (
 /obj/machinery/flasher{
 	id = "Cell 3";
 	pixel_x = -28
@@ -61504,7 +61540,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsb" = (
+"Qsk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -61514,7 +61550,7 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"Qsc" = (
+"Qsl" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -61526,44 +61562,44 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
-"Qsd" = (
+"Qsm" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
 /area/hallway/primary/fore)
-"Qse" = (
+"Qsn" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"Qsf" = (
+"Qso" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"Qsg" = (
+"Qsp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/red/side{
 	dir = 5
 	},
 /area/hallway/primary/fore)
-"Qsh" = (
+"Qsq" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/hallway/primary/fore)
-"Qsi" = (
+"Qsr" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
 /area/hallway/primary/fore)
-"Qsj" = (
+"Qss" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsk" = (
+"Qst" = (
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 28
@@ -61573,7 +61609,7 @@
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsl" = (
+"Qsu" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "briggate";
@@ -61592,7 +61628,7 @@
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
-"Qsm" = (
+"Qsv" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "seclobby";
 	name = "security blast door"
@@ -61604,20 +61640,20 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/brig)
-"Qsn" = (
+"Qsw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qso" = (
+"Qsx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsp" = (
+"Qsy" = (
 /obj/structure/sign/securearea{
 	pixel_y = 32
 	},
@@ -61625,7 +61661,7 @@
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsq" = (
+"Qsz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
@@ -61637,31 +61673,31 @@
 	dir = 1
 	},
 /area/hallway/primary/fore)
-"Qsr" = (
+"QsA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
 /area/hallway/primary/fore)
-"Qss" = (
+"QsB" = (
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
-"Qst" = (
+"QsC" = (
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
-"Qsu" = (
+"QsD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/hallway/primary/fore)
-"Qsv" = (
+"QsE" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
 /area/hallway/primary/fore)
-"Qsw" = (
+"QsF" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
@@ -61671,12 +61707,12 @@
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
-"Qsx" = (
+"QsG" = (
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/hallway/primary/fore)
-"Qsy" = (
+"QsH" = (
 /obj/machinery/flasher{
 	id = "brigentry";
 	pixel_x = 0;
@@ -61688,21 +61724,21 @@
 	},
 /turf/open/floor/plasteel/red/side,
 /area/hallway/primary/fore)
-"Qsz" = (
+"QsI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"QsA" = (
+"QsJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"QsB" = (
+"QsK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -84920,10 +84956,10 @@ abc
 aea
 aeH
 aft
-Qrv
-Qrw
-Qrx
-QrD
+QrE
+QrF
+QrG
+QrM
 abc
 QmH
 QmH
@@ -85179,8 +85215,8 @@ aeJ
 afw
 abc
 abc
-Qry
-QrE
+QrH
+QrN
 abc
 QmH
 aaf
@@ -85436,8 +85472,8 @@ aeI
 afv
 agf
 afA
-Qrz
-QrF
+QrI
+QrO
 afA
 aiV
 aiT
@@ -85693,9 +85729,9 @@ aeL
 afy
 agh
 afA
-QrA
-QrG
 QrJ
+QrP
+QrS
 aiV
 ajs
 akb
@@ -85950,9 +85986,9 @@ aeK
 afx
 agg
 afA
-QrB
-QrH
 QrK
+QrQ
+QrT
 aiV
 ajr
 aka
@@ -86207,9 +86243,9 @@ aeN
 afA
 afA
 afA
-QrC
-QrI
 QrL
+QrR
+QrU
 aiV
 aju
 akd
@@ -88270,8 +88306,8 @@ agj
 auj
 akl
 akO
-QrT
-QrY
+Qsc
+Qsh
 amg
 aiX
 anw
@@ -88785,7 +88821,7 @@ ajD
 akm
 akP
 aly
-QrZ
+Qsi
 amQ
 aiX
 anw
@@ -89040,8 +89076,8 @@ aiO
 agj
 aja
 akl
-QrR
-QrU
+Qsa
+Qsd
 amh
 ami
 aiX
@@ -89296,7 +89332,7 @@ agP
 agP
 aiz
 ajg
-QrO
+QrX
 akQ
 agj
 agj
@@ -89534,7 +89570,7 @@ aaa
 aaa
 aaf
 aaf
-aaa
+QqR
 aaf
 aai
 abi
@@ -89556,7 +89592,7 @@ ajb
 ajF
 akN
 alw
-Qsa
+Qsj
 amQ
 aiX
 anw
@@ -89809,10 +89845,10 @@ agn
 agR
 agn
 ajc
-QrM
-akv
-QrS
 QrV
+akv
+Qsb
+Qse
 aww
 amk
 aiX
@@ -90048,15 +90084,15 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqS
 aaf
 aaZ
-QqR
-QqZ
-Qrh
+Qra
+Qri
+Qrq
 aaZ
 cpg
-Qrt
+QrC
 acv
 adi
 aaZ
@@ -90067,7 +90103,7 @@ ahQ
 aiI
 aiH
 ajB
-QrP
+QrY
 akQ
 agj
 agj
@@ -90305,17 +90341,17 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqT
 aaf
 aaZ
-QqS
-Qra
-Qri
+Qrb
+Qrj
+Qrr
 aaZ
 acl
 cxA
 acL
-Qru
+QrD
 aaZ
 agp
 agT
@@ -90323,7 +90359,7 @@ ahx
 ahS
 aiK
 ajc
-QrN
+QrW
 akm
 akT
 alf
@@ -90562,14 +90598,14 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqU
 aaf
 aaZ
-QqT
-Qrb
-Qrj
+Qrc
+Qrk
+Qrs
 aaZ
-Qrp
+Qry
 adk
 adK
 cqG
@@ -90583,8 +90619,8 @@ ajc
 ajI
 akl
 akS
-QrW
-Qsb
+Qsf
+Qsk
 amp
 aiX
 anS
@@ -90819,14 +90855,14 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqV
 aaf
 aaZ
-QqU
-Qrc
-Qrk
+Qrd
+Qrl
+Qrt
 aaZ
-Qrq
+Qrz
 acM
 adQ
 cwM
@@ -90844,7 +90880,7 @@ agj
 agj
 agj
 aiX
-Qsp
+Qsy
 aoz
 apm
 aqd
@@ -91076,14 +91112,14 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqW
 aaf
 aaZ
-QqV
-Qrd
-Qrl
+Qre
+Qrm
+Qru
 aaZ
-Qrr
+QrA
 coS
 aet
 cxA
@@ -91101,8 +91137,8 @@ alz
 aml
 amT
 aiX
-Qsq
-Qsw
+Qsz
+QsF
 apl
 aqc
 aqc
@@ -91333,14 +91369,14 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqX
 aaf
 aaZ
-QqW
-Qre
-Qrm
+Qrf
+Qrn
+Qrv
 abQ
-Qrs
+QrB
 adj
 arc
 blT
@@ -91357,9 +91393,9 @@ akV
 alB
 amn
 amV
-Qsl
+Qsu
 anB
-Qsx
+QsG
 aod
 aqf
 ahT
@@ -91590,12 +91626,12 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqY
 aaf
 aaZ
-QqX
+Qrg
 ack
-Qrn
+Qrw
 abN
 ack
 bkA
@@ -91612,9 +91648,9 @@ ajI
 akp
 amS
 alA
-Qsc
+Qsl
 amm
-Qsm
+Qsv
 anT
 anT
 aod
@@ -91847,12 +91883,12 @@ aaa
 aaa
 aaa
 aaf
-aaa
+QqZ
 aaf
 aaZ
-QqY
-Qrf
+Qrh
 Qro
+Qrx
 aci
 acm
 cpA
@@ -91869,7 +91905,7 @@ ajJ
 akr
 amS
 alC
-Qsd
+Qsm
 amX
 amX
 amX
@@ -92104,11 +92140,11 @@ aaa
 aaa
 aaf
 aaf
-aaf
+abY
 aaf
 aaZ
 aaZ
-Qrg
+Qrp
 avB
 aaZ
 aaZ
@@ -92123,16 +92159,16 @@ aii
 agn
 ajd
 ajI
-QrQ
+QrZ
 akW
 anw
 amo
 amX
 amX
-Qsr
-Qsy
-Qsz
-QsB
+QsA
+QsH
+QsI
+QsK
 arf
 apY
 ate
@@ -92383,10 +92419,10 @@ ajI
 ahY
 akW
 anA
-Qse
-Qsh
+Qsn
+Qsq
 anB
-Qss
+QsB
 aoD
 aod
 aqe
@@ -92639,11 +92675,11 @@ ajf
 ajK
 aks
 akY
-QrX
-Qsf
-Qsi
+Qsg
+Qso
+Qsr
 amo
-Qst
+QsC
 aoC
 aod
 aqe
@@ -92897,10 +92933,10 @@ ajB
 akp
 aiX
 akz
-Qsg
-Qsj
-Qsn
-Qsu
+Qsp
+Qss
+Qsw
+QsD
 aoF
 apo
 aqh
@@ -93155,11 +93191,11 @@ aku
 aiX
 alE
 amq
-Qsk
-Qso
-Qsv
+Qst
+Qsx
+QsE
 aoE
-QsA
+QsJ
 aqg
 aun
 asf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -93351,8 +93351,8 @@ aaa
 aaa
 aaa
 aaa
-abP
 abp
+abP
 abR
 abP
 abP

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -28095,6 +28095,7 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/holopad,
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "bgw" = (
@@ -28944,7 +28945,7 @@
 /area/security/brig)
 "bio" = (
 /obj/machinery/light/small,
-/obj/machinery/holopad,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/whitered/side,
 /area/security/brig)
 "bip" = (
@@ -41783,21 +41784,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bFj" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
 /area/security/brig)
 "bFk" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
@@ -41812,11 +41803,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/security/cell/westright{
 	id = "brig1";
@@ -43788,12 +43774,6 @@
 	},
 /area/hallway/primary/starboard)
 "bIY" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -45782,11 +45762,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/security/cell/westright{
 	id = "brig2";
@@ -48042,12 +48017,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/starboard)
 "bQV" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -106597,11 +106566,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "efr" = (
-/obj/structure/table/glass,
-/obj/machinery/computer/med_data/laptop,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_y = 32
 	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 9
 	},
@@ -108983,11 +108951,6 @@
 	},
 /area/maintenance/port/fore)
 "erg" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -159408,13 +159371,13 @@ bwi
 bxY
 efF
 bjQ
-bDn
-bFi
-bHa
 bdi
-bDn
-bFi
-bHa
+bdi
+bdi
+bdi
+bdi
+bdi
+bdi
 bdi
 bTh
 bVn
@@ -159927,7 +159890,7 @@ bFk
 bHc
 bAb
 bLc
-bit
+bgA
 bOO
 bIZ
 bTj

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5236,25 +5236,21 @@
 	},
 /area/security/brig)
 "akv" = (
-/obj/structure/table,
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/obj/machinery/computer/med_data/laptop,
+/obj/machinery/chem_dispenser{
+	layer = 2.7
+	},
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
 /area/security/brig)
 "akw" = (
-/obj/structure/table,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 5
 	},
@@ -12672,11 +12668,6 @@
 "ayx" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -12705,11 +12696,6 @@
 "ayz" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
@@ -12725,11 +12711,6 @@
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "ayA" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
@@ -13274,11 +13255,6 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "azE" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "azF" = (
@@ -15317,12 +15293,6 @@
 	},
 /area/hallway/primary/fore)
 "aDz" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_y = 32
-	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Cells";
 	dir = 2;
@@ -85683,11 +85653,6 @@
 	},
 /area/maintenance/starboard/fore)
 "dCj" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
@@ -111035,7 +111000,7 @@ awZ
 ayw
 azD
 aAY
-aCk
+ajm
 aDw
 aDC
 aGb
@@ -111292,8 +111257,8 @@ axa
 ayx
 azE
 azE
-aCl
-aDx
+ajm
+aDw
 aEK
 aGc
 aHx
@@ -111549,7 +111514,7 @@ axb
 ayy
 azF
 aAZ
-aCm
+ajm
 aDw
 aEL
 aGd
@@ -111807,7 +111772,7 @@ ahx
 ahx
 ahx
 ajm
-aDy
+aDw
 aEM
 aGe
 aHx
@@ -112063,7 +112028,7 @@ axd
 ayw
 azG
 aAY
-aCk
+ajm
 aDw
 aEN
 aGf
@@ -112320,8 +112285,8 @@ axe
 ayz
 dCj
 azE
-aCl
-aDx
+ajm
+aDw
 dCo
 aGg
 aHx
@@ -112577,7 +112542,7 @@ axb
 ayy
 azF
 aBa
-aCm
+ajm
 aDw
 aEO
 aGh
@@ -113091,7 +113056,7 @@ axd
 ayw
 azH
 aAY
-aCk
+ajm
 aDw
 aEO
 aGg
@@ -113348,8 +113313,8 @@ axa
 ayA
 azE
 azE
-aCl
-aDx
+ajm
+aDw
 aEQ
 aGj
 aHz
@@ -113605,7 +113570,7 @@ axg
 ayy
 azF
 aBb
-aCm
+ajm
 aDw
 aEN
 aGk


### PR DESCRIPTION
I was too lazy to copy&paste old hippie's entire security department

:cl: deathride58
add: Boxstation's security now has a high security cell, accessible via fake wall from the execution room.
add: Boxstation's security now has a public lobby, complete with water cooler and soda dispenser!
add: Boxstation now has a non-lethal armory, containing hardsuits, armor, barrier grenades, and mounted flashers
tweak: Security on all maps now have reinforced walls in place of electrified windows.
tweak: Security on all maps now have a chem dispenser and chemmaster.
/:cl:

![secboxarmoryupd8](https://user-images.githubusercontent.com/6356337/31581130-f4bc29e6-b130-11e7-87a2-59ff4a5d3310.PNG)
The new non-lethal armory makes it harder to break into the normal armory from space. This means raiding the armory from space is a little harder, and leaves the Warden and AI with a little more warning before the lethal armory gets breached.
![secboxhighseccell](https://user-images.githubusercontent.com/6356337/31580148-7feb2416-b115-11e7-8ff2-f3a410deebd4.PNG)
Self explanatory.
![secinfirmary](https://user-images.githubusercontent.com/6356337/31580149-8381b72a-b115-11e7-8a22-37b5f68ef58b.PNG)
This is a straight-forward, unashamed buff to security. Should be self explanatory.
![secboxlobbyandcells](https://user-images.githubusercontent.com/6356337/31580150-873dc2dc-b115-11e7-9524-96f35a872025.PNG)
The lobby is rather self explanatory. The cell windows being replaced with reinforced walls is for the sake of Security's sanity, as its not uncommon that riots end up starting whenever someone ends up in the brig. 99% of the rounds I've played as sec, the cell window shutters had to be closed. This change essentially makes the cell shutters permanent, while also giving those without security access a more straight-forward way of breaking out prisoners. Double-edged sword.
