### PR TITLE
Ports TG's nekomimi to Cit's mammal sprite accessories system

### DIFF
--- a/code/modules/mob/dead/new_player/sprite_accessories_Citadel.dm
+++ b/code/modules/mob/dead/new_player/sprite_accessories_Citadel.dm
@@ -16,7 +16,7 @@
 /datum/sprite_accessory/moth_wings/none
 	name = "None"
 	icon_state = "none"
-	
+
 /***************** Alphabetical Order please ***************
 ************* Keep it to Ears, Tails, Tails Animated *********/
 
@@ -513,6 +513,25 @@
 	name = "Murid"
 	icon_state = "murid"
 	color_src = 0
+
+/datum/sprite_accessory/mam_ears/neko
+	name = "Neko"
+	icon_state = "cat"
+	hasinner = 1
+	color_src = HAIR
+	icon = 'icons/mob/mutant_bodyparts.dmi'
+
+/datum/sprite_accessory/mam_tails/neko
+	name = "Neko"
+	icon_state = "cat"
+	color_src = HAIR
+	icon = 'icons/mob/mutant_bodyparts.dmi'
+
+/datum/sprite_accessory/mam_tails_animated/neko
+	name = "Neko"
+	icon_state = "cat"
+	color_src = HAIR
+	icon = 'icons/mob/mutant_bodyparts.dmi'
 
 /datum/sprite_accessory/mam_ears/otie
 	name = "Otusian"


### PR DESCRIPTION
:cl: Toriate
add: Readded classic kitty ears as "neko" ears and tails in the character creator
/:cl:


To hell with "racism" from upstream!

![dreamseeker_2018-02-08_12-54-29](https://user-images.githubusercontent.com/31995558/35956353-1a84c412-0cd0-11e8-9a02-fd895863ae3b.png)

![2018-02-08_12-54-51](https://user-images.githubusercontent.com/31995558/35956361-24b64a96-0cd0-11e8-8b36-f7b7ae78c1c3.png)

As seen in the screenshots, the ears and tails are named "Neko".