### PR TITLE
Reduces base rnd point generation rate to 1,200 points per minute

### DIFF
--- a/modular_citadel/code/controllers/subsystem/research.dm
+++ b/modular_citadel/code/controllers/subsystem/research.dm
@@ -1,0 +1,2 @@
+/datum/controller/subsystem/research
+	single_server_income = 20

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2521,6 +2521,7 @@
 #include "modular_citadel\code\controllers\configuration\entries\general.dm"
 #include "modular_citadel\code\controllers\subsystem\cit_nightshift.dm"
 #include "modular_citadel\code\controllers\subsystem\job.dm"
+#include "modular_citadel\code\controllers\subsystem\research.dm"
 #include "modular_citadel\code\controllers\subsystem\shuttle.dm"
 #include "modular_citadel\code\datums\uplink_items_cit.dm"
 #include "modular_citadel\code\datums\mutations\hulk.dm"


### PR DESCRIPTION
Title. Does exactly as it says on the tin.

:cl: deathride58
balance: RnD's base research point generation rate has been decreased to 1,200 points per minute.
/:cl:

Prior value was 3,258 points per minute. This meant RnD got completed around the 40 minute mark. This change lets techwebs actually act like the timegate it's supposed to be.