### PR TITLE
[Ready for Review] Revamps Wish Granters

### DIFF
--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -1,0 +1,52 @@
+/obj/machinery/wish_granter/attack_hand(mob/living/carbon/user)
+	if(charges <= 0)
+		to_chat(user, "The Wish Granter lies silent.")
+		return
+
+	else if(!ishuman(user))
+		to_chat(user, "You feel a dark stirring inside of the Wish Granter, something you want nothing of. Your instincts are better than any man's.")
+		return
+
+	else if(is_special_character(user))
+		to_chat(user, "Even to a heart as dark as yours, you know nothing good will come of this.  Something instinctual makes you pull away.")
+
+	else if (!insisting)
+		to_chat(user, "Your first touch makes the Wish Granter stir, listening to you.  Are you really sure you want to do this?")
+		insisting++
+
+	else
+		to_chat(user, "You speak.  [pick("I want the station to disappear","Humanity is corrupt, mankind must be destroyed","I want to be rich", "I want to rule the world","I want immortality.")].  The Wish Granter answers.")
+		if(alert("Are you really sure?", "Confirm decision", "Yes", "No") == "Yes")
+			if(alert("Are you really, really sure?", "Confirm decision", "Yes", "No") == "Yes")					if(alert("Do you really want to become an antagonist and do anything you want?", "Confirm decision", "Yes", "No") == "Yes")
+				if(alert("You have a chance of being dusted if you keep clicking yes. Are you sure?", "Confirm decision", "Yes", "No") == "Yes")
+					if(alert("Do you want to self-antag so badly you'd risk being dusted?", "Confirm decision", "Yes", "No") == "Yes")
+						if(alert("Really?", "Confirm decision", "Yes", "No") == "Yes")
+							if (prob(75))
+								to_chat(user, "Your head pounds for a moment, before your vision clears. You instantly regret all of your life choices up to this point. Your flesh rapidly flashes away into dust.")
+								user.dust()
+								insisting = 0
+								return
+							else
+								to_chat(user, "Your head pounds for a moment, before your vision clears.  You are the avatar of the Wish Granter, and your power is LIMITLESS!  And it's all yours.  You need to make sure no one can take it from you.  No one can know, first.")
+								charges--
+								insisting = 0
+								user.mind.add_antag_datum(/datum/antagonist/wishgranter)
+								to_chat(user, "You have a very great feeling about this!")
+								return
+						else
+							insisting = 0
+							return
+					else
+						insisting = 0
+						return
+				else
+					insisting = 0
+					return
+			else
+				insisting = 0
+				return
+		else
+			insisting = 0
+			return
+
+	return

--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -14,11 +14,13 @@
 	else
 		if(is_special_character(user))
 			to_chat(user, "You speak.  [pick("I want power","Humanity is corrupt, mankind must be destroyed", "I want to rule the world","I want immortality")].  The Wish Granter answers.")
-			to_chat(user, "Your head pounds for a moment, before your vision clears. The Wish Granter has given you limitless power, and it's all yours!")
+			to_chat(user, "Your head pounds for a moment, before your vision clears. The Wish Granter, sensing the darkness in your heart, has given you limitless power, and it's all yours!")
 			user.dna.add_mutation(HULK)
 			user.dna.add_mutation(XRAY)
 			user.dna.add_mutation(COLDRES)
 			user.dna.add_mutation(TK)
+			user.next_move_modifier *= 0.5	//half the delay between attacks!
+			to_chat(user, "Things around you feel slower!")
 			charges--
 			insisting = FALSE
 			to_chat(user, "You have a very great feeling about this!")
@@ -77,8 +79,10 @@
 						to_chat(user, "[killreward] materializes into your hands!")
 					else
 						to_chat(user, "[killreward] materializes onto the floor.")
+					user.next_move_modifier *= 0.8	//20% less delay between attacks!
+					to_chat(user, "Things around you feel slightly slower!")
 					var/mob/living/simple_animal/hostile/venus_human_trap/killwish = new /mob/living/simple_animal/hostile/venus_human_trap(loc)
-					killwish.maxHealth = 2500
+					killwish.maxHealth = 1500
 					killwish.health = killwish.maxHealth
 					killwish.grasp_range = 6
 					killwish.melee_damage_upper = 30

--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -17,7 +17,7 @@
 	else
 		to_chat(user, "You speak.  [pick("I want the station to disappear","Humanity is corrupt, mankind must be destroyed","I want to be rich", "I want to rule the world","I want immortality.")].  The Wish Granter answers.")
 		if(alert("Are you really sure?", "Confirm decision", "Yes", "No") == "Yes")
