### PR TITLE
Removed "You feel very bloated!" chat message

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -145,10 +145,10 @@
 	bodies = old_species.bodies
 
 /datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
-	if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
+	/*if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
 		if(prob(5))
-			to_chat(H, "<span class='notice'>You feel very bloated!</span>")
-	else if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+			to_chat(H, "<span class='notice'>You feel very bloated!</span>")*/
+	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
 		H.blood_volume += 3
 		H.nutrition -= 2.5
 


### PR DESCRIPTION
[Changelogs]: 

:cl: 
del: Removed chat message from slimepeople when they had enough slime to split
/:cl:

[why]: This is a quality of life thing, as it is annoying to get a message for an ability that isn't even usable anymore
