### PR TITLE
Darkens chatbox a tad bit to go along with the ported Oracle theme

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -10,7 +10,7 @@ html, body {
 	color: #000000;
 }
 body {
-	background: #fff;
+	background: #E0E0E0; /*CIT CHANGE - darkens chatbox a lil*/
     font-family: Verdana, sans-serif;
     font-size: 9pt;
     line-height: 1.2;


### PR DESCRIPTION
Title. Same exact color as Oraclestation's chat, where our dark UI theme was ported from.

Matches the screenshot here: https://camo.githubusercontent.com/fd16907f85324591b189a3318cc2a74ad99ad80f/68747470733a2f2f692e696d6775722e636f6d2f5a504f67634c302e6a7067

:cl: deathride58
tweak: The chatbox is now a liiiiittle darker to avoid contrasting as much with the dark UI
/:cl:
