### PR TITLE
Removes Golem access to the station

### DIFF
--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -338,7 +338,7 @@ update_label("John Doe", "Clowny")
 
 /obj/item/card/id/mining
 	name = "mining ID"
-	access = list(ACCESS_MINING, ACCESS_MINING_STATION, ACCESS_MAILSORTING, ACCESS_MINERAL_STOREROOM)
+	access = list(ACCESS_MINERAL_STOREROOM) // CITADEL CHANGE removes golem's ability to get on the station willy nilly.
 
 /obj/item/card/id/away
 	name = "a perfectly generic identification card"


### PR DESCRIPTION
They're the new ashwalkers but with R&D toys and a license to grief due to 'lol w/e' as flavor text objectives.

No I'm not modularizing it. it's a quick fix.