### PR TITLE
Undoes Borer HUDs

### DIFF
--- a/code/__DEFINES/atom_hud.dm
+++ b/code/__DEFINES/atom_hud.dm
@@ -40,8 +40,7 @@
 #define ANTAG_HUD_SINTOUCHED	16
 #define ANTAG_HUD_SOULLESS		17
 #define ANTAG_HUD_CLOCKWORK		18
-#define ANTAG_HUD_BORER			19
-#define ANTAG_HUD_BROTHER		20
+#define ANTAG_HUD_BROTHER		19
 
 // Notification action types
 #define NOTIFY_JUMP "jump"

--- a/code/datums/hud.dm
+++ b/code/datums/hud.dm
@@ -20,7 +20,6 @@ GLOBAL_LIST_INIT(huds, list(
 	ANTAG_HUD_SINTOUCHED = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_SOULLESS = new/datum/atom_hud/antag/hidden(),
 	ANTAG_HUD_CLOCKWORK = new/datum/atom_hud/antag(),
-	ANTAG_HUD_BORER = new/datum/atom_hud/antag(),
 	ANTAG_HUD_BROTHER = new/datum/atom_hud/antag/hidden(),
 	))
 

--- a/code/game/gamemodes/antag_spawner_cit.dm
+++ b/code/game/gamemodes/antag_spawner_cit.dm
@@ -26,7 +26,7 @@ obj/item/antag_spawner/syndi_borer/spawn_antag(client/C, turf/T, mob/owner)
 		to_chat(B, "<B>You are awake at last! Seek out whoever released you and aid them as best you can!</B>")
 		if(new_objective)
 			to_chat(B, "<B>Objective #[1]</B>: [new_objective.explanation_text]")
-		SSticker.mode.update_borer_icons_added(B)
+
 /obj/item/antag_spawner/syndi_borer/proc/check_usability(mob/user)
 	if(used)
 		to_chat(user, "<span class='warning'>[src] appears to be empty!</span>")

--- a/code/game/gamemodes/miniantags/borer/borer.dm
+++ b/code/game/gamemodes/miniantags/borer/borer.dm
@@ -415,7 +415,6 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 	victim = C
 	forceMove(victim)
 
-	SSticker.mode.update_borer_icons_added_host(victim.mind)
 
 	RemoveBorerActions()
 	GrantInfestActions()
@@ -591,7 +590,6 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 	var/mob/living/V = victim
 	V.verbs -= /mob/living/proc/borer_comm
 	talk_to_borer_action.Remove(victim)
-	SSticker.mode.update_borer_icons_removed_host(victim.mind)
 	victim = null
 	return
 
@@ -1099,27 +1097,3 @@ GLOBAL_VAR_INIT(total_borer_hosts_needed, 10)
 /datum/action/innate/borer/jumpstart_host/Activate()
 	var/mob/living/simple_animal/borer/B = owner
 	B.jumpstart()
-
-
-//HUD STUFF
-/datum/game_mode/proc/update_borer_icons_added(datum/mind/borer_mind)
-	var/datum/atom_hud/antag/borerhud = GLOB.huds[ANTAG_HUD_BORER]
-	borerhud.join_hud(borer_mind.current)
-	set_antag_hud(borer_mind.current, "hudbrainworm")
-
-/datum/game_mode/proc/update_borer_icons_removed(datum/mind/borer_mind)
-	var/datum/atom_hud/antag/borerhud = GLOB.huds[ANTAG_HUD_BORER]
-	borerhud.leave_hud(borer_mind.current)
-	set_antag_hud(borer_mind.current, null)
-
-/datum/game_mode/proc/update_borer_icons_added_host(datum/mind/host_mind)
-	var/datum/atom_hud/antag/hosthud = GLOB.huds[ANTAG_HUD_BORER] //Invisible to self
-	hosthud.self_visible = FALSE
-	hosthud.join_hud(host_mind.current)
-	set_antag_hud(host_mind.current, "hudbrainworm")
-
-/datum/game_mode/proc/update_borer_icons_removed_host(datum/mind/host_mind)
-	var/datum/atom_hud/antag/hosthud = GLOB.huds[ANTAG_HUD_BORER] //Invisible to self
-	hosthud.self_visible = FALSE //Probably not needed as we're deleting?
-	hosthud.leave_hud(host_mind.current)
-	set_antag_hud(host_mind.current, null)


### PR DESCRIPTION
:cl:ktccd
del: Removed borer-HUDs
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
Critical flaw in antag-HUD system prevented proper use, since automatic reverting of original PR is no longer possible, (Probably due to another antag-hud being added afterwards), this is a manual one.
Basically, antag-HUDs can only ever have ONE icon, and the latest one applied undoes any previous ones.
This is kind of a flaw in how antag-HUDs work in general, so this bug exists in many places, but seeing as I'm maintaining borers, I'm removing it for them, it was only a minor quality-of-life thing anyway, not very critical. Refactoring antag-HUDs to work with more than 1 antag is waaaaay outside what I can reasonably do...