### PR TITLE
[DNM - UNTIL OOM IS FIXED] Revert "Temporarily disables lavaland lighting"

### DIFF
--- a/modular_citadel/hopefully_temporary_patches.dm
+++ b/modular_citadel/hopefully_temporary_patches.dm
@@ -1,8 +1,0 @@
-/area/lavaland
-	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
-
-/area/mine/explored
-	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED
-
-/area/mine/unexplored
-	dynamic_lighting = DYNAMIC_LIGHTING_DISABLED

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2509,7 +2509,6 @@
 #include "modular_citadel\citadel_ghostrole_spawners.dm"
 #include "modular_citadel\cydonian_armor.dm"
 #include "modular_citadel\dresscode_values.dm"
-#include "modular_citadel\hopefully_temporary_patches.dm"
 #include "modular_citadel\simplemob_vore_values.dm"
 #include "modular_citadel\code\init.dm"
 #include "modular_citadel\code\__HELPERS\lists.dm"


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#5486 
Reason: Bandaid patch.