### PR TITLE
Fixes flavor text on examine

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -346,4 +346,4 @@
 		
 	msg += "*---------*</span>"
 
-to_chat(user, msg)
+	to_chat(user, msg)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -341,6 +341,9 @@
 						msg += "<a href='?src=[REF(src)];hud=s;add_crime=1'>\[Add crime\]</a> "
 						msg += "<a href='?src=[REF(src)];hud=s;view_comment=1'>\[View comment log\]</a> "
 						msg += "<a href='?src=[REF(src)];hud=s;add_comment=1'>\[Add comment\]</a>\n"
+	if(print_flavor_text() && get_visible_name() != "Unknown")//Are we sure we know who this is? Don't show flavor text unless we can recognize them. Prevents certain metagaming with impersonation.
+		msg += "[print_flavor_text()]\n"
+		
 	msg += "*---------*</span>"
 
-	to_chat(user, msg)
+to_chat(user, msg)


### PR DESCRIPTION
:cl:
fix: Flavor text can be examined again
/:cl:
