### PR TITLE
blacklists holoparasites from discounting

### DIFF
--- a/modular_citadel/code/datums/uplink_items_cit.dm
+++ b/modular_citadel/code/datums/uplink_items_cit.dm
@@ -38,6 +38,7 @@
 	item = /obj/item/gun/ballistic/automatic/pistol/antitank/syndicate
 	cost = 14
 	surplus = 25
+	cant_discount = TRUE
 	include_modes = list(/datum/game_mode/nuclear)
 
 /*		Commented out due to introduction of reskinnable stetchkins. May still have a niche if people decide it somehow has value.

--- a/modular_citadel/code/datums/uplink_items_cit.dm
+++ b/modular_citadel/code/datums/uplink_items_cit.dm
@@ -16,6 +16,7 @@
 			NOTE: The precise nature of the symbiosis required by the parasites renders them incompatible with changelings" //updated to actually describe what they do and warn traitorchans not to buy it
 	item = /obj/item/storage/box/syndie_kit/holoparasite
 	refundable = TRUE
+	cant_discount = TRUE
 	cost = 15
 	surplus = 20 //Nobody needs a ton of parasites
 	exclude_modes = list(/datum/game_mode/nuclear)
@@ -38,7 +39,6 @@
 	item = /obj/item/gun/ballistic/automatic/pistol/antitank/syndicate
 	cost = 14
 	surplus = 25
-	cant_discount = TRUE
 	include_modes = list(/datum/game_mode/nuclear)
 
 /*		Commented out due to introduction of reskinnable stetchkins. May still have a niche if people decide it somehow has value.


### PR DESCRIPTION
:cl: Cebutris
fix: Holoparasite injectors can no longer be discounted
/:cl:

[why]: This allowed people to buy them at a discounted price, and then refund them for extra TC. Whoops.