### PR TITLE
Moves toggle animal digestion button to object tab

### DIFF
--- a/code/modules/vore/eating/simple_animal_vr.dm
+++ b/code/modules/vore/eating/simple_animal_vr.dm
@@ -10,7 +10,7 @@
 /mob/living/simple_animal/verb/toggle_digestion()
 	set name = "Toggle Animal's Digestion"
 	set desc = "Enables digestion on this mob for 20 minutes."
-	set category = "Vore"
+	set category = "Object"
 	set src in oview(1)
 
 	var/datum/belly/B = vore_organs[vore_selected]


### PR DESCRIPTION
When observing, getting in range of any simplemob causes a lagspike from the vore tab getting added, and getting out of the range of the simplemob results in the vore tab getting removed. This causes lagspikes that only get worse the longer the client's running, with ~0.3 seconds if the client's only been running for a couple of minutes, all the way to 10+ seconds on low-end PCs if the client's been running for around two hours.

Moving the toggle animal digestion button to a tab that will always exist, the object tab, will prevent these massive lagspikes from occurring. This is exactly what this PR does.

in layman's terms: This fixes the lagspikes that occur while floating around as an observer.

:cl: deathride58
tweak: The toggle animal digestion button has been moved to the object tab. This means observers running byond on low-end hardware will no longer get massive lagspikes when entering a tile adjacent to a simplemob.
/:cl: