### PR TITLE
Gives banana spiders mouse opacity fulltile, they're no longer able to pull objects, and they become dense when controlled by players.

### DIFF
--- a/modular_citadel/code/modules/mob/living/simple_animal/banana_spider.dm
+++ b/modular_citadel/code/modules/mob/living/simple_animal/banana_spider.dm
@@ -129,6 +129,8 @@
 /mob/living/simple_animal/banana_spider/ex_act()
 	return
 
+/mob/living/simple_animal/banana_spider/start_pulling()
+	return FALSE			//No.
 
 /obj/item/reagent_containers/food/snacks/deadbanana_spider
 	name = "dead banana spider"

--- a/modular_citadel/code/modules/mob/living/simple_animal/banana_spider.dm
+++ b/modular_citadel/code/modules/mob/living/simple_animal/banana_spider.dm
@@ -66,6 +66,7 @@
 	response_disarm = "shoos"
 	response_harm   = "splats"
 	speak_emote = list("chitters")
+	mouse_opacity = 2
 	density = FALSE
 	ventcrawler = VENTCRAWLER_ALWAYS
 	gold_core_spawnable = FRIENDLY_SPAWN
@@ -99,7 +100,7 @@
 		return
 	src.sentience_act()
 	src.key = user.key
-
+	density = TRUE
 
 /mob/living/simple_animal/banana_spider/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
Who thought nearly unhittable player-controlled stuns were a good idea?