### PR TITLE
Sleeper Nerfs

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -15,7 +15,7 @@
 	state_open = TRUE
 	circuit = /obj/item/circuitboard/machine/sleeper
 	var/efficiency = 1
-	var/min_health = -25
+	var/min_health = 30
 	var/list/available_chems
 	var/controls_inside = FALSE
 	var/list/possible_chems = list(
@@ -42,7 +42,7 @@
 		I += M.rating
 
 	efficiency = initial(efficiency)* E
-	min_health = initial(min_health) * E
+	min_health = initial(min_health) - (10*E)
 	available_chems = list()
 	for(var/i in 1 to I)
 		available_chems |= possible_chems[i]


### PR DESCRIPTION
:cl: Poojawa
balance: Sleepers are no longer go-to magic fix alls
tweak: Minimum Heal values at tier 4 is now 1 instead of -100 for Sleepers
/:cl:

This is the start of PoojyChem rebalance of medbay. Currently the meta is throw a patch on someone and shove them into a sleeper for free, universal treatment no matter what injuries they've gotten. Making cryo tubes completely unneeded past thirty minutes into a round when someone's in science and upgrading stuff. 

Now instead of stopping magical chem injections almost never, they're returned back to previous intentions of medbay machinery of light - moderate - major injuries. While Cryo remains for Major - Critical - mortal injuries. 

Medihound sleepers are unaffected by these changes, they'll keep being useful for everything.