### PR TITLE
Restricts Supply Console to Quatermaster access

### DIFF
--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -9,7 +9,7 @@
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
-	req_access = list(ACCESS_QM)
+	req_access = list(ACCESS_CARGO)
 
 	light_color = "#E2853D"//orange
 

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -9,7 +9,6 @@
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
-	req_access = list(ACCESS_CARGO)
 
 	light_color = "#E2853D"//orange
 
@@ -19,7 +18,6 @@
 	icon_screen = "request"
 	circuit = /obj/item/circuitboard/computer/cargo/request
 	requestonly = TRUE
-	req_access = list()
 
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
@@ -35,7 +33,6 @@
 
 	emagged = TRUE
 	contraband = TRUE
-	req_access = list()
 
 	// This also permamently sets this on the circuit board
 	var/obj/item/circuitboard/computer/cargo/board = circuit
@@ -102,9 +99,6 @@
 
 /obj/machinery/computer/cargo/ui_act(action, params, datum/tgui/ui)
 	if(..())
-		return
-	if(!allowed(usr))
-		to_chat(usr, "<span class='notice'>Access denied.</span>")
 		return
 	if(action != "add" && requestonly)
 		return

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -19,6 +19,7 @@
 	icon_screen = "request"
 	circuit = /obj/item/circuitboard/computer/cargo/request
 	requestonly = TRUE
+	req_access = list()
 
 /obj/machinery/computer/cargo/Initialize()
 	. = ..()
@@ -34,6 +35,7 @@
 
 	emagged = TRUE
 	contraband = TRUE
+	req_access = list()
 
 	// This also permamently sets this on the circuit board
 	var/obj/item/circuitboard/computer/cargo/board = circuit
@@ -100,6 +102,9 @@
 
 /obj/machinery/computer/cargo/ui_act(action, params, datum/tgui/ui)
 	if(..())
+		return
+	if(!allowed(usr))
+		to_chat(usr, "<span class='notice'>Access denied.</span>")
 		return
 	if(action != "add" && requestonly)
 		return

--- a/code/modules/cargo/console.dm
+++ b/code/modules/cargo/console.dm
@@ -9,6 +9,7 @@
 		cannot transport live organisms, classified nuclear weaponry or \
 		homing beacons."
 	var/blockade_warning = "Bluespace instability detected. Shuttle movement impossible."
+	req_access = list(ACCESS_QM)
 
 	light_color = "#E2853D"//orange
 

--- a/modular_citadel/code/modules/cargo/console.dm
+++ b/modular_citadel/code/modules/cargo/console.dm
@@ -1,0 +1,15 @@
+/obj/machinery/computer/cargo
+	req_access = list(ACCESS_CARGO)
+	
+/obj/machinery/computer/cargo/request
+	req_access = list()
+
+/obj/machinery/computer/cargo/emag_act(mob/user)
+	req_access = list()
+	. = ..()
+
+/obj/machinery/computer/cargo/ui_act(action, params, datum/tgui/ui)
+	if(!allowed(usr))
+		to_chat(usr, "<span class='notice'>Access denied.</span>")
+		return
+	. = ..()

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2507,6 +2507,7 @@
 #include "modular_citadel\code\game\objects\items\devices\PDA\PDA.dm"
 #include "modular_citadel\code\game\objects\items\devices\radio\shockcollar.dm"
 #include "modular_citadel\code\game\objects\items\melee\eutactic_blades.dm"
+#include "modular_citadel\code\modules\cargo\console.dm"
 #include "modular_citadel\code\modules\client\preferences.dm"
 #include "modular_citadel\code\modules\client\preferences_savefile.dm"
 #include "modular_citadel\code\modules\client\loadout\_donator.dm"


### PR DESCRIPTION
:cl: 
balance: Supply Console is locked to Cargo Access only.
/:cl:

[why]: # Stops the clown from ordering corgis probably. also actually makes sense because the quartermaster is the one whose job it is to approve or deny shipments.

Papers, please.
