### PR TITLE
Polishes code for cit's recolorable assets

### DIFF
--- a/code/citadel/cit_guns.dm
+++ b/code/citadel/cit_guns.dm
@@ -1068,6 +1068,7 @@ obj/item/projectile/bullet/c10mm/soporific
 				if(arm_color_input)
 					arm_color = sanitize_hexcolor(arm_color_input, desired_format=6, include_crunch=1)
 				update_icon()
+				A.UpdateButtonIcon()
 
 	else
 		..()
@@ -1210,6 +1211,10 @@ obj/item/gun/energy/e_gun/cx/update_icon()
 		body_overlay.color = body_color
 	add_overlay(body_overlay)
 
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_hands()
+
 obj/item/gun/energy/e_gun/cx/ui_action_click(mob/user, var/datum/action/A)
 	if(istype(A, /datum/action/item_action/pick_color))
 		if(alert("Are you sure you want to repaint your gun?", "Confirm Repaint", "Yes", "No") == "Yes")
@@ -1217,6 +1222,7 @@ obj/item/gun/energy/e_gun/cx/ui_action_click(mob/user, var/datum/action/A)
 			if(body_color_input)
 				body_color = sanitize_hexcolor(body_color_input, desired_format=6, include_crunch=1)
 		update_icon()
+		A.UpdateButtonIcon()
 	else
 		..()
 

--- a/code/citadel/cit_weapons.dm
+++ b/code/citadel/cit_weapons.dm
@@ -32,6 +32,10 @@
 		set_light(0)
 		update_icon()
 
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
+
 	add_fingerprint(user)
 
 /obj/item/toy/sword/cx/update_icon()
@@ -49,6 +53,10 @@
 	if(active)
 		add_overlay(blade_overlay)
 
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_hands()
+
 /obj/item/toy/sword/cx/ui_action_click(mob/user, var/datum/action/A)
 	if(istype(A, /datum/action/item_action/pick_color))
 		if(alert("Are you sure you want to recolor your blade?", "Confirm Repaint", "Yes", "No") == "Yes")
@@ -56,10 +64,8 @@
 			if(energy_color_input)
 				light_color = sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1)
 			update_icon()
-			if(ismob(loc))
-				var/mob/M = loc
-				M.update_inv_hands()
 			update_light()
+			A.UpdateButtonIcon()
 
 	else
 		..()
@@ -146,6 +152,9 @@
 		update_icon()
 	transform_messages(user, supress_message_text)
 	add_fingerprint(user)
+	for(var/X in actions)
+		var/datum/action/A = X
+		A.UpdateButtonIcon()
 	return TRUE
 
 /obj/item/melee/transforming/energy/sword/cx/transform_messages(mob/living/user, supress_message_text)
@@ -168,6 +177,10 @@
 	if(active)
 		add_overlay(blade_overlay)
 
+	if(ismob(loc))
+		var/mob/M = loc
+		M.update_inv_hands()
+
 /obj/item/melee/transforming/energy/sword/cx/ui_action_click(mob/user, var/datum/action/A)
 	if(istype(A, /datum/action/item_action/pick_color))
 		if(alert("Are you sure you want to recolor your blade?", "Confirm Repaint", "Yes", "No") == "Yes")
@@ -175,10 +188,8 @@
 			if(energy_color_input)
 				light_color = sanitize_hexcolor(energy_color_input, desired_format=6, include_crunch=1)
 			update_icon()
-			if(ismob(loc))
-				var/mob/M = loc
-				M.update_inv_hands()
 			update_light()
+			A.UpdateButtonIcon()
 
 	else
 		..()


### PR DESCRIPTION
:cl: Toriate
tweak: Recolorable items now update their button icon when recolored, however due to an upstream issue with overlays and button icons, it's a bit wonky
tweak: Recolorable items with recolorable inhands have had their inhand update procs moved under the update icon proc instead of being part of the recolor button code
tweak: Model D's inhand sprites will now actually update upon recoloring
/:cl:


This should make the recolorable guns and NEBs update their action button icons when recolored, however due to what I think is an upstream issue with overlays and action button icons, the icons will always be "one step behind". Regardless, having it actually be one step behind is a marginal improvement from only updating when the items are dropped and picked back up.

Also, the egun's inhands will now update upon recoloring, unlike its previous behavior of needing to have its modes cycled in order to update the inhand sprite to reflect its actual color.

Honestly, I'm not sure if any of the "optimizations" (moving the inhand updating procs to be called under the update icon proc) in this PR are actually good, so if anyone could point out any flaws in my logic, that'd be great.