### PR TITLE
Ash walker tendril no longer spawns chasm on death

### DIFF
--- a/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
+++ b/code/modules/ruins/objects_and_mobs/ash_walker_den.dm
@@ -9,7 +9,7 @@
 	faction = list("ashwalker")
 	health = 200
 	maxHealth = 200
-	loot = list(/obj/effect/collapse)
+	loot = null
 	var/meat_counter = 6
 
 /mob/living/simple_animal/hostile/spawner/lavaland/ash_walker/death()


### PR DESCRIPTION
:cl: 
del: Removed chasm that spawns on killing ash walker tendril
/:cl:
