### PR TITLE
Removes borer event from rotation

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -1,8 +1,8 @@
 /datum/round_event_control/borer
 	name = "Borer"
 	typepath = /datum/round_event/borer
-	weight = 0 //Default weight
-	max_occurrences = 1
+	weight = 0
+	max_occurrences = 0
 	min_players = 20 //10 is MINIMUM needed, but this is not a gamemode that does well in lowpop
 	earliest_start = 24000 //40 min, double default timer
 

--- a/code/game/gamemodes/miniantags/borer/borer_event.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_event.dm
@@ -1,7 +1,7 @@
 /datum/round_event_control/borer
 	name = "Borer"
 	typepath = /datum/round_event/borer
-	weight = 10 //Default weight
+	weight = 0 //Default weight
 	max_occurrences = 1
 	min_players = 20 //10 is MINIMUM needed, but this is not a gamemode that does well in lowpop
 	earliest_start = 24000 //40 min, double default timer


### PR DESCRIPTION
Following a discussion in admin chat I have made this. Doesn't effect Syndicate Borers, and admins can still trigger the event, but it won't trigger on it's own