### PR TITLE
Makes Catknights Cats Again

### DIFF
--- a/modular_citadel/citadel_ghostrole_spawners.dm
+++ b/modular_citadel/citadel_ghostrole_spawners.dm
@@ -17,7 +17,8 @@
 /obj/effect/mob_spawn/human/lavaknight/special(mob/living/new_spawn)
 	if(ishuman(new_spawn))
 		var/mob/living/carbon/human/H = new_spawn
-		H.dna.features["ears"] = "Cat"	//cat people
+		H.dna.features["mam_ears"] = "Cat, Big"	//cat people
+		H.dna.features["mcolor"] = H.hair_color
 		H.update_body()
 
 /obj/effect/mob_spawn/human/lavaknight/Destroy()


### PR DESCRIPTION
:cl: Toriate
fix: fixed catknights not having cat ears
/:cl:


With the removal of regular neko ears and tails upstream, the specific method I used to give catknights cat ears no longer work, leading to #5016.

This PR will utilize Citadel's mammal ears system to make catknights cats again.

![dreamseeker_2018-02-06_22-29-58](https://user-images.githubusercontent.com/31995558/35864876-fae9c762-0b8d-11e8-8fda-9c6374efcb14.png)

Fixes #5016 