### PR TITLE
What a mess.

### DIFF
--- a/_maps/cit_map_files/BoxStation/BoxStation.dmm
+++ b/_maps/cit_map_files/BoxStation/BoxStation.dmm
@@ -25477,8 +25477,8 @@
 /area/quartermaster/sorting)
 "bml" = (
 /obj/machinery/mineral/ore_redemption{
-	input_dir = 4;
-	output_dir = 8
+	input_dir = 8;
+	output_dir = 4
 	},
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/eastleft{


### PR DESCRIPTION
This should fix the issue of having the minerals and output coming out of the wrong sides of the ORM.

[Changelogs]: 
fix: Swapped input output of the ORM on box station. I can't believe I messed this up.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)