-			if(alert("Are you really, really sure?", "Confirm decision", "Yes", "No") == "Yes")					if(alert("Do you really want to become an antagonist and do anything you want?", "Confirm decision", "Yes", "No") == "Yes")
+			if(alert("Are you really, really sure?", "Confirm decision", "Yes", "No") == "Yes")
 				if(alert("You have a chance of being dusted if you keep clicking yes. Are you sure?", "Confirm decision", "Yes", "No") == "Yes")
 					if(alert("Do you want to self-antag so badly you'd risk being dusted?", "Confirm decision", "Yes", "No") == "Yes")
 						if(alert("Really?", "Confirm decision", "Yes", "No") == "Yes")

--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -59,7 +59,7 @@
 					user.dna.add_mutation(BLINDMUT)
 					user.adjust_eye_damage(100)
 					var/list/destinations = list()
-					for(var/obj/item/device/radio/beacon/B in GLOB.teleportbeacons)
+					for(var/obj/item/device/beacon/B in GLOB.teleportbeacons)
 						var/turf/T = get_turf(B)
 						if(is_station_level(T.z))
 							destinations += B

--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -29,6 +29,8 @@
 			var/wish = input("You want...","Wish") as null|anything in list("Power","Wealth","The Station To Disappear","To Kill","Nothing")
 			switch(wish)
 				if("Power")	//Gives infinite power in exchange for infinite power going off in your face!
+					if(charges <= 0)
+						return
 					to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
 					to_chat(user, "The Wish Granter punishes you for your selfishness, warping itself into a delaminating supermatter shard!")
 					var/obj/item/stock_parts/cell/infinite/powah = new /obj/item/stock_parts/cell/infinite(get_turf(user))
@@ -44,6 +46,8 @@
 					if(!charges)
 						qdel(src)
 				if("Wealth")	//Gives 1 million space bucks in exchange for being turned into gold!
+					if(charges <= 0)
+						return
 					to_chat(user, "<B>Your wish is granted, but at a cost...</B>")
 					to_chat(user, "The Wish Granter punishes you for your selfishness, warping your body to match the greed in your heart.")
 					new /obj/structure/closet/crate/trashcart/moneywish(loc)
@@ -54,6 +58,8 @@
 					if(!charges)
 						qdel(src)
 				if("The Station To Disappear")	//teleports you to the station and makes you blind, making the station disappear for you!
+					if(charges <= 0)
+						return
 					to_chat(user, "<B>Your wish is 'granted', but at a terrible cost...</B>")
 					to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your eyes to match the darkness in your heart.")
 					user.dna.add_mutation(BLINDMUT)
@@ -72,6 +78,8 @@
 					if(!charges)
 						qdel(src)
 				if("To Kill")	//Makes you kill things in exchange for rewards!
+					if(charges <= 0)
+						return
 					to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
 					to_chat(user, "The Wish Granter punishes you for your wickedness, warping itself into a dastardly creature for you to kill! ...but it almost seems to reward you for this.")
 					var/obj/item/melee/transforming/energy/sword/cx/killreward = new /obj/item/melee/transforming/energy/sword/cx(get_turf(user))
@@ -93,6 +101,8 @@
 					if(!charges)
 						qdel(src)
 				if("Nothing")	//Makes the wish granter disappear
+					if(charges <= 0)
+						return
 					to_chat(user, "<B>The Wish Granter vanishes from sight!</B>")
 					to_chat(user, "You feel as if you just narrowly avoided a terrible fate...")
 					charges--

--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -24,7 +24,7 @@
 			to_chat(user, "You have a very great feeling about this!")
 		else
 			to_chat(user, "The Wish Granter awaits your wish.")
-			var/wish = input("You want...","Wish") as null|anything in list("Power","Wealth","For The Station To Disappear","To Kill","Nothing")
+			var/wish = input("You want...","Wish") as null|anything in list("Power","Wealth","The Station To Disappear","To Kill","Nothing")
 			switch(wish)
 				if("Power")	//Gives infinite power in exchange for infinite power going off in your face!
 					to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
@@ -51,9 +51,9 @@
 					insisting = FALSE
 					if(!charges)
 						qdel(src)
-				if("For The Station To Disappear")	//teleports you to the station and makes you blind, making the station disappear for you!
+				if("The Station To Disappear")	//teleports you to the station and makes you blind, making the station disappear for you!
 					to_chat(user, "<B>Your wish is 'granted', but at a terrible cost...</B>")
-					to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
+					to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your eyes to match the darkness in your heart.")
 					user.dna.add_mutation(BLINDMUT)
 					user.adjust_eye_damage(100)
 					var/list/destinations = list()
@@ -71,12 +71,19 @@
 						qdel(src)
 				if("To Kill")	//Makes you kill things in exchange for rewards!
 					to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
-					to_chat(user, "The Wish Granter punishes you for your wickedness, morphing into a dastardly creature for you to kill!")
-					var/mob/living/simple_animal/hostile/megafauna/colossus/killwish = new /mob/living/simple_animal/hostile/megafauna/colossus(loc)
-					killwish.maxHealth = 3000
+					to_chat(user, "The Wish Granter punishes you for your wickedness, warping itself into a dastardly creature for you to kill! ...but it almost seems to reward you for this.")
+					var/obj/item/melee/transforming/energy/sword/cx/killreward = new /obj/item/melee/transforming/energy/sword/cx(get_turf(user))
+					if(user.put_in_hands(killreward))
+						to_chat(user, "[killreward] materializes into your hands!")
+					else
+						to_chat(user, "[killreward] materializes onto the floor.")
+					var/mob/living/simple_animal/hostile/venus_human_trap/killwish = new /mob/living/simple_animal/hostile/venus_human_trap(loc)
+					killwish.maxHealth = 2500
 					killwish.health = killwish.maxHealth
-					user.dna.add_mutation(HULK)
-					user.dna.add_mutation(LASEREYES)
+					killwish.grasp_range = 6
+					killwish.melee_damage_upper = 30
+					killwish.grasp_chance = 50
+					killwish.loot = list(/obj/item/twohanded/hypereutactic)
 					charges--
 					insisting = FALSE
 					if(!charges)

--- a/modular_citadel/code/game/machinery/wishgranter.dm
+++ b/modular_citadel/code/game/machinery/wishgranter.dm
@@ -7,46 +7,94 @@
 		to_chat(user, "You feel a dark stirring inside of the Wish Granter, something you want nothing of. Your instincts are better than any man's.")
 		return
 
-	else if(is_special_character(user))
-		to_chat(user, "Even to a heart as dark as yours, you know nothing good will come of this.  Something instinctual makes you pull away.")
-
 	else if (!insisting)
 		to_chat(user, "Your first touch makes the Wish Granter stir, listening to you.  Are you really sure you want to do this?")
 		insisting++
 
 	else
-		to_chat(user, "You speak.  [pick("I want the station to disappear","Humanity is corrupt, mankind must be destroyed","I want to be rich", "I want to rule the world","I want immortality.")].  The Wish Granter answers.")
-		if(alert("Are you really sure?", "Confirm decision", "Yes", "No") == "Yes")
-			if(alert("Are you really, really sure?", "Confirm decision", "Yes", "No") == "Yes")
-				if(alert("You have a chance of being dusted if you keep clicking yes. Are you sure?", "Confirm decision", "Yes", "No") == "Yes")
-					if(alert("Do you want to self-antag so badly you'd risk being dusted?", "Confirm decision", "Yes", "No") == "Yes")
-						if(alert("Really?", "Confirm decision", "Yes", "No") == "Yes")
-							if (prob(75))
-								to_chat(user, "Your head pounds for a moment, before your vision clears. You instantly regret all of your life choices up to this point. Your flesh rapidly flashes away into dust.")
-								user.dust()
-								insisting = 0
-								return
-							else
-								to_chat(user, "Your head pounds for a moment, before your vision clears.  You are the avatar of the Wish Granter, and your power is LIMITLESS!  And it's all yours.  You need to make sure no one can take it from you.  No one can know, first.")
-								charges--
-								insisting = 0
-								user.mind.add_antag_datum(/datum/antagonist/wishgranter)
-								to_chat(user, "You have a very great feeling about this!")
-								return
-						else
-							insisting = 0
-							return
-					else
-						insisting = 0
-						return
-				else
-					insisting = 0
-					return
-			else
-				insisting = 0
-				return
+		if(is_special_character(user))
+			to_chat(user, "You speak.  [pick("I want power","Humanity is corrupt, mankind must be destroyed", "I want to rule the world","I want immortality")].  The Wish Granter answers.")
+			to_chat(user, "Your head pounds for a moment, before your vision clears. The Wish Granter has given you limitless power, and it's all yours!")
+			user.dna.add_mutation(HULK)
+			user.dna.add_mutation(XRAY)
+			user.dna.add_mutation(COLDRES)
+			user.dna.add_mutation(TK)
+			charges--
+			insisting = FALSE
+			to_chat(user, "You have a very great feeling about this!")
 		else
