### PR TITLE
removes riot foam darts from autolathe

### DIFF
--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -655,7 +655,7 @@
 	materials = list(MAT_METAL = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
 	category = list("hacked", "Security")
-
+/*
 /datum/design/riot_dart
 	name = "Foam riot dart"
 	id = "riot_dart"
@@ -671,7 +671,7 @@
 	materials = list(MAT_METAL = 50000) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
 	category = list("hacked", "Security")
-
+*/
 /datum/design/a357
 	name = "Ammo box (.357)"
 	id = "a357"


### PR DESCRIPTION
With the new accessibility of dart guns introduced by Camile's memeguns, this has become a bit of a problem, especially with public autholathes existing on most maps. This PR removes them from the autolathe. I was thinking of adding them to a contraband crate in cargo (I.E the stuff you get from multitooling the board, not emagging the console), but I'll wait for more feedback about this PR

🆑 Cebutris
del: riot foam darts removed from autolathe
/ 🆑 