### PR TITLE
Fixes certain crew objectives giving out red text

### DIFF
--- a/code/citadel/crew_objectives/cit_crewobjectives_civilian.dm
+++ b/code/citadel/crew_objectives/cit_crewobjectives_civilian.dm
@@ -23,7 +23,7 @@
 
 /datum/objective/crew/druglordbot/check_completion()
 	var/pillcount = target_amount
-	if(owner.current)
+	if(owner && owner.current)
 		if(owner.current.contents)
 			for(var/obj/item/reagent_containers/food/snacks/grown/P in owner.current.get_contents())
 				if(P.reagents.has_reagent(targetchem))
@@ -53,7 +53,7 @@
 	explanation_text = "Personally deliver at least [target_amount] [initial(foodpath.name)]s to Centcom."
 
 /datum/objective/crew/foodhoard/check_completion()
-	if(owner.current && owner.current.check_contents_for(foodpath) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
+	if(owner && owner.current && owner.current.check_contents_for(foodpath) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
 		return TRUE
 	else
 		return FALSE
@@ -151,8 +151,9 @@
 
 /datum/objective/crew/nullrod/check_completion()
 	if(owner && owner.current)
-		if(owner.current.check_contents_for(typesof(/obj/item/nullrod)))
-			return TRUE
+		for(var/nullrodtypes in typesof(/obj/item/nullrod))
+			if(owner.current.check_contents_for(nullrodtypes))
+				return TRUE
 		if(owner.current.getorgan(/obj/item/organ/genital/penis))
 			return TRUE
 	return FALSE
@@ -227,10 +228,11 @@
 			explanation_text += "on a space suit." replace this if you're making this monstrosity work	*/
 
 /datum/objective/crew/pwrgame/check_completion()
-	if(owner.current && owner.current.check_contents_for(typesof(targettidegarb)))
-		return TRUE
-	else
-		return FALSE
+	if(owner && owner.current)
+		for(var/tidegarbtypes in typesof(targettidegarb))
+			if(owner.current.check_contents_for(tidegarbtypes))
+				return TRUE
+	return FALSE
 
 /datum/objective/crew/promotion //ported from Goon
 	explanation_text = "Have a non-assistant ID registered to you at the end of the shift."

--- a/code/citadel/crew_objectives/cit_crewobjectives_civilian.dm
+++ b/code/citadel/crew_objectives/cit_crewobjectives_civilian.dm
@@ -23,7 +23,7 @@
 
 /datum/objective/crew/druglordbot/check_completion()
 	var/pillcount = target_amount
-	if(owner && owner.current)
+	if(owner.current)
 		if(owner.current.contents)
 			for(var/obj/item/reagent_containers/food/snacks/grown/P in owner.current.get_contents())
 				if(P.reagents.has_reagent(targetchem))
@@ -53,7 +53,7 @@
 	explanation_text = "Personally deliver at least [target_amount] [initial(foodpath.name)]s to Centcom."
 
 /datum/objective/crew/foodhoard/check_completion()
-	if(owner && owner.current && owner.current.check_contents_for(foodpath) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
+	if(owner.current && owner.current.check_contents_for(foodpath) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
 		return TRUE
 	else
 		return FALSE
@@ -151,9 +151,8 @@
 
 /datum/objective/crew/nullrod/check_completion()
 	if(owner && owner.current)
-		for(var/nullrodtypes in typesof(/obj/item/nullrod))
-			if(owner.current.check_contents_for(nullrodtypes))
-				return TRUE
+		if(owner.current.check_contents_for(typesof(/obj/item/nullrod)))
+			return TRUE
 		if(owner.current.getorgan(/obj/item/organ/genital/penis))
 			return TRUE
 	return FALSE
@@ -228,11 +227,10 @@
 			explanation_text += "on a space suit." replace this if you're making this monstrosity work	*/
 
 /datum/objective/crew/pwrgame/check_completion()
-	if(owner && owner.current)
-		for(var/tidegarbtypes in typesof(targettidegarb))
-			if(owner.current.check_contents_for(tidegarbtypes))
-				return TRUE
-	return FALSE
+	if(owner.current && owner.current.check_contents_for(typesof(targettidegarb)))
+		return TRUE
+	else
+		return FALSE
 
 /datum/objective/crew/promotion //ported from Goon
 	explanation_text = "Have a non-assistant ID registered to you at the end of the shift."

--- a/code/citadel/crew_objectives/cit_crewobjectives_command.dm
+++ b/code/citadel/crew_objectives/cit_crewobjectives_command.dm
@@ -5,7 +5,7 @@
 	jobs = "captain"
 
 /datum/objective/crew/caphat/check_completion()
-	if(owner.current && owner.current.check_contents_for(/obj/item/clothing/head/caphat))
+	if(owner && owner.current && owner.current.check_contents_for(/obj/item/clothing/head/caphat))
 		return TRUE
 	else
 		return FALSE
@@ -15,7 +15,7 @@
 	jobs = "captain" //give this to other heads at your own risk.
 
 /datum/objective/crew/datfukkendisk/check_completion()
-	if(owner.current && owner.current.check_contents_for(/obj/item/disk/nuclear) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
+	if(owner && owner.current && owner.current.check_contents_for(/obj/item/disk/nuclear) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
 		return TRUE
 	else
 		return FALSE
@@ -25,7 +25,7 @@
 	jobs = "headofpersonnel"
 
 /datum/objective/crew/ian/check_completion()
-	if(owner.current)
+	if(owner && owner.current)
 		for(var/mob/living/simple_animal/pet/dog/corgi/Ian/goodboy in GLOB.mob_list)
 			if(goodboy.stat != DEAD && SSshuttle.emergency.shuttle_areas[get_area(goodboy)])
 				return TRUE

--- a/code/citadel/crew_objectives/cit_crewobjectives_command.dm
+++ b/code/citadel/crew_objectives/cit_crewobjectives_command.dm
@@ -5,7 +5,7 @@
 	jobs = "captain"
 
 /datum/objective/crew/caphat/check_completion()
-	if(owner && owner.current && owner.current.check_contents_for(/obj/item/clothing/head/caphat))
+	if(owner.current && owner.current.check_contents_for(/obj/item/clothing/head/caphat))
 		return TRUE
 	else
 		return FALSE
@@ -15,7 +15,7 @@
 	jobs = "captain" //give this to other heads at your own risk.
 
 /datum/objective/crew/datfukkendisk/check_completion()
-	if(owner && owner.current && owner.current.check_contents_for(/obj/item/disk/nuclear) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
+	if(owner.current && owner.current.check_contents_for(/obj/item/disk/nuclear) && SSshuttle.emergency.shuttle_areas[get_area(owner.current)])
 		return TRUE
 	else
 		return FALSE
@@ -25,7 +25,7 @@
 	jobs = "headofpersonnel"
 
 /datum/objective/crew/ian/check_completion()
-	if(owner && owner.current)
+	if(owner.current)
 		for(var/mob/living/simple_animal/pet/dog/corgi/Ian/goodboy in GLOB.mob_list)
 			if(goodboy.stat != DEAD && SSshuttle.emergency.shuttle_areas[get_area(goodboy)])
 				return TRUE


### PR DESCRIPTION
:cl: deathride58
fix: The assistant objective revolving around finding specific items now functions properly.
fix: The objective for chaplains keeping their null rod is now 100% functional.
fix: Various other crew objectives will no longer be subject to failing randomly for no discernible reason.
/:cl:

Either TG removed support for lists in check_contents_for, or I seriously need to stop drinking when testing things. Either way, my shitcode is fixed now.

Also adds an additional check for just the "owner" variable for objectives that were missing it, since BYOND has a nasty habit of randomly assuming referenced variables are null unless that variable has been confirmed to exist via an if(var).

