### PR TITLE
Fixes the Mk.37F ejecting broken foam dart "casings"

### DIFF
--- a/code/citadel/cit_guns.dm
+++ b/code/citadel/cit_guns.dm
@@ -1155,7 +1155,7 @@ obj/item/projectile/bullet/c10mm/soporific
 	pin = /obj/item/device/firing_pin
 	spawnwithmagazine = TRUE
 	obj_flags = 0
-	casing_ejector = 0
+	casing_ejector = FALSE
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol
 	can_suppress = FALSE
 	actions_types = list(/datum/action/item_action/pick_color)

--- a/code/citadel/cit_guns.dm
+++ b/code/citadel/cit_guns.dm
@@ -1155,6 +1155,7 @@ obj/item/projectile/bullet/c10mm/soporific
 	pin = /obj/item/device/firing_pin
 	spawnwithmagazine = TRUE
 	obj_flags = 0
+	casing_ejector = 0
 	mag_type = /obj/item/ammo_box/magazine/toy/pistol
 	can_suppress = FALSE
 	actions_types = list(/datum/action/item_action/pick_color)


### PR DESCRIPTION
:cl: Toriate
fix: fixed the Foam Force Mk.37F pistol ejecting "casings" that are utterly broken
/:cl:


An absolute derp on my part that should have been fixed in one of the many patches I made for these guns in a panic.