### PR TITLE
Hopefully fixes human tails/ears not saving, and fixes new/random characters having underwear

### DIFF
--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -20,32 +20,35 @@
 		else
 			return "000"
 
-/proc/random_underwear(gender)
+/proc/random_underwear(gender)//Cit change - makes random underwear always return nude
 	if(!GLOB.underwear_list.len)
 		init_sprite_accessory_subtypes(/datum/sprite_accessory/underwear, GLOB.underwear_list, GLOB.underwear_m, GLOB.underwear_f)
-	switch(gender)
+	return "Nude"
+	/*switch(gender)
 		if(MALE)
 			return pick(GLOB.underwear_m)
 		if(FEMALE)
 			return pick(GLOB.underwear_f)
 		else
-			return pick(GLOB.underwear_list)
+			return pick(GLOB.underwear_list)*/
 
-/proc/random_undershirt(gender)
+/proc/random_undershirt(gender)//Cit change - makes random underwear always return nude
 	if(!GLOB.undershirt_list.len)
 		init_sprite_accessory_subtypes(/datum/sprite_accessory/undershirt, GLOB.undershirt_list, GLOB.undershirt_m, GLOB.undershirt_f)
-	switch(gender)
+	return "Nude"
+	/*switch(gender)
 		if(MALE)
 			return pick(GLOB.undershirt_m)
 		if(FEMALE)
 			return pick(GLOB.undershirt_f)
 		else
-			return pick(GLOB.undershirt_list)
+			return pick(GLOB.undershirt_list)*/
 
-/proc/random_socks()
+/proc/random_socks()//Cit change - makes random underwear always return nude
 	if(!GLOB.socks_list.len)
 		init_sprite_accessory_subtypes(/datum/sprite_accessory/socks, GLOB.socks_list)
-	return pick(GLOB.socks_list)
+	return "Nude"
+	//return pick(GLOB.socks_list)
 
 /proc/random_features()
 	if(!GLOB.tails_list_human.len)

--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -3,8 +3,8 @@
 	id = "human"
 	default_color = "FFFFFF"
 	species_traits = list(MUTCOLORS_PARTSONLY,SPECIES_ORGANIC,EYECOLOR,HAIR,FACEHAIR,LIPS)
-	mutant_bodyparts = list("tail_human", "ears", "wings", "taur")
-	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None", "taur" = "none")
+	mutant_bodyparts = list("mam_tail", "mam_ears", "wings", "taur")
+	default_features = list("mcolor" = "FFF", "mam_tail" = "None", "mam_ears" = "None", "wings" = "None", "taur" = "none")
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW


### PR DESCRIPTION
These changes are a little hacky, but they're only intended to be temporary until the underlying issues are resolved.

The underwear fix can be removed whenever someone figures out how to get underwear layering properly with genitals.

The human tails/ears save fix can be removed when the actual issue causing its inability to actually save is discovered, though it can be kept and moved to modular_citadel to allow human mutant bodyparts to stay in sync with cit's mutant bodyparts.

:cl: deathride58
fix: New and random characters no longer get generated with underwear
fix: Human tails and ears now save properly again! As a side effect, tails/ears that were previously exclusive to mammals are now available to humans.
/:cl:

Fixes #4092 