### PR TITLE
Boxstation Edits: Legless Warden edition

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -60533,7 +60533,7 @@
 "Qvy" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
-/area/space)
+/area/maintenance/starboard/fore)
 "Qvz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -107043,7 +107043,7 @@ aaf
 aaf
 aaf
 aaf
-QoE
+alP
 Qvy
 alP
 anf
@@ -107300,8 +107300,8 @@ aaa
 aaa
 aaa
 aaa
-QoE
-QoE
+alP
+alP
 alP
 anf
 alP

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -888,6 +888,7 @@
 /area/security/main)
 "acr" = (
 /obj/structure/chair/comfy/black,
+/obj/effect/landmark/start/head_of_security,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
 "acs" = (
@@ -2141,16 +2142,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/rack,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = -3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas/sechailer,
-/obj/item/clothing/mask/gas/sechailer{
-	pixel_x = 3;
-	pixel_y = -3
-	},
+/obj/structure/closet/secure_closet/warden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aeX" = (
@@ -2570,7 +2562,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/landmark/start/head_of_security,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -2737,7 +2728,6 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "agr" = (
-/obj/machinery/computer/secure_data,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -2948,6 +2938,9 @@
 "agT" = (
 /obj/structure/cable{
 	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -3194,9 +3187,6 @@
 /area/security/warden)
 "ahx" = (
 /obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
 	icon_state = "2-4"
 	},
 /obj/structure/cable{
@@ -3215,8 +3205,8 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -3415,7 +3405,7 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ahQ" = (
-/obj/structure/closet/secure_closet/warden,
+/obj/machinery/computer/security,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -3441,7 +3431,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahS" = (
-/obj/structure/table,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -3481,7 +3470,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahY" = (
@@ -3549,14 +3537,12 @@
 	},
 /area/security/brig)
 "aie" = (
-/obj/structure/table,
-/obj/item/folder/red,
-/obj/item/pen,
-/obj/item/hand_labeler,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/item/book/manual/wiki/security_space_law,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aif" = (
@@ -3815,42 +3801,33 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aiJ" = (
-/obj/structure/table/reinforced,
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/door/window/brigdoor{
-	dir = 1;
-	name = "Armory Desk";
-	req_access_txt = "3"
-	},
-/obj/machinery/door/window/southleft{
-	name = "Reception Desk";
-	req_access_txt = "63"
-	},
-/obj/item/paper_bin{
-	pixel_x = -3;
-	pixel_y = 7
-	},
-/obj/item/pen{
-	pixel_x = 4;
-	pixel_y = 4
-	},
+/obj/machinery/computer/crew,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aiK" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/warden,
+/obj/machinery/button/door{
+	id = "Prison Gate";
+	name = "Prison Wing Lockdown";
+	pixel_x = -27;
+	pixel_y = 8;
+	req_access_txt = "2"
+	},
+/obj/machinery/button/door{
+	id = "seclobby";
+	name = "Security Lobby Lockdown";
+	pixel_x = -27;
+	pixel_y = -2;
+	req_access_txt = "2"
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "1-2"
 	},
-/obj/structure/cable,
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "aiL" = (
 /obj/structure/cable{
@@ -3900,6 +3877,10 @@
 /area/security/brig)
 "aiR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 2;
+	pixel_y = 24
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
@@ -3970,18 +3951,15 @@
 /obj/structure/sign/goldenplaque{
 	pixel_y = 32
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
 /area/security/brig)
 "aje" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/machinery/firealarm{
-	dir = 2;
-	pixel_y = 24
-	},
+/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/red/side{
-	dir = 1
+	dir = 9
 	},
 /area/security/brig)
 "ajf" = (
@@ -3998,6 +3976,7 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajh" = (
@@ -4229,11 +4208,12 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side{
+	dir = 8
+	},
 /area/security/brig)
 "ajK" = (
 /obj/structure/cable{
@@ -4554,6 +4534,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
 	},
@@ -4820,18 +4803,14 @@
 /area/security/brig)
 "akY" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "seclobby";
-	name = "security shutters"
-	},
-/obj/machinery/door/airlock/glass_security{
-	cyclelinkeddir = 2;
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 1;
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -5568,6 +5547,15 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
+/obj/machinery/button/door{
+	desc = "A remote control switch for the medbay foyer.";
+	id = "lobbyairlock";
+	name = "Security Lobby Doors Control";
+	normaldoorcontrol = 1;
+	pixel_x = -26;
+	pixel_y = -2;
+	req_access_txt = "63"
+	},
 /turf/open/floor/plasteel/black,
 /area/security/brig)
 "amU" = (
@@ -5980,12 +5968,12 @@
 /area/hallway/primary/fore)
 "anU" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass{
-	name = "Courtroom"
-	},
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "seclobby";
 	name = "security shutters"
+	},
+/obj/machinery/door/airlock/glass{
+	name = "Courtroom"
 	},
 /turf/open/floor/plasteel/black,
 /area/security/courtroom)
@@ -6219,6 +6207,7 @@
 	codes_txt = "patrol;next_patrol=EVA";
 	location = "Security"
 	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aoz" = (
@@ -6241,7 +6230,6 @@
 	dir = 1;
 	pixel_y = -24
 	},
