### PR TITLE
[Ready for speedmerge] Adds a button in the game options menu to toggle widescreen on/off

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -539,10 +539,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			tokens[ckey] = cid_check_reconnect()
 
 			sleep(15 SECONDS) //Longer sleep here since this would trigger if a client tries to reconnect manually because the inital reconnect failed
-			
+
 			 //we sleep after telling the client to reconnect, so if we still exist something is up
 			log_access("Forced disconnect: [key] [computer_id] [address] - CID randomizer check")
-			
+
 			qdel(src)
 			return TRUE
 
@@ -585,10 +585,10 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 			tokens[ckey] = cid_check_reconnect()
 
 			sleep(5 SECONDS) //browse is queued, we don't want them to disconnect before getting the browse() command.
-			
+
 			//we sleep after telling the client to reconnect, so if we still exist something is up
 			log_access("Forced disconnect: [key] [computer_id] [address] - CID randomizer check")
-			
+
 			qdel(src)
 			return TRUE
 
@@ -708,6 +708,12 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 /client/proc/change_view(new_size)
 	if (isnull(new_size))
 		CRASH("change_view called without argument.")
+
+//CIT CHANGES START HERE - makes change_view change DEFAULT_VIEW to 15x15 depending on preferences
+	if(prefs && CONFIG_GET(string/default_view))
+		if(!prefs.widescreenpref && new_size == CONFIG_GET(string/default_view))
+			new_size = "15x15"
+//END OF CIT CHANGES
 
 	view = new_size
 	apply_clickcatcher()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -186,9 +186,6 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 	var/action_buttons_screen_locs = list()
 
-	var/screenshake = 100
-	var/damagescreenshake = 2
-	var/arousable = TRUE
 
 /datum/preferences/New(client/C)
 	parent = C
@@ -385,6 +382,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				else
 					dat += "High"
 			dat += "</a><br>"
+
+			dat += "<b>Widescreen:</b> <a href='?_src_=prefs;preference=widescreenpref'>[widescreenpref ? "Enabled ([CONFIG_GET(string/default_view)])" : "Disabled (15x15)"]</a><br>"
 
 			dat += "<b>Screen Shake:</b> <a href='?_src_=prefs;preference=screenshake'>[(screenshake==100) ? "Full" : ((screenshake==0) ? "None" : "[screenshake]")]</a><br>"
 
@@ -1195,7 +1194,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 					new_wings = input(user, "Choose your character's wings:", "Character Preference") as null|anything in GLOB.r_wings_list
 					if(new_wings)
 						features["wings"] = new_wings
-						
+
 				if("moth_wings")
 					var/new_moth_wings
 					new_moth_wings = input(user, "Choose your character's wings:", "Character Preference") as null|anything in GLOB.moth_wings_list
@@ -1565,6 +1564,9 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 							features["exhibitionist"] = TRUE
 						else
 							features["exhibitionist"] = FALSE
+				if("widescreenpref")
+					widescreenpref = !widescreenpref
+					user.client.change_view(CONFIG_GET(string/default_view))
 				if ("screenshake")
 					var/desiredshake = input(user, "Set the amount of screenshake you want. \n(0 = disabled, 100 = full, 200 = maximum.)", "Character Preference", screenshake)  as null|num
 					if (!isnull(desiredshake))

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -200,6 +200,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	S["arousable"]			>> arousable
 	S["screenshake"]		>> screenshake
 	S["damagescreenshake"]		>> damagescreenshake
+	S["widescreenpref"]				>> widescreenpref
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -229,6 +230,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	screenshake			= sanitize_integer(screenshake, 0, 800, initial(screenshake))
 	damagescreenshake	= sanitize_integer(damagescreenshake, 0, 2, initial(damagescreenshake))
+	widescreenpref			= sanitize_integer(widescreenpref, 0, 1, initial(widescreenpref))
 
 	return 1
 
@@ -275,6 +277,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["screenshake"], screenshake)
 	WRITE_FILE(S["damagescreenshake"], damagescreenshake)
 	WRITE_FILE(S["arousable"], arousable)
+	WRITE_FILE(S["widescreenpref"], widescreenpref)
 
 	return 1
 

--- a/modular_citadel/code/modules/client/preferences.dm
+++ b/modular_citadel/code/modules/client/preferences.dm
@@ -7,6 +7,10 @@
 	var/list/gear_categories
 	var/list/chosen_gear
 	var/gear_tab
+	var/screenshake = 100
+	var/damagescreenshake = 2
+	var/arousable = TRUE
+	var/widescreenpref = TRUE
 
 /datum/preferences/New(client/C)
 	..()


### PR DESCRIPTION
Tested and works.

Some people just don't like change. Some folks like their five paragraph longs ERP emotes. Whatever the reason, this change allows those who have strong opinions about screen resolution to coexist with those that prefer the wider screen resolution.

:cl: deathride58
add: You can now toggle between the server's 21x15 view resolution and TG's default 15x15 view resolution in the game options menu. Look for the "Widescreen" entry in the game options menu.
/:cl: