### PR TITLE
Further rebalancing of Cit_guns projectiles

### DIFF
--- a/code/citadel/cit_guns.dm
+++ b/code/citadel/cit_guns.dm
@@ -213,6 +213,8 @@
 	damage = 15
 	armour_penetration = 10
 	light_range = 2
+	speed = 1.2
+	range = 25
 	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/bullet/nlmags //non-lethal boolets
@@ -220,9 +222,11 @@
 	icon_state = "magjectile-nl"
 	damage = 1
 	knockdown = 0
-	stamina = 25
+	stamina = 30
 	armour_penetration = -10
 	light_range = 2
+	speed = 1.2
+	range = 25
 	light_color = LIGHT_COLOR_BLUE
 
 
@@ -378,19 +382,23 @@
 /obj/item/projectile/bullet/magrifle
 	icon = 'icons/obj/guns/cit_guns.dmi'
 	icon_state = "magjectile-large"
-	damage = 25
+	damage = 20
 	armour_penetration = 25
 	light_range = 3
+	speed = 1.2
+	range = 35
 	light_color = LIGHT_COLOR_RED
 
 /obj/item/projectile/bullet/nlmagrifle //non-lethal boolets
 	icon = 'icons/obj/guns/cit_guns.dmi'
 	icon_state = "magjectile-large-nl"
-	damage = 2
+	damage = 1
 	knockdown = 0
-	stamina = 30
+	stamina = 35
 	armour_penetration = -10
 	light_range = 3
+	speed = 1.0
+	range = 35
 	light_color = LIGHT_COLOR_BLUE
 
 ///ammo casings///
@@ -1070,12 +1078,16 @@ obj/item/projectile/bullet/c10mm/soporific
 	name = "9mm frangible bullet"
 	damage = 15
 	stamina = 0
+	speed = 1.0
+	range = 20
 	armour_penetration = -25
 
 /obj/item/projectile/bullet/c9mm/rubber
 	name = "9mm rubber bullet"
-	damage = 2
-	stamina = 25
+	damage = 5
+	stamina = 30
+	speed = 1.2
+	range = 14
 	knockdown = 0
 
 /obj/item/ammo_casing/c9mm/frangible

--- a/code/citadel/cit_guns.dm
+++ b/code/citadel/cit_guns.dm
@@ -1132,9 +1132,9 @@ obj/item/projectile/bullet/c10mm/soporific
 	name = "Box of 9mm Frangible Bullets"
 	id = "9mm_frag"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
+	materials = list(MAT_METAL = 25000)
 	build_path = /obj/item/ammo_box/c9mm/frangible
-	category = list("initial", "Security")
+	category = list("hacked", "Security")
 
 /datum/design/c9mmrubber
 	name = "Box of 9mm Rubber Bullets"


### PR DESCRIPTION
:cl: Toriate
balance: Mag weapon projectiles now have slower projectile speeds and reduced range. Non-lethal shots brought up to 3 shots to knockdown, lethal shots now weaker than ever.
balance: Non-lethal 9mms now have drastically lower range and slower projectile speeds
/:cl:


The changes to the magweapon projectiles should make them less broken, require more skill to land hits, and not excessively weak.

The 9mms are still unimplemented after their hasty removal, and probably won't be coming back anytime soon despite me touching them in this PR. The reduced range of rubber shots would bring them closer to tasers, except slower still, and with no instastun. The frangible bullets now make more sense for reducing collateral damage due to their 20 tile range.