-/obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/red/side{
 	dir = 10
 	},
@@ -13719,9 +13707,6 @@
 "aHp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/structure/filingcabinet/chestdrawer,
 /turf/open/floor/plasteel/showroomfloor,
@@ -49831,6 +49816,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "csT" = (
@@ -52901,6 +52889,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cAu" = (
@@ -53041,7 +53032,9 @@
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "cAQ" = (
-/obj/structure/chair,
+/obj/structure/chair{
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cAR" = (
@@ -54719,6 +54712,9 @@
 /area/engine/engineering)
 "cGu" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGv" = (
@@ -54726,32 +54722,33 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGx" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
+/obj/machinery/meter,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/atmospherics/components/binary/valve/digital{
+	dir = 4;
+	name = "Output Release"
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
 "cGD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cGE" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -54762,8 +54759,8 @@
 /area/engine/engineering)
 "cGH" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -54786,11 +54783,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cGL" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cGM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -54897,32 +54893,34 @@
 /area/engine/engineering)
 "cHl" = (
 /obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cHn" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHo" = (
 /obj/structure/reflector/single/anchored{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cHp" = (
 /obj/structure/reflector/single/anchored{
 	dir = 5
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/black,
 /area/engine/engineering)
 "cHr" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/light,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cHs" = (
@@ -57859,6 +57857,10 @@
 /obj/structure/window/reinforced,
 /obj/vehicle/secway,
 /obj/item/key/security,
+/obj/machinery/door/window/eastleft{
+	name = "Secway Docking Port"
+	},
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "QoG" = (
@@ -58152,6 +58154,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "Qpk" = (
@@ -58343,15 +58346,13 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "QpI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/machinery/door_timer{
 	id = "Cell 2";
 	name = "Cell 2";
 	pixel_y = -32
 	},
 /obj/machinery/light,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel/red/corner,
 /area/security/brig)
 "QpJ" = (
@@ -58389,18 +58390,14 @@
 /area/security/brig)
 "QpM" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/glass_security{
-	cyclelinkeddir = 2;
-	id_tag = "innerbrig";
-	name = "Brig";
-	req_access_txt = "63"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "seclobby";
-	name = "security shutters"
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 1;
+	id_tag = "outerbrig";
+	name = "Brig";
+	req_access_txt = "63"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 9
@@ -58560,7 +58557,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
-	id_tag = "outerbrig";
+	id_tag = "lobbyairlock";
 	name = "Security Lobby";
 	req_access_txt = "0"
 	},
@@ -58596,7 +58593,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/glass_security{
 	cyclelinkeddir = 1;
-	id_tag = "outerbrig";
+	id_tag = "lobbyairlock";
 	name = "Security Lobby";
 	req_access_txt = "0"
 	},
@@ -58696,9 +58693,6 @@
 /turf/open/floor/wood,
 /area/maintenance/bar/cafe)
 "QqD" = (
-/obj/structure/chair/wood{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
@@ -58708,7 +58702,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/table/wood,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -58718,9 +58711,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/structure/chair/wood{
-	dir = 8
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar/cafe)
@@ -58995,14 +58985,7 @@
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/theatre/clown)
 "Qrn" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/item/bikehorn,
+/obj/structure/displaycase/clown,
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/theatre/clown)
 "Qro" = (
@@ -59649,7 +59632,8 @@
 	},
 /area/maintenance/bar)
 "Qth" = (
-/obj/machinery/vending/boozeomat,
+/obj/structure/table/wood,
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "Qti" = (
@@ -59723,7 +59707,7 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "Qts" = (
-/obj/machinery/chem_dispenser/drinks,
+/obj/item/storage/box/drinkingglasses,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -59875,14 +59859,13 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "QtX" = (
-/obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/wood{
 	icon_state = "wood-broken"
 	},
 /area/maintenance/bar)
 "QtY" = (
-/obj/structure/table/wood/poker,
+/obj/structure/chair/stool,
 /turf/open/floor/wood{
 	icon_state = "wood-broken7"
 	},
@@ -60349,6 +60332,365 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
+"Qvg" = (
+/obj/structure/window/reinforced,
+/obj/machinery/door/window/eastleft{
+	name = "Cyborg Docking Port"
+	},
+/obj/machinery/recharge_station,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/main)
+"Qvh" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/warden";
+	dir = 1;
+	name = "Brig Control APC";
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"Qvi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/rack,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas/sechailer,
+/obj/item/clothing/mask/gas/sechailer{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"Qvj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
+"Qvk" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"Qvl" = (
+/obj/machinery/computer/secure_data,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"Qvm" = (
+/obj/structure/table,
+/obj/item/folder/red,
+/obj/item/pen,
+/obj/item/hand_labeler,
+/obj/item/book/manual/wiki/security_space_law,
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"Qvn" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/window/brigdoor{
+	dir = 1;
+	name = "Armory Desk";
+	req_access_txt = "3"
+	},
+/obj/machinery/door/window/southleft{
+	name = "Reception Desk";
+	req_access_txt = "63"
+	},
+/obj/item/paper_bin{
+	pixel_x = -3;
+	pixel_y = 7
+	},
+/obj/item/pen{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/security/warden)
+"Qvo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 4
+	},
+/area/security/brig)
+"Qvp" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/brig)
+"Qvq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 1
+	},
+/area/security/brig)
+"Qvr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 2;
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 9
+	},
+/area/security/brig)
+"Qvs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/red/side,
+/area/security/brig)
+"Qvt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/corner{
+	dir = 8
+	},
+/area/security/brig)
+"Qvu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/glass_security{
+	cyclelinkeddir = 2;
+	id_tag = "innerbrig";
+	name = "Brig";
+	req_access_txt = "63"
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/security/brig)
+"Qvv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 10
+	},
+/area/security/brig)
+"Qvw" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "seclobby";
+	name = "security shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
+"Qvx" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "seclobby";
+	name = "security shutters"
+	},
+/turf/open/floor/plating,
+/area/security/brig)
+"Qvy" = (
+/obj/machinery/vending/kink,
+/turf/open/floor/plating,
+/area/space)
+"Qvz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvG" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"QvH" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"QvI" = (
+/obj/structure/table/wood/poker,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/storage/pill_bottle/dice,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"QvJ" = (
+/turf/closed/wall,
+/area/engine/gravity_generator)
+"QvK" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"QvL" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"QvM" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"QvN" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"QvO" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"QvP" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"QvQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"QvR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/binary/valve{
+	dir = 4;
+	name = "Output to Waste"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"QvS" = (
+/obj/structure/table,
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvV" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvY" = (
+/obj/structure/girder,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"QvZ" = (
+/obj/structure/rack,
+/obj/item/wrench,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
+"Qwa" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"Qwb" = (
+/obj/machinery/light,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"Qwc" = (
+/obj/structure/rack,
+/obj/item/crowbar/large,
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel/black,
+/area/engine/engineering)
 
 (1,1,1) = {"
 aaa
@@ -80245,7 +80587,7 @@ avY
 axo
 ayB
 Qqu
-QqB
+Qqz
 QqK
 QqR
 QqV
@@ -80812,7 +81154,7 @@ aaa
 bCq
 bPV
 bCq
-Qsn
+Qsm
 bTw
 bCq
 bVD
@@ -80838,7 +81180,7 @@ aaa
 aaa
 aaf
 aaa
-bCq
+bLv
 bCq
 bLv
 bLv
@@ -81018,12 +81360,12 @@ ayC
 azH
 QqE
 aBS
-aDr
-aDr
-aDr
-aDr
-aDr
-aDr
+QqR
+QqR
+QqR
+QqR
+QqR
+QqR
 aLE
 aLE
 aOl
@@ -81070,7 +81412,7 @@ bCq
 bPW
 Qsl
 bSp
-bTv
+Qsq
 bCq
 bVC
 bWx
@@ -81096,7 +81438,7 @@ bLv
 bLv
 bLv
 bCq
-ciT
+bJe
 cqK
 crl
 bLv
@@ -81612,8 +81954,8 @@ bLv
 bCq
 cqv
 cqL
-bJe
-bLv
+ciT
+bCq
 Qoi
 aaT
 aaT
@@ -81786,7 +82128,7 @@ aag
 avY
 axo
 ayB
-Qqy
+Qqv
 QqH
 QqO
 aDv
@@ -81842,19 +82184,19 @@ bPY
 cOw
 bCq
 Qsr
-Qsy
-QsG
-QsQ
-Qtb
+Qsr
+Qsr
+Qsr
+Qsr
 Qtm
-Qtx
-QtH
-cjn
-cjn
-cjn
-cjn
-cjn
-cjn
+Qsr
+Qsr
+Qsr
+Qsr
+Qsr
+Qsr
+Qsr
+Qsr
 bUs
 bLv
 aaa
@@ -82098,20 +82440,20 @@ bCq
 bPX
 bRg
 bRg
-Qss
+Qsr
 Qsz
 bVG
 QsR
 Qtc
-Qtn
+Qsz
 Qty
-QtI
-bcU
+Qsr
+Qsz
 QtV
 bVG
-bcU
+Qsz
 Quq
-cjn
+Qsr
 bUs
 bLv
 aaa
@@ -82126,7 +82468,7 @@ aaa
 aaa
 aaf
 aaf
-QuD
+QvJ
 aaa
 QuJ
 bij
@@ -82308,7 +82650,7 @@ Qra
 Qrh
 Qrn
 Qrt
-aKx
+Qru
 aLE
 aMS
 aOi
@@ -82355,20 +82697,20 @@ bLv
 bQa
 bHE
 bHE
-Qst
+Qsr
 QsA
 QsH
 QsS
 Qtd
 Qto
-Qtz
+Qtd
 QtJ
-QtP
-QtW
+Qtd
+Qtd
 Qud
-Qum
+Qua
 Qur
-cjn
+Qsr
 bUs
 bLv
 aaf
@@ -82620,12 +82962,12 @@ Qte
 Qtp
 QtA
 QtK
-QtQ
+QtA
 QtX
 Que
 bdV
-bcU
-cjn
+Qsz
+Qsr
 bUs
 bLv
 aaa
@@ -82869,20 +83211,20 @@ bLv
 bHE
 bHE
 bSs
-Qsv
+Qsr
 QsC
 QsJ
 QsU
 Qtf
-Qtq
-bcU
+QsJ
+Qsz
 QtL
-QtR
-cCa
+QtS
+bdV
 Quf
 cCa
 Qus
-cjn
+Qsr
 bUs
 bLv
 aaa
@@ -82901,7 +83243,7 @@ QuF
 btF
 bsc
 QuQ
-QuU
+QuT
 QuZ
 bgN
 big
@@ -83126,20 +83468,20 @@ bCq
 bHE
 bRh
 bSr
-Qsw
+Qsr
 QsD
 QsK
 QsV
 Qtg
 Qtr
 QtB
-QtM
-bdV
+Qsr
+Qsz
 QtY
-Qug
+Quf
 cCa
 Qut
-cjn
+Qsr
 bUs
 bLv
 aaf
@@ -83158,8 +83500,8 @@ QuG
 btG
 QuM
 bsc
-QuV
-Qva
+QuT
+QuY
 bgN
 bii
 big
@@ -83383,20 +83725,20 @@ bCq
 bOK
 bCq
 bCq
-Qsx
+Qsr
 QsE
 QsL
 QsW
 Qth
 Qts
-QtC
-cjn
+Qsr
+Qsr
+Qsz
 bdV
-QtZ
-Quh
+QvI
 Qun
 bdV
-cjn
+Qsr
 bUs
 bLv
 aaa
@@ -83410,9 +83752,9 @@ coz
 cpn
 Quy
 Quz
-QuC
+Quz
 QuH
-QuI
+Quz
 QuN
 QuR
 QuW
@@ -83642,18 +83984,18 @@ bLv
 aaa
 bLv
 QsF
-QsM
-QsX
-Qti
-Qtt
-QtD
-bcU
-bcU
-bdV
+QsL
+Qsr
+Qsr
+Qsr
+Qsr
+Qsz
+Qsz
+Qsz
 Qui
 bdV
 Quu
-cjn
+Qsr
 bUs
 bLv
 aaa
@@ -83668,7 +84010,7 @@ cpm
 cjJ
 aaf
 aaf
-Qol
+QvK
 aaa
 QuO
 bgO
@@ -83898,19 +84240,19 @@ bHE
 bLv
 aaf
 bLv
-bUt
-QsN
+QsF
+QsL
 QsY
 Qtj
 Qtu
 QtE
-bcU
+Qsz
 QtS
 Qua
 Quj
-bcU
-bcU
-cjn
+Qsz
+Qsz
+Qsr
 bUs
 bLv
 aaf
@@ -83925,7 +84267,7 @@ cjJ
 cjJ
 aaa
 aaa
-Qol
+QvL
 aaf
 aaa
 aaa
@@ -84155,19 +84497,19 @@ bLv
 bCq
 aaa
 bLv
-bUt
-QsO
+QsF
+QsL
 QsZ
 Qtk
 Qtv
-QtF
+Qsr
 QtN
 QtT
 Qub
 Quk
 Quo
 Quv
-cjn
+Qsr
 bUs
 bCq
 aaa
@@ -84182,7 +84524,7 @@ cpo
 cjJ
 aaa
 aaa
-Qol
+QvM
 aaf
 Qoi
 aaa
@@ -84334,8 +84676,8 @@ afy
 agh
 afA
 Qpu
-QpA
-QpD
+Qpv
+Qpv
 aiV
 ajs
 akb
@@ -84415,15 +84757,15 @@ bTB
 bUv
 QsP
 Qta
-Qtl
-Qtw
-QtG
-QtO
-QtU
-Quc
-Qul
-Qup
-Quw
+Qta
+Qta
+Qta
+Qta
+Qta
+Qta
+Qta
+Qta
+Qta
 car
 bUs
 bCq
@@ -84592,7 +84934,7 @@ agg
 afA
 Qpv
 QpB
-QpE
+Qpv
 aiV
 ajr
 aka
@@ -84849,7 +85191,7 @@ afA
 afA
 Qpw
 QpC
-QpF
+Qpv
 aiV
 aju
 akd
@@ -85629,7 +85971,7 @@ afL
 aez
 ahU
 aiX
-anz
+anw
 aov
 cCi
 air
@@ -85886,7 +86228,7 @@ ajc
 afM
 afN
 aiX
-anz
+anw
 aov
 cCi
 aqX
@@ -86143,7 +86485,7 @@ adL
 ahr
 aih
 aiX
-anz
+anw
 aov
 ape
 arT
@@ -86400,7 +86742,7 @@ agj
 agj
 agj
 aiX
-anQ
+Qqf
 aov
 cCi
 apU
@@ -87027,7 +87369,7 @@ aaT
 aaf
 aaf
 aaf
-aaa
+Qoi
 aaa
 aaa
 aaa
@@ -87532,15 +87874,15 @@ cFI
 cGd
 cGs
 cGr
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+aaa
 aaa
 aaf
-aaa
-aaf
-aaa
-aaa
-aaa
-aaf
-aaa
 aaa
 aaa
 aaa
@@ -87682,7 +88024,7 @@ aja
 akl
 akP
 alx
-amh
+QpP
 ami
 aiX
 anw
@@ -87720,7 +88062,7 @@ aZP
 bbh
 bcc
 bdd
-bbX
+QvH
 bfr
 bbX
 bif
@@ -87789,16 +88131,16 @@ cqb
 cAo
 cGt
 cgx
-ccw
-ccw
-ccw
-ccw
+QvS
+csd
+cHa
+csd
+QvZ
 ccw
 aaa
 Qod
 aaT
 Qod
-aaa
 aaa
 aaa
 aaa
@@ -88046,16 +88388,16 @@ cFJ
 cSH
 cGu
 cGH
+QvT
+QvW
 cGR
-cHa
 csd
-ciZ
+csd
 ccw
 aaa
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -88245,10 +88587,10 @@ aaa
 Qoi
 aaa
 QrT
-bsb
-bsb
-bsb
-bsb
+QrT
+QrT
+QrT
+QrT
 aXf
 aJq
 byU
@@ -88307,13 +88649,13 @@ cGS
 cHb
 cHg
 cHn
+Qwa
 ccw
 aaf
 aaT
 ctv
 aaT
 aaf
-aaa
 aaa
 aaa
 aaa
@@ -88448,7 +88790,7 @@ agR
 agn
 agR
 agn
-ajc
+Qvj
 QpG
 akv
 QpL
@@ -88501,11 +88843,11 @@ aBb
 aBb
 QrP
 aaa
-bsb
+QrT
 QrV
 Qsc
 Qsf
-bsb
+QrT
 aXf
 aJq
 bBi
@@ -88558,18 +88900,18 @@ cEz
 cMD
 cFL
 cGf
-cGu
+QvN
 cMm
 ciZ
 cHc
 cAu
 cAu
+ciZ
 ccw
 aaa
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -88688,7 +89030,7 @@ aaa
 aaa
 aaa
 aaf
-Qow
+Qov
 aaf
 aaZ
 adi
@@ -88701,12 +89043,12 @@ acv
 Qpn
 aaZ
 aeW
-agQ
-ahv
+Qvi
+agp
 ahQ
+Qvk
 aiI
-aiH
-ajB
+ajI
 QpJ
 akQ
 agj
@@ -88750,7 +89092,7 @@ aZR
 aZR
 aZR
 bft
-QrB
+Qrz
 aBa
 aBT
 bmv
@@ -88758,7 +89100,7 @@ aEN
 aGb
 bpg
 aaa
-bsb
+QrT
 QrW
 buP
 bwm
@@ -88815,18 +89157,18 @@ cFe
 cMD
 cFM
 czE
-cGu
+QvO
 ccw
 cGT
 csd
 csd
-ciZ
+csd
+csd
 ccw
 aaf
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -88945,25 +89287,25 @@ aaa
 aaa
 aaa
 aaf
-Qox
+Qov
 aaf
 aaZ
 adi
 QoR
-Qpa
+QoZ
 aaZ
 acl
 cxA
 acL
 Qpo
 aaZ
-agp
+Qvh
 agT
 ahx
 ahS
 aiK
-ajc
-QpH
+Qvn
+QpG
 akm
 akT
 aly
@@ -89007,7 +89349,7 @@ bbm
 bdh
 bee
 bfv
-QrC
+Qrz
 aBa
 QrL
 aEM
@@ -89078,6 +89420,7 @@ cGU
 csd
 csd
 cHo
+csd
 ccw
 aaa
 aaT
@@ -89086,7 +89429,6 @@ aaT
 aaa
 aaa
 aae
-aaa
 aaa
 aaa
 aaa
@@ -89202,7 +89544,7 @@ aaa
 aaa
 aaa
 aaf
-Qoy
+Qov
 aaf
 aaZ
 adi
@@ -89214,29 +89556,29 @@ adk
 adK
 cqG
 aeX
-ago
+agt
 agS
 agQ
-ahR
+agt
 aiJ
-ajc
+aiL
 ajI
 akl
 akS
 alx
-amh
+QpP
 amp
 aiX
 anS
 aoy
-apj
-anz
-anz
-anz
-anz
-anz
-anz
-awk
+Qvz
+QvA
+QvB
+QvC
+QvD
+QvE
+QvF
+QvG
 axB
 anz
 anz
@@ -89264,7 +89606,7 @@ bcf
 bdg
 bed
 bfv
-QrD
+Qrz
 aBa
 aBV
 alu
@@ -89329,18 +89671,18 @@ cMH
 cMN
 cFO
 cSI
-csC
+cSI
 cMm
 cGV
 csd
 cGV
-ccw
+QvY
+csd
 ccw
 aaa
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -89459,11 +89801,11 @@ aaa
 aaa
 aaa
 aaf
-Qoz
+Qov
 aaf
 aaZ
 adi
-QoT
+QoR
 Qpc
 aaZ
 Qpi
@@ -89475,9 +89817,9 @@ agr
 agU
 ahy
 ahX
-aiL
-ajc
-ajI
+Qvl
+aiN
+Qvo
 akq
 akQ
 agj
@@ -89521,7 +89863,7 @@ bbm
 bdh
 bef
 bfv
-QrE
+Qrz
 aBa
 QrM
 aEO
@@ -89592,12 +89934,12 @@ csd
 csd
 csd
 cHp
+csd
 ccw
 aaf
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -89716,12 +90058,12 @@ aaa
 aaa
 aaa
 aaf
-QoA
+Qov
 aaf
 aaZ
 QoK
 QoU
-Qpd
+Qpc
 aaZ
 Qpj
 coS
@@ -89732,10 +90074,10 @@ agt
 agt
 ahz
 aie
-aiN
-ajc
-ajI
-akp
+agt
+aiM
+Qvp
+Qvs
 akU
 alz
 aml
@@ -89778,7 +90120,7 @@ aZR
 aZR
 aZR
 bfw
-QrF
+Qrz
 aBa
 aBW
 bjy
@@ -89786,7 +90128,7 @@ aEP
 aGe
 bpi
 aaa
-bsb
+QrT
 Qsa
 buR
 aFM
@@ -89843,18 +90185,18 @@ cFh
 cMD
 cFM
 czE
-cGu
+QvP
 ccw
 cGT
 csd
 csd
-ciZ
+csd
+csd
 ccw
 aaf
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -89973,7 +90315,7 @@ aaa
 aaa
 aaa
 aaf
-QoB
+Qov
 aaf
 aaZ
 QoL
@@ -89989,17 +90331,17 @@ cml
 agV
 cxk
 aig
-aiM
-ajc
-ajI
-akp
+Qvm
+agn
+Qvq
+Qvt
 akV
 alB
 amn
 amV
 Qqb
 anB
-Qqo
+QpX
 aod
 aqf
 ahT
@@ -90043,11 +90385,11 @@ aBc
 aBc
 QrR
 aaa
-bsb
+QrT
 Qsb
 Qse
 Qsh
-bsb
+QrT
 aJq
 aJq
 bBu
@@ -90100,18 +90442,18 @@ cEz
 cMD
 cFR
 cSJ
-cGu
+QvQ
 cMm
 ciZ
 cHd
 cHj
 cHd
+ciZ
 ccw
 aaa
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -90230,7 +90572,7 @@ aaa
 aaa
 aaa
 aaf
-QoC
+Qov
 aaf
 aaZ
 QoM
@@ -90238,18 +90580,18 @@ ack
 Qpf
 abN
 Qpl
-bkA
+acF
 acF
 aes
 avB
 amN
 agt
-awN
+ahB
 aHp
-aIF
-ajc
-ajI
-akp
+agn
+agn
+Qvr
+Qvu
 amS
 alA
 QpT
@@ -90292,19 +90634,19 @@ bcg
 aZU
 beg
 aYB
-QrH
-QrK
+Qrz
+QrJ
 aaf
 aaf
 Qoi
 aaa
 Qoi
 aaa
-bsb
-bsb
-bsb
-bsb
-bsb
+QrT
+QrT
+QrT
+QrT
+QrT
 aJq
 aJq
 bBt
@@ -90357,19 +90699,19 @@ cFj
 cEf
 cFS
 cGg
-cGv
+QvR
 cGI
 cGS
 cHe
 cHe
 cHr
+Qwb
 ccw
 aaf
 aaT
 ctv
 aaT
 aaf
-aaa
 aaa
 aaa
 aaa
@@ -90487,7 +90829,7 @@ aaa
 aaa
 aaa
 aaf
-QoD
+Qov
 aaf
 aaZ
 QoN
@@ -90506,13 +90848,13 @@ aij
 agn
 aje
 ajJ
-akr
-amS
+Qvv
+Qvw
 alC
 QpU
-amX
-amX
-amX
+QpU
+QpU
+QpU
 aoB
 aod
 aqe
@@ -90616,16 +90958,16 @@ cFT
 cSK
 cGx
 cGK
+QvU
+QvX
 cGY
-cEk
 csd
-cHs
+csd
 ccw
 aaf
 aaT
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -90762,13 +91104,13 @@ ahE
 aii
 agn
 ajd
-ajI
-akp
-amS
+ajb
+akr
+Qvx
 QpO
 amo
-amX
-amX
+QpU
+QpU
 Qqi
 Qqp
 Qqq
@@ -90873,16 +91215,16 @@ cqb
 cGh
 cGC
 cey
-ccw
-ccw
+QvV
+csd
 cHl
-ccw
+csd
+Qwc
 ccw
 aaf
 aaT
 aaT
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -91003,8 +91345,8 @@ aaa
 aaa
 abp
 QoF
-QoH
-abO
+QoF
+Qvg
 abO
 abO
 acO
@@ -91019,11 +91361,11 @@ ahA
 ahZ
 adR
 aiQ
-ajI
+QpG
 akt
 QpM
 anw
-QpV
+QpO
 QpX
 anB
 Qqj
@@ -91130,15 +91472,15 @@ cBR
 cGi
 cGD
 cGL
-aag
-aag
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
 aaf
+Qoi
 aaf
-aaf
-aaf
-aaa
-aaf
-aaa
 aaa
 aaa
 aaa
@@ -91280,10 +91622,10 @@ ajK
 aks
 akY
 anA
-QpW
+QpO
 QpY
 amo
-Qqk
+Qqj
 aoC
 aod
 aqe
@@ -91394,8 +91736,8 @@ aaf
 aaa
 aaa
 aaa
-aaf
-aaa
+aHr
+Qoi
 aaa
 aaa
 aaa
@@ -91519,10 +91861,10 @@ abp
 abO
 abO
 QoO
-QoY
-acq
-acq
-acq
+QoO
+QoO
+QoO
+QoO
 abO
 aew
 afe
@@ -91539,7 +91881,7 @@ aiX
 akz
 alf
 QpZ
-Qqd
+QpZ
 Qql
 aoF
 apo
@@ -92034,9 +92376,9 @@ aco
 QoI
 QoP
 abR
-abP
-abP
-abP
+QoP
+QoP
+QoP
 abl
 abp
 abp
@@ -92164,7 +92506,7 @@ aaf
 aaf
 ctv
 aaT
-aaa
+Qoi
 aaf
 aaa
 aaa
@@ -92287,8 +92629,8 @@ aaa
 aaf
 aaf
 QoE
-QoG
-QoJ
+QoE
+QoE
 abq
 abq
 abq
@@ -92417,11 +92759,11 @@ aaa
 aaa
 aaa
 aaa
+aaa
 ctv
 ctv
 ctv
 aaT
-aaa
 aaa
 aaa
 aaa
@@ -106701,8 +107043,8 @@ aaf
 aaf
 aaf
 aaf
-aaf
-aaf
+QoE
+Qvy
 alP
 anf
 alP
@@ -106958,8 +107300,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaf
+QoE
+QoE
 alP
 anf
 alP

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -3405,10 +3405,10 @@
 /turf/open/floor/plasteel/white,
 /area/security/brig)
 "ahQ" = (
-/obj/machinery/computer/security,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/computer/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "ahR" = (
@@ -59707,8 +59707,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "Qts" = (
-/obj/item/storage/box/drinkingglasses,
 /obj/structure/table/wood,
+/obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "Qtt" = (
@@ -81180,8 +81180,8 @@ aaa
 aaa
 aaf
 aaa
-bLv
 bCq
+bLv
 bLv
 bLv
 bLv
@@ -87624,8 +87624,8 @@ aaf
 aaa
 aaa
 aaa
-aaf
 aaa
+aaf
 aaa
 aaa
 aaa
@@ -88789,8 +88789,8 @@ agn
 agR
 agn
 agR
-agn
 Qvj
+agn
 QpG
 akv
 QpL
@@ -92246,10 +92246,10 @@ aaa
 aaa
 aaf
 aaa
+aaa
 aaf
 ctv
 aaT
-aaa
 aaf
 aaa
 aaa
@@ -92502,11 +92502,11 @@ ccw
 aaf
 aaf
 aaf
+Qoi
 aaf
 aaf
 ctv
 aaT
-Qoi
 aaf
 aaa
 aaa
@@ -93016,11 +93016,11 @@ aaa
 aaa
 aaa
 aaa
-aaT
-aaT
-aaT
-aaT
 aaa
+aaT
+aaT
+aaT
+aaT
 aaa
 aae
 aaa

--- a/code/citadel/cit_displaycases.dm
+++ b/code/citadel/cit_displaycases.dm
@@ -1,0 +1,5 @@
+/obj/structure/displaycase/clown
+	desc = "In the event of clown, honk glass."
+	alert = 1
+	start_showpiece_type = /obj/item/bikehorn
+	req_access = list(ACCESS_CENT_GENERAL)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -168,6 +168,7 @@
 #include "code\citadel\cit_areas.dm"
 #include "code\citadel\cit_arousal.dm"
 #include "code\citadel\cit_crewobjectives.dm"
+#include "code\citadel\cit_displaycases.dm"
 #include "code\citadel\cit_emotes.dm"
 #include "code\citadel\cit_genemods.dm"
 #include "code\citadel\cit_guns.dm"


### PR DESCRIPTION
Plenty of QoL changes to go around.

:cl: deathride58
tweak: Warden's office on Boxstation has been expanded one tile downward.
tweak: Warden's office on Boxstation has been reorganized.
tweak: Security on Boxstation now has actual brig interior doors.
tweak: Reinforced windows have been added between the internal Security Lobby and external Security Lobby.
tweak: Secways on Boxstation now have fancier docks.
tweak: Security on Boxstation now has a cyborg recharging station, right below the two secways.
tweak: On Boxstation, the Head of Security will now spawn in their office.
tweak: Boxstation's Clown Office now contains a proper display case for the emergency bike horn instead of a reinforced glass encasement.
tweak: The center-most table has been removed from the Abandoned Cafe on Boxstation.
tweak: Boxstation's Conference Room now has a coffee vendor again.
tweak: The dare dice table in Boxstation's maint bar has been reduced in vertical size by one tile.
tweak: The booze-o-mat in Boxstation's maint bar has been replaced with a box of drinking glasses. Mix your own booze for once, nerds.
tweak: The maintenance observatory room in Boxstation's maintenance is now properly angled toward space.
tweak: Boxstation's emitter room in engineering has been expanded. (From #3717)
tweak: Boxstation's engineering now features a pump to redirect waste gas into the waste loop. (From #3717)
/:cl:

## Screenshots
![image](https://user-images.githubusercontent.com/6356337/32402611-6da53cee-c0fe-11e7-811b-c4ff1988dc2a.png)

![image](https://user-images.githubusercontent.com/6356337/32402616-853d4748-c0fe-11e7-832f-9cff6fa8fd63.png)

![image](https://user-images.githubusercontent.com/6356337/32402621-b0415af6-c0fe-11e7-9b0f-ddc03866e07a.png)

![image](https://user-images.githubusercontent.com/6356337/32402636-bf1e084e-c0fe-11e7-9aef-205046cbb87f.png)

![image](https://user-images.githubusercontent.com/6356337/32402637-cb815d8e-c0fe-11e7-8082-83fe0dc18fec.png)

![image](https://user-images.githubusercontent.com/6356337/32402609-5e815eaa-c0fe-11e7-86c2-208b8fa0b08a.png)


## This PR makes the following obsolete
Closes #3717