### PR TITLE
Fixes character slot changing erroring out due to attempt_vr runtimes

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1608,11 +1608,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					attempt_vr(parent.prefs_vr,"load_vore","")
 
 				if("changeslot")
-					attempt_vr(parent.prefs_vr,"load_vore","")
 					if(!load_character(text2num(href_list["num"])))
 						random_character()
 						real_name = random_unique_name(gender)
 						save_character()
+					attempt_vr(parent.prefs_vr,"load_vore","")
 
 				if("tab")
 					if (href_list["tab"])


### PR DESCRIPTION
REE

this is why you actually test the code instead of assuming something specific is happening

:cl: deathride58
fix: You can now change character slots again
/:cl:
