### PR TITLE
Sec map changes part 2: "It's so easy to break into" edition

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -902,6 +902,9 @@
 /area/security/main)
 "acq" = (
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "acr" = (
@@ -42505,8 +42508,8 @@
 	d2 = 8;
 	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -61798,7 +61801,21 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "QsN" = (
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"QsO" = (
 /obj/structure/closet/l3closet/security,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"QsP" = (
+/obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 
@@ -92460,7 +92477,7 @@ abO
 abO
 abO
 acO
-abl
+abO
 abO
 abO
 afc
@@ -92969,13 +92986,13 @@ aaa
 aaa
 abp
 abO
+QsN
+QsP
 acq
 acq
 acq
 acq
-acq
-acq
-acq
+abO
 aew
 afe
 afS
@@ -93483,13 +93500,13 @@ aaa
 aaa
 abp
 aco
-QsN
+QsO
 abP
 abR
 abP
 abP
 abP
-abP
+abl
 abp
 abp
 abp

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1117,7 +1117,6 @@
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
 "acO" = (
-/obj/structure/closet/l3closet/security,
 /obj/machinery/camera{
 	c_tag = "Brig Equipment Room";
 	dir = 4
@@ -3272,7 +3271,8 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/chem_master,
+/obj/machinery/iv_drip,
+/obj/item/reagent_containers/blood/empty,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 5
 	},
@@ -3313,7 +3313,8 @@
 	name = "Station Intercom (General)";
 	pixel_y = 24
 	},
-/obj/machinery/chem_dispenser,
+/obj/structure/table/glass,
+/obj/machinery/computer/med_data/laptop,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
@@ -3640,6 +3641,13 @@
 	pixel_y = 8;
 	req_access_txt = "2"
 	},
+/obj/machinery/button/door{
+	id = "seclobby";
+	name = "Security Lobby Lockdown";
+	pixel_x = -27;
+	pixel_y = -2;
+	req_access_txt = "2"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahS" = (
@@ -3710,8 +3718,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/vehicle/secway,
-/obj/item/key/security,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -4821,7 +4827,9 @@
 	d2 = 2;
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/red/side,
+/turf/open/floor/plasteel/red/side{
+	dir = 5
+	},
 /area/security/brig)
 "akt" = (
 /obj/machinery/light,
@@ -4873,6 +4881,9 @@
 /area/security/courtroom)
 "akz" = (
 /obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
@@ -5102,8 +5113,12 @@
 	d2 = 8;
 	icon_state = "4-8"
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "seclobby";
+	name = "security shutters"
+	},
 /turf/open/floor/plasteel/red/side{
-	dir = 5
+	dir = 9
 	},
 /area/security/brig)
 "akX" = (
@@ -5128,7 +5143,20 @@
 	d2 = 8;
 	icon_state = "1-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "seclobby";
+	name = "security shutters"
+	},
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 2;
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 5
+	},
 /area/security/brig)
 "akZ" = (
 /obj/structure/cable{
@@ -5319,6 +5347,10 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "alx" = (
+/obj/machinery/flasher{
+	id = "Cell 4";
+	pixel_x = -28
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "aly" = (
@@ -5668,6 +5700,10 @@
 /area/security/brig)
 "amq" = (
 /obj/machinery/vending/snack/random,
+/obj/machinery/flasher{
+	id = "brigentry";
+	pixel_x = 28
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
@@ -6178,9 +6214,9 @@
 /area/hallway/primary/fore)
 "anC" = (
 /obj/effect/spawner/structure/window,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "seclobby";
-	name = "security lobby blast door"
+	name = "security shutters"
 	},
 /turf/open/floor/plating,
 /area/security/courtroom)
@@ -6317,9 +6353,9 @@
 "anT" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "seclobby";
-	name = "security lobby blast door"
+	name = "security shutters"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -6328,9 +6364,9 @@
 /obj/machinery/door/airlock/glass{
 	name = "Courtroom"
 	},
-/obj/machinery/door/poddoor/preopen{
+/obj/machinery/door/poddoor/shutters/preopen{
 	id = "seclobby";
-	name = "security lobby blast door"
+	name = "security shutters"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/courtroom)
@@ -7200,8 +7236,8 @@
 	dir = 1
 	},
 /obj/structure/disposalpipe/junction{
-	dir = 8;
-	icon_state = "pipe-j1"
+	dir = 4;
+	icon_state = "pipe-j2"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -61608,10 +61644,6 @@
 	},
 /area/hallway/primary/fore)
 "Qst" = (
-/obj/machinery/flasher{
-	id = "brigentry";
-	pixel_x = 28
-	},
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -61637,15 +61669,15 @@
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "Qsv" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "seclobby";
-	name = "security blast door"
-	},
 /obj/structure/cable{
 	d2 = 8;
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "seclobby";
+	name = "security shutters"
+	},
 /turf/open/floor/plating,
 /area/security/brig)
 "Qsw" = (
@@ -61753,6 +61785,22 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"QsL" = (
+/obj/structure/window/reinforced,
+/obj/vehicle/secway,
+/obj/item/key/security,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"QsM" = (
+/obj/structure/window/reinforced,
+/obj/vehicle/secway,
+/obj/item/key/security,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"QsN" = (
+/obj/structure/closet/l3closet/security,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
 
 (1,1,1) = {"
 aaa
@@ -85738,8 +85786,8 @@ afy
 agh
 afA
 QrJ
-QrP
-QrS
+QrK
+QrK
 aiV
 ajs
 akb
@@ -85996,7 +86044,7 @@ agg
 afA
 QrK
 QrQ
-QrT
+QrK
 aiV
 ajr
 aka
@@ -86253,7 +86301,7 @@ afA
 afA
 QrL
 QrR
-QrU
+QrK
 aiV
 aju
 akd
@@ -87802,7 +87850,7 @@ akj
 agj
 agj
 agj
-aiX
+agj
 aiX
 anQ
 aov
@@ -89085,8 +89133,8 @@ agj
 aja
 akl
 Qsa
-Qsd
-amh
+Qsc
+Qsh
 ami
 aiX
 anw
@@ -89835,7 +89883,7 @@ aaf
 aaf
 aaf
 aaf
-aaf
+abY
 aaR
 aaZ
 aaZ
@@ -90092,7 +90140,7 @@ aaa
 aaa
 aaa
 aaf
-QqS
+QqR
 aaf
 aaZ
 Qra
@@ -90349,12 +90397,12 @@ aaa
 aaa
 aaa
 aaf
-QqT
+QqR
 aaf
 aaZ
 Qrb
 Qrj
-Qrr
+Qrq
 aaZ
 acl
 cxA
@@ -90367,10 +90415,10 @@ ahx
 ahS
 aiK
 ajc
-QrW
+QrV
 akm
 akT
-alf
+aly
 alx
 amQ
 aiX
@@ -90606,10 +90654,10 @@ aaa
 aaa
 aaa
 aaf
-QqU
+QqR
 aaf
 aaZ
-Qrc
+Qrb
 Qrk
 Qrs
 aaZ
@@ -90627,8 +90675,8 @@ ajc
 ajI
 akl
 akS
-Qsf
-Qsk
+Qsc
+Qsh
 amp
 aiX
 anS
@@ -90860,10 +90908,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
+QmH
+QmH
 aaf
-QqV
+QqR
 aaf
 aaZ
 Qrd
@@ -91120,12 +91168,12 @@ aaa
 aaa
 aaa
 aaf
-QqW
+QqR
 aaf
 aaZ
 Qre
 Qrm
-Qru
+Qrt
 aaZ
 QrA
 coS
@@ -91377,7 +91425,7 @@ aaa
 aaa
 aaa
 aaf
-QqX
+QqR
 aaf
 aaZ
 Qrf
@@ -91403,7 +91451,7 @@ amn
 amV
 Qsu
 anB
-QsG
+Qsq
 aod
 aqf
 ahT
@@ -91634,7 +91682,7 @@ aaa
 aaa
 aaa
 aaf
-QqY
+QqR
 aaf
 aaZ
 Qrg
@@ -91891,7 +91939,7 @@ aaa
 aaa
 aaa
 aaf
-QqZ
+QqR
 aaf
 aaZ
 Qrh
@@ -91914,9 +91962,9 @@ akr
 amS
 alC
 Qsm
-amX
-amX
-amX
+Qsm
+Qsm
+Qsm
 aoB
 aod
 aqe
@@ -92148,8 +92196,8 @@ aaa
 aaa
 aaf
 aaf
-abY
-aaf
+aaZ
+aaZ
 aaZ
 aaZ
 Qrp
@@ -92167,12 +92215,12 @@ aii
 agn
 ajd
 ajI
-QrZ
-akW
-anw
+akp
+amS
+Qsn
 amo
-amX
-amX
+Qsm
+Qsm
 QsA
 QsH
 QsI
@@ -92404,11 +92452,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
-aaf
+QmH
 abp
-aco
+QsL
+QsM
+abO
 abO
 abO
 acO
@@ -92424,9 +92472,9 @@ ahZ
 adR
 aiQ
 ajI
-ahY
+QrZ
 akW
-anA
+anw
 Qsn
 Qsq
 anB
@@ -92662,9 +92710,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
 abo
+abO
+abO
 abO
 abO
 abO
@@ -92683,11 +92731,11 @@ ajf
 ajK
 aks
 akY
-Qsg
-Qso
+anA
+Qsn
 Qsr
 amo
-QsC
+QsB
 aoC
 aod
 aqe
@@ -92919,10 +92967,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
 abp
 abO
+acq
+acq
 acq
 acq
 acq
@@ -92943,7 +92991,7 @@ aiX
 akz
 Qsp
 Qss
-Qsw
+Qss
 QsD
 aoF
 apo
@@ -93176,9 +93224,9 @@ aaa
 aaa
 aaa
 aaf
-aaf
-aaf
 abo
+abO
+abO
 abO
 abO
 acp
@@ -93433,9 +93481,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
 abp
+aco
+QsN
 abP
 abR
 abP
@@ -93690,8 +93738,8 @@ aaa
 aaa
 aaf
 aaf
-aaf
-aaf
+abp
+abp
 abp
 abq
 abq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -8795,7 +8795,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 2;
-	network = list("Engine");
+	network = list("Engine")
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -41790,21 +41790,11 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "bFj" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
 /area/security/brig)
 "bFk" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
@@ -41819,11 +41809,6 @@
 	d1 = 2;
 	d2 = 4;
 	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
 	},
 /obj/machinery/door/window/brigdoor/security/cell/westright{
 	id = "brig1";
@@ -43795,12 +43780,6 @@
 	},
 /area/hallway/primary/starboard)
 "bIY" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 32
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -45790,11 +45769,6 @@
 	d2 = 4;
 	icon_state = "2-4"
 	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/door/window/brigdoor/security/cell/westright{
 	id = "brig2";
 	name = "Cell 2"
@@ -45860,6 +45834,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/item/gun/ballistic/shotgun/riot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced{
+	dir = 1;
+	pixel_y = 1
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bNh" = (
@@ -46820,6 +46801,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bOX" = (
@@ -48049,12 +48033,6 @@
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/starboard)
 "bQV" = (
-/obj/structure/sign/securearea{
-	desc = "A warning sign which reads 'HIGH VOLTAGE'";
-	icon_state = "shock";
-	name = "HIGH VOLTAGE";
-	pixel_x = 32
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
@@ -48139,6 +48117,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bRd" = (
@@ -49580,6 +49561,10 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "bTv" = (
@@ -53355,12 +53340,12 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "caE" = (
-/obj/machinery/computer/security,
 /obj/structure/cable/white{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
@@ -53376,7 +53361,6 @@
 	},
 /area/security/brig)
 "caG" = (
-/obj/machinery/computer/secure_data,
 /obj/structure/cable/white{
 	d1 = 1;
 	d2 = 2;
@@ -54283,17 +54267,15 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "cco" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/table/reinforced,
 /obj/machinery/newscaster/security_unit{
 	pixel_x = -32
 	},
-/obj/item/clipboard,
-/obj/item/toy/figure/secofficer,
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
+	},
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
@@ -54302,17 +54284,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/neutral,
 /area/security/brig)
 "ccq" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/filingcabinet/chestdrawer,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/obj/structure/cable/white{
+	d1 = 1;
+	d2 = 4;
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -54322,17 +54313,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
 	},
 /area/security/brig)
 "ccs" = (
-/obj/structure/cable/white{
-	d1 = 2;
-	d2 = 4;
-	icon_state = "2-4"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cct" = (
@@ -55186,11 +55182,6 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "cdZ" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/sign/nanotrasen{
 	pixel_y = -32
 	},
@@ -55202,69 +55193,36 @@
 	dir = 1;
 	name = "security camera"
 	},
+/obj/structure/table/reinforced,
+/obj/item/clipboard,
+/obj/item/toy/figure/secofficer,
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "cea" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -26
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/red/side{
 	dir = 6
 	},
 /area/security/brig)
 "ceb" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Desk";
-	req_access_txt = "63"
-	},
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 8
-	},
+/turf/closed/wall,
 /area/security/brig)
 "cec" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
 "ced" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 8;
-	icon_state = "1-8"
-	},
 /obj/structure/chair{
 	dir = 1
 	},
@@ -106863,11 +106821,6 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "efM" = (
-/obj/structure/cable/white{
-	d1 = 1;
-	d2 = 4;
-	icon_state = "1-4"
-	},
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
 /obj/machinery/light/small{
@@ -108990,11 +108943,6 @@
 	},
 /area/maintenance/port/fore)
 "erg" = (
-/obj/structure/cable/white{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -109458,6 +109406,24 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
+"YGL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Desk";
+	req_access_txt = "63"
+	},
+/obj/structure/cable/white{
+	d1 = 4;
+	d2 = 8;
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
+/area/security/brig)
 
 (1,1,1) = {"
 aaa
@@ -159435,20 +159401,20 @@ bwi
 bxY
 efF
 bjQ
-bDn
-bFi
-bHa
 bdi
-bDn
-bFi
-bHa
+bdi
+bdi
+bdi
+bdi
+bdi
+bdi
 bdi
 bTh
 bVn
 bWY
 bdi
-bdi
-bDq
+bIZ
+YGL
 ceb
 bdi
 cgU
@@ -159954,7 +159920,7 @@ bFk
 bHc
 bAb
 bLc
-bit
+bgA
 bOO
 bIZ
 bTj

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -31711,6 +31711,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -32839,6 +32840,7 @@
 /area/security/main)
 "bpz" = (
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -33557,6 +33559,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -34196,6 +34199,7 @@
 	pixel_x = 32
 	},
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5240,9 +5240,8 @@
 /obj/machinery/airalarm{
 	pixel_y = 28
 	},
-/obj/machinery/chem_dispenser{
-	layer = 2.7
-	},
+/obj/machinery/computer/med_data/laptop,
+/obj/structure/table,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
@@ -5251,7 +5250,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/chem_master,
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen,
 /turf/open/floor/plasteel/whitered/side{
 	dir = 5
 	},
@@ -14114,16 +14118,21 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/cable/yellow{
+	d1 = 2;
+	d2 = 4;
+	icon_state = "2-4"
+	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "aBh" = (
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
+	},
+/obj/structure/cable/yellow{
+	d1 = 1;
+	d2 = 8;
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
@@ -14769,23 +14778,8 @@
 	},
 /area/security/brig)
 "aCq" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_security{
-	name = "Security Desk";
-	req_access_txt = "63"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	d1 = 1;
-	d2 = 2;
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	d1 = 2;
-	d2 = 8;
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/black,
+/turf/closed/wall,
 /area/security/brig)
 "aCr" = (
 /obj/machinery/door/airlock/security{
@@ -15347,7 +15341,6 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aDF" = (
-/obj/machinery/computer/secure_data,
 /obj/machinery/button/flasher{
 	id = "secentranceflasher";
 	name = "Brig Entrance Flash Control";
@@ -15395,18 +15388,15 @@
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "aDG" = (
-/obj/structure/filingcabinet/chestdrawer{
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/black,
-/area/security/brig)
-"aDH" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 2;
 	icon_state = "1-2"
 	},
+/turf/open/floor/plasteel/black,
+/area/security/brig)
+"aDH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -15428,6 +15418,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = 29;
 	pixel_y = -2
+	},
+/obj/structure/filingcabinet/chestdrawer{
+	pixel_y = 3
 	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
@@ -16174,22 +16167,17 @@
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "aEX" = (
-/obj/structure/cable/yellow{
-	d1 = 4;
-	d2 = 8;
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/black,
-/area/security/brig)
-"aEY" = (
 /obj/structure/cable/yellow{
 	d1 = 1;
 	d2 = 8;
 	icon_state = "1-8"
 	},
+/turf/open/floor/plasteel/black,
+/area/security/brig)
+"aEY" = (
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -16197,6 +16185,15 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/item/folder/red{
+	pixel_x = 3
+	},
+/obj/item/folder/white{
+	pixel_x = -4;
+	pixel_y = 2
+	},
+/obj/item/restraints/handcuffs,
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "aEZ" = (
@@ -16969,21 +16966,13 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "aGq" = (
-/obj/machinery/computer/security,
 /obj/machinery/newscaster/security_unit{
 	pixel_y = -30
 	},
+/obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "aGr" = (
-/obj/structure/table,
-/obj/item/folder/red{
-	pixel_x = 3
-	},
-/obj/item/folder/white{
-	pixel_x = -4;
-	pixel_y = 2
-	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 1;
@@ -16991,7 +16980,7 @@
 	network = list("Prison");
 	pixel_y = -30
 	},
-/obj/item/restraints/handcuffs,
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "aGs" = (
@@ -85480,11 +85469,16 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "dBH" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
-	icon_state = "0-4";
-	d2 = 4
+	d1 = 1;
+	d2 = 2;
+	icon_state = "1-2"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	name = "Security Desk";
+	req_access_txt = "63"
 	},
 /turf/open/floor/plating,
 /area/security/brig)
@@ -115117,7 +115111,7 @@ axm
 dBD
 azL
 aBf
-ajm
+ahx
 aDF
 aEW
 aGq

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -4821,11 +4821,13 @@
 "ajE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajG" = (
@@ -4840,11 +4842,13 @@
 "ajH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/landmark/secequipment,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault,
 /area/security/main)
 "ajJ" = (


### PR DESCRIPTION
:cl: deathride58
tweak: Boxstation security's equipment room is now two tiles larger. The security vendor, biohazard locker, and bomb suit locker are now on the same wall as the rest of the sec equipment lockers.
tweak: Boxstation's security equipment room is now equipped with two secways.
tweak: Security on all maps no longer contain chem dispensers or chemmasters.
tweak: All maps now share the same vulnerability involving the security desk that Boxstation does.
tweak: Deltastation now has windows surrounding the lethal weaponry in the armory, similar to Boxstation's armory.
tweak: Deltastation's map changes have been restored after the previous sync.
tweak: Boxstation's security lobby disposals has been fixed
tweak: Fixed stray r-wall between the evidence room and cell 1 in Boxstation.
tweak: Replaced the blast doors in Boxstation's security lobby with shutters.
tweak: Boxstation now has markings where extra security equipment will spawn.
/:cl:

Screenshots!
![image](https://user-images.githubusercontent.com/6356337/31739791-21c62d1c-b41d-11e7-9f51-be35ade132a3.png)
![image](https://user-images.githubusercontent.com/6356337/31739845-51e0a720-b41d-11e7-829e-d48ce3d01c7f.png)
Metastation and Deltastation now share the same vulnerability involving the security desk that Boxstation does.

![image](https://user-images.githubusercontent.com/6356337/31739821-3e1b10d6-b41d-11e7-835c-4fa7dbe04941.png)
Deltastation's armory now has windows surrounding lethal weaponry. Self-explanatory.

![image](https://user-images.githubusercontent.com/6356337/31739891-71a23376-b41d-11e7-9030-0d523d79405d.png)
Self-explanatory.