### PR TITLE
Fixes night lighting not going into effect properly at the start of the round

### DIFF
--- a/modular_citadel/code/controllers/subsystem/cit_nightshift.dm
+++ b/modular_citadel/code/controllers/subsystem/cit_nightshift.dm
@@ -31,6 +31,7 @@ SUBSYSTEM_DEF(nightshift)
 		var/nighttime = text2num(time2text(world.timeofday,"hh"))
 		if(!nightshift && ((nighttime >= CONFIG_GET(number/nightshift_start)) || (nighttime <= CONFIG_GET(number/nightshift_finish))))
 			nightshift = TRUE
+			updatenightlights()
 	. = ..()
 
 /datum/controller/subsystem/nightshift/fire(resumed = 0)


### PR DESCRIPTION
Title.

:cl: deathride58
fix: Roundstart night lighting now works properly again.
/:cl:
