### PR TITLE
dog borgs module icon fix

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -352,7 +352,7 @@
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/security,
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "k9"
-	moduleselect_icon = "k9"
+	moduleselect_icon = "security"
 	can_be_pushed = FALSE
 	hat_offset = INFINITY
 
@@ -387,7 +387,7 @@
 	ratvar_modules = list(/obj/item/clockwork/slab/cyborg/medical,
 		/obj/item/clockwork/weapon/ratvarian_spear)
 	cyborg_base_icon = "medihound"
-	moduleselect_icon = "medihound"
+	moduleselect_icon = "medical"
 	can_be_pushed = FALSE
 	hat_offset = INFINITY
 
@@ -409,7 +409,7 @@
 		/obj/item/clockwork/slab/cyborg/janitor,
 		/obj/item/clockwork/replica_fabricator/cyborg)
 	cyborg_base_icon = "scrubpup"
-	moduleselect_icon = "scrubpup"
+	moduleselect_icon = "janitor"
 	hat_offset = INFINITY
 	clean_on_move = TRUE
 


### PR DESCRIPTION
:cl: ganglyalexander
fix: module icons for dog borgs now reference to a existing icon
/:cl:

dog borg module icon now references to a existing icon.

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Without a existing icon for the module the dog borgs are unplayable, adding this icon will allow players to play dog borgs