-			insisting = 0
-			return
+			to_chat(user, "The Wish Granter awaits your wish.")
+			var/wish = input("You want...","Wish") as null|anything in list("Power","Wealth","For The Station To Disappear","To Kill","Nothing")
+			switch(wish)
+				if("Power")	//Gives infinite power in exchange for infinite power going off in your face!
+					to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
+					to_chat(user, "The Wish Granter punishes you for your selfishness, warping itself into a delaminating supermatter shard!")
+					var/obj/item/stock_parts/cell/infinite/powah = new /obj/item/stock_parts/cell/infinite(get_turf(user))
+					if(user.put_in_hands(powah))
+						to_chat(user, "[powah] materializes into your hands!")
+					else
+						to_chat(user, "[powah] materializes onto the floor.")
+					var/obj/machinery/power/supermatter_shard/powerwish = new /obj/machinery/power/supermatter_shard(loc)
+					powerwish.damage = 700	//right at the emergency threshold
+					powerwish.produces_gas = FALSE
+					charges--
+					insisting = FALSE
+					if(!charges)
+						qdel(src)
+				if("Wealth")	//Gives 1 million space bucks in exchange for being turned into gold!
+					to_chat(user, "<B>Your wish is granted, but at a cost...</B>")
+					to_chat(user, "The Wish Granter punishes you for your selfishness, warping your body to match the greed in your heart.")
+					new /obj/structure/closet/crate/trashcart/moneywish(loc)
+					new /obj/structure/closet/crate/trashcart/moneywish(loc)
+					user.set_species(/datum/species/golem/gold)
+					charges--
+					insisting = FALSE
+					if(!charges)
+						qdel(src)
+				if("For The Station To Disappear")	//teleports you to the station and makes you blind, making the station disappear for you!
+					to_chat(user, "<B>Your wish is 'granted', but at a terrible cost...</B>")
+					to_chat(user, "The Wish Granter punishes you for your selfishness, claiming your soul and warping your body to match the darkness in your heart.")
+					user.dna.add_mutation(BLINDMUT)
+					user.adjust_eye_damage(100)
+					var/list/destinations = list()
+					for(var/obj/item/device/radio/beacon/B in GLOB.teleportbeacons)
+						var/turf/T = get_turf(B)
+						if(is_station_level(T.z))
+							destinations += B
+					var/chosen_beacon = pick(destinations)
+					var/obj/effect/portal/jaunt_tunnel/J = new (get_turf(src), src, 100, null, FALSE, get_turf(chosen_beacon))
+					try_move_adjacent(J)
+					playsound(src,'sound/effects/sparks4.ogg',50,1)
+					charges--
+					insisting = FALSE
+					if(!charges)
+						qdel(src)
+				if("To Kill")	//Makes you kill things in exchange for rewards!
+					to_chat(user, "<B>Your wish is granted, but at a terrible cost...</B>")
+					to_chat(user, "The Wish Granter punishes you for your wickedness, morphing into a dastardly creature for you to kill!")
+					var/mob/living/simple_animal/hostile/megafauna/colossus/killwish = new /mob/living/simple_animal/hostile/megafauna/colossus(loc)
+					killwish.maxHealth = 3000
+					killwish.health = killwish.maxHealth
+					user.dna.add_mutation(HULK)
+					user.dna.add_mutation(LASEREYES)
+					charges--
+					insisting = FALSE
+					if(!charges)
+						qdel(src)
+				if("Nothing")	//Makes the wish granter disappear
+					to_chat(user, "<B>The Wish Granter vanishes from sight!</B>")
+					to_chat(user, "You feel as if you just narrowly avoided a terrible fate...")
+					charges--
+					insisting = FALSE
+					qdel(src)
 
-	return
+//ITEMS THAT IT USES
+
+/obj/structure/closet/crate/trashcart/moneywish
+	desc = "A heavy, metal trashcart with wheels. Filled with cash."
+	name = "loaded trash cart"
+
+/obj/structure/closet/crate/trashcart/moneywish/PopulateContents()	//25*20*1000=500,000
+	for(var/i = 0, i < 25, i++)
+		var/obj/item/stack/spacecash/c1000/lodsamoney = new /obj/item/stack/spacecash/c1000(src)
+		lodsamoney.amount = lodsamoney.max_amount

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -11,16 +11,18 @@
 	lefthand_file = 'modular_citadel/icons/eutactic/mob/noneutactic_left.dmi'
 	righthand_file = 'modular_citadel/icons/eutactic/mob/noneutactic_right.dmi'
 	force = 3
+	force_on = 21
 	throwforce = 5
+	throwforce_on = 20
 	hitsound = "swing_hit" //it starts deactivated
 	hitsound_on = 'sound/weapons/nebhit.ogg'
 	attack_verb_off = list("tapped", "poked")
 	throw_speed = 3
 	throw_range = 5
 	sharpness = IS_SHARP
-	embedding = list("embedded_pain_multiplier" = 6, "embed_chance" = 40, "embedded_fall_chance" = 10)
-	armour_penetration = 0
-	block_chance = 60
+	embedding = list("embedded_pain_multiplier" = 6, "embed_chance" = 20, "embedded_fall_chance" = 60)
+	armour_penetration = 10
+	block_chance = 35
 	light_color = "#37FFF7"
 	actions_types = list()
 
@@ -217,14 +219,14 @@
 	w_class = WEIGHT_CLASS_SMALL
 	var/w_class_on = WEIGHT_CLASS_BULKY
 	force_unwielded = 3
-	force_wielded = 40
+	force_wielded = 30
 	wieldsound = 'sound/weapons/nebon.ogg'
 	unwieldsound = 'sound/weapons/neboff.ogg'
 	hitsound = "swing_hit"
-	armour_penetration = 40
+	armour_penetration = 10
 	light_color = "#37FFF7"
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "destroyed", "ripped", "devastated", "shredded")
-	block_chance = 75
+	block_chance = 25
 	max_integrity = 200
 	armor = list(melee = 0, bullet = 0, laser = 0, energy = 0, bomb = 0, bio = 0, rad = 0, fire = 100, acid = 70)
 	resistance_flags = FIRE_PROOF

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -392,8 +392,9 @@
 			which utilizes a hardlight blade that is dynamically 'forged' on demand to create a deadly sharp edge that is unbreakable. \
 			It appears to have a wooden grip and a shaved down guard."
 	icon_state = "cxsword_hilt_traitor"
+	force_on = 30
 	armour_penetration = 35
-	embedding = list("embedded_pain_multiplier" = 10, "embed_chance" = 70, "embedded_fall_chance" = 0)
+	embedding = list("embedded_pain_multiplier" = 10, "embed_chance" = 75, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 10)
 	block_chance = 50
 	hitsound_on = 'sound/weapons/blade1.ogg'
 	light_color = "#37F0FF"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2550,6 +2550,7 @@
 #include "modular_citadel\code\game\machinery\Sleeper.dm"
 #include "modular_citadel\code\game\machinery\toylathe.dm"
 #include "modular_citadel\code\game\machinery\vending.dm"
+#include "modular_citadel\code\game\machinery\wishgranter.dm"
 #include "modular_citadel\code\game\machinery\computer\card.dm"
 #include "modular_citadel\code\game\objects\ids.dm"
 #include "modular_citadel\code\game\objects\tools.dm"


### PR DESCRIPTION
:cl: Toriate
tweak: Wish Granters have been revamped to have a list of selectable wishes. Find out what they do at your own peril!
balance: Eutactic blades have had their numbers nerfed drastically.
/:cl:

This PR serves to address the complaints about wishgranters being free self-antag tokens. They now have a variety of different selectable wishes, with extremely selfish options giving more negative effects, while relatively harmless wishes create challenges for the user to face while also rewarding them.

Currently, there are five wishes.

The first, power, gives the user an infinite powercell while shoving a delaminating SM shard in their faces.

The second, wealth, gives the user 2 crates with 500,000 dollars in them while also turning them into a gold golem.

The third, "I want the station to disappear", teleports the user to the station while blinding them.

The fourth, To Kill, gives the user a non-eutactic blade and spawns a Venus Man Eater with 1500 health and ramped up aggressiveness that will drop a Hyper Eutactic Blade on death. It also gives the user a 0.8 attack delay multiplier.

The fifth, nothing, makes the Wish Granter disappear.

Antagonists who use the Wish Granter will gain the generic set of powers (TK. Xray, coldresist), as well as getting their attack delay halved.

This PR also nerfs the NEB and HEB to be not OP. Further number tweaking may be necessary, depending on how it pans out.