### PR TITLE
Re-disables slimeperson splitting

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -128,10 +128,10 @@
 /datum/species/jelly/slime/on_species_gain(mob/living/carbon/C, datum/species/old_species)
 	..()
 	if(ishuman(C))
-		slime_split = new
+		/*slime_split = new
 		slime_split.Grant(C)
 		swap_body = new
-		swap_body.Grant(C)
+		swap_body.Grant(C)*/
 
 		if(!bodies || !bodies.len)
 			bodies = list(C)
@@ -145,10 +145,10 @@
 	bodies = old_species.bodies
 
 /datum/species/jelly/slime/spec_life(mob/living/carbon/human/H)
-	if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
+	/*if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
 		if(prob(5))
-			to_chat(H, "<span class='notice'>You feel very bloated!</span>")
-	else if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
+			to_chat(H, "<span class='notice'>You feel very bloated!</span>")*/
+	if(H.nutrition >= NUTRITION_LEVEL_WELL_FED)
 		H.blood_volume += 3
 		H.nutrition -= 2.5
 


### PR DESCRIPTION
I'll modularize this when I get around to modularizing 99% of cit's code

:cl: deathride58
fix: Slimepeople are no longer able to split again.
/:cl:
