### PR TITLE
Adjusting Prayer Beads to be more useful

### DIFF
--- a/modular_citadel/code/game/objects/items/holy_weapons.dm
+++ b/modular_citadel/code/game/objects/items/holy_weapons.dm
@@ -41,7 +41,7 @@
 					remove_servant_of_ratvar(M)
 
 			to_chat(target, "<span class='notice'>[user]'s prayer to [deity_name] has eased your pain!</span>")
-			target.adjustToxLoss(-5)
+			target.adjustToxLoss(-5, TRUE, TRUE)
 			target.adjustOxyLoss(-5)
 			target.adjustBruteLoss(-5)
 			target.adjustFireLoss(-5)

--- a/modular_citadel/code/game/objects/items/holy_weapons.dm
+++ b/modular_citadel/code/game/objects/items/holy_weapons.dm
@@ -30,7 +30,7 @@
 		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [deity_name].</span>")
 
 	praying = TRUE
-	if(do_after(user, 150, target = M))
+	if(do_after(user, 100, target = M))
 		if(istype(M, /mob/living/carbon/human)) // This probably should not work on catpeople. They're unholy abominations.
 			var/mob/living/carbon/human/target = M
 
@@ -40,12 +40,11 @@
 				else if(is_servant_of_ratvar(M))
 					remove_servant_of_ratvar(M)
 
-			if(prob(25))
-				to_chat(target, "<span class='notice'>[user]'s prayer to [deity_name] has eased your pain!</span>")
-				target.adjustToxLoss(-5)
-				target.adjustOxyLoss(-5)
-				target.adjustBruteLoss(-5)
-				target.adjustFireLoss(-5)
+			to_chat(target, "<span class='notice'>[user]'s prayer to [deity_name] has eased your pain!</span>")
+			target.adjustToxLoss(-5)
+			target.adjustOxyLoss(-5)
+			target.adjustBruteLoss(-5)
+			target.adjustFireLoss(-5)
 
 			praying = FALSE
 


### PR DESCRIPTION
:cl: RealDonaldTrump
tweak: Removed the probability check from prayer beads for their low amount of healing, as well as lowering the time needed to heal from 15 seconds to 10 seconds. Slimepeople won't get harmed by prayer beads either.
/:cl:

Since you sacrifice the ability to deal damage with your various null rod weapons to be the true embodiment of a healslut, the beads now actually are reliable healing tools.