### PR TITLE
Fixes LOOC error messages not appearing in goonchat

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -4,12 +4,12 @@
 	set category = "OOC"
 
 	if(GLOB.say_disabled)	//This is here to try to identify lag problems
-		usr << "<span class='danger'> Speech is currently admin-disabled.</span>"
+		to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
 		return
 
 	if(!mob)	return
 	if(IsGuestKey(key))
-		src << "Guests may not use OOC."
+		to_chat(src, "Guests may not use OOC.")
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
@@ -17,23 +17,23 @@
 		return
 
 	if(!(prefs.toggles & CHAT_OOC))
-		src << "<span class='danger'> You have OOC muted.</span>"
+		to_chat(src, "<span class='danger'> You have OOC muted.</span>")
 		return
 
 	if(!holder)
 		if(!GLOB.ooc_allowed)
-			src << "<span class='danger'> OOC is globally muted</span>"
+			to_chat(src, "<span class='danger'> OOC is globally muted</span>")
 			return
 		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
-			usr << "<span class='danger'> OOC for dead mobs has been turned off.</span>"
+			to_chat(usr, "<span class='danger'> OOC for dead mobs has been turned off.</span>")
 			return
 		if(prefs.muted & MUTE_OOC)
-			src << "<span class='danger'> You cannot use OOC (muted).</span>"
+			to_chat(src, "<span class='danger'> You cannot use OOC (muted).</span>")
 			return
 		if(handle_spam_prevention(msg,MUTE_OOC))
 			return
 		if(findtext(msg, "byond://"))
-			src << "<B>Advertising other servers is not allowed.</B>"
+			to_chat(src, "<B>Advertising other servers is not allowed.</B>")
 			log_admin("[key_name(src)] has attempted to advertise in LOOC: [msg]")
 			return
 


### PR DESCRIPTION
Errors were still using << instead of to_chat()

:cl: deathride58
fix: Fixed LOOC error messages not appearing in goonchat
/:cl: