### PR TITLE
Tweaks borers from a balance point

### DIFF
--- a/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
@@ -31,10 +31,10 @@
 	chem_desc = "Heals burn damage."
 	chem_message = "<span class='notice'>A stream of burn-healing kelotane spreads throughout your body.</span>"
 
-/datum/borer_chem/charcoal
-	chemname = "charcoal"
-	chem_desc = "Slowly heals toxin damage, will also slowly remove any other chemicals."
-	chem_message = "<span class='notice'>A measure of toxin-purging charcoal cleanses your bloodstream.</span>"
+/datum/borer_chem/inacusiate
+	chemname = "inacusiate"
+	chem_desc = "Heals ear damage."
+	chem_message = "<span class='notice'>You can hear more clearly now.</span>"
 
 /datum/borer_chem/methamphetamine
 	chemname = "methamphetamine"
@@ -42,11 +42,6 @@
 	chemuse = 50
 	quantity = 9
 	chem_message = "<span class='notice'>Your mind races, your heartrate skyrockets as methamphetamines enters your bloodstream!</span>"
-
-/datum/borer_chem/salbutamol
-	chemname = "salbutamol"
-	chem_desc = "Heals suffocation damage."
-	chem_message = "<span class='notice'>Your breathing becomes lighter, as oxygen fills your lungs from the inside.</span>"
 
 /datum/borer_chem/spacedrugs
 	chemname = "space_drugs"
@@ -65,11 +60,6 @@
 	chem_desc = "The most potent alcoholic 'beverage', with the fastest toxicity."
 	chemuse = 50
 	chem_message = "<span class='notice'>You feel like you've downed a shot of 200 proof vodka.</span>"
-
-/datum/borer_chem/rezadone
-	chemname = "rezadone"
-	chem_desc = "Heals cellular damage."
-	chem_message = "<span class='notice'>You feel a warmth spread throughout your body as rezadone repairs corrupted DNA.</span>"
 
 /datum/borer_chem/crocin
 	chemname = "aphro"

--- a/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
+++ b/code/game/gamemodes/miniantags/borer/borer_chemicals.dm
@@ -40,7 +40,6 @@
 	chemname = "methamphetamine"
 	chem_desc = "Reduces stun times, increases stamina and run speed while dealing brain damage. If overdosed it will deal toxin and brain damage."
 	chemuse = 50
-	quantity = 9
 	chem_message = "<span class='notice'>Your mind races, your heartrate skyrockets as methamphetamines enters your bloodstream!</span>"
 
 /datum/borer_chem/spacedrugs


### PR DESCRIPTION
Tweaks borers a little

Removes rezadone from borers - Clone damage is the hardest damage to treat. And should stay so borers dont need to be heal everything machines even if they can cause clone damage by overdosing it.

Removes charcosl from borers - in trade for the meth stun escape as you now need to be carefull by not overdosing meth otherwise you put your guy in danger

Removes salbumatol from borers - salbumatol can not be overdosed and heals suffocation damage, ephi serves the purpose most part as it caps oxygen damage to 25 and the borer can use other chems to heal the host further

Adds inascusiate to borers - they are ear worms so it be logical they have some kind of ear damage helping chem so you can hear easier after fucking up in a explosion for example


:cl: Improvedname
tweak: changes borers around a bit
add: adds inacusiate to borers
del: removes charcoal from borers
del: removes salbumatol from borers
del: removes rezadone from borers
/:cl:
