### PR TITLE
Adds stunsword modification kits to the security vendor

### DIFF
--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -1,0 +1,3 @@
+/obj/machinery/vending/security
+	contraband = list(/obj/item/clothing/glasses/sunglasses = 2, /obj/item/storage/fancy/donut_box = 2, /obj/item/device/ssword_kit = 1)
+	premium = list(/obj/item/coin/antagtoken = 1, /obj/item/device/ssword_kit = 1)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2523,6 +2523,7 @@
 #include "modular_citadel\code\datums\mutations\hulk.dm"
 #include "modular_citadel\code\game\gamemodes\miniantags\bot_swarm\swarmer_event.dm"
 #include "modular_citadel\code\game\machinery\Sleeper.dm"
+#include "modular_citadel\code\game\machinery\vending.dm"
 #include "modular_citadel\code\game\objects\ids.dm"
 #include "modular_citadel\code\game\objects\items\handcuffs.dm"
 #include "modular_citadel\code\game\objects\items\holy_weapons.dm"


### PR DESCRIPTION

:cl: Cebutris
add: Security vendors now have a stunsword modification kit available for purchase with a coin. There might be another somewhere in there, but that would require tampering with it, and you're a good little redshirt, aren't you?
/:cl:

[why]:   Makes my amazing swords available to players