### PR TITLE
Fixes flavortext sanitation so it doesn't break quotes and newlines

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -938,10 +938,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(features["flavor_text"])) as message
+					var/msg = stripped_multiline_input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(features["flavor_text"]), MAX_MESSAGE_LEN*2, TRUE) as message
 					if(msg != null)
-						msg = sanitize(copytext(msg, 1, MAX_MESSAGE_LEN))
-						msg = html_encode(msg)
+						msg = copytext(msg, 1, MAX_MESSAGE_LEN*2)
 						features["flavor_text"] = msg
 
 				if("metadata")


### PR DESCRIPTION
:cl: deathride58
fix: Flavortext is now what you see is what you get. Please update your flavortext if it was affected by the old sanitation.
tweak: Flavortext can now hold twice the normal amount of text.
/:cl:

Proof it works
![image](https://user-images.githubusercontent.com/6356337/32751595-7e195dec-c894-11e7-8a8b-9697bea518b4.png)
![image](https://user-images.githubusercontent.com/6356337/32751604-83667848-c894-11e7-954b-59401f81c03c.png)
