### PR TITLE
All Maps now have Tesla as a primary engine

### DIFF
--- a/_maps/cit_map_files/BoxStation/BoxStation.dmm
+++ b/_maps/cit_map_files/BoxStation/BoxStation.dmm
@@ -243,7 +243,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaU" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel/floorgrime,
@@ -51347,6 +51347,12 @@
 	dir = 4
 	},
 /area/engine/engineering)
+"cDO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52076,6 +52082,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cQZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cSz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52110,14 +52122,14 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cSK" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cSL" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -52499,10 +52511,6 @@
 	dir = 6
 	},
 /area/security/brig)
-"dsi" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "dAS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52510,12 +52518,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"dFK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "dLQ" = (
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -52541,10 +52543,6 @@
 	dir = 4
 	},
 /area/security/brig)
-"eas" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "eaI" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -52562,6 +52560,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"ejb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "ejX" = (
 /obj/machinery/light{
 	dir = 1
@@ -52597,9 +52602,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ewI" = (
-/turf/open/space/basic,
-/area/engine/engineering)
 "eyM" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -52620,18 +52622,12 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
-"eIw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+"eHD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"eNN" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "eRz" = (
 /obj/structure/lattice,
@@ -52691,12 +52687,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"fAy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"fFB" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "fIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -52721,12 +52722,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
-"fNU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "fXR" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52766,6 +52761,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
+"gre" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "gtB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -52869,34 +52867,61 @@
 /obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
+"hmW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"hyz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hCi" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"hFp" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -2
+"hDa" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"hMa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"hQd" = (
+/turf/open/space/basic,
 /area/engine/engineering)
 "hSW" = (
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
-"hWL" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+"ieW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/structure/grille,
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
+/area/space/nearstation)
 "ilg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
@@ -52913,6 +52938,14 @@
 /obj/machinery/droneDispenser,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"iqO" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "itG" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -52930,9 +52963,6 @@
 /obj/item/coin/iron,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"iDK" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -53029,6 +53059,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"jyX" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "jAD" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -53045,12 +53079,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jDa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "jHt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -53097,6 +53125,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jZh" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "khb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -53143,16 +53178,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kqG" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "kyO" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -53165,6 +53190,9 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"kAr" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "kDA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53187,6 +53215,12 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
+"kNw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -53368,16 +53402,44 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
+"mzz" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "mHd" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"mLm" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"mMg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "mNi" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"mQs" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "mRe" = (
 /obj/machinery/light{
 	dir = 8
@@ -53391,13 +53453,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
-"mSU" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "mXj" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
@@ -53407,13 +53462,6 @@
 "nnM" = (
 /turf/closed/wall/r_wall,
 /area/security/armory)
-"nqi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "nsq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53422,13 +53470,6 @@
 	dir = 8
 	},
 /area/security/brig)
-"nuq" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nwx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -53516,12 +53557,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nXx" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
+"nXy" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "nYI" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -53531,6 +53570,13 @@
 /obj/item/device/electropack/shockcollar,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"oaS" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "obC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -53560,16 +53606,6 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space/nearstation)
-"ong" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "onN" = (
 /obj/machinery/light{
 	dir = 1
@@ -53611,16 +53647,18 @@
 	dir = 10
 	},
 /area/security/brig)
-"oGr" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
+"oAQ" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
+/area/engine/engineering)
+"oHi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "oHU" = (
 /obj/structure/cable{
@@ -53645,11 +53683,20 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oVp" = (
-/obj/structure/cable{
+"oUs" = (
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -25;
+	req_access_txt = "11"
+	},
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "oZl" = (
 /turf/open/floor/plasteel/purple/side{
@@ -53667,31 +53714,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"pfN" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"piR" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "plH" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	dir = 4;
@@ -53719,6 +53741,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"pmD" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "pzG" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32
@@ -53810,15 +53835,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"qgd" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "qiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53861,12 +53877,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"quC" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "quH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -53891,36 +53901,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"qUp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "qWq" = (
 /turf/closed/wall,
 /area/space)
-"rge" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "rhJ" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"riY" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"rot" = (
-/turf/open/space/basic,
-/area/space/nearstation)
 "ruZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -53958,20 +53960,22 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"rPV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
+"rNn" = (
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "rWu" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
+"rZV" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "saK" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -53984,6 +53988,20 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"spp" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "srd" = (
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -54006,6 +54024,12 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hallway/secondary/service)
+"sAz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sGJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
@@ -54072,6 +54096,12 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"sWi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sXy" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -54102,6 +54132,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"tfw" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "thu" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54125,25 +54160,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"ttY" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"tyw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "10;13"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "tBz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -54154,14 +54170,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space/nearstation)
-"tGQ" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine Containment Starboard Aft";
-	dir = 1;
-	network = list("engine")
+"tHc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
+/area/space/nearstation)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
@@ -54192,6 +54206,15 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"ugZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "ujc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/red/side{
@@ -54248,6 +54271,20 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"uuA" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
@@ -54255,6 +54292,12 @@
 "uvy" = (
 /turf/closed/wall/r_wall,
 /area/space)
+"uAt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "uMX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -54334,26 +54377,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
-"vdq" = (
-/obj/structure/grille,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
+"vie" = (
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
-"vkE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"vtT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "vxh" = (
 /obj/structure/table,
@@ -54385,10 +54413,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"vCV" = (
-/obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
+"vHQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vNJ" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/wood,
@@ -54451,21 +54482,9 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
-"wjA" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine Containment Port Aft";
-	dir = 1;
-	network = list("engine")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "wkN" = (
 /turf/closed/wall,
 /area/science/circuit)
-"wmQ" = (
-/obj/machinery/power/grounding_rod,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "wqO" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -54510,21 +54529,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"wIQ" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	req_access_txt = "11"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wMS" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -54575,12 +54579,6 @@
 /obj/structure/closet/l3closet/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space/nearstation)
-"xel" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "xgX" = (
 /obj/item/shard,
 /obj/item/wirecutters,
@@ -54616,12 +54614,6 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
-"xpv" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xug" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54651,6 +54643,22 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xJs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"xMh" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xTa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -54679,6 +54687,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"yam" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ycu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -77658,10 +77670,10 @@ abc
 abc
 afu
 abc
-aaa
-aaa
-aaa
-aaa
+abc
+abc
+abc
+abc
 aaa
 aaa
 aaa
@@ -78280,7 +78292,7 @@ cjJ
 aaa
 aaa
 crn
-rot
+pmD
 aaa
 aaa
 aaa
@@ -78537,7 +78549,7 @@ cjJ
 aaa
 aaa
 crn
-rot
+pmD
 aaa
 aaa
 aaa
@@ -78794,7 +78806,7 @@ cjJ
 aaf
 aaf
 cig
-rot
+pmD
 aaa
 aaa
 aaa
@@ -79565,7 +79577,7 @@ cgR
 cgR
 cqN
 cro
-rot
+pmD
 aaa
 aaa
 aaa
@@ -79822,7 +79834,7 @@ ciN
 cji
 cDZ
 crr
-rot
+pmD
 aaa
 aaa
 aaa
@@ -80079,7 +80091,7 @@ cnv
 cDB
 cqP
 crq
-rot
+pmD
 aaa
 aaa
 aaa
@@ -80593,20 +80605,20 @@ cpX
 cqz
 cqQ
 ccw
-rot
+pmD
 aaa
 aaa
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
 aaa
 aaa
 aaa
 aaa
 aaa
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
 hCi
 hCi
 aaa
@@ -80850,20 +80862,20 @@ clJ
 cig
 cig
 ccw
-rot
-rot
-ctv
-ctv
-ctv
-ctv
-ctv
+pmD
+pmD
+uvy
+uvy
+uvy
+uvy
+uvy
 aaa
 aaa
 aaa
-ctv
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
+uvy
 uvy
 hCi
 hCi
@@ -81101,7 +81113,7 @@ ccw
 ccw
 ccw
 cnZ
-rPV
+oHi
 cpt
 cpt
 cpt
@@ -81360,7 +81372,7 @@ cnt
 cob
 coL
 cDo
-nuq
+oaS
 cgR
 cqT
 ccw
@@ -81376,12 +81388,12 @@ ccw
 ccw
 cGE
 cFn
-mSU
-eas
-eas
+jZh
+mzz
+mzz
 ccw
 uvy
-aaf
+nXy
 aaa
 aaa
 aaa
@@ -81619,23 +81631,23 @@ coK
 cpu
 cMm
 ckH
-oVp
-tyw
+uAt
+hMa
 crK
 cEK
 csa
-iDK
-ong
-iDK
+gre
+mQs
+gre
 cGr
-qUp
-kqG
-qUp
-hWL
-iDK
-ong
-iDK
-iDK
+vHQ
+hDa
+vHQ
+mLm
+gre
+mQs
+gre
+gre
 ccw
 uvy
 hCi
@@ -81874,28 +81886,28 @@ cgR
 cnZ
 chF
 ciO
-nuq
+oaS
 cgR
 cqT
 ccw
 cig
 ccw
 cFb
-iDK
+gre
 cFI
-iDK
-iDK
-iDK
-iDK
-iDK
-iDK
-iDK
+gre
+gre
+gre
+gre
+gre
+gre
+gre
 cFI
-iDK
-wjA
+gre
+iqO
 ccw
 uvy
-eRz
+tfw
 aaa
 aaa
 aaa
@@ -82129,27 +82141,27 @@ ceZ
 clQ
 cgR
 cnZ
-rPV
+oHi
 cgR
 cgR
 cgR
 cqT
-oGr
+fFB
 cEs
-iDK
-wmQ
+gre
+rNn
 cAp
-xpv
+xJs
 cAo
-xpv
+xJs
 cAo
-xpv
+xJs
 cAo
-xpv
-quC
-iDK
-iDK
-iDK
+xJs
+cQZ
+gre
+gre
+gre
 ccw
 uvy
 aaT
@@ -82386,27 +82398,27 @@ cTd
 ckF
 ckF
 cgK
-rPV
+oHi
 cgR
 cgR
 cgR
 cqT
-oGr
+fFB
 csP
-iDK
-iDK
+gre
+gre
 cAq
-aaH
+kAr
 cSH
-aaH
+kAr
 cSH
-aaH
+kAr
 cSH
-aaH
+kAr
 cSH
-aaH
-iDK
-iDK
+kAr
+gre
+gre
 ccw
 uvy
 aaT
@@ -82648,10 +82660,10 @@ cpx
 cqd
 cjc
 cqU
-oGr
+fFB
 csP
-iDK
-wmQ
+gre
+rNn
 cAq
 cFK
 aoV
@@ -82662,8 +82674,8 @@ aaa
 aoV
 aoV
 cFK
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -82903,14 +82915,14 @@ cnZ
 cDh
 cpy
 ccw
-piR
+hyz
 ccw
 ccw
 cqY
 cqY
 cqY
 cAq
-aah
+aoV
 aoV
 aoV
 hCi
@@ -82919,8 +82931,8 @@ aaa
 aoV
 aoV
 aoV
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -83161,13 +83173,13 @@ cDh
 ccw
 cqf
 cqD
-wIQ
+oUs
 crs
 cEv
-qgd
+ugZ
 cqY
 cAq
-aah
+aoV
 aoV
 aaa
 aaa
@@ -83176,8 +83188,8 @@ aaa
 aaa
 aoV
 aoV
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -83415,26 +83427,26 @@ cmL
 cgR
 cnZ
 chX
-pfN
+spp
 cqh
 cqF
 cra
 crI
 cEw
-nqi
+ejb
 cqY
 cAq
-rot
 aaa
 aaa
-dFK
+aaa
+cDO
 cGU
-fNU
+sWi
 aaa
 hCi
 cFK
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -83671,7 +83683,7 @@ clJ
 cmL
 cnv
 cnZ
-vkE
+eHD
 ccw
 cqg
 cqE
@@ -83679,19 +83691,19 @@ cqZ
 crt
 cMH
 cAm
-ttY
+mMg
 cMN
 gXs
 aaf
 aaf
-xel
+kNw
 cGV
-jDa
+tHc
 aaf
 aaf
 gXs
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -83928,27 +83940,27 @@ ccw
 cmN
 cgR
 cnZ
-vkE
-piR
+eHD
+hyz
 cqj
 cSG
 crb
 cru
 cEx
-vtT
+oAQ
 cqY
 cAq
 cFK
 hCi
 aaa
-nXx
-fAy
-rge
+hmW
+sAz
+ieW
 aaa
 aaa
 aaa
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -84185,7 +84197,7 @@ clM
 cfz
 cgR
 cnZ
-vkE
+eHD
 ccw
 cqi
 cMD
@@ -84195,7 +84207,7 @@ cMD
 cEy
 cqY
 cAq
-aah
+aoV
 aoV
 aaa
 aaa
@@ -84204,8 +84216,8 @@ aaa
 aaa
 aoV
 aoV
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -84442,17 +84454,17 @@ cfa
 cje
 cgR
 cnZ
-vkE
+eHD
 cpy
 ccw
-piR
+hyz
 ccw
 ccw
 cqY
 cqY
 cqY
 cAq
-aah
+aoV
 aoV
 aaa
 aaa
@@ -84461,8 +84473,8 @@ hCi
 aaa
 aoV
 aoV
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -84704,10 +84716,10 @@ cpD
 cDw
 cDF
 cEa
-oGr
+fFB
 csP
-iDK
-wmQ
+gre
+rNn
 cAq
 cFK
 aoV
@@ -84718,8 +84730,8 @@ cFK
 aoV
 aoV
 cFK
-aaH
-iDK
+kAr
+gre
 ccw
 uvy
 aaT
@@ -84961,22 +84973,22 @@ cgR
 cgR
 cgR
 cqT
-oGr
+fFB
 csP
-iDK
-iDK
+gre
+gre
 cAq
-aaH
+kAr
 cSK
-aaH
+kAr
 cSK
-aaH
+kAr
 cSK
-aaH
+kAr
 cSK
-aaH
-iDK
-iDK
+kAr
+gre
+gre
 ccw
 uvy
 aaT
@@ -85218,22 +85230,22 @@ cnx
 cDx
 cqb
 cqT
-oGr
+fFB
 cEs
-iDK
-wmQ
+gre
+rNn
 cAr
-xpv
+xJs
 cGh
-xpv
+xJs
 cGh
-xpv
+xJs
 cGh
-xpv
-eIw
-iDK
-iDK
-iDK
+xJs
+vie
+gre
+gre
+gre
 ccw
 uvy
 aaT
@@ -85479,18 +85491,18 @@ ccw
 ccw
 ccw
 crc
-iDK
+gre
 cBR
-iDK
-iDK
-iDK
-iDK
-iDK
-iDK
-iDK
+gre
+gre
+gre
+gre
+gre
+gre
+gre
 cBR
-iDK
-tGQ
+gre
+riY
 ccw
 uvy
 aaT
@@ -85730,24 +85742,24 @@ cDe
 cDk
 coc
 cqa
-hFp
-oVp
-tyw
+uuA
+uAt
+hMa
 czF
 cEK
 csd
-iDK
+gre
 cFU
-iDK
+gre
 cGE
-qUp
+vHQ
 cGZ
-qUp
+vHQ
 csx
-iDK
+gre
 cFU
-iDK
-iDK
+gre
+gre
 ccw
 uvy
 hCi
@@ -85994,20 +86006,20 @@ crM
 ccw
 crV
 cFn
-vdq
+xMh
 cFn
-hWL
+mLm
 ccw
 ccw
 ccw
 cGr
 cFn
-eNN
-eas
-eas
+rZV
+mzz
+mzz
 ccw
 uvy
-aaf
+nXy
 aaf
 aaa
 aaa
@@ -86262,7 +86274,7 @@ ccw
 ccw
 ccw
 ccw
-dsi
+jyX
 uvy
 hCi
 aaa
@@ -86510,17 +86522,17 @@ ccw
 ccw
 ccw
 ccw
-ewI
-rot
-rot
-rot
-ctv
-ctv
-ctv
-ctv
+hQd
+pmD
+pmD
+pmD
+uvy
+uvy
+uvy
+uvy
 uvy
 aaa
-aaf
+nXy
 hCi
 aaa
 aaa
@@ -86771,10 +86783,10 @@ aaa
 aaa
 aaa
 aaa
-rot
-ctv
-ctv
-ctv
+pmD
+uvy
+uvy
+uvy
 hCi
 hCi
 hCi
@@ -87000,7 +87012,7 @@ caE
 cbA
 ccy
 bOd
-vCV
+yam
 bQu
 cfO
 cgW
@@ -87245,7 +87257,7 @@ bIF
 bOZ
 bQp
 bRA
-vCV
+yam
 bTO
 bUL
 bVU

--- a/_maps/cit_map_files/BoxStation/BoxStation.dmm
+++ b/_maps/cit_map_files/BoxStation/BoxStation.dmm
@@ -78,7 +78,7 @@
 /obj/item/device/plant_analyzer,
 /obj/machinery/camera{
 	c_tag = "Prison Common Room";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/green/side{
 	dir = 5
@@ -758,8 +758,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/recharger{
 	pixel_y = 4
@@ -817,7 +816,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 3";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -848,7 +847,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 2";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -870,7 +869,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 1";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /obj/item/device/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -1605,7 +1604,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1644,7 +1643,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -1652,7 +1651,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hallway";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -1801,8 +1800,7 @@
 "aeC" = (
 /obj/machinery/camera{
 	c_tag = "Security Escape Pod";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/security/main)
@@ -2441,10 +2439,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"agd" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal,
@@ -3441,8 +3435,7 @@
 "aiq" = (
 /obj/machinery/camera{
 	c_tag = "Security Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/computer/secure_data{
 	dir = 1
@@ -3865,7 +3858,7 @@
 	},
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -7388,7 +7381,7 @@
 /obj/machinery/camera{
 	c_tag = "Auxillary Mining Base";
 	dir = 8;
-	network = list("SS13","AuxBase")
+	network = list("ss13","auxbase")
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
@@ -7673,8 +7666,7 @@
 /obj/structure/table/wood,
 /obj/machinery/camera{
 	c_tag = "Law Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -7685,7 +7677,7 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 1;
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = -27
 	},
 /turf/open/floor/wood,
@@ -8915,7 +8907,7 @@
 	desc = "Used for the Auxillary Mining Base.";
 	dir = 8;
 	name = "Auxillary Base Monitor";
-	network = list("AuxBase");
+	network = list("auxbase");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/yellow/side{
@@ -10504,8 +10496,7 @@
 "aBh" = (
 /obj/machinery/camera{
 	c_tag = "EVA Maintenance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -10973,8 +10964,7 @@
 "aCp" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals North";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -11963,8 +11953,7 @@
 "aER" = (
 /obj/machinery/camera{
 	c_tag = "Gateway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/table,
 /obj/structure/sign/warning/biohazard{
@@ -12319,8 +12308,7 @@
 "aFO" = (
 /obj/machinery/camera{
 	c_tag = "Garden";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -12435,7 +12423,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/vault/corner{
@@ -12933,8 +12921,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -13432,8 +13419,7 @@
 /obj/structure/chair/office/dark,
 /obj/machinery/camera{
 	c_tag = "Library North";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -15079,8 +15065,7 @@
 "aMM" = (
 /obj/machinery/camera{
 	c_tag = "Chapel North";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -16856,8 +16841,7 @@
 "aRP" = (
 /obj/machinery/camera{
 	c_tag = "Library South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -16972,8 +16956,7 @@
 "aSf" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -17276,8 +17259,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/table,
 /obj/machinery/chem_dispenser/drinks,
@@ -17465,8 +17447,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -17607,7 +17588,7 @@
 /area/bridge)
 "aUd" = (
 /obj/machinery/computer/security/mining{
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 6
@@ -17626,8 +17607,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -17756,8 +17736,7 @@
 "aUy" = (
 /obj/machinery/camera{
 	c_tag = "Vacant Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
@@ -17843,8 +17822,7 @@
 "aUM" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Bay 2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -18006,8 +17984,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/red/corner{
@@ -18336,8 +18313,7 @@
 "aVV" = (
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
@@ -19613,8 +19589,7 @@
 "aYT" = (
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank/high,
 /turf/open/floor/plasteel,
@@ -19739,8 +19714,7 @@
 "aZm" = (
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -20486,8 +20460,7 @@
 "bbr" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -20554,8 +20527,7 @@
 "bbA" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/white/corner{
 	dir = 1
@@ -20846,8 +20818,7 @@
 "bcr" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -20884,8 +20855,7 @@
 "bcx" = (
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 5";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -21155,8 +21125,7 @@
 "bdn" = (
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/status_display{
@@ -22443,8 +22412,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Delivery Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/requests_console{
 	department = "Cargo Bay";
@@ -22628,8 +22596,7 @@
 "bhc" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/firealarm{
 	dir = 2;
@@ -22668,8 +22635,7 @@
 "bhj" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/requests_console{
 	department = "Security";
@@ -23335,7 +23301,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/button/door{
 	dir = 2;
@@ -23377,8 +23343,7 @@
 "biS" = (
 /obj/machinery/camera{
 	c_tag = "Research Division Access";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -23417,7 +23382,7 @@
 /obj/machinery/camera{
 	c_tag = "Research and Development";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /obj/machinery/button/door{
@@ -23657,8 +23622,7 @@
 "bjy" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -23858,8 +23822,7 @@
 "bkb" = (
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -24384,8 +24347,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/white,
@@ -25488,7 +25450,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/disposal/bin,
@@ -26785,8 +26747,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -27065,7 +27026,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
@@ -27194,8 +27155,7 @@
 /obj/item/device/multitool,
 /obj/machinery/camera{
 	c_tag = "Cargo Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -27473,7 +27433,6 @@
 /obj/machinery/camera{
 	c_tag = "Medbay East";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/white,
@@ -27654,7 +27613,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab - South";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
@@ -27935,8 +27894,7 @@
 "btA" = (
 /obj/machinery/camera{
 	c_tag = "Research Division West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28796,7 +28754,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/firealarm{
 	dir = 1;
@@ -28831,7 +28789,6 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Access";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -29065,8 +29022,7 @@
 "bwf" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/brown/corner{
@@ -29288,8 +29244,7 @@
 /obj/structure/table/glass,
 /obj/machinery/camera{
 	c_tag = "Medbay Cryogenics";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
@@ -29307,8 +29262,7 @@
 "bwL" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/table,
 /obj/machinery/firealarm{
@@ -29563,7 +29517,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD","MiniSat");
+	network = list("rd","minisat");
 	pixel_y = 2
 	},
 /obj/structure/table,
@@ -30206,7 +30160,7 @@
 	},
 /obj/machinery/computer/security/mining{
 	dir = 8;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -30503,7 +30457,7 @@
 /obj/machinery/camera{
 	c_tag = "Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /obj/machinery/power/apc{
@@ -30558,7 +30512,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30879,8 +30833,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
@@ -30983,7 +30936,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Science";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/newscaster{
 	pixel_x = -30
@@ -31100,7 +31053,7 @@
 "bAS" = (
 /obj/machinery/computer/security/mining{
 	dir = 4;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
@@ -31671,7 +31624,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom (General)";
@@ -31708,7 +31661,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentor Lab Chamber";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light,
 /obj/structure/sign/warning/nosmoking{
@@ -31915,8 +31868,7 @@
 /obj/structure/closet/secure_closet/medical3,
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -31998,8 +31950,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -32291,8 +32242,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
@@ -32538,7 +32488,6 @@
 /obj/machinery/camera{
 	c_tag = "Chief Medical Office";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/barber,
@@ -32550,7 +32499,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -32641,7 +32590,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab West";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -32751,12 +32700,11 @@
 /area/maintenance/port/fore)
 "bEK" = (
 /obj/machinery/computer/security/mining{
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
@@ -33293,7 +33241,7 @@
 /turf/open/floor/plating,
 /area/science/mixing)
 "bGd" = (
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot{
@@ -33737,7 +33685,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Storage";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/storage)
@@ -33872,7 +33820,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -33991,8 +33939,7 @@
 "bHL" = (
 /obj/machinery/camera{
 	c_tag = "Research Division South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/plasteel/white/side{
@@ -34036,8 +33983,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/caution/corner{
@@ -34134,7 +34080,6 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
 	dir = 1;
-	network = list("SS13");
 	pixel_x = 22
 	},
 /obj/machinery/light,
@@ -35522,7 +35467,7 @@
 "bKY" = (
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
-	network = list("Xeno");
+	network = list("xeno");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -35686,7 +35631,7 @@
 	invuln = 1;
 	light = null;
 	name = "Hardened Bomb-Test Camera";
-	network = list("Toxins");
+	network = list("toxins");
 	use_power = 0
 	},
 /obj/item/target/alien/anchored,
@@ -36533,7 +36478,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Lab East";
 	dir = 8;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -36663,8 +36608,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 4
@@ -36683,8 +36627,7 @@
 "bNT" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics North West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -36833,8 +36776,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Virology Airlock";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -37750,8 +37692,7 @@
 "bQq" = (
 /obj/machinery/camera{
 	c_tag = "Security Post - Engineering";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -37924,7 +37865,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology North";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -37961,7 +37902,7 @@
 /obj/machinery/camera{
 	c_tag = "Testing Lab North";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
@@ -38009,7 +37950,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 2;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 28
 	},
 /obj/item/device/integrated_circuit_printer,
@@ -38134,7 +38075,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("singularity");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -38560,8 +38501,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Telecomms Monitoring";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
@@ -38903,7 +38843,7 @@
 /obj/item/crowbar,
 /obj/machinery/computer/security/telescreen{
 	name = "Test Chamber Monitor";
-	network = list("Test");
+	network = list("test");
 	pixel_y = -30
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -39941,8 +39881,7 @@
 "bVN" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -40367,8 +40306,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics West";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40395,9 +40333,6 @@
 /area/engine/atmos)
 "bWU" = (
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40640,11 +40575,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"bXu" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "bXv" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -40828,8 +40758,7 @@
 "bXV" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
@@ -41237,7 +41166,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology South";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -41881,8 +41810,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Central";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 0;
@@ -42184,8 +42112,7 @@
 "cbl" = (
 /obj/machinery/camera{
 	c_tag = "Telecomms Server Room";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -42267,7 +42194,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/yellow/corner{
@@ -42499,7 +42425,7 @@
 /obj/machinery/camera{
 	c_tag = "Testing Chamber";
 	dir = 1;
-	network = list("Test","RD")
+	network = list("test","rd")
 	},
 /obj/machinery/light,
 /turf/open/floor/engine,
@@ -42537,7 +42463,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 1;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = -28
 	},
 /obj/item/device/integrated_circuit_printer,
@@ -43473,8 +43399,7 @@
 "cex" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -43794,7 +43719,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Kill Room";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
@@ -43895,16 +43820,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/chief)
-"cfI" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/engine/engineering)
 "cfJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -44207,13 +44122,13 @@
 /area/engine/engineering)
 "cgw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cgx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgy" = (
 /obj/machinery/light/small{
@@ -44283,32 +44198,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cgI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cgJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cgL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgO" = (
 /obj/structure/rack,
@@ -44322,17 +44227,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/chief)
-"cgQ" = (
-/obj/machinery/camera{
-	c_tag = "Engineering East";
-	dir = 8;
-	network = list("SS13")
-	},
-/obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
-	},
-/area/engine/engineering)
 "cgR" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44693,25 +44587,24 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chH" = (
 /obj/structure/closet/firecloset,
@@ -44809,35 +44702,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"chV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "chX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chY" = (
 /obj/machinery/shieldgen,
@@ -44921,24 +44794,6 @@
 "cig" = (
 /turf/closed/wall,
 /area/engine/engineering)
-"cii" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/device/geiger_counter,
-/obj/item/device/geiger_counter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cij" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable{
@@ -44976,15 +44831,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"cip" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ciq" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -44994,13 +44840,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"cir" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cis" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
@@ -45128,7 +44967,7 @@
 /obj/machinery/camera{
 	c_tag = "Turbine Chamber";
 	dir = 4;
-	network = list("Turbine")
+	network = list("turbine")
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -45141,14 +44980,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/book/manual/engineering_singularity_safety{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/engineering_particle_accelerator{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/turf/open/floor/engine,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciP" = (
 /obj/structure/cable{
@@ -45286,17 +45129,10 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/chief)
-"cjh" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cji" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45335,8 +45171,7 @@
 "cjl" = (
 /obj/machinery/camera{
 	c_tag = "Engineering MiniSat Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -45515,8 +45350,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -45531,7 +45365,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
+	},
 /area/engine/engineering)
 "cjP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -45574,7 +45410,7 @@
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/vault,
@@ -46197,8 +46033,7 @@
 /obj/structure/chair/stool,
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Control";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -46759,8 +46594,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "SMES Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -46788,8 +46622,7 @@
 "cnt" = (
 /obj/machinery/camera{
 	c_tag = "Engineering West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -46805,16 +46638,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/chair/sofa/left{
+	icon_state = "sofaend_left";
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
@@ -46999,8 +46827,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "SMES Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -47049,14 +46876,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -47071,25 +46895,32 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cob" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/obj/item/stack/cable_coil,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -47258,38 +47089,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"coL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"coM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"coL" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "coS" = (
 /obj/structure/rack,
@@ -47455,50 +47275,37 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpt" = (
-/obj/structure/table,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/engineering)
+"cpu" = (
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
 /obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/glass,
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cpx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cpu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cpv" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cpx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cpy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cpA" = (
 /obj/structure/chair/office/dark{
@@ -47513,19 +47320,17 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "cpD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cpG" = (
 /obj/structure/table/optable,
@@ -47660,8 +47465,7 @@
 "cpV" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
 /turf/open/floor/plasteel,
@@ -47683,133 +47487,72 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cpZ" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cqa" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqb" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"cqb" = (
+/obj/structure/chair/sofa/right{
+	icon_state = "sofaend_right";
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/structure/closet/radiation,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqe" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Filter";
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("SS13","Engine");
+	c_tag = "Engineering Center";
+	dir = 2;
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = -24;
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cql" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+"cqh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cqm" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+"cqi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqn" = (
 /obj/structure/grille,
@@ -47827,8 +47570,7 @@
 "cqp" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Escape Pod";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -47906,54 +47648,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "10;13"
+"cqC" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cqD" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"cqE" = (
+/obj/structure/particle_accelerator/end_cap,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cqC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqD" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cqF" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cqG" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -48041,70 +47768,49 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqS" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
 	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "cqT" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cqU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 25;
+	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cqY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cra" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm/engine{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"crb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Gas to Chamber"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"crc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/obj/structure/particle_accelerator/fuel_chamber,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"crd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+"cra" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crb" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crc" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Fore";
+	dir = 2;
+	network = list("engine")
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -48167,40 +47873,38 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/crowbar,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crt" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/particle_accelerator/power_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cru" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"crv" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/item/screwdriver,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
 /area/engine/engineering)
 "cry" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48288,43 +47992,34 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"crH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "crI" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"crJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"crK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"crL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+"crJ" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#fff4bc"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crM" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#fff4bc"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crP" = (
 /obj/machinery/light,
@@ -48337,25 +48032,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crT" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"crU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
 "crV" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crW" = (
 /obj/machinery/light/small{
@@ -48375,38 +48057,29 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crZ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "csa" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space,
 /area/maintenance/aft)
 "csd" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cse" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48425,13 +48098,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"csj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "csk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
@@ -48462,7 +48128,7 @@
 	desc = "Used for watching the turbine vent.";
 	dir = 1;
 	name = "turbine vent monitor";
-	network = list("Turbine");
+	network = list("turbine");
 	pixel_y = -29
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -48492,26 +48158,22 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
 "css" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
-"csu" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"csv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csy" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -48520,19 +48182,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"csA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
 "csD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -48544,24 +48193,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"csH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"csI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "csM" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -48579,27 +48210,9 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "csP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"csR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48696,7 +48309,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Pod Access";
 	dir = 1;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -48978,7 +48591,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Teleporter";
 	dir = 1;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -49033,7 +48646,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
@@ -49213,7 +48826,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Atmospherics";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/airalarm{
@@ -49253,7 +48866,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Antechamber";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/turretid{
@@ -49342,7 +48955,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Service Bay";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/airalarm{
@@ -49772,7 +49385,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External NorthWest";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -49819,7 +49432,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External NorthEast";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -49835,7 +49448,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Core Hallway";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/firealarm{
 	dir = 8;
@@ -50213,7 +49826,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber North";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -50629,18 +50242,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"czE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "czF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50874,97 +50483,40 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cAl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"cAm" = (
+/obj/item/wirecutters,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cAo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAm" = (
-/obj/machinery/power/supermatter_shard/crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cAo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop to Gas";
-	on = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Mix";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAu" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAy" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
@@ -51079,9 +50631,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cAP" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 25;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAQ" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -51147,7 +50707,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External SouthWest";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -51182,7 +50742,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External SouthEast";
 	dir = 4;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -51212,7 +50772,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat AI Chamber South";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai)
@@ -51244,7 +50804,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat External South";
 	dir = 2;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/space,
@@ -51290,8 +50850,7 @@
 "cBn" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/freezer,
@@ -51496,10 +51055,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cBS" = (
 /obj/structure/cable{
@@ -51675,89 +51231,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
-"cCB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine";
-	on = 0
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCE" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCF" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"cCG" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCQ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCS" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -51777,77 +51250,33 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cDh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/device/flashlight,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDj" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51864,90 +51293,39 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDo" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/pen,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDt" = (
+/obj/structure/table,
+/obj/item/twohanded/rcl/pre_loaded,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDw" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cDx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa{
+	icon_state = "sofamiddle";
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos to Loop";
-	on = 0
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDz" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDB" = (
@@ -51957,103 +51335,18 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDC" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cDD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cDE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "cDF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cDG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDH" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDL" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cDN" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
-"cDY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "cDZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52062,824 +51355,139 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cEa" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cEd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 4;
-	network = list("SS13","Engine")
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
-"cEe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEf" = (
-/obj/machinery/ai_status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cEg" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cEh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("SS13","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cEl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "cEm" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"cEr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cEs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Cooling Loop";
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEt" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEu" = (
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 2;
-	network = list("Engine");
-	pixel_x = 23
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEv" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEy" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Gas";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cEK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cEL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cET" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cFb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cFc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"cEv" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Cooling Loop Bypass"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFe" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cFh" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cFj" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
-"cFk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Bypass"
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
-"cFm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"cFn" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+"cEw" = (
+/obj/structure/particle_accelerator/particle_emitter/left,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEx" = (
+/obj/structure/particle_accelerator/particle_emitter/right,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEy" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/space,
-/area/space/nearstation)
-"cFo" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"cFu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cFw" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cFy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+"cEK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cFz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+"cFb" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Fore";
+	dir = 2;
+	network = list("engine")
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cFA" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/dark,
+"cFn" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 2;
-	network = list("SS13","Engine");
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cFP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cFU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGd" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGe" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGf" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8;
-	filter_type = "n2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGg" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGh" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGj" = (
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGk" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGl" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGt" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
-	name = "Output Release";
-	open = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGE" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGH" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGK" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGU" = (
-/obj/structure/reflector/double/anchored{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGV" = (
-/obj/structure/reflector/box/anchored{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	volume_rate = 200
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cHa" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cHb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHc" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHd" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHe" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHj" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
 	state = 2
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHn" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cHo" = (
-/obj/structure/reflector/single/anchored{
-	dir = 9
+"cGh" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cHp" = (
-/obj/structure/reflector/single/anchored{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cHr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGE" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cGV" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cGZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHD" = (
 /obj/structure/cable{
@@ -53218,8 +51826,13 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "cMm" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cMC" = (
 /obj/machinery/computer/security/telescreen{
@@ -53227,7 +51840,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("singularity");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53238,15 +51851,24 @@
 	},
 /area/engine/engineering)
 "cMD" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMH" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cMN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
+/area/engine/engineering)
+"cMH" = (
+/obj/structure/particle_accelerator/particle_emitter/center,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cMQ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -53479,41 +52101,23 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
 "cSG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cSH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cSI" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cSJ" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cSK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cSL" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -53895,6 +52499,10 @@
 	dir = 6
 	},
 /area/security/brig)
+"dsi" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "dAS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53902,6 +52510,12 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
+"dFK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dLQ" = (
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -53927,6 +52541,10 @@
 	dir = 4
 	},
 /area/security/brig)
+"eas" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "eaI" = (
 /obj/structure/table/reinforced,
 /obj/item/device/radio/intercom{
@@ -53979,6 +52597,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"ewI" = (
+/turf/open/space/basic,
+/area/engine/engineering)
 "eyM" = (
 /obj/machinery/mineral/ore_redemption{
 	input_dir = 2;
@@ -53999,6 +52620,19 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
+"eIw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"eNN" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "eRz" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -54057,10 +52691,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"fsQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+"fAy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "fIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54085,6 +52721,12 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
+"fNU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "fXR" = (
 /obj/structure/table/wood/poker,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -54231,13 +52873,29 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"hFp" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hSW" = (
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
-"ijc" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/dark,
+"hWL" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ilg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54272,6 +52930,9 @@
 /obj/item/coin/iron,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"iDK" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "iEJ" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod One"
@@ -54330,7 +52991,7 @@
 /obj/machinery/camera{
 	c_tag = "Circuitry Lab";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
@@ -54384,6 +53045,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jDa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "jHt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -54412,15 +53079,6 @@
 	dir = 9
 	},
 /area/security/brig)
-"jMY" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "jSO" = (
 /obj/machinery/light{
 	dir = 4
@@ -54485,6 +53143,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kqG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "kyO" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -54534,13 +53202,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"kQq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kSb" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -54707,17 +53368,6 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"mBv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "Output to Waste"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mHd" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -54741,6 +53391,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
+"mSU" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "mXj" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
@@ -54750,9 +53407,12 @@
 "nnM" = (
 /turf/closed/wall/r_wall,
 /area/security/armory)
-"noK" = (
-/obj/structure/girder,
-/turf/open/floor/plasteel/dark,
+"nqi" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "nsq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54762,6 +53422,13 @@
 	dir = 8
 	},
 /area/security/brig)
+"nuq" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nwx" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -54787,10 +53454,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"nzh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nAv" = (
 /obj/structure/table,
 /obj/item/grenade/barrier{
@@ -54853,6 +53516,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"nXx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nYI" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -54891,6 +53560,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space/nearstation)
+"ong" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "onN" = (
 /obj/machinery/light{
 	dir = 1
@@ -54932,8 +53611,15 @@
 	dir = 10
 	},
 /area/security/brig)
-"oDF" = (
-/obj/machinery/light,
+"oGr" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "oHU" = (
@@ -54959,6 +53645,12 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oVp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "oZl" = (
 /turf/open/floor/plasteel/purple/side{
 	tag = "icon-purple (NORTH)";
@@ -54975,6 +53667,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
+"pfN" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"piR" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "plH" = (
 /obj/machinery/door/window/brigdoor/security/cell{
 	dir = 4;
@@ -55093,6 +53810,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qgd" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qiH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55135,6 +53861,12 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
+"quC" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "quH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55159,9 +53891,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"qUp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "qWq" = (
 /turf/closed/wall,
 /area/space)
+"rge" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "rhJ" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/decal/cleanable/blood/old,
@@ -55173,6 +53918,9 @@
 /obj/item/reagent_containers/food/drinks/beer,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"rot" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "ruZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -55210,6 +53958,15 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"rPV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "rWu" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
@@ -55368,6 +54125,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
+"ttY" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"tyw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tBz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
@@ -55378,6 +54154,14 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"tGQ" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
@@ -55408,22 +54192,6 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"udp" = (
-/obj/item/crowbar/large,
-/obj/structure/rack,
-/obj/item/device/flashlight,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"uhH" = (
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ujc" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plasteel/red/side{
@@ -55462,7 +54230,7 @@
 /obj/item/screwdriver,
 /obj/machinery/camera{
 	c_tag = "Circuitry Lab North";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
@@ -55566,6 +54334,27 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"vdq" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"vkE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vtT" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "vxh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -55596,6 +54385,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vCV" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "vNJ" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/wood,
@@ -55658,9 +54451,21 @@
 /obj/effect/turf_decal/delivery/white,
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
+"wjA" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wkN" = (
 /turf/closed/wall,
 /area/science/circuit)
+"wmQ" = (
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wqO" = (
 /obj/structure/rack,
 /obj/item/gun/energy/e_gun/dragnet,
@@ -55705,6 +54510,21 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"wIQ" = (
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -25;
+	req_access_txt = "11"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wMS" = (
 /obj/structure/rack,
 /obj/item/clothing/suit/armor/riot{
@@ -55755,6 +54575,12 @@
 /obj/structure/closet/l3closet/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space/nearstation)
+"xel" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "xgX" = (
 /obj/item/shard,
 /obj/item/wirecutters,
@@ -55790,6 +54616,12 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
+"xpv" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xug" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -79203,8 +78035,8 @@ aaa
 aaa
 aaa
 aaa
-aaT
-aaT
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -79448,21 +78280,21 @@ cjJ
 aaa
 aaa
 crn
-aaf
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
+rot
 aaa
-aaf
-ctv
-aaT
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -79705,21 +78537,21 @@ cjJ
 aaa
 aaa
 crn
-aaf
-aaT
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-aaT
+rot
 aaa
-aaf
-ctv
-ctv
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -79962,20 +78794,20 @@ cjJ
 aaf
 aaf
 cig
-aaf
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaf
-aaf
-aaf
-aaf
+rot
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80220,17 +79052,17 @@ ccw
 ccw
 ccw
 aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80477,19 +79309,19 @@ cqw
 cqO
 crp
 aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
-aaT
-aaT
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80733,20 +79565,20 @@ cgR
 cgR
 cqN
 cro
-cEl
-cEE
-cEl
-cFm
-csx
-cFm
-cFm
-csx
-csv
+rot
 aaa
 aaa
-aaT
-ctv
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80990,20 +79822,20 @@ ciN
 cji
 cDZ
 crr
-crJ
-crT
-crJ
-cFn
-css
-csx
-csx
-css
-csb
-aaf
-aaf
-aaT
-ctv
-aaT
+rot
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81243,24 +80075,24 @@ ccw
 cfL
 coH
 cBO
-cgR
+cnv
 cDB
 cqP
 crq
-crZ
-crT
-crZ
-cFo
-css
-cFm
-cFm
-css
-csv
+rot
 aaa
 aaa
-aaT
-ctv
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81504,21 +80336,21 @@ cgR
 cqx
 cqR
 crp
-crJ
-crT
-crJ
-cFn
-css
-csx
-csx
-css
-csb
-aaf
-aaf
-aaT
-ctv
-aaT
-aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+hCi
 aaa
 aaa
 aaa
@@ -81761,22 +80593,22 @@ cpX
 cqz
 cqQ
 ccw
-crH
-crT
-crZ
-cFo
-css
-cFm
-cFm
-css
-csv
+rot
 aaa
 aaa
-aaT
 ctv
-aaT
+ctv
+ctv
 aaa
 aaa
+aaa
+aaa
+aaa
+ctv
+ctv
+ctv
+hCi
+hCi
 aaa
 aaa
 aaa
@@ -82018,24 +80850,24 @@ clJ
 cig
 cig
 ccw
-crJ
-crT
-crJ
-cFn
-css
-csx
-csx
-css
-csb
-aaf
-aaf
-aaT
+rot
+rot
 ctv
-aaT
+ctv
+ctv
+ctv
+ctv
 aaa
 aaa
 aaa
-aaa
+ctv
+ctv
+ctv
+ctv
+uvy
+hCi
+hCi
+hCi
 aaa
 aaa
 aaa
@@ -82269,30 +81101,30 @@ ccw
 ccw
 ccw
 cnZ
-coH
+rPV
 cpt
-cpZ
-cig
+cpt
+cpt
 cqS
 ccw
-crH
-crT
-crZ
-cFo
-css
-cFm
-cFm
-css
-csv
-aaa
-aaa
-aaT
-ctv
-aaT
-aaa
-aaa
-aaf
-aaa
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+cpy
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -82528,27 +81360,27 @@ cnt
 cob
 coL
 cDo
+nuq
 cgR
-cqA
 cqT
-csg
+ccw
 crJ
-crU
+ccw
 csb
 cFn
 css
+cFn
 csx
-csx
-css
-csb
-aaf
-aaf
-aaT
-aaT
-aaT
-gXs
-aaf
-aaf
+ccw
+ccw
+ccw
+cGE
+cFn
+mSU
+eas
+eas
+ccw
+uvy
 aaf
 aaa
 aaa
@@ -82786,27 +81618,27 @@ cgw
 coK
 cpu
 cMm
-ccw
-ccw
-ccw
+ckH
+oVp
+tyw
 crK
 cEK
 csa
-csj
-csa
-csa
+iDK
+ong
+iDK
 cGr
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+qUp
+kqG
+qUp
+hWL
+iDK
+ong
+iDK
+iDK
+ccw
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -83039,30 +81871,30 @@ ckG
 clJ
 cmF
 cgR
-cgI
+cnZ
 chF
 ciO
-cqc
-cqc
-cqc
-cEd
-cEr
-cEL
+nuq
+cgR
+cqT
+ccw
+cig
+ccw
 cFb
-cFu
+iDK
 cFI
-cGd
-cGs
-cGr
+iDK
+iDK
+iDK
+iDK
+iDK
+iDK
+iDK
+cFI
+iDK
+wjA
 ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-aaa
-eRz
-aaT
+uvy
 eRz
 aaa
 aaa
@@ -83296,30 +82128,30 @@ cTa
 ceZ
 clQ
 cgR
-cgx
-coM
-cpv
-cqb
-cqb
-cqb
-cqb
+cnZ
+rPV
+cgR
+cgR
+cgR
+cqT
+oGr
 cEs
-cqb
-cqb
+iDK
+wmQ
 cAp
-cqb
+xpv
 cAo
-cGt
-cgx
-jMY
-csd
-cHa
-csd
-uhH
+xpv
+cAo
+xpv
+cAo
+xpv
+quC
+iDK
+iDK
+iDK
 ccw
-aaa
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -83554,29 +82386,29 @@ cTd
 ckF
 ckF
 cgK
-cDg
-cDp
-cqe
-cqB
-cqB
-cEe
+rPV
+cgR
+cgR
+cgR
+cqT
+oGr
 csP
-cAl
-cFc
+iDK
+iDK
 cAq
-cFJ
+aaH
 cSH
-cGu
-cGH
-fsQ
-fsQ
-cGR
-csd
-csd
+aaH
+cSH
+aaH
+cSH
+aaH
+cSH
+aaH
+iDK
+iDK
 ccw
-aaa
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -83814,26 +82646,26 @@ cgJ
 chG
 cpx
 cqd
-cDC
+cjc
 cqU
-cEf
-cEt
-cEM
-csA
-cEg
+oGr
+csP
+iDK
+wmQ
+cAq
 cFK
-cGe
-cGv
-cGI
-cGS
-cHb
-cHg
-cHn
-oDF
+aoV
+aoV
+cFK
+gXs
+aaa
+aoV
+aoV
+cFK
+aaH
+iDK
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaf
 aaa
@@ -84067,30 +82899,30 @@ cig
 cig
 cTf
 cgR
-ccw
+cnZ
 cDh
 cpy
-cDv
-cDD
-cqU
-cMD
-cEu
-cEz
-cEz
-cMD
-cFL
-cGf
-kQq
-cMm
-ciZ
-cHc
-cAu
-cAu
-ciZ
 ccw
+piR
+ccw
+ccw
+cqY
+cqY
+cqY
+cAq
+aah
+aoV
+aoV
+hCi
+aaf
 aaa
-aaT
-ctv
+aoV
+aoV
+aoV
+aaH
+iDK
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -84324,30 +83156,30 @@ ckI
 clJ
 cmL
 cBO
+cnZ
+cDh
 ccw
-chV
-cpx
 cqf
 cqD
-cMD
+wIQ
 crs
 cEv
-cEv
-cFe
-cMD
-cFM
-czE
-kQq
-ccw
-cGT
-csd
-csd
-csd
-csd
-ccw
+qgd
+cqY
+cAq
+aah
+aoV
+aaa
+aaa
 aaf
-aaT
-ctv
+aaa
+aaa
+aoV
+aoV
+aaH
+iDK
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -84581,30 +83413,30 @@ ckK
 clJ
 cmL
 cgR
-cgL
+cnZ
 chX
-cpx
+pfN
 cqh
 cqF
 cra
 crI
 cEw
-cEw
-cEw
-cFw
-cFN
-csH
-csR
-cMm
-cGU
-csd
-csd
-cHo
-csd
-ccw
+nqi
+cqY
+cAq
+rot
 aaa
-aaT
-ctv
+aaa
+dFK
+cGU
+fNU
+aaa
+hCi
+cFK
+aaH
+iDK
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -84838,30 +83670,30 @@ ckI
 clJ
 cmL
 cnv
-cMm
-chX
-cpx
+cnZ
+vkE
+ccw
 cqg
 cqE
 cqZ
 crt
 cMH
 cAm
-cMH
+ttY
 cMN
-cFO
-cSI
-cSI
-cMm
+gXs
+aaf
+aaf
+xel
 cGV
-csd
-cGV
-noK
-csd
+jDa
+aaf
+aaf
+gXs
+aaH
+iDK
 ccw
-aaa
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -85095,30 +83927,30 @@ cfb
 ccw
 cmN
 cgR
-cgL
-chX
-cpx
+cnZ
+vkE
+piR
 cqj
 cSG
 crb
 cru
 cEx
-cEx
-cEx
-cAP
-cFP
-csI
-cAt
-cMm
-csd
-csd
-csd
-cHp
-csd
+vtT
+cqY
+cAq
+cFK
+hCi
+aaa
+nXx
+fAy
+rge
+aaa
+aaa
+aaa
+aaH
+iDK
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -85352,30 +84184,30 @@ cfb
 clM
 cfz
 cgR
+cnZ
+vkE
 ccw
-cii
-cpx
 cqi
 cMD
 cAP
-crv
-cEy
-cEy
-cFh
 cMD
-cFM
-czE
-kQq
-ccw
-cGT
-csd
-csd
-csd
-csd
-ccw
+cMD
+cEy
+cqY
+cAq
+aah
+aoV
+aaa
+aaa
 aaf
-aaT
-ctv
+aaa
+aaa
+aoV
+aoV
+aaH
+iDK
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -85609,30 +84441,30 @@ cfb
 cfa
 cje
 cgR
+cnZ
+vkE
+cpy
 ccw
-cDi
-cDr
-cDw
-cDE
-cEa
-cMD
-cEz
-cEz
-cEz
-cMD
-cFR
-cSJ
-kQq
-cMm
-ciZ
-cHd
-cHj
-cHd
-ciZ
+piR
 ccw
+ccw
+cqY
+cqY
+cqY
+cAq
+aah
+aoV
 aaa
-aaT
-ctv
+aaa
+aaf
+hCi
+aaa
+aoV
+aoV
+aaH
+iDK
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -85866,30 +84698,30 @@ ckL
 cmF
 cje
 cgR
-cMm
-chX
+cnZ
+cjS
 cpD
 cDw
 cDF
 cEa
-cEg
-cEA
-cET
-cFj
-cEf
-cFS
-cGg
-mBv
-cGI
-cGS
-cHe
-cHe
-cHr
-oDF
+oGr
+csP
+iDK
+wmQ
+cAq
+cFK
+aoV
+aaa
+aaa
+gXs
+cFK
+aoV
+aoV
+cFK
+aaH
+iDK
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaf
 aaa
@@ -86123,30 +84955,30 @@ ceq
 clQ
 cje
 cgR
-cMm
-cDj
-cDs
-cql
-cDG
-cDG
-cEh
-cEB
-cEU
-cFk
-cAs
-cFT
+cnZ
+cjS
+cgR
+cgR
+cgR
+cqT
+oGr
+csP
+iDK
+iDK
+cAq
+aaH
 cSK
-cGx
-cGK
-nzh
-nzh
-cGY
-csd
-csd
+aaH
+cSK
+aaH
+cSK
+aaH
+cSK
+aaH
+iDK
+iDK
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -86380,30 +85212,30 @@ ckO
 ckH
 cja
 cny
-ccw
-cip
+cnZ
+cjS
 cnx
 cDx
 cqb
-cqb
-cqb
-cEC
-cqb
-cqb
+cqT
+oGr
+cEs
+iDK
+wmQ
 cAr
-cqb
+xpv
 cGh
-cGC
-cey
-ijc
-csd
-cEk
-csd
-udp
+xpv
+cGh
+xpv
+cGh
+xpv
+eIw
+iDK
+iDK
+iDK
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -86637,30 +85469,30 @@ cfb
 clR
 cgR
 cgR
-cMm
-cir
+cnZ
+cjS
 cDt
 cDy
 cqC
+cqT
+ccw
+ccw
+ccw
 crc
-cEi
-cED
-crc
-crc
-cFy
+iDK
 cBR
-cGi
-cGD
-cGL
+iDK
+iDK
+iDK
+iDK
+iDK
+iDK
+iDK
+cBR
+iDK
+tGQ
 ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-aaa
-aaT
-aaT
+uvy
 aaT
 aaa
 aaa
@@ -86898,27 +85730,27 @@ cDe
 cDk
 coc
 cqa
-cig
-ccw
-ccw
+hFp
+oVp
+tyw
 czF
+cEK
 csd
-csd
-cFz
+iDK
 cFU
-cGj
+iDK
 cGE
-cGM
+qUp
 cGZ
-aag
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+qUp
+csx
+iDK
+cFU
+iDK
+iDK
+ccw
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -87154,27 +85986,27 @@ cgU
 cgU
 cis
 cjN
-cDz
-cDH
-cMm
-csd
-crM
-crV
-crV
-cFA
-csd
-cGk
+cgR
+cgR
+cqT
 ccw
-aag
-aag
-aag
-aaf
-aaf
-aaf
-aaf
-gXs
-aaf
-aaf
+crM
+ccw
+crV
+cFn
+vdq
+cFn
+hWL
+ccw
+ccw
+ccw
+cGr
+cFn
+eNN
+eas
+eas
+ccw
+uvy
 aaf
 aaf
 aaa
@@ -87407,32 +86239,32 @@ ccw
 cet
 cfd
 cfB
-cfI
-cgQ
+cfB
+cfB
 cjS
 cjN
-cqm
 cgR
-crd
-cEk
-crL
-cEW
-cse
-cse
-csu
-cGl
+cgR
+cqT
 ccw
-aaa
-aaa
-aaf
-aaa
-aaf
-ctv
-aaT
-aaa
-aaa
-aaf
-aaa
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+cpy
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+dsi
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -87668,28 +86500,28 @@ ccw
 ccw
 cDl
 cjN
-cjh
-cDI
+cgR
+cgR
+cgR
+cqS
 ccw
 ccw
 ccw
 ccw
 ccw
-cMm
-cMm
-cMm
 ccw
-aaf
-aaf
-aaf
-aaf
-aaf
+ewI
+rot
+rot
+rot
 ctv
-aaT
-aaa
+ctv
+ctv
+ctv
+uvy
 aaa
 aaf
-aaa
+hCi
 aaa
 aaa
 aaa
@@ -87926,7 +86758,7 @@ ccw
 cDm
 cjP
 ckF
-cDJ
+ckF
 ckF
 cpE
 cjR
@@ -87939,13 +86771,13 @@ aaa
 aaa
 aaa
 aaa
+rot
 ctv
 ctv
 ctv
-aaT
-aaa
-aaa
-aaa
+hCi
+hCi
+hCi
 aaa
 aaa
 aaa
@@ -88168,7 +87000,7 @@ caE
 cbA
 ccy
 bOd
-bOd
+vCV
 bQu
 cfO
 cgW
@@ -88190,17 +87022,17 @@ ccw
 crX
 cfK
 aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaT
-aaT
-aaT
-aaT
-aaa
+hCi
+hCi
+hCi
+hCi
+hCi
+hCi
+gXs
+gXs
+gXs
+gXs
+hCi
 aaa
 aaa
 aae
@@ -88413,7 +87245,7 @@ bIF
 bOZ
 bQp
 bRA
-bOd
+vCV
 bTO
 bUL
 bVU
@@ -88440,7 +87272,7 @@ ccw
 cpa
 cjc
 cqo
-cDL
+ccw
 cjk
 cjm
 ccw
@@ -88456,7 +87288,7 @@ aaa
 aaa
 aaa
 aaa
-eRz
+gXs
 aaa
 aaa
 aaa
@@ -88697,7 +87529,7 @@ ccw
 ccw
 cpI
 ccw
-cDL
+ccw
 cjl
 cjQ
 cjV
@@ -88954,7 +87786,7 @@ cig
 cpb
 ciZ
 cqp
-cDN
+cig
 cjT
 cgR
 crP
@@ -89211,7 +88043,7 @@ cig
 cig
 czg
 cig
-cDN
+cig
 crh
 crA
 crR
@@ -89468,7 +88300,7 @@ cig
 cpc
 cpJ
 cpc
-cDN
+cig
 cqY
 cqY
 cqY
@@ -89701,7 +88533,7 @@ bRF
 bSM
 bTS
 bUQ
-agd
+bWa
 bUO
 bVZ
 bVZ
@@ -89725,7 +88557,7 @@ cig
 cpd
 czM
 cpd
-cDN
+cig
 aaa
 aaa
 aaa
@@ -89958,8 +88790,8 @@ bRE
 bSJ
 bPe
 bOd
-cCB
-cCC
+bOd
+bOd
 bXT
 bXT
 bXT
@@ -89982,7 +88814,7 @@ ccw
 cpd
 czL
 cpd
-cDL
+ccw
 aaf
 aaa
 aaa
@@ -90216,7 +89048,7 @@ bSM
 bTU
 bUS
 bUS
-cCD
+bUS
 bXU
 bUS
 bUS
@@ -90239,7 +89071,7 @@ aaa
 cpd
 cpM
 cpd
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -90473,7 +89305,7 @@ bSN
 bTT
 bUR
 bWb
-cCE
+bUR
 bTT
 bUR
 bZJ
@@ -90496,7 +89328,7 @@ aaa
 aaa
 czN
 aaa
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -90753,7 +89585,7 @@ aaa
 aaa
 aaa
 aaa
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -90987,7 +89819,7 @@ bSP
 bPh
 bQy
 bRI
-cCF
+bQy
 bPh
 bQy
 bRI
@@ -91010,7 +89842,7 @@ aaa
 aaa
 aaa
 aaa
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -91244,16 +90076,16 @@ aaf
 bRK
 aaf
 bVv
-cCG
-cCH
-cCI
-cCJ
-cCI
-cCH
-cCI
-cCJ
-cCI
-cCP
+aaf
+bRK
+aaf
+bVv
+aaf
+bRK
+aaf
+bVv
+aaf
+aaf
 bLK
 chg
 bLK
@@ -91267,7 +90099,7 @@ aoV
 aoV
 aoV
 aoV
-cCQ
+aaf
 aoV
 aaa
 aaa
@@ -91510,7 +90342,7 @@ bPj
 bQA
 bPj
 bOh
-cCQ
+aaf
 bLK
 cyG
 bLK
@@ -91524,7 +90356,7 @@ aoV
 aoV
 aoV
 aoV
-cCQ
+aaf
 aoV
 aaa
 aaa
@@ -91767,21 +90599,21 @@ cbI
 ccC
 cdD
 bOh
-cCG
-cCS
-cCS
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cDY
+aaf
+aah
+aah
+aaf
+aaf
+aaf
+aaf
+aaf
+aah
+aah
+aah
+aah
+aah
+aah
+aaf
 aaf
 aaf
 aaf
@@ -106150,7 +104982,7 @@ bTr
 bTr
 bTr
 bTr
-bXu
+bTr
 bTr
 bTr
 bTr

--- a/_maps/cit_map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/cit_map_files/Deltastation/DeltaStation2.dmm
@@ -3966,7 +3966,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Engine - Fore";
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -8666,7 +8666,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 2;
-	network = list("Engine")
+	network = list("engine")
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
@@ -9182,10 +9182,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
-"ayK" = (
-/obj/machinery/power/supermatter_shard/crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "ayL" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -9245,7 +9241,7 @@
 	c_tag = "Supermatter Engine - Starboard";
 	dir = 8;
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -9646,7 +9642,7 @@
 	c_tag = "Supermatter Engine - Port";
 	dir = 4;
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -11684,7 +11680,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Engine - Aft";
 	name = "atmospherics camera";
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -12900,7 +12896,7 @@
 	c_tag = "Prison - Garden";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 1
@@ -17780,7 +17776,7 @@
 	c_tag = "Prison - Relaxation Area";
 	dir = 1;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plating,
 /area/security/prison)
@@ -19590,7 +19586,7 @@
 	c_tag = "Prison - Cell 3";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -19630,7 +19626,7 @@
 	c_tag = "Prison - Cell 2";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -19662,7 +19658,7 @@
 	c_tag = "Prison - Cell 1";
 	dir = 2;
 	name = "prison camera";
-	network = list("SS13","prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -29378,7 +29374,7 @@
 "bpg" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /obj/item/device/radio/intercom{
 	name = "Station Intercom";
@@ -29694,7 +29690,7 @@
 	c_tag = "AI Satellite - Fore";
 	dir = 1;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -32973,7 +32969,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Chamber - Fore";
 	name = "motion-sensitive ai camera";
-	network = list("AI")
+	network = list("ai")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
@@ -33462,8 +33458,7 @@
 "bxe" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -33589,7 +33584,7 @@
 	c_tag = "AI Satellite - Fore Port";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -33649,7 +33644,7 @@
 	c_tag = "AI Satellite - Fore Starboard";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -35403,7 +35398,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/caution{
@@ -35744,7 +35739,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons and the AI's satellite from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD","Sat");
+	network = list("rd","minisat");
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/dark,
@@ -41547,7 +41542,7 @@
 	c_tag = "Telecomms - Monitoring";
 	dir = 2;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -42033,7 +42028,7 @@
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
 	name = "motion-sensitive ai camera";
-	network = list("AI")
+	network = list("ai")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai)
@@ -42974,7 +42969,7 @@
 	c_tag = "AI Satellite - Port";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -43042,7 +43037,7 @@
 	c_tag = "AI Satellite - Starboard";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -43954,7 +43949,7 @@
 	c_tag = "AI Satellite - Antechamber";
 	dir = 2;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault,
@@ -44798,8 +44793,7 @@
 "bTl" = (
 /obj/machinery/camera/motion{
 	c_tag = "Armoury - Exterior";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -44874,7 +44868,7 @@
 	c_tag = "AI Satellite - Maintenance";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -44962,7 +44956,7 @@
 	c_tag = "AI Satellite - Teleporter";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -45078,7 +45072,7 @@
 	c_tag = "AI Satellite - Transit Tube";
 	dir = 2;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/item/clipboard,
@@ -46442,7 +46436,7 @@
 	desc = "Used for watching the AI's satellite.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("Sat");
+	network = list("minisat");
 	pixel_y = 2
 	},
 /turf/open/floor/plasteel/vault{
@@ -46489,7 +46483,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = -30
 	},
 /mob/living/simple_animal/parrot/Poly,
@@ -49781,7 +49775,7 @@
 	c_tag = "Telecomms - Chamber Port";
 	dir = 4;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -50225,7 +50219,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI - Upload";
 	name = "motion-sensitive ai camera";
-	network = list("Sat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -50252,6 +50246,10 @@
 /obj/structure/cable/white,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -51319,8 +51317,9 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Fore Starboard";
 	dir = 8;
-	network = list("Singularity")
+	network = list("singularity")
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cfC" = (
@@ -51668,7 +51667,7 @@
 	c_tag = "Telecomms - Chamber Starboard";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/vault/telecomms{
 	dir = 8
@@ -52292,7 +52291,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "chu" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -53036,7 +53034,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Fore Port";
 	dir = 4;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -53057,10 +53055,10 @@
 "cjb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -53076,25 +53074,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cje" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cjf" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engpa";
-	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -53334,8 +53315,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "Bridge - Captain's Emergency Escape";
 	dir = 4;
-	name = "command camera";
-	network = list("SS13")
+	name = "command camera"
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53663,13 +53643,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ckx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cky" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -53685,6 +53658,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ckA" = (
@@ -53693,34 +53667,10 @@
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"ckB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ckC" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "ckD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54292,20 +54242,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "clS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/field/generator{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"clT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/field/generator{
-	anchored = 1
+	anchored = 1;
+	state = 2
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -54318,19 +54257,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"clV" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engpa";
-	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "clW" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -54340,9 +54266,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "clX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55094,7 +55017,7 @@
 	c_tag = "AI Satellite - Aft Port";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -55169,7 +55092,7 @@
 	c_tag = "AI Satellite - Aft Starboard";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault{
@@ -55207,9 +55130,6 @@
 /obj/machinery/door/poddoor/shutters/preopen{
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -55473,7 +55393,7 @@
 	c_tag = "Telecomms - Cooling Room";
 	dir = 8;
 	name = "telecomms camera";
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -55895,9 +55815,6 @@
 "cpc" = (
 /obj/structure/cable{
 	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56458,6 +56375,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqr" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	icon_state = "emitter_left";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqs" = (
@@ -56466,6 +56387,7 @@
 /area/engine/engineering)
 "cqt" = (
 /obj/structure/cable,
+/obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqu" = (
@@ -57027,7 +56949,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "crJ" = (
-/obj/item/wrench,
+/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "crK" = (
@@ -57068,7 +56990,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crO" = (
-/obj/item/weldingtool/largetank,
+/obj/structure/particle_accelerator/fuel_chamber{
+	icon_state = "fuel_chamber";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crP" = (
@@ -57092,7 +57017,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Engine Containment Telescreen";
-	network = list("Singularity");
+	network = list("singularity");
 	pixel_x = -30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -57846,7 +57771,10 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ctp" = (
-/obj/item/wrench,
+/obj/structure/particle_accelerator/particle_emitter/right{
+	icon_state = "emitter_right";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ctq" = (
@@ -58650,7 +58578,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Particle Accelerator";
 	dir = 1;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -58658,9 +58586,6 @@
 "cuT" = (
 /obj/structure/cable{
 	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -58716,6 +58641,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cva" = (
@@ -59873,24 +59799,6 @@
 	dir = 4
 	},
 /area/crew_quarters/fitness/recreation)
-"cxA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cxB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cxD" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -60710,13 +60618,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"czp" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "czq" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -60730,33 +60631,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"czs" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engpa";
-	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"czt" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/engineering)
 "czu" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -61344,7 +61221,7 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Aft Port";
 	dir = 4;
-	network = list("Singularity")
+	network = list("singularity")
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -61358,10 +61235,10 @@
 "cAI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -61373,11 +61250,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAK" = (
-/obj/machinery/power/rad_collector/anchored,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -62961,8 +62834,9 @@
 /obj/machinery/camera/emp_proof{
 	c_tag = "Containment - Aft Starboard";
 	dir = 8;
-	network = list("Singularity")
+	network = list("singularity")
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cDW" = (
@@ -63846,6 +63720,12 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	icon_state = "emitter";
+	state = 2
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFI" = (
@@ -67620,7 +67500,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 1";
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67633,7 +67513,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 2";
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67646,7 +67526,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology - Cell 3";
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -67663,7 +67543,7 @@
 	c_tag = "Xenobiology - Killroom Chamber";
 	dir = 2;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault/killroom,
 /area/science/xenobiology)
@@ -69712,7 +69592,7 @@
 	c_tag = "Xenobiology - Port";
 	dir = 2;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -72180,7 +72060,7 @@
 	c_tag = "Xenobiology - Secure Cell";
 	dir = 4;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -72394,7 +72274,7 @@
 	c_tag = "Science - Fore";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
@@ -72454,7 +72334,7 @@
 	c_tag = "Security Post - Science";
 	dir = 8;
 	name = "security camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 6
@@ -72505,7 +72385,7 @@
 	c_tag = "Science - Waiting Room";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8
@@ -73201,7 +73081,7 @@
 	c_tag = "Xenobiology - Starboard";
 	dir = 8;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -74963,7 +74843,7 @@
 	c_tag = "Science - Research Division Access";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -76222,7 +76102,7 @@
 	c_tag = "Science - Research and Development";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/lab)
@@ -76290,7 +76170,7 @@
 	c_tag = "Medbay - Chemistry";
 	dir = 8;
 	name = "medbay camera";
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
@@ -76676,7 +76556,7 @@
 	c_tag = "Xenobiology - Cell 4";
 	dir = 1;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -76688,7 +76568,7 @@
 	c_tag = "Xenobiology - Cell 5";
 	dir = 1;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -76700,7 +76580,7 @@
 	c_tag = "Xenobiology - Cell 6";
 	dir = 1;
 	name = "xenobiology camera";
-	network = list("SS13","xeno","RD")
+	network = list("ss13","xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -76745,7 +76625,7 @@
 	c_tag = "Science - Port";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
@@ -76812,7 +76692,7 @@
 	c_tag = "Science - Center";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
@@ -77966,7 +77846,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white/corner,
@@ -78125,7 +78005,7 @@
 	c_tag = "Science - Experimentation Lab";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -79526,7 +79406,7 @@
 	c_tag = "Science - Lab Access";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -81872,7 +81752,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -82119,7 +81999,7 @@
 	c_tag = "Science - Research Director's Office";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -83970,7 +83850,7 @@
 	c_tag = "Science - Experimentor";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -83985,7 +83865,7 @@
 	c_tag = "Science - Toxins Mixing Lab Fore";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 8
@@ -84027,7 +83907,7 @@
 	c_tag = "Science - Firing Range";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -84124,7 +84004,7 @@
 	c_tag = "Science - Aft Center";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -84167,7 +84047,7 @@
 	c_tag = "Science - Mech Bay";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -87081,7 +86961,7 @@
 	c_tag = "Science - Research Director's Quarters";
 	dir = 1;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 1
@@ -87777,7 +87657,7 @@
 	c_tag = "Science - Robotics Lab";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -88615,7 +88495,7 @@
 	c_tag = "Science - Toxins Launch Site";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -88730,7 +88610,7 @@
 	c_tag = "Science - Toxins Mixing Lab Aft";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -89358,7 +89238,7 @@
 	dir = 4;
 	layer = 4;
 	name = "Testing Site Telescreen";
-	network = list("Toxins")
+	network = list("toxins")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -90187,7 +90067,7 @@
 	c_tag = "Science - Server Room";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
@@ -90200,7 +90080,7 @@
 	c_tag = "Science - Aft";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8
@@ -90673,7 +90553,7 @@
 /turf/open/floor/plating/airless,
 /area/science/test_area)
 "dJJ" = (
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -90861,7 +90741,7 @@
 	c_tag = "Science - Toxins Secure Storage";
 	dir = 4;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -91663,7 +91543,7 @@
 	invuln = 1;
 	light = null;
 	name = "hardened testing camera";
-	network = list("Toxins");
+	network = list("toxins");
 	start_active = 1;
 	use_power = 0
 	},
@@ -93003,7 +92883,7 @@
 	c_tag = "Science - Break Room";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 4
@@ -100888,7 +100768,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Service Bay";
 	dir = 8;
-	network = list("MiniSat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -100912,6 +100792,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"giB" = (
+/obj/structure/particle_accelerator/end_cap{
+	icon_state = "end_cap";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "gmj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -100954,6 +100841,12 @@
 	dir = 10
 	},
 /area/science/circuit)
+"hiz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "hrP" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -101032,7 +100925,7 @@
 	c_tag = "Science - Experimentation Lab";
 	dir = 2;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/requests_console{
 	department = "Circuitry Lab";
@@ -101159,6 +101052,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
+"mId" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"mRo" = (
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"nBz" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "oZC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -101232,9 +101134,27 @@
 	dir = 6
 	},
 /area/science/circuit)
+"rQf" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	icon_state = "emitter_center";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"sar" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "saw" = (
 /turf/closed/wall,
 /area/science/circuit)
+"taK" = (
+/obj/structure/particle_accelerator/power_box{
+	icon_state = "power_box";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tmi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -101249,6 +101169,9 @@
 	dir = 10
 	},
 /area/science/misc_lab)
+"tTq" = (
+/turf/open/space,
+/area/space/nearstation)
 "upk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -101294,6 +101217,9 @@
 	dir = 5
 	},
 /area/medical/morgue)
+"vYn" = (
+/turf/open/space,
+/area/space)
 "wei" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -101338,7 +101264,7 @@
 	c_tag = "Science - Lab Access";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/structure/sign/departments/science{
 	pixel_x = 32
@@ -101363,6 +101289,10 @@
 	},
 /turf/open/floor/plasteel/white/side,
 /area/science/circuit)
+"xSx" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "yjc" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/research/abandoned";
@@ -121815,14 +121745,14 @@ aaa
 cja
 ckw
 clS
-aad
-aad
-clR
-aaa
-abj
-aad
-aad
-cxA
+tTq
+tTq
+clS
+sar
+mId
+tTq
+tTq
+clS
 ctn
 cja
 aaa
@@ -122070,17 +122000,17 @@ cdC
 cfA
 aad
 cjb
-ckx
+cky
+tTq
+vYn
+vYn
+xSx
 aad
-aaa
-aaa
-abj
-aad
-abj
-aaa
-aaa
-aad
-czp
+mId
+vYn
+vYn
+tTq
+czq
 cAI
 aad
 cDT
@@ -122328,15 +122258,15 @@ cfA
 aaa
 cja
 ckw
+tTq
+vYn
+mId
+mId
 aad
-aaa
-abj
-abj
-abj
-abj
-abj
-aaa
-aad
+mId
+mId
+vYn
+tTq
 ctn
 cja
 aaa
@@ -122583,19 +122513,19 @@ car
 cbP
 cfA
 abj
-cja
-ckw
-ckw
-abj
-abj
+cjb
+cky
+mId
+mId
+mId
 cqo
 clR
 ctm
-abj
-abj
-abj
-ctn
-cja
+mId
+xSx
+clS
+czq
+cAI
 abj
 cDT
 cFJ
@@ -122840,19 +122770,19 @@ car
 cbP
 cdC
 aad
-cjb
-cky
-aaa
+cja
+ckw
+sar
 aad
-abj
+aad
 ckw
 crJ
-ctn
-abj
+hiz
 aad
-aaa
-czq
-cAI
+aad
+sar
+ctn
+cja
 aad
 cdC
 cFJ
@@ -123097,19 +123027,19 @@ car
 cbP
 cfA
 abj
-cja
-ckw
-abj
-abj
-abj
+cjb
+cky
+clS
+xSx
+mId
 cqp
 crK
 cto
-abj
-abj
-ctn
-ctn
-cja
+mId
+mId
+mId
+czq
+cAI
 abj
 cDT
 cFJ
@@ -123356,15 +123286,15 @@ cfA
 aaa
 cja
 ckw
+tTq
+vYn
+mId
+mId
 aad
-aaa
-abj
-abj
-abj
-abj
-abj
-aaa
-aad
+mId
+mId
+vYn
+tTq
 ctn
 cja
 aaa
@@ -123612,17 +123542,17 @@ cdC
 cfA
 aad
 cjb
-ckx
+cky
+tTq
+vYn
+aaa
+mId
 aad
+xSx
 aaa
-aaa
-abj
-aad
-abj
-aaa
-aaa
-aad
-czp
+vYn
+tTq
+czq
 cAI
 aad
 cDU
@@ -123870,15 +123800,15 @@ cfA
 aaa
 cja
 ckw
-clT
-aad
-aad
-abj
-aaa
-crK
-aad
-aad
-cxB
+clS
+tTq
+mId
+mId
+sar
+clS
+tTq
+tTq
+clS
 ctn
 cja
 aaa
@@ -124381,8 +124311,8 @@ car
 cbT
 cdG
 cfB
-aaa
-aad
+nBz
+mRo
 aaa
 aad
 cjd
@@ -124394,8 +124324,8 @@ cjd
 cjd
 aad
 aaa
-aad
-aaa
+mRo
+nBz
 cDV
 cFL
 cHg
@@ -124902,7 +124832,7 @@ cje
 cjd
 cpa
 cqr
-cqr
+rQf
 ctp
 cuQ
 cjd
@@ -125153,19 +125083,19 @@ cbV
 cdJ
 car
 chv
-cjf
+chv
 ckA
-clV
+chv
 cnC
 cpa
 cqs
-cqr
+taK
 ctq
 cuR
 cnC
-cjf
-czs
-clV
+chv
+chv
+chv
 chv
 car
 cFO
@@ -125411,7 +125341,7 @@ cdK
 cfD
 chw
 cjg
-ckB
+chw
 clW
 cnD
 cpb
@@ -125421,7 +125351,7 @@ ctr
 cuS
 cnD
 cxD
-ckB
+chw
 chw
 chw
 cDW
@@ -125668,17 +125598,17 @@ cdL
 cfE
 chx
 cjh
-ckC
+cjn
 clX
 cnE
 cpc
 cqu
-cqr
+giB
 cts
 cuT
 cnE
 clX
-czt
+cjn
 cAL
 cCs
 cDX
@@ -127155,7 +127085,7 @@ atS
 avb
 awh
 axz
-ayK
+axz
 axz
 aAW
 axz

--- a/_maps/cit_map_files/MetaStation/MetaStation.dmm
+++ b/_maps/cit_map_files/MetaStation/MetaStation.dmm
@@ -11247,6 +11247,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "axN" = (
@@ -11359,6 +11362,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -12260,6 +12266,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -12457,6 +12466,9 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -16090,6 +16102,9 @@
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -21282,6 +21297,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light,
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aTI" = (
@@ -22514,9 +22530,7 @@
 	req_access = null;
 	req_access_txt = "32"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aWv" = (
 /turf/closed/wall,
@@ -47824,6 +47838,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bXc" = (
@@ -56896,6 +56913,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -71873,9 +71893,10 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -71892,9 +71913,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYc" = (
 /obj/structure/table/optable{
@@ -71916,9 +71935,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYE" = (
 /obj/structure/closet/toolcloset,
@@ -72232,6 +72249,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -76171,6 +76191,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dZD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "eln" = (
 /turf/open/space/basic,
 /area/engine/engineering)
@@ -76257,6 +76283,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"eHX" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eXy" = (
 /obj/machinery/airalarm{
 	pixel_y = 32
@@ -76352,10 +76384,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"gry" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space)
 "gEk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -76421,10 +76449,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"iad" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
+"hWU" = (
 /turf/open/floor/plating/airless,
 /area/space)
 "ioI" = (
@@ -76454,12 +76479,6 @@
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/science/lab)
-"iHb" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "iOa" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/maintenance/starboard)
@@ -76524,9 +76543,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "jIV" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -76608,12 +76625,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"kWa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "lal" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -76657,9 +76668,6 @@
 "lHL" = (
 /turf/open/space/basic,
 /area/space/nearstation)
-"lJj" = (
-/turf/open/floor/plating/airless,
-/area/space)
 "lLj" = (
 /turf/open/floor/plasteel/yellow/side{
 	dir = 8
@@ -76721,6 +76729,12 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"mwK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "mzh" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -76728,10 +76742,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"mPF" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/space)
 "ngl" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/plasteel/white,
@@ -76904,6 +76914,14 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oWo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/starboard/fore)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -76959,6 +76977,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"pYA" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qnJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76973,6 +76998,12 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/science/circuit)
+"qoX" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qqg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -76989,6 +77020,12 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
+"qJG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qJZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -77018,14 +77055,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"rLy" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Containment - Aft Starboard";
-	dir = 8;
-	network = list("singularity")
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77078,6 +77107,10 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"swQ" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "sGh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -77104,14 +77137,19 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"sOW" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "sSU" = (
 /turf/closed/wall/r_wall,
 /area/space)
-"tco" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+"sZQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/area/engine/break_room)
+/turf/closed/wall,
+/area/engine/engineering)
 "tjH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -77229,6 +77267,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vmz" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
+"vHD" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -77295,6 +77343,9 @@
 /area/science/misc_lab)
 "xcM" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
@@ -77387,6 +77438,14 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
+"yeY" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Starboard";
+	dir = 8;
+	network = list("singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -117840,7 +117899,7 @@ arJ
 arI
 dnh
 dqu
-doh
+oWo
 axO
 axY
 aAo
@@ -118886,8 +118945,8 @@ dfh
 aBO
 aBO
 aBK
-aTK
-aVe
+pYA
+sZQ
 axY
 aYu
 aYu
@@ -119648,7 +119707,7 @@ aCW
 aBO
 aFA
 aGZ
-kWa
+qJG
 aJu
 aKG
 aJu
@@ -119900,12 +119959,12 @@ axY
 axY
 ayW
 bTq
-aBO
+eHX
 aBO
 aBO
 aFC
 axY
-kWa
+qJG
 aJu
 aKH
 aMk
@@ -119913,7 +119972,7 @@ aNu
 axY
 dfp
 aBO
-aBO
+eHX
 dfP
 dfY
 axY
@@ -120162,7 +120221,7 @@ aBO
 aBO
 der
 axY
-kWa
+qJG
 aJu
 aKI
 tDM
@@ -120177,11 +120236,11 @@ axY
 atm
 dgc
 alq
-apf
+apc
 aWu
-tco
-tco
-tco
+bif
+bif
+bif
 bhT
 bhT
 brK
@@ -120411,7 +120470,7 @@ ati
 ajb
 avB
 axY
-aJu
+qoX
 bUw
 aJu
 axY
@@ -120419,7 +120478,7 @@ axY
 axY
 axY
 djt
-kWa
+qJG
 daZ
 dbb
 rVX
@@ -120430,7 +120489,7 @@ axY
 axY
 aJu
 bUw
-aJu
+swQ
 axY
 alq
 alq
@@ -120676,7 +120735,7 @@ ddO
 aEr
 ddO
 djt
-kWa
+qJG
 aJu
 rEi
 dfa
@@ -121436,27 +121495,27 @@ apn
 aqy
 arT
 apm
-dnS
+vHD
 avB
 axY
 goZ
 ddO
 aAx
-mPF
+sOW
 aIe
 aOS
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
-iad
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
 dBB
 aIe
-mPF
+sOW
 cWu
 ddO
 aYx
@@ -121701,7 +121760,7 @@ xqB
 aAx
 aaa
 aIe
-iHb
+dZD
 dev
 aav
 aav
@@ -121956,7 +122015,7 @@ dqT
 fGs
 ddO
 aAx
-mPF
+sOW
 def
 aCZ
 aav
@@ -121970,7 +122029,7 @@ aav
 aav
 xfK
 obN
-mPF
+sOW
 cWu
 ddO
 dgg
@@ -122215,7 +122274,7 @@ dPf
 aAx
 aaa
 aIe
-iHb
+dZD
 aav
 aav
 aaa
@@ -122470,7 +122529,7 @@ dqT
 axY
 fGs
 aAx
-gry
+vmz
 def
 aCZ
 aaa
@@ -122484,7 +122543,7 @@ vLD
 dev
 xfK
 obN
-gry
+vmz
 cWu
 dgg
 axY
@@ -122727,9 +122786,9 @@ dqT
 axY
 fGs
 ddO
-mPF
+sOW
 aIe
-iHb
+dZD
 lMJ
 aaf
 aaf
@@ -122741,7 +122800,7 @@ aaf
 lMJ
 dfz
 aIe
-mPF
+sOW
 ddO
 dgg
 axY
@@ -122984,7 +123043,7 @@ dqT
 axY
 fGs
 aAx
-gry
+vmz
 def
 aCZ
 dev
@@ -122998,7 +123057,7 @@ aaa
 aaa
 xfK
 obN
-gry
+vmz
 cWu
 dgg
 axY
@@ -123243,7 +123302,7 @@ rTo
 aAx
 aaa
 aIe
-iHb
+dZD
 aav
 aav
 aaa
@@ -123498,7 +123557,7 @@ dqT
 fGs
 ddO
 aAx
-mPF
+sOW
 dtL
 aCZ
 aav
@@ -123512,7 +123571,7 @@ aav
 aav
 xfK
 xLP
-mPF
+sOW
 pWF
 ddO
 dgg
@@ -123756,8 +123815,8 @@ drT
 xqB
 aAx
 aaa
-gry
-iHb
+vmz
+dZD
 dev
 aav
 aaa
@@ -123768,7 +123827,7 @@ aav
 aav
 dev
 dfz
-gry
+vmz
 aaa
 cWu
 dge
@@ -124012,21 +124071,21 @@ dqT
 axY
 axY
 ddO
-lJj
-lJj
+hWU
+hWU
 gKb
-lJj
-lJj
-lJj
-lJj
-lJj
-lJj
-lJj
-lJj
-lJj
-rLy
-lJj
-lJj
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+yeY
+hWU
+hWU
 ddO
 axY
 axY

--- a/_maps/cit_map_files/MetaStation/MetaStation.dmm
+++ b/_maps/cit_map_files/MetaStation/MetaStation.dmm
@@ -11792,7 +11792,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aza" = (
 /obj/structure/cable/white{
@@ -13698,7 +13698,7 @@
 	},
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aCZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -13706,7 +13706,7 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aDa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -16033,13 +16033,6 @@
 	dir = 2
 	},
 /area/crew_quarters/dorms)
-"aHP" = (
-/obj/structure/particle_accelerator/particle_emitter/left{
-	icon_state = "emitter_left";
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "aHQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16128,7 +16121,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -17276,21 +17269,21 @@
 	icon_state = "end_cap";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aKH" = (
 /obj/structure/particle_accelerator/fuel_chamber{
 	icon_state = "fuel_chamber";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aKI" = (
 /obj/structure/particle_accelerator/power_box{
 	icon_state = "power_box";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aKN" = (
 /obj/machinery/door/poddoor{
@@ -17891,7 +17884,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMk" = (
 /obj/machinery/particle_accelerator/control_box,
@@ -17899,7 +17892,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMo" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18384,7 +18377,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aNw" = (
 /obj/structure/window/reinforced{
@@ -19079,7 +19072,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aOT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20751,7 +20744,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21314,12 +21307,6 @@
 "aTK" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aTO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -22527,7 +22514,9 @@
 	req_access = null;
 	req_access_txt = "32"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "aWv" = (
 /turf/closed/wall,
@@ -31767,9 +31756,6 @@
 	dir = 6
 	},
 /area/security/checkpoint/customs)
-"bpu" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "bpv" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -46592,7 +46578,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "bUx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47079,7 +47065,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "bVA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_access_txt = "null";
@@ -71831,6 +71816,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
+"cWu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cWA" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -71882,16 +71873,10 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cXM" = (
-/obj/structure/cable/white{
-	icon_state = "2-4"
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
 	},
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/area/maintenance/starboard)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -71907,7 +71892,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "cYc" = (
 /obj/structure/table/optable{
@@ -71925,17 +71912,13 @@
 	dir = 1
 	},
 /area/science/robotics/lab)
-"cYi" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/engine/engineering)
 "cYj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "cYE" = (
 /obj/structure/closet/toolcloset,
@@ -72265,14 +72248,14 @@
 	icon_state = "emitter_right";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dbb" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
 	icon_state = "emitter_center";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dbd" = (
 /obj/structure/sink/kitchen{
@@ -73543,14 +73526,14 @@
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dem" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "den" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73590,7 +73573,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "deM" = (
 /obj/structure/table,
 /obj/effect/turf_decal/delivery,
@@ -73615,7 +73598,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "deY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -73626,7 +73609,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dfh" = (
 /obj/structure/table,
@@ -73652,7 +73635,7 @@
 "dfz" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "dfD" = (
 /obj/item/book/manual/engineering_singularity_safety{
 	pixel_x = 3;
@@ -73673,7 +73656,7 @@
 	},
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "dfP" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -73712,7 +73695,9 @@
 /obj/item/clothing/head/soft/rainbow,
 /obj/item/clothing/shoes/sneakers/rainbow,
 /obj/item/clothing/under/color/rainbow,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "dgd" = (
 /obj/structure/cable/white{
@@ -74797,7 +74782,7 @@
 /area/science/xenobiology)
 "djt" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "djx" = (
 /obj/machinery/camera/emp_proof{
@@ -74866,26 +74851,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
-"dkr" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Containment Access";
-	req_access_txt = "10; 13"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "dlI" = (
 /obj/structure/closet/secure_closet/engineering_electrical,
 /turf/open/floor/plasteel/yellow/side{
@@ -75102,6 +75067,14 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
+"drT" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dsg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75142,6 +75115,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dtL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/space,
+/area/space)
 "dtP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75478,21 +75458,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dBy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dBB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "dBC" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -76149,16 +76129,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"dFT" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "dGH" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -76182,6 +76152,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dPf" = (
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dYu" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -76191,11 +76171,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"emE" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
+"eln" = (
+/turf/open/space/basic,
+/area/engine/engineering)
+"enN" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "eoK" = (
 /obj/structure/disposalpipe/segment{
@@ -76229,10 +76210,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"evc" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 8
+"esV" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "evy" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -76244,6 +76231,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"eEu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "eFN" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "crematoriumChapel";
@@ -76274,12 +76280,48 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"fjy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"foU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 8;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("singularity");
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
 "fDD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"fGs" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"fWO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "gfh" = (
 /obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
@@ -76302,6 +76344,18 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"goZ" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"gry" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "gEk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -76327,14 +76381,14 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
-"gLz" = (
-/obj/structure/cable{
-	icon_state = "0-2"
+"gKb" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Fore Starboard";
+	dir = 8;
+	network = list("singularity")
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -76367,39 +76421,9 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
-"hze" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/space,
-/area/space/nearstation)
-"hAc" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"hHc" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"hJX" = (
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/structure/grille,
+"iad" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"ior" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/plating/airless,
 /area/space)
@@ -76430,15 +76454,37 @@
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/science/lab)
-"iRf" = (
-/turf/open/space/basic,
-/area/space/nearstation)
-"jnX" = (
+"iHb" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"iOa" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/maintenance/starboard)
+"iTS" = (
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"jjF" = (
 /obj/structure/cable/white{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
 /obj/structure/grille,
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "jwW" = (
@@ -76471,15 +76517,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
-"jFg" = (
-/obj/structure/cable/white{
-	icon_state = "2-8"
+"jFx" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/starboard)
+"jIV" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "jKK" = (
 /obj/machinery/door/airlock/external{
@@ -76490,24 +76543,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"kfh" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"krz" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -76561,13 +76600,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"kUD" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "kVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -76576,18 +76608,18 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"kWa" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "lal" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"lhK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating/airless,
-/area/space)
 "llb" = (
 /obj/structure/table/reinforced,
 /obj/item/device/integrated_circuit_printer,
@@ -76607,10 +76639,6 @@
 /obj/item/device/multitool,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"lwB" = (
-/obj/structure/lattice,
-/turf/open/space,
-/area/engine/engineering)
 "lzk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -76626,6 +76654,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"lHL" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"lJj" = (
+/turf/open/floor/plating/airless,
+/area/space)
+"lLj" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/engineering)
 "lMz" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -76643,21 +76682,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"lOO" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/engine/engineering)
-"lPF" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -76671,9 +76695,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
-"mdf" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "mjJ" = (
 /obj/structure/reagent_dispensers/beerkeg{
 	desc = "One of the more successful achievements of the Nanotrasen Corporate Warfare Division, their nuclear fission explosives are renowned for being cheap to produce and devastatingly effective. Signs explain that though this particular device has been decommissioned, every Nanotrasen station is equipped with an equivalent one, just in case. All Captains carefully guard the disk needed to detonate them - at least, the sign says they do. There seems to be a tap on the back.";
@@ -76685,6 +76706,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"moI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "mvj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -76694,10 +76721,6 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"myV" = (
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "mzh" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -76705,17 +76728,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"mGi" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+"mPF" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "ngl" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/plasteel/white,
@@ -76737,6 +76753,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/circuit)
+"nte" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"nwU" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "nyo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -76771,10 +76811,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage/wing)
+"nKh" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "obb" = (
 /obj/structure/target_stake,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"obN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space)
+"ocj" = (
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ocT" = (
 /obj/machinery/light{
 	dir = 1
@@ -76794,22 +76857,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oep" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the Engine.";
-	dir = 8;
-	layer = 4;
-	name = "Engine Monitor";
-	network = list("singularity");
-	pixel_x = 30
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/engine/engineering)
 "ohj" = (
 /obj/item/device/integrated_electronics/analyzer,
 /obj/item/device/integrated_electronics/debugger,
@@ -76857,22 +76904,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"pff" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating/airless,
-/area/space)
-"puW" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/space,
-/area/space/nearstation)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -76889,11 +76920,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pwF" = (
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
-	},
-/area/engine/engineering)
 "pzj" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -76910,12 +76936,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"pPJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -76925,14 +76945,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"pVn" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Containment - Aft Starboard";
-	dir = 8;
-	network = list("singularity")
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "pVo" = (
 /obj/machinery/light,
 /obj/machinery/vending/kink,
@@ -76940,13 +76952,13 @@
 	dir = 2
 	},
 /area/crew_quarters/locker)
-"qcW" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "2-8"
+"pWF" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "qnJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76991,16 +77003,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"qXk" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "rzX" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -77010,6 +77012,20 @@
 	dir = 1
 	},
 /area/science/lab)
+"rEi" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"rLy" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Starboard";
+	dir = 8;
+	network = list("singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77029,6 +77045,29 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rTo" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"rVX" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	icon_state = "emitter_left";
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"rWa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "sdi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -77039,33 +77078,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"sjZ" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "External Containment Access";
-	req_access_txt = "10; 13"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"suq" = (
-/obj/structure/grille,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "sGh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -77092,14 +77104,19 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"sSU" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"tco" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/engine/break_room)
 "tjH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"trf" = (
-/turf/open/space/basic,
-/area/engine/engineering)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77117,7 +77134,7 @@
 /area/science/circuit)
 "tDM" = (
 /obj/item/wrench,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
@@ -77125,6 +77142,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tMT" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/engine/engineering)
 "tVY" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -77137,9 +77158,6 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"uch" = (
-/turf/closed/wall/mineral/plastitanium,
-/area/maintenance/starboard)
 "upN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -77178,6 +77196,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"uQo" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
 "uRM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77186,15 +77209,6 @@
 	dir = 2
 	},
 /area/science/research)
-"uTQ" = (
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "uTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77215,40 +77229,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
-"vwp" = (
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/turf_decal/delivery,
-/obj/structure/table,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/engine/engineering)
-"vzK" = (
-/obj/structure/cable/white,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/power/emitter{
-	anchored = 1;
-	state = 2
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"wco" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
+"vSl" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
@@ -77277,10 +77270,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"wIF" = (
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wKo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -77304,11 +77293,36 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xcM" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"xfK" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space)
 "xkG" = (
 /obj/item/device/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xqB" = (
+/obj/structure/cable/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xse" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -77340,6 +77354,19 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xLP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space)
+"xNI" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -77350,6 +77377,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xWZ" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -117557,8 +117594,8 @@ aFu
 aBI
 aBI
 aJn
-evc
-evc
+lLj
+lLj
 aNq
 aBI
 aPZ
@@ -118320,7 +118357,7 @@ avt
 awJ
 axS
 axY
-cYi
+jIV
 ddW
 aCT
 aEp
@@ -118591,7 +118628,7 @@ aBO
 aBO
 aBO
 aGX
-aTO
+aBK
 aTK
 aVd
 aBI
@@ -118834,21 +118871,21 @@ avv
 axY
 axU
 ayS
-wIF
+enN
 ddX
 deb
 aBO
 aBO
-vwp
+iTS
 deM
-lOO
-oep
+uQo
+foU
 aMg
-wco
+xcM
 dfh
 aBO
 aBO
-aTO
+aBK
 aTK
 aVe
 axY
@@ -119103,7 +119140,7 @@ axY
 aMh
 axY
 axY
-pwF
+nKh
 aBO
 aSz
 aTK
@@ -119611,17 +119648,17 @@ aCW
 aBO
 aFA
 aGZ
-emE
-ddO
+kWa
+aJu
 aKG
-ddO
+aJu
 dBy
 aGZ
-pwF
+nKh
 aBO
 dfD
 aTK
-pPJ
+rWa
 aJu
 aYu
 aZN
@@ -119868,8 +119905,8 @@ aBO
 aBO
 aFC
 axY
-emE
-ddO
+kWa
+aJu
 aKH
 aMk
 aNu
@@ -120125,8 +120162,8 @@ aBO
 aBO
 der
 axY
-emE
-ddO
+kWa
+aJu
 aKI
 tDM
 dBy
@@ -120140,11 +120177,11 @@ axY
 atm
 dgc
 alq
-apc
+apf
 aWu
-bif
-bif
-bif
+tco
+tco
+tco
 bhT
 bhT
 brK
@@ -120374,26 +120411,26 @@ ati
 ajb
 avB
 axY
-ddO
+aJu
 bUw
-ddO
+aJu
 axY
 axY
 axY
 axY
 djt
-emE
+kWa
 daZ
 dbb
-aHP
+rVX
 dBy
 djt
 axY
 axY
 axY
-ddO
+aJu
 bUw
-ddO
+aJu
 axY
 alq
 alq
@@ -120632,16 +120669,16 @@ ajb
 avC
 axY
 axY
-sjZ
+eEu
 axY
 axY
 ddO
 aEr
 ddO
 djt
-emE
-ddO
-kfh
+kWa
+aJu
+rEi
 dfa
 aNv
 djt
@@ -120649,13 +120686,13 @@ ddO
 djx
 axY
 axY
-dkr
+nwU
 axY
 axY
 alq
 cXI
 cYj
-uch
+iOa
 bga
 big
 bga
@@ -120889,7 +120926,7 @@ dpL
 avD
 axY
 axY
-hAc
+xNI
 ddO
 ddO
 ddO
@@ -120898,7 +120935,7 @@ ddO
 djt
 djt
 djt
-hHc
+aRm
 djt
 djt
 djt
@@ -120911,8 +120948,8 @@ dgd
 dgj
 atm
 alq
-uTQ
-uch
+jFx
+iOa
 bgb
 cTu
 bgb
@@ -121148,7 +121185,7 @@ axY
 ayc
 aza
 ddO
-iRf
+aaa
 aCY
 dem
 dem
@@ -121162,12 +121199,12 @@ dem
 dem
 dem
 dfI
-iRf
+aaa
 ddO
 ddO
 aYx
-bpu
-iRf
+sSU
+lHL
 lMJ
 dgI
 bgb
@@ -121402,31 +121439,31 @@ apm
 dnS
 avB
 axY
-suq
+goZ
 ddO
 aAx
-aaf
+mPF
 aIe
 aOS
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
+iad
 dBB
 aIe
-aaf
-emE
+mPF
+cWu
 ddO
 aYx
-bpu
+sSU
 lMJ
 lMJ
-iRf
+lHL
 bgb
 bij
 bgb
@@ -121659,31 +121696,31 @@ atk
 aux
 avF
 dqT
-mGi
-vzK
+esV
+xqB
 aAx
-iRf
+aaa
 aIe
-den
+iHb
 dev
-dew
-dew
+aav
+aav
 dev
 lMJ
-iRf
-dew
-dew
+aaa
+aav
+aav
 dev
 dfz
 aIe
-iRf
-emE
+aaa
+cWu
 dge
 azd
-bpu
+sSU
 lMJ
 lMJ
-iRf
+lHL
 aaa
 cUL
 aaa
@@ -121916,13 +121953,13 @@ atl
 auy
 dnS
 dqT
-jnX
+fGs
 ddO
 aAx
-aaf
+mPF
 def
 aCZ
-dew
+aav
 aav
 aav
 vLD
@@ -121930,17 +121967,17 @@ aaf
 aaa
 aav
 aav
-dew
-gLz
-puW
-aaf
-emE
+aav
+xfK
+obN
+mPF
+cWu
 ddO
 dgg
-bpu
+sSU
 lMJ
-iRf
-iRf
+lHL
+lHL
 anT
 aaf
 aaf
@@ -122172,14 +122209,14 @@ apm
 apm
 dnh
 dnS
-dnz
-jFg
-dFT
+dqT
+xWZ
+dPf
 aAx
-iRf
+aaa
 aIe
-den
-dew
+iHb
+aav
 aav
 aaa
 aaa
@@ -122187,17 +122224,17 @@ aaf
 aaa
 aaa
 aav
-dew
+aav
 dfz
 aIe
-iRf
-emE
+aaa
+cWu
 aWK
 dgk
-bpu
+sSU
 lMJ
-iRf
-iRf
+lHL
+lHL
 anT
 dew
 dew
@@ -122431,30 +122468,30 @@ auz
 dqp
 dqT
 axY
-jnX
+fGs
 aAx
-ack
+gry
 def
 aCZ
-iRf
+aaa
 aaa
 aaa
 ddZ
 cDu
-lhK
+fWO
 aaa
 vLD
 dev
-gLz
-puW
-ack
-emE
+xfK
+obN
+gry
+cWu
 dgg
 axY
-bpu
+sSU
 lMJ
-iRf
-iRf
+lHL
+lHL
 anT
 aaa
 aaa
@@ -122688,29 +122725,29 @@ auA
 dnS
 dqT
 axY
-jnX
+fGs
 ddO
-aaf
+mPF
 aIe
-den
+iHb
 lMJ
 aaf
 aaf
 den
-myV
+nte
 aMo
 aaf
 aaf
 lMJ
 dfz
 aIe
-aaf
+mPF
 ddO
 dgg
 axY
-bpu
+sSU
 lMJ
-iRf
+lHL
 aaa
 anT
 aaa
@@ -122945,30 +122982,30 @@ auB
 avG
 dqT
 axY
-jnX
+fGs
 aAx
-ack
+gry
 def
 aCZ
 dev
 vLD
 aaa
-pff
+fjy
 deY
-ior
+moI
 aaa
 aaa
-iRf
-gLz
-puW
-ack
-emE
+aaa
+xfK
+obN
+gry
+cWu
 dgg
 axY
-bpu
+sSU
 lMJ
-iRf
-iRf
+lHL
+lHL
 anT
 aaa
 aaa
@@ -123201,13 +123238,13 @@ dnh
 dnh
 jKK
 dqT
-cXM
-qXk
+ocj
+rTo
 aAx
-iRf
+aaa
 aIe
-den
-dew
+iHb
+aav
 aav
 aaa
 aaa
@@ -123215,16 +123252,16 @@ aaf
 aaa
 aaa
 aav
-dew
+aav
 dfz
 aIe
-iRf
-emE
-hJX
+aaa
+cWu
+jjF
 dgm
-bpu
+sSU
 lMJ
-iRf
+lHL
 aaa
 anT
 aaa
@@ -123458,13 +123495,13 @@ atn
 bOY
 avG
 dqT
-jnX
+fGs
 ddO
 aAx
-aaf
-qcW
+mPF
+dtL
 aCZ
-dew
+aav
 aav
 aaa
 aaa
@@ -123472,17 +123509,17 @@ aaf
 vLD
 aaa
 aav
-dew
-gLz
-hze
-aaf
-kUD
+aav
+xfK
+xLP
+mPF
+pWF
 ddO
 dgg
-bpu
+sSU
 lMJ
-iRf
-iRf
+lHL
+lHL
 anT
 aaf
 aaf
@@ -123715,28 +123752,28 @@ dnh
 dnh
 lNZ
 dqT
-krz
-vzK
+drT
+xqB
 aAx
-iRf
-ack
-den
+aaa
+gry
+iHb
 dev
-dew
-iRf
-iRf
+aav
+aaa
+aaa
 lMJ
 dev
-dew
-dew
+aav
+aav
 dev
 dfz
-ack
-iRf
-emE
+gry
+aaa
+cWu
 dge
-lPF
-mdf
+vSl
+sSU
 lMJ
 aaa
 aaa
@@ -123975,25 +124012,25 @@ dqT
 axY
 axY
 ddO
-anS
-anS
-pVn
-anS
-anS
-anS
-anS
-anS
-anS
-anS
-anS
-anS
-pVn
-anS
-anS
+lJj
+lJj
+gKb
+lJj
+lJj
+lJj
+lJj
+lJj
+lJj
+lJj
+lJj
+lJj
+rLy
+lJj
+lJj
 ddO
 axY
 axY
-mdf
+sSU
 lMJ
 aaa
 aaa
@@ -124235,22 +124272,22 @@ axY
 axY
 axY
 axY
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
 axY
 axY
 axY
 axY
 axY
 axY
-bpu
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+sSU
 lMJ
 aaa
 aaa
@@ -124504,10 +124541,10 @@ axY
 axY
 axY
 axY
-trf
-lwB
+eln
+tMT
 aaa
-iRf
+lHL
 lMJ
 aaa
 aaa

--- a/_maps/cit_map_files/MetaStation/MetaStation.dmm
+++ b/_maps/cit_map_files/MetaStation/MetaStation.dmm
@@ -188,7 +188,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hydroponics";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1035,7 +1035,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Chamber";
 	dir = 1;
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1120,7 +1120,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Sanitarium";
 	dir = 2;
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/whitered/side{
 	dir = 1
@@ -1425,7 +1425,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 3";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1448,7 +1448,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 2";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1480,7 +1480,7 @@
 /obj/structure/bed,
 /obj/machinery/camera{
 	c_tag = "Prison Cell 1";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
@@ -1533,8 +1533,7 @@
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
 	c_tag = "Armory - External";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -2147,12 +2146,12 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/machinery/camera{
 	c_tag = "Prison Hallway Port";
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -2218,7 +2217,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/corner{
@@ -2295,7 +2294,7 @@
 /obj/machinery/camera{
 	c_tag = "Prison Hallway Starboard";
 	dir = 2;
-	network = list("SS13","Prison")
+	network = list("ss13","prison")
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -2399,8 +2398,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Head of Security's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -3421,8 +3419,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
@@ -3562,8 +3559,7 @@
 /obj/machinery/light,
 /obj/machinery/camera/motion{
 	c_tag = "Armory - Internal";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault,
 /area/ai_monitored/security/armory)
@@ -3622,7 +3618,7 @@
 	desc = "Used for watching certain areas.";
 	dir = 1;
 	name = "Head of Security's Monitor";
-	network = list("Prison","MiniSat","tcomm");
+	network = list("prison","minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault,
@@ -3925,8 +3921,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Security - EVA Storage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -3991,8 +3986,7 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera{
 	c_tag = "Evidence Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/item/storage/secure/safe{
 	name = "evidence safe";
@@ -4446,7 +4440,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/vault,
@@ -4922,8 +4916,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Secure Gear Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/flasher/portable,
 /obj/effect/turf_decal/bot,
@@ -5182,8 +5175,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Firing Range";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -5321,10 +5313,6 @@
 /area/crew_quarters/fitness/recreation)
 "alq" = (
 /turf/closed/wall,
-/area/maintenance/starboard)
-"alr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
 /area/maintenance/starboard)
 "als" = (
 /obj/machinery/light{
@@ -6050,8 +6038,7 @@
 "amM" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -6349,8 +6336,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Security - Office - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 8
@@ -6749,8 +6735,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Infirmary";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/clothing/under/rank/medical/purple{
 	pixel_y = -4
@@ -7464,8 +7449,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Warden's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical{
@@ -7508,8 +7492,7 @@
 /obj/structure/closet/wardrobe/red,
 /obj/machinery/camera{
 	c_tag = "Security - Gear Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
@@ -7567,8 +7550,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Office - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/red/side{
@@ -7776,8 +7758,7 @@
 	pixel_y = 8
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/fore)
@@ -7976,7 +7957,7 @@
 "aqY" = (
 /obj/machinery/computer/security{
 	name = "Labor Camp Monitoring";
-	network = list("Labor")
+	network = list("labor")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -7992,7 +7973,7 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 2;
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_x = -30
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -9947,8 +9928,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Entrance";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -10927,8 +10907,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/door_timer{
 	id = "Cell 1";
@@ -11100,8 +11079,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Brig - Hallway - Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -11372,17 +11350,18 @@
 	req_one_access_txt = "0"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/engineering)
 "axV" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "axW" = (
 /obj/structure/disposalpipe/segment,
@@ -11392,10 +11371,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "axX" = (
 /obj/machinery/light_switch{
@@ -11411,41 +11389,21 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "axY" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"axZ" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"aya" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ayc" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath{
-	pixel_x = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"aye" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "ayf" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass{
@@ -11788,46 +11746,59 @@
 	dir = 1;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
 /area/engine/engineering)
 "ayT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ayX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"aza" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"ayX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"aza" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "azb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -11839,13 +11810,18 @@
 	},
 /area/security/brig)
 "azd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aze" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -12231,7 +12207,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /obj/item/device/flashlight/lamp/green{
@@ -12473,13 +12449,17 @@
 "aAo" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/engineering)
 "aAp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/engine/engineering)
 "aAr" = (
 /obj/item/device/radio/intercom{
@@ -12490,18 +12470,14 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -12515,27 +12491,21 @@
 	sortType = 4
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aAw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "aAx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aAz" = (
 /obj/structure/table/wood,
@@ -12559,7 +12529,7 @@
 	id = "mining_home";
 	name = "mining shuttle bay";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/mining/box;
+	roundstart_template = /datum/map_template/shuttle/mining/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -12762,7 +12732,7 @@
 	id = "laborcamp_home";
 	name = "fore bay 1";
 	width = 9;
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -12782,8 +12752,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Labor Shuttle Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/flasher{
 	id = "PRelease";
@@ -12894,8 +12863,7 @@
 /obj/effect/landmark/blobstart,
 /obj/machinery/camera{
 	c_tag = "Detective's Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
@@ -13115,8 +13083,7 @@
 "aBG" = (
 /obj/machinery/camera{
 	c_tag = "Engineering - Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/bot{
@@ -13156,17 +13123,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -13179,9 +13142,6 @@
 	},
 /obj/machinery/rnd/circuit_imprinter,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBM" = (
@@ -13191,9 +13151,6 @@
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBN" = (
@@ -13202,21 +13159,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"aBQ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBS" = (
 /obj/item/stack/ore/silver,
@@ -13230,8 +13176,7 @@
 /obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -13259,8 +13204,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Mining Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/mineral/equipment_vendor,
 /turf/open/floor/plasteel/brown{
@@ -13336,8 +13280,7 @@
 "aCg" = (
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -13732,9 +13675,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCV" = (
@@ -13744,38 +13684,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"aCX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aCZ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aDa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -13939,8 +13870,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Cells";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -14057,8 +13987,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig - Desk";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	freerange = 0;
@@ -14379,10 +14308,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14405,31 +14333,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aEq" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEr" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Fore Port";
+	dir = 4;
+	network = list("singularity")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aEt" = (
 /obj/structure/table,
@@ -14448,7 +14361,7 @@
 "aEv" = (
 /obj/machinery/computer/security/mining{
 	dir = 4;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
@@ -14777,8 +14690,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Restrooms";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet/restrooms)
@@ -14968,10 +14880,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14989,52 +14900,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aFz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aFA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aFB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/rack,
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = -26;
+	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
+/obj/item/clothing/gloves/color/black,
+/obj/item/wrench,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aFC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aFD" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/meter,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aFE" = (
 /obj/structure/table/wood,
@@ -15215,8 +15100,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing - Security Access Door";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -15457,7 +15341,7 @@
 	desc = "Used for watching Prison Wing holding areas.";
 	dir = 1;
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = -30
 	},
 /obj/item/restraints/handcuffs,
@@ -15782,10 +15666,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15796,31 +15679,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aGY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aGZ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "External Gas to Loop"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engpa";
+	name = "Engineering Chamber Shutters"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"aHa" = (
-/obj/structure/cable/white,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHb" = (
 /obj/machinery/camera{
@@ -16167,6 +16033,13 @@
 	dir = 2
 	},
 /area/crew_quarters/dorms)
+"aHP" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	icon_state = "emitter_left";
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aHQ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -16241,42 +16114,21 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aHZ" = (
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/turf_decal/delivery,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aIc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aIe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -16352,8 +16204,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/map/right{
 	desc = "A framed picture of the station. Clockwise from security at the top (red), you see engineering (yellow), science (purple), escape (red and white), medbay (green), arrivals (blue and white), and finally cargo (brown).";
@@ -16478,8 +16329,7 @@
 "aIt" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Storage Wing Entrance";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -16544,8 +16394,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Storage Wing";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/structure/cable/yellow{
@@ -16745,8 +16594,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Courtroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/blue/side{
 	dir = 1
@@ -16795,7 +16643,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/wood,
@@ -16945,8 +16793,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Secure Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -16958,34 +16805,13 @@
 /obj/structure/table,
 /obj/item/airlock_painter,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aJp" = (
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJu" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aJv" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "aJB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -17432,12 +17258,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aKA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aKB" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17451,53 +17271,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aKF" = (
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = 24;
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aKG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/structure/particle_accelerator/end_cap{
+	icon_state = "end_cap";
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aKH" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Chamber";
-	on = 0
+/obj/structure/particle_accelerator/fuel_chamber{
+	icon_state = "fuel_chamber";
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aKI" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/structure/particle_accelerator/power_box{
+	icon_state = "power_box";
+	dir = 4
 	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"aKL" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix Bypass";
-	on = 0
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aKN" = (
 /obj/machinery/door/poddoor{
@@ -17792,7 +17585,7 @@
 /obj/structure/table,
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Fore";
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
@@ -17891,8 +17684,7 @@
 /obj/machinery/photocopier,
 /obj/machinery/camera{
 	c_tag = "Law Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
@@ -17962,8 +17754,7 @@
 /obj/structure/disposalpipe/trunk,
 /obj/machinery/camera{
 	c_tag = "Locker Room Starboard";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/warning/pods{
 	pixel_y = 30
@@ -18050,12 +17841,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aMc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aMd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -18076,62 +17861,52 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMg" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/plating,
 /area/engine/engineering)
 "aMh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engpa";
+	name = "Engineering Chamber Shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aMi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"aMi" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Gas to Filter"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aMj" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "aMk" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"aMm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aMo" = (
-/obj/structure/reflector/box/anchored{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aMq" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
@@ -18200,8 +17975,7 @@
 /area/quartermaster/storage)
 "aMA" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/rack,
 /obj/item/storage/toolbox/electrical{
@@ -18579,7 +18353,9 @@
 	maxcharge = 15000
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
 /area/engine/engineering)
 "aNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18589,17 +18365,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNu" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Gas to Filter";
-	on = 0
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Particle Accelerator";
+	dir = 1;
+	network = list("singularity")
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aNv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aNw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -18772,8 +18558,7 @@
 /area/quartermaster/qm)
 "aNP" = (
 /obj/machinery/camera/autoname{
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19245,8 +19030,7 @@
 /obj/machinery/disposal/bin,
 /obj/machinery/camera{
 	c_tag = "Garden";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
@@ -19265,10 +19049,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19291,26 +19074,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aOR" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+"aOS" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aOS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aOT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19556,8 +19325,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -19637,8 +19405,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 2
@@ -19838,8 +19605,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Power Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/modular_computer/console/preset/engineering,
 /turf/open/floor/plasteel/vault,
@@ -19857,41 +19623,32 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/engineering)
 "aPZ" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aQa" = (
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
 	},
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/rack,
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = 26;
+	req_access_txt = "11"
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+/obj/item/storage/belt/utility,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aQe" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aQf" = (
 /obj/structure/chair{
@@ -19979,8 +19736,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/paper_bin{
 	pixel_x = -1;
@@ -19997,7 +19753,7 @@
 "aQq" = (
 /obj/machinery/computer/security/mining{
 	dir = 4;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/light_switch{
 	pixel_x = -23
@@ -20111,7 +19867,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Port";
 	dir = 1;
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20134,7 +19890,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Chamber - Starboard";
 	dir = 1;
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /turf/open/floor/circuit,
 /area/ai_monitored/turret_protected/ai_upload)
@@ -20248,8 +20004,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Crew Quarters Entrance";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -20498,19 +20253,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aRo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20521,9 +20266,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20550,13 +20292,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"aRv" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aRy" = (
 /turf/closed/wall/r_wall,
@@ -20974,10 +20709,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -21006,9 +20740,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSx" = (
@@ -21019,35 +20751,38 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSz" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/pen,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson,
+/obj/item/paper_bin{
+	layer = 2.9
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table/glass,
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21366,8 +21101,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Courtroom - Gallery";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -21458,8 +21192,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -21535,10 +21268,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTG" = (
 /obj/structure/disposalpipe/segment{
@@ -21550,26 +21282,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aTI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21579,9 +21302,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -21595,29 +21315,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aTM" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aTN" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aTO" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21655,7 +21356,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore Port";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -21707,7 +21408,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore Starboard";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -21757,8 +21458,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/conveyor{
 	dir = 1;
@@ -21957,7 +21657,7 @@
 	desc = "Used for watching the AI Upload.";
 	dir = 4;
 	name = "AI Upload Monitor";
-	network = list("AIUpload");
+	network = list("aiupload");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/vault{
@@ -21983,12 +21683,12 @@
 	desc = "Used for watching areas on the MiniSat.";
 	dir = 8;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_x = 29
 	},
 /obj/machinery/camera/motion{
 	c_tag = "AI Upload Foyer";
-	network = list("SS13","RD","AIUpload")
+	network = list("ss13","rd","aiupload")
 	},
 /obj/machinery/airalarm{
 	pixel_y = 26
@@ -22225,7 +21925,9 @@
 "aUY" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
 /area/engine/engineering)
 "aUZ" = (
 /obj/structure/disposalpipe/segment,
@@ -22236,8 +21938,8 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
 	},
 /area/engine/engineering)
 "aVa" = (
@@ -22274,31 +21976,13 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aVe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"aVf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"aVh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aVk" = (
 /obj/structure/window/reinforced{
@@ -22334,7 +22018,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Fore";
 	dir = 2;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 2;
@@ -22402,8 +22086,7 @@
 /obj/structure/chair,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Fore Arm - Far";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -22584,7 +22267,7 @@
 	},
 /obj/machinery/computer/security/mining{
 	dir = 8;
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -22688,8 +22371,7 @@
 "aWd" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -22840,10 +22522,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aWu" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Four";
+	req_access = null;
+	req_access_txt = "32"
 	},
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/maintenance/starboard)
 "aWv" = (
 /turf/closed/wall,
@@ -22929,18 +22613,16 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"aWH" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "aWK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aWL" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -23063,8 +22745,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Fore Arm";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -23183,8 +22864,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/supply)
@@ -23368,8 +23048,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - AI Upload";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/sign/warning/securearea{
 	desc = "A warning sign which reads 'HIGH-POWER TURRETS AHEAD'.";
@@ -23785,8 +23464,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chief Engineer's Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -23841,17 +23519,20 @@
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
 "aYx" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aYy" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
 	dir = 4;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 4;
@@ -23997,8 +23678,7 @@
 "aYP" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Bay - Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -24565,7 +24245,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
 	dir = 2;
-	network = list("RD")
+	network = list("rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 10
@@ -24968,8 +24648,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Port Corner";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -25150,8 +24829,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Courtroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -25219,8 +24897,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Fore - Starboard Corner";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -25464,7 +25141,7 @@
 	desc = "Used for monitoring the engine.";
 	dir = 8;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/vault{
@@ -25503,8 +25180,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Entrance";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -25519,7 +25195,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 4;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_x = -29
 	},
 /turf/open/floor/plasteel/red/side{
@@ -25577,7 +25253,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Starboard";
 	dir = 8;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/structure/showcase/cyborg/old{
 	dir = 8;
@@ -25731,8 +25407,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 4
@@ -25842,8 +25517,7 @@
 "bcr" = (
 /obj/machinery/camera{
 	c_tag = "Auxiliary Tool Storage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/airalarm{
 	dir = 8;
@@ -26062,7 +25736,7 @@
 	desc = "Used for monitoring the engine.";
 	dir = 8;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/red/side{
@@ -26166,8 +25840,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Customs Checkpoint";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -26687,7 +26360,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/vault{
@@ -26754,8 +26427,7 @@
 "bem" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for the engineering security doors.";
@@ -26835,7 +26507,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Port Fore";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -26876,7 +26548,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Starboard Fore";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -27046,8 +26718,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Office";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -27117,8 +26788,7 @@
 /obj/item/reagent_containers/spray/cleaner,
 /obj/machinery/camera{
 	c_tag = "Custodial Closet";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -27321,8 +26991,7 @@
 /obj/effect/landmark/start/captain,
 /obj/machinery/camera{
 	c_tag = "Captain's Quarters";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
@@ -28105,8 +27774,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Central";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/darkbrown/side{
@@ -28331,8 +27999,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Tech Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 1
@@ -28626,7 +28293,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Space Access";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -28669,7 +28336,7 @@
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Aft";
 	dir = 1;
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -29569,8 +29236,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargo - Mailroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 2
@@ -29856,7 +29522,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/computer/security/mining{
-	network = list("MINE","AuxBase")
+	network = list("mine","auxbase")
 	},
 /obj/machinery/keycard_auth{
 	pixel_y = 24
@@ -30071,8 +29737,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Auxiliary Tool Storage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -30114,8 +29779,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Engineering";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/caution/corner{
 	dir = 8
@@ -30610,7 +30274,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching Prison Wing holding areas.";
 	name = "Prison Monitor";
-	network = list("Prison");
+	network = list("prison");
 	pixel_y = 30
 	},
 /turf/open/floor/wood,
@@ -30786,8 +30450,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 4
@@ -31029,8 +30692,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -31226,7 +30888,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat - Antechamber";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -31352,8 +31014,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals - Station Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -31475,8 +31136,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Middle";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -31649,8 +31309,7 @@
 /obj/structure/cable/yellow,
 /obj/machinery/camera{
 	c_tag = "Bridge - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/side{
 	dir = 8
@@ -31808,8 +31467,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Art Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/neutral/corner{
@@ -31882,8 +31540,7 @@
 /obj/item/gun/ballistic/revolver/doublebarrel,
 /obj/machinery/camera{
 	c_tag = "Bar - Backroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -32095,7 +31752,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Fore";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -32495,8 +32152,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Lounge";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/grimy,
@@ -32816,7 +32472,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/darkblue/side{
@@ -33285,8 +32941,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering - Foyer - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/cafeteria{
@@ -33456,7 +33111,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior Access";
 	dir = 1;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/power/apc{
 	aidisabled = 0;
@@ -33550,7 +33205,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = -28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33572,7 +33227,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Foyer";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
@@ -33630,7 +33285,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 8;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/vault{
@@ -33655,7 +33310,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel/dark,
@@ -33679,7 +33334,7 @@
 /obj/machinery/camera/motion{
 	c_tag = "MiniSat Maintenance";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -33904,8 +33559,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -34050,8 +33704,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Command Chair";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/carpet,
 /area/bridge)
@@ -34424,7 +34077,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/darkblue/corner,
@@ -34555,8 +34208,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
@@ -34870,8 +34522,7 @@
 "buJ" = (
 /obj/machinery/camera{
 	c_tag = "Captain's Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
@@ -34883,8 +34534,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Captain's Office - Emergency Escape";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
@@ -35173,8 +34823,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/machinery/camera{
 	c_tag = "Engineering - Transit Tube Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
@@ -35659,8 +35308,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Port Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
@@ -35699,8 +35347,7 @@
 "bwv" = (
 /obj/machinery/camera{
 	c_tag = "Council Chamber";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 1
@@ -35737,8 +35384,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bridge - Starboard Access";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/darkblue/corner,
 /area/bridge)
@@ -35886,8 +35532,7 @@
 "bwM" = (
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/machinery/requests_console{
 	department = "Bar";
@@ -35985,8 +35630,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Club - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -36182,8 +35826,7 @@
 "bxu" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Middle Arm - Far";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/status_display{
 	pixel_y = -32
@@ -36229,8 +35872,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Middle Arm";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -36885,8 +36527,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Control Room";
-	network = list("SS13")
+	c_tag = "Atmospherics - Control Room"
 	},
 /obj/machinery/computer/station_alert,
 /turf/open/floor/plasteel/caution{
@@ -36954,8 +36595,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Entrance";
-	network = list("SS13")
+	c_tag = "Atmospherics - Entrance"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -37041,8 +36681,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
-	c_tag = "Atmospherics - Distro Loop";
-	network = list("SS13")
+	c_tag = "Atmospherics - Distro Loop"
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 1
@@ -37110,7 +36749,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Port Aft";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
@@ -37202,7 +36841,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Starboard Aft";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -37281,8 +36920,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
@@ -37493,7 +37131,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "MiniSat Monitor";
-	network = list("MiniSat","tcomm");
+	network = list("minisat","tcomm");
 	pixel_y = -29
 	},
 /obj/structure/bed/dogbed/renault,
@@ -37640,8 +37278,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway - Atmospherics";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 8
@@ -37859,8 +37496,7 @@
 "bAZ" = (
 /obj/machinery/camera{
 	c_tag = "Head of Personnel's Office";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/item/storage/box/PDAs{
@@ -38565,7 +38201,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space/nearstation)
 "bCA" = (
@@ -38670,8 +38305,7 @@
 /obj/machinery/light/small,
 /obj/machinery/camera{
 	c_tag = "Auxilary Restrooms";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/toilet/auxiliary)
@@ -38948,8 +38582,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Starboard";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 4
@@ -39246,7 +38879,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
 	dir = 2;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -39277,7 +38910,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
 	dir = 2;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/tcommsat/server)
@@ -39376,8 +39009,7 @@
 	pixel_x = -32
 	},
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/displaycase/trophy,
 /turf/open/floor/wood,
@@ -39511,8 +39143,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -40310,8 +39941,7 @@
 "bGb" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Mix";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
@@ -40432,8 +40062,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Port";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -40565,8 +40194,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Command Hallway - Central";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -41358,8 +40986,7 @@
 /obj/machinery/light,
 /obj/machinery/camera{
 	c_tag = "Kitchen Hatch";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/bar,
 /area/crew_quarters/bar)
@@ -41641,7 +41268,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Control Room";
 	dir = 1;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/structure/table/wood,
 /obj/item/pen,
@@ -42181,8 +41808,7 @@
 "bKn" = (
 /obj/machinery/camera{
 	c_tag = "Club - Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = -29
@@ -42404,7 +42030,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft Starboard";
 	dir = 4;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/structure/window/reinforced{
 	dir = 4
@@ -42457,8 +42083,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/arrival{
 	dir = 4
@@ -42793,8 +42418,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Starboard - Kitchen";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -42921,8 +42545,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/storage/tcom)
@@ -43002,8 +42625,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Central";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -43030,10 +42652,6 @@
 "bMh" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/machinery/meter,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bMi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMj" = (
@@ -43073,8 +42691,7 @@
 "bMn" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2O";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
@@ -43089,7 +42706,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Port";
 	dir = 4;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
@@ -43127,7 +42744,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft-Starboard";
 	dir = 8;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -43146,8 +42763,7 @@
 "bMu" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals - Aft Arm - Far";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
@@ -43325,8 +42941,7 @@
 /obj/item/folder,
 /obj/item/folder,
 /obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /obj/item/device/taperecorder,
@@ -43435,8 +43050,7 @@
 "bMZ" = (
 /obj/machinery/camera{
 	c_tag = "Teleporter Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/rack,
 /obj/structure/window/reinforced{
@@ -43531,8 +43145,7 @@
 /obj/item/clothing/glasses/sunglasses,
 /obj/machinery/camera{
 	c_tag = "Corporate Showroom";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
@@ -43591,8 +43204,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway - Atrium";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -43921,7 +43533,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft Port";
 	dir = 8;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -43944,7 +43556,7 @@
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Aft";
 	dir = 1;
-	network = list("SS13","tcomm")
+	network = list("ss13","tcomm")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/ntnet_relay,
@@ -45605,8 +45217,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Gateway - Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -45686,8 +45297,7 @@
 /obj/item/kitchen/rollingpin,
 /obj/machinery/camera{
 	c_tag = "Kitchen";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 2
@@ -45779,8 +45389,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Kitchen - Coldroom";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -45843,8 +45452,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -45901,8 +45509,7 @@
 "bSl" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Toxins";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/plasma,
 /area/engine/atmos)
@@ -46366,8 +45973,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -46402,10 +46008,10 @@
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
 "bTq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -46453,8 +46059,7 @@
 	pixel_y = -24
 	},
 /obj/machinery/camera/autoname{
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/table/wood,
 /turf/open/floor/wood,
@@ -46982,8 +46587,12 @@
 	},
 /area/maintenance/starboard)
 "bUw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "bUx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47619,8 +47228,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Port Solar Maintenance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
@@ -47801,8 +47409,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port Corner";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8
@@ -48018,8 +47625,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard Corner";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 2
@@ -48405,8 +48011,7 @@
 "bXs" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - CO2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
@@ -48561,8 +48166,7 @@
 "bXQ" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Port";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
@@ -48600,8 +48204,7 @@
 "bXW" = (
 /obj/machinery/camera{
 	c_tag = "Central Primary Hallway - Aft-Starboard";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/purple/corner{
 	dir = 2
@@ -48669,8 +48272,7 @@
 /area/hallway/primary/central)
 "bYe" = (
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/item/paper/guides/jobs/hydroponics,
@@ -48737,8 +48339,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/stripes/line{
@@ -48843,8 +48444,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Port-Aft";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 8
@@ -49125,7 +48725,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Medbay";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 1
@@ -49831,7 +49431,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Lobby";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -50547,7 +50147,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -50573,7 +50173,7 @@
 	desc = "Used for monitoring medbay to ensure patient safety.";
 	dir = 1;
 	name = "Medbay Monitor";
-	network = list("Medbay");
+	network = list("medbay");
 	pixel_y = -29
 	},
 /obj/item/device/radio/intercom{
@@ -50755,7 +50355,7 @@
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 8;
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_x = 28;
 	pixel_y = 2
 	},
@@ -50789,8 +50389,7 @@
 /obj/item/paper/guides/jobs/hydroponics,
 /obj/machinery/camera{
 	c_tag = "Hydroponics - Foyer";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/device/radio/intercom{
 	pixel_y = -25
@@ -51093,8 +50692,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics - Starboard Aft";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
@@ -51539,7 +51137,7 @@
 /obj/machinery/camera{
 	c_tag = "Security Post - Research Division";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 4
@@ -51908,7 +51506,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 2
@@ -53294,7 +52892,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab - Test Chamber";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -53413,7 +53011,7 @@
 /obj/machinery/camera{
 	c_tag = "MiniSat Exterior - Aft";
 	dir = 2;
-	network = list("MiniSat")
+	network = list("minisat")
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -53662,7 +53260,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Fore";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
@@ -53890,7 +53488,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Airlock";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -54041,8 +53639,7 @@
 "cje" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/n2,
 /area/engine/atmos)
@@ -54056,8 +53653,7 @@
 "cjh" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - O2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/o2,
 /area/engine/atmos)
@@ -54072,8 +53668,7 @@
 "cjk" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - Air";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/engine/air,
 /area/engine/atmos)
@@ -54234,7 +53829,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Sleepers";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 10
@@ -55119,8 +54714,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/firealarm{
 	dir = 4;
@@ -55305,7 +54899,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Break Room";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -55667,7 +55261,7 @@
 /obj/machinery/camera{
 	c_tag = "Research and Development";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light_switch{
 	pixel_x = 27
@@ -56199,7 +55793,7 @@
 /obj/machinery/camera{
 	c_tag = "Chemistry";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light{
 	dir = 8
@@ -56394,7 +55988,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Central";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -56781,7 +56375,7 @@
 /obj/machinery/camera{
 	c_tag = "CMO's Office";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/barber{
 	dir = 8
@@ -57306,23 +56900,20 @@
 	},
 /area/maintenance/port/aft)
 "cpR" = (
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = -26;
+	req_access_txt = "11"
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 8;
-	network = list("SS13","Engine")
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/airalarm/engine{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cpS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -57816,7 +57407,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Starboard";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -57901,7 +57492,7 @@
 /obj/machinery/camera{
 	c_tag = "Experimentation Lab";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/white,
@@ -58089,7 +57680,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Cryo";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/item/screwdriver{
 	pixel_y = 6
@@ -58524,7 +58115,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Surgery";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
@@ -58587,7 +58178,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 2
@@ -58611,7 +58202,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Central";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -58735,7 +58326,7 @@
 	desc = "Used for monitoring medbay to ensure patient safety.";
 	dir = 8;
 	name = "Medbay Monitor";
-	network = list("Medbay");
+	network = list("medbay");
 	pixel_x = 29
 	},
 /obj/item/device/radio/intercom{
@@ -59004,7 +58595,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -59127,7 +58718,7 @@
 	active_power_usage = 0;
 	c_tag = "Turbine Vent";
 	dir = 4;
-	network = list("Turbine");
+	network = list("turbine");
 	use_power = 0
 	},
 /turf/open/space,
@@ -59971,7 +59562,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins Storage";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -60177,7 +59768,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Lab";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue,
 /area/medical/genetics)
@@ -60717,7 +60308,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Desk";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/structure/table/glass,
 /turf/open/floor/plasteel/blue/side{
@@ -60802,7 +60393,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Mech Bay";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/airalarm{
 	dir = 4;
@@ -60879,7 +60470,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/light,
 /turf/open/floor/plasteel/cafeteria{
@@ -61242,7 +60833,7 @@
 /obj/machinery/camera{
 	c_tag = "Mech Bay";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
@@ -61253,7 +60844,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Testing Range";
 	dir = 8;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_y = -22
 	},
 /obj/machinery/airalarm{
@@ -61670,7 +61261,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister,
@@ -61856,7 +61447,7 @@
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning Lab";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 6
@@ -62443,8 +62034,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Middle";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -62799,7 +62389,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63237,7 +62827,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Test Chamber Telescreen";
-	network = list("Toxins");
+	network = list("toxins");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -63328,7 +62918,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Break Room";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/cafeteria{
 	dir = 5
@@ -63715,7 +63305,7 @@
 /obj/machinery/camera{
 	c_tag = "Medbay Hallway Aft";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 5
@@ -63899,7 +63489,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics - Fore";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -64060,7 +63650,7 @@
 	light = null;
 	luminosity = 3;
 	name = "Hardened Bomb-Test Camera";
-	network = list("Toxins");
+	network = list("toxins");
 	use_power = 0
 	},
 /obj/item/target/alien/anchored,
@@ -64978,7 +64568,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Robotics";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -65047,7 +64637,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins - Mixing Area";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65107,7 +64697,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Cells";
 	dir = 4;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 9
@@ -66174,7 +65764,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Lab";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/structure/sink{
 	dir = 4;
@@ -66201,7 +65791,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Airlock";
 	dir = 1;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light,
 /obj/structure/closet/l3closet,
@@ -66233,7 +65823,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Entrance";
 	dir = 8;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -66531,7 +66121,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division - Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /obj/machinery/power/apc{
@@ -66826,8 +66416,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway - Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/escape{
 	dir = 2
@@ -67585,7 +67174,7 @@
 /obj/machinery/camera{
 	c_tag = "Virology - Break Room";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
@@ -68280,7 +67869,7 @@
 	desc = "Used for watching the turbine vent.";
 	dir = 8;
 	name = "turbine vent monitor";
-	network = list("Turbine");
+	network = list("turbine");
 	pixel_x = 29
 	},
 /obj/machinery/button/door{
@@ -68565,8 +68154,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Fore";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
@@ -68640,8 +68228,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Aft Starboard Solar Maintenance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
@@ -68811,8 +68398,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Fore";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/table/wood,
 /turf/open/floor/plasteel/vault,
@@ -68983,7 +68569,6 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching output from station security cameras.";
 	name = "Security Camera Monitor";
-	network = list("SS13");
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -69192,8 +68777,7 @@
 "cNu" = (
 /obj/machinery/camera{
 	c_tag = "Chapel Office - Backroom";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/item/device/radio/intercom{
 	dir = 4;
@@ -69524,8 +69108,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
@@ -69697,8 +69280,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Security Post";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = -4;
@@ -70243,8 +69825,7 @@
 "cPO" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Aft";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/machinery/light{
 	dir = 8
@@ -70309,8 +69890,7 @@
 "cPV" = (
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Starboard Aft";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light{
 	dir = 4
@@ -70514,7 +70094,7 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Hallway - Xenobiology Lab Access";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -70560,7 +70140,7 @@
 /obj/machinery/camera{
 	c_tag = "Toxins - Launch Area";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/suit_storage_unit/rd,
 /obj/effect/turf_decal/bot{
@@ -70577,7 +70157,7 @@
 /turf/open/floor/plasteel/vault,
 /area/chapel/main)
 "cQB" = (
-/obj/machinery/doppler_array{
+/obj/machinery/doppler_array/research/science{
 	dir = 4
 	},
 /obj/item/device/radio/intercom{
@@ -70658,8 +70238,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Starboard";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/chapel{
 	dir = 4
@@ -70884,8 +70463,7 @@
 "cRn" = (
 /obj/machinery/camera{
 	c_tag = "Chapel - Port";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/structure/chair/comfy/black{
 	dir = 4
@@ -71334,7 +70912,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #1";
 	dir = 4;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -71408,7 +70986,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #2";
 	dir = 8;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -71909,7 +71487,7 @@
 /obj/machinery/computer/security/telescreen{
 	dir = 1;
 	name = "Test Chamber Monitor";
-	network = list("Xeno");
+	network = list("xeno");
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
@@ -72289,18 +71867,6 @@
 /obj/structure/easel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cXz" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 1;
-	network = list("SS13","Engine")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cXA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
@@ -72313,9 +71879,19 @@
 	},
 /area/construction/mining/aux_base)
 "cXI" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"cXM" = (
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -72325,11 +71901,12 @@
 	},
 /area/construction/mining/aux_base)
 "cXZ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYc" = (
@@ -72342,15 +71919,22 @@
 /obj/machinery/camera{
 	c_tag = "Robotics - Aft";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
 /area/science/robotics/lab)
+"cYi" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "cYj" = (
-/obj/structure/closet/firecloset,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYE" = (
@@ -72386,7 +71970,7 @@
 	desc = "Used for the Auxillary Mining Base.";
 	dir = 1;
 	name = "Auxillary Base Monitor";
-	network = list("AuxBase");
+	network = list("auxbase");
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -72582,7 +72166,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Test Chamber";
 	dir = 1;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72657,14 +72241,16 @@
 /turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "daW" = (
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = 26;
+	req_access_txt = "11"
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "daX" = (
 /obj/structure/cable/yellow{
@@ -72674,27 +72260,20 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
-"daY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "daZ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/structure/particle_accelerator/particle_emitter/right{
+	icon_state = "emitter_right";
+	dir = 4
 	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dbb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/structure/particle_accelerator/particle_emitter/center{
+	icon_state = "emitter_center";
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dbd" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -72707,30 +72286,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"dbg" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dbh" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "dbj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -72760,7 +72315,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #3";
 	dir = 4;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72771,7 +72326,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #4";
 	dir = 8;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72784,7 +72339,7 @@
 /obj/machinery/camera{
 	c_tag = "Morgue";
 	dir = 2;
-	network = list("SS13","Medbay")
+	network = list("ss13","medbay")
 	},
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -72798,7 +72353,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #5";
 	dir = 4;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72809,7 +72364,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Pen #6";
 	dir = 8;
-	network = list("SS13","RD","Xeno")
+	network = list("ss13","rd","xeno")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -72822,7 +72377,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Kill Chamber";
 	dir = 1;
-	network = list("SS13","RD","Xeno");
+	network = list("ss13","rd","xeno");
 	start_active = 1
 	},
 /turf/open/floor/circuit/killroom,
@@ -73059,7 +72614,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Fore";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
@@ -73299,7 +72854,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Airlock";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -73492,7 +73047,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Central";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
@@ -73687,7 +73242,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Aft-Port";
 	dir = 4;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -73702,7 +73257,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Aft-Starboard";
 	dir = 8;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -73927,15 +73482,11 @@
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
 "ddO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ddP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -73950,39 +73501,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ddS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 4;
-	network = list("SS13","Engine")
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddT" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ddW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -73997,28 +73517,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ddY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ddZ" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dea" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	volume_rate = 200
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
+/area/space)
 "deb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -74026,644 +73532,153 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"ded" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dee" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "def" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"deh" = (
-/obj/structure/cable/white{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dei" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dej" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dek" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Mix to Gas"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"del" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dem" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Mix"
-	},
-/obj/structure/cable/white{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/space,
+/area/space/nearstation)
+"dem" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/space,
+/area/space/nearstation)
 "den" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dep" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"deq" = (
-/obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "der" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"des" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deu" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "dev" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"dew" = (
+/turf/open/space,
+/area/space/nearstation)
+"deB" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engpa";
+	name = "Engineering Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dew" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dex" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dey" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deA" = (
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deC" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "deD" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"deI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deK" = (
-/obj/structure/cable/white,
-/obj/machinery/power/emitter/anchored{
-	dir = 2;
-	state = 2
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deL" = (
-/obj/structure/cable/white,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deM" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"deN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"deU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deV" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"deW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 4;
-	network = list("SS13","Engine")
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deY" = (
-/obj/structure/reflector/single/anchored{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfa" = (
-/obj/machinery/power/supermatter_shard/crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfb" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dfc" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dfd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dff" = (
-/obj/structure/reflector/double/anchored{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dfg" = (
-/obj/structure/reflector/single/anchored{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfh" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dfi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dfk" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfp" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dfq" = (
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 4;
-	network = list("Engine")
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dft" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"deM" = (
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/engine,
 /area/engine/engineering)
-"dfu" = (
+"deV" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"deY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	filter_type = "n2"
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"dfa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"dfh" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"dfp" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/engine/engineering)
 "dfz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfA" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfB" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 1;
-	state = 2
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfC" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 1;
-	state = 2
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dfD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/book/manual/engineering_singularity_safety{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/engineering_particle_accelerator{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "dfI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop Bypass"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfJ" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfM" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfO" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dfP" = (
 /obj/structure/cable/white{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Atmos to Loop"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfQ" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Cold Loop";
-	on = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfS" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cold Loop to Gas";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfV" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dfW" = (
-/obj/item/wrench,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "dfX" = (
 /obj/structure/disposalpipe/segment,
@@ -74681,272 +73696,88 @@
 	},
 /area/engine/engineering)
 "dfY" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dfZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "dga" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dgb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "dgc" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
+/obj/item/clothing/gloves/color/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/clothing/shoes/sneakers/rainbow,
+/obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dgd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dge" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
-"dgf" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/cable/white{
+	icon_state = "0-2"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	icon_state = "emitter";
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
-"dgh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"dgi" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/obj/structure/grille,
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgk" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"dgo" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"dgp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"dgr" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgt" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgu" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
-"dgv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
-"dgw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgz" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dgA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgB" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "dgI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgK" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgN" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dha" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dhc" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dhe" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"dhg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"dhh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine";
-	on = 0
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"dhi" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	icon_state = "left";
-	name = "Inner Pipe Access";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"dhj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"dhk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"dhl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
+/turf/closed/wall/mineral/plastitanium,
 /area/space/nearstation)
 "dhn" = (
 /obj/structure/table,
@@ -75376,8 +74207,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Theatre - Stage";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small{
 	dir = 4
@@ -75544,8 +74374,7 @@
 "dir" = (
 /obj/machinery/camera{
 	c_tag = "Theatre - Backstage";
-	dir = 1;
-	network = list("SS13")
+	dir = 1
 	},
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = -32
@@ -75894,8 +74723,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Departure Lounge - Port Fore";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-24"
@@ -75945,8 +74773,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel - Funeral Parlour";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
@@ -75969,26 +74796,18 @@
 /turf/open/space,
 /area/science/xenobiology)
 "djt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "djx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Port";
+	dir = 4;
+	network = list("singularity")
 	},
-/obj/item/crowbar,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "djz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -76026,7 +74845,7 @@
 	id = "arrivals_stationary";
 	name = "arrivals";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	roundstart_template = /datum/map_template/shuttle/arrival/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -76047,13 +74866,32 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/main)
+"dkr" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dlI" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dlN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "dlV" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
@@ -76638,45 +75476,23 @@
 /area/engine/gravity_generator)
 "dBw" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dBx" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dBy" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dBz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dBA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dBB" = (
-/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
+"dBy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"dBB" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dBC" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -77333,6 +76149,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dFT" = (
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dGH" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white,
@@ -77365,6 +76191,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"emE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "eoK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -77397,6 +76229,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"evc" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/engineering)
 "evy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -77490,6 +76327,14 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"gLz" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -77522,6 +76367,42 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hze" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
+"hAc" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"hHc" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"hJX" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"ior" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -77549,6 +76430,17 @@
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/science/lab)
+"iRf" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"jnX" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -77560,7 +76452,7 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
@@ -77579,6 +76471,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"jFg" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "jKK" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -77588,10 +76490,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"kfh" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"krz" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -77645,6 +76561,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"kUD" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "kVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77659,6 +76582,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"lhK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "llb" = (
 /obj/structure/table/reinforced,
 /obj/item/device/integrated_circuit_printer,
@@ -77678,6 +76607,10 @@
 /obj/item/device/multitool,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"lwB" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/engine/engineering)
 "lzk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -77710,6 +76643,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lOO" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"lPF" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -77723,6 +76671,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/server)
+"mdf" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "mjJ" = (
 /obj/structure/reagent_dispensers/beerkeg{
 	desc = "One of the more successful achievements of the Nanotrasen Corporate Warfare Division, their nuclear fission explosives are renowned for being cheap to produce and devastatingly effective. Signs explain that though this particular device has been decommissioned, every Nanotrasen station is equipped with an equivalent one, just in case. All Captains carefully guard the disk needed to detonate them - at least, the sign says they do. There seems to be a tap on the back.";
@@ -77743,6 +76694,10 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"myV" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "mzh" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -77750,6 +76705,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"mGi" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ngl" = (
 /obj/machinery/bookbinder,
 /turf/open/floor/plasteel/white,
@@ -77823,11 +76789,27 @@
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of your own office.";
 	name = "Research Monitor";
-	network = list("RD");
+	network = list("rd");
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oep" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 8;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("singularity");
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
 "ohj" = (
 /obj/item/device/integrated_electronics/analyzer,
 /obj/item/device/integrated_electronics/debugger,
@@ -77875,6 +76857,22 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"pff" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"puW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77891,6 +76889,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pwF" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "pzj" = (
 /obj/machinery/door/airlock/external,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -77907,6 +76910,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"pPJ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "pSX" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Escape Airlock"
@@ -77916,6 +76925,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"pVn" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Starboard";
+	dir = 8;
+	network = list("singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "pVo" = (
 /obj/machinery/light,
 /obj/machinery/vending/kink,
@@ -77923,6 +76940,13 @@
 	dir = 2
 	},
 /area/crew_quarters/locker)
+"qcW" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "qnJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77963,10 +76987,20 @@
 /obj/machinery/camera{
 	c_tag = "Research Division Circuitry Lab";
 	dir = 1;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"qXk" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "rzX" = (
 /obj/structure/chair/office/light{
 	dir = 1;
@@ -78005,6 +77039,33 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"sjZ" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"suq" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "sGh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -78036,6 +77097,9 @@
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"trf" = (
+/turf/open/space/basic,
+/area/engine/engineering)
 "tsx" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -78052,16 +77116,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "tDM" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
@@ -78080,6 +77137,9 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"uch" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/maintenance/starboard)
 "upN" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -78126,6 +77186,15 @@
 	dir = 2
 	},
 /area/science/research)
+"uTQ" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
 "uTS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -78142,15 +77211,45 @@
 "vhG" = (
 /obj/structure/table/glass,
 /obj/machinery/camera/autoname{
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vwp" = (
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"vzK" = (
+/obj/structure/cable/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"wco" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -78178,6 +77277,10 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"wIF" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wKo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -118454,12 +117557,12 @@ aFu
 aBI
 aBI
 aJn
-aCO
-aFq
+evc
+evc
 aNq
 aBI
 aPZ
-aRo
+aSB
 aSu
 aTG
 aUZ
@@ -118710,12 +117813,12 @@ aEn
 aFv
 aGV
 aHX
-aEi
-aKA
-aMc
-aEi
+aBO
+aBO
+aBO
+aBO
 aOO
-aEi
+aBO
 aRp
 aSv
 aTH
@@ -119217,7 +118320,7 @@ avt
 awJ
 axS
 axY
-aCO
+cYi
 ddW
 aCT
 aEp
@@ -119477,16 +118580,16 @@ axY
 aAr
 ddX
 aCU
-aEq
-aTO
+aCW
+aBO
 aGX
-aHZ
-aJp
-aTO
+aBO
+aBO
+aBO
 aSB
-aTO
-aOR
-aQa
+aBO
+aBO
+aBO
 aGX
 aTO
 aTK
@@ -119731,22 +118834,22 @@ avv
 axY
 axU
 ayS
-dCk
-ddY
+wIF
+ddX
 deb
-deh
-aFz
-aCZ
+aBO
+aBO
+vwp
 deM
-axY
-aCZ
+lOO
+oep
 aMg
-aCZ
+wco
 dfh
-deM
-aCZ
-aFz
-deh
+aBO
+aBO
+aTO
+aTK
 aVe
 axY
 aYu
@@ -119991,21 +119094,21 @@ ddP
 aAt
 aBL
 deb
-dei
+aBO
 aFA
+axY
+axY
 deB
-deB
-deB
-deB
+axY
 aMh
-deB
-deB
-deB
-deB
+axY
+axY
+pwF
+aBO
 aSz
-aTM
+aTK
 aVe
-apc
+aJu
 aYu
 aZL
 bbB
@@ -120248,21 +119351,21 @@ aAu
 ddQ
 aBM
 aCV
-aEr
+aBO
 aFB
-aGY
+axY
 daW
 dBw
-aKF
+dBw
 aMi
 cpR
-dfi
+axY
 aQd
-dBA
+aBO
 aSA
-aTN
-aVf
-apc
+aTK
+aVe
+aJu
 aYu
 aZM
 bbC
@@ -120505,21 +119608,21 @@ ayV
 aAv
 aBN
 aCW
-aEr
-aFC
+aBO
+aFA
 aGZ
-aGZ
-dlI
+emE
+ddO
 aKG
-aMj
+ddO
 dBy
-dlI
-aQe
-aRv
+aGZ
+pwF
+aBO
 dfD
-aTN
-aVe
-apc
+aTK
+pPJ
+aJu
 aYu
 aZN
 bbD
@@ -120761,22 +119864,22 @@ axY
 ayW
 bTq
 aBO
-aCX
-dej
+aBO
+aBO
 aFC
-deC
-deC
-dlI
+axY
+emE
+ddO
 aKH
 aMk
 aNu
-dlI
+axY
 dfp
-dfp
-dfE
+aBO
+aBO
 dfP
 dfY
-dgc
+axY
 aYu
 cXA
 cXA
@@ -121014,30 +120117,30 @@ ath
 ajb
 avA
 axY
-axZ
+axY
 ayX
-ddS
-bUw
-aCY
-dek
+axY
+axY
+aBO
+aBO
 der
-deD
-dlI
-aJv
+axY
+emE
+ddO
 aKI
 tDM
-dfb
-dfj
+dBy
+axY
 dlI
-deD
-dfF
-aTN
-aVe
-aWH
-dgi
+aBO
+axY
+axY
+ayX
+axY
+atm
 dgc
-aqq
-aqr
+alq
+apc
 aWu
 bif
 bif
@@ -121273,27 +120376,27 @@ avB
 axY
 ddO
 bUw
-ddT
-ddZ
-ded
-del
-des
+ddO
+axY
+axY
+axY
+axY
 djt
-daY
+emE
 daZ
 dbb
-aMk
-aNv
-dfk
-dfq
+aHP
+dBy
 djt
-dfG
-dfQ
-dfZ
-apc
-apc
-dgo
-apc
+axY
+axY
+axY
+ddO
+bUw
+ddO
+axY
+alq
+alq
 cXZ
 atm
 bfZ
@@ -121528,31 +120631,31 @@ ajb
 ajb
 avC
 axY
-aya
-bUw
-ddU
-aBQ
-dee
+axY
+sjZ
+axY
+axY
+ddO
 aEr
-des
+ddO
 djt
-daY
-daZ
-dbb
+emE
+ddO
+kfh
 dfa
 aNv
-dfk
-daY
+djt
+ddO
 djx
-dfG
-cXz
-aVe
-atm
-alr
-dgp
+axY
+axY
+dkr
+axY
+axY
+alq
 cXI
 cYj
-atm
+uch
 bga
 big
 bga
@@ -121571,7 +120674,7 @@ bFS
 bHy
 bIV
 bKC
-bMi
+bAQ
 bNU
 bMg
 bQV
@@ -121785,31 +120888,31 @@ dps
 dpL
 avD
 axY
+axY
+hAc
 ddO
-bUw
-ddV
-aBQ
-dee
-aEr
-aKL
+ddO
+ddO
+ddO
+ddO
 djt
-daY
-deS
-dbb
-aMk
-aNv
-dfm
-daY
 djt
-dbg
-dfR
+djt
+hHc
+djt
+djt
+djt
+ddO
+ddO
+ddO
+ddO
 dga
 dgd
 dgj
-dgp
-alr
 atm
-atm
+alq
+uTQ
+uch
 bgb
 cTu
 bgb
@@ -121828,8 +120931,8 @@ bFT
 bHz
 bIW
 bKD
-dhe
-dhg
+bCi
+bCi
 bPu
 bPu
 bPu
@@ -122044,28 +121147,28 @@ avE
 axY
 ayc
 aza
-aAw
-bUw
+ddO
+iRf
 aCY
 dem
-aFD
+dem
 deD
-dlI
-dlI
+deD
+deD
 deV
-dlN
-dfc
-dlI
-dlI
-deD
+dem
+dem
+dem
+dem
+dem
 dfI
-dfS
-aVh
-aaf
+iRf
+ddO
+ddO
 aYx
-dgr
-dgw
-dgA
+bpu
+iRf
+lMJ
 dgI
 bgb
 cTi
@@ -122086,7 +121189,7 @@ bHy
 bIX
 bKE
 bKE
-dhh
+bKE
 bPv
 bKE
 bKE
@@ -122299,31 +121402,31 @@ apm
 dnS
 avB
 axY
-axY
-bTq
+suq
+ddO
 aAx
-aBO
+aaf
 aIe
 aOS
-deu
-deI
-deN
-deI
-deW
-aMm
-dfd
-deN
-dft
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
 dBB
-dbh
-dfT
-aVh
-aaa
+aIe
+aaf
+emE
+ddO
 aYx
-dgf
-dgj
-ack
-dgJ
+bpu
+lMJ
+lMJ
+iRf
 bgb
 bij
 bgb
@@ -122343,7 +121446,7 @@ bHA
 bIY
 bKF
 bMk
-dhi
+bNV
 bPw
 bQW
 bSj
@@ -122556,31 +121659,31 @@ atk
 aux
 avF
 dqT
-dqT
-aaf
-ack
-dea
-aIc
+mGi
+vzK
+aAx
+iRf
+aIe
 den
 dev
-deJ
-deO
-deU
-deX
-dBx
-dfe
-dBz
-dfu
+dew
+dew
+dev
+lMJ
+iRf
+dew
+dew
+dev
 dfz
-dfJ
-dfU
-dga
+aIe
+iRf
+emE
 dge
 azd
-azd
-azd
-dgB
-dgK
+bpu
+lMJ
+lMJ
+iRf
 aaa
 cUL
 aaa
@@ -122600,7 +121703,7 @@ bHB
 bIZ
 bKG
 bMl
-dhj
+bKG
 bIZ
 bKG
 bMl
@@ -122813,31 +121916,31 @@ atl
 auy
 dnS
 dqT
-dqT
+jnX
+ddO
+aAx
 aaf
-ack
-ack
 def
 aCZ
 dew
-aCZ
-axY
-axY
-aCZ
-aCZ
-aCZ
-axY
-axY
-aCZ
+aav
+aav
+vLD
+aaf
+aaa
+aav
+aav
 dew
-aCZ
-aVe
-dgf
-dgk
-dgt
-dgk
-dgv
-dgJ
+gLz
+puW
+aaf
+emE
+ddO
+dgg
+bpu
+lMJ
+iRf
+iRf
 anT
 aaf
 aaf
@@ -122857,7 +121960,7 @@ bza
 bJa
 bza
 bFX
-dhk
+bza
 bJa
 bza
 bFX
@@ -123070,51 +122173,51 @@ apm
 dnh
 dnS
 dnz
-dqT
+jFg
+dFT
+aAx
+iRf
+aIe
+den
+dew
+aav
+aaa
+aaa
 aaf
-aaf
-aaf
-def
-ddZ
-dex
-aJu
-ddZ
-ddZ
-ddZ
-aMo
-dff
-ddZ
-ddZ
-aJu
-dex
-ddZ
-aVe
+aaa
+aaa
+aav
+dew
+dfz
+aIe
+iRf
+emE
 aWK
 dgk
-dgt
-dgk
-dgB
-dgM
-dgN
-dgO
-dgO
-dgw
-dgO
-dgS
-dgO
-dgO
-dgw
-dgw
-dgw
-dgw
+bpu
+lMJ
+iRf
+iRf
+anT
+dew
+dew
+aaf
+dew
+bpw
+dew
+dew
+aaf
+aaf
+aaf
+aaf
 bCz
-dgw
-dha
-dgw
-dhc
-dgw
-dha
-dhl
+aaf
+bFY
+aaf
+bJb
+aaf
+bFY
+aaf
 bJb
 aaf
 bFY
@@ -123327,31 +122430,31 @@ dnh
 auz
 dqp
 dqT
-dqT
+axY
+jnX
+aAx
+ack
+def
+aCZ
+iRf
 aaa
 aaa
+ddZ
+cDu
+lhK
 aaa
-bTq
-dep
-dey
-aHa
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-dfA
-dfM
-dfV
-dgb
+vLD
+dev
+gLz
+puW
+ack
+emE
 dgg
-azd
-azd
-azd
-dgv
-aaf
+axY
+bpu
+lMJ
+iRf
+iRf
 anT
 aaa
 aaa
@@ -123584,30 +122687,30 @@ dni
 auA
 dnS
 dqT
-aaa
-aaa
-aaa
-aaa
 axY
-deq
-dey
-deK
-ddZ
-ddZ
-ddZ
+jnX
+ddO
+aaf
+aIe
+den
+lMJ
+aaf
+aaf
+den
+myV
 aMo
-ddZ
-ddZ
-ddZ
-dfB
-dfM
-dfW
+aaf
+aaf
+lMJ
+dfz
+aIe
+aaf
+ddO
+dgg
 axY
-aWK
-dgk
-dgt
-dgk
-dgB
+bpu
+lMJ
+iRf
 aaa
 anT
 aaa
@@ -123841,31 +122944,31 @@ dnh
 auB
 avG
 dqT
-aaa
-aaa
-aaa
-aaa
 axY
-aJu
-deA
-deL
-aJu
-aJu
+jnX
+aAx
+ack
+def
+aCZ
+dev
+vLD
+aaa
+pff
 deY
+ior
+aaa
+aaa
+iRf
+gLz
+puW
+ack
+emE
+dgg
 axY
-dfg
-aJu
-aJu
-dfC
-dfO
-ddZ
-axY
-dgh
-dgk
-dgk
-dgk
-dgv
-aaf
+bpu
+lMJ
+iRf
+iRf
 anT
 aaa
 aaa
@@ -124098,30 +123201,30 @@ dnh
 dnh
 jKK
 dqT
+cXM
+qXk
+aAx
+iRf
+aIe
+den
+dew
+aav
+aaa
+aaa
 aaf
 aaa
 aaa
-aaa
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-aWK
+aav
+dew
+dfz
+aIe
+iRf
+emE
+hJX
 dgm
-dgu
-dgm
-dgB
+bpu
+lMJ
+iRf
 aaa
 anT
 aaa
@@ -124355,31 +123458,31 @@ atn
 bOY
 avG
 dqT
+jnX
+ddO
+aAx
 aaf
+qcW
+aCZ
+dew
+aav
 aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
 aaa
 aaf
+vLD
 aaa
+aav
+dew
+gLz
+hze
 aaf
-aaa
-aaf
-aaf
-ack
-ack
-aye
-dgv
-aye
-dgv
-aaf
+kUD
+ddO
+dgg
+bpu
+lMJ
+iRf
+iRf
 anT
 aaf
 aaf
@@ -124612,29 +123715,29 @@ dnh
 dnh
 lNZ
 dqT
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-aaf
+krz
+vzK
+aAx
+iRf
+ack
+den
+dev
+dew
+iRf
+iRf
+lMJ
+dev
+dew
+dew
+dev
+dfz
+ack
+iRf
+emE
+dge
+lPF
+mdf
+lMJ
 aaa
 aaa
 aaf
@@ -124869,29 +123972,29 @@ aaa
 aaf
 ack
 dqT
-aaf
-anT
-anT
-anT
-anT
-aaf
-anT
-anT
-anT
-anT
-anT
-anT
-aqB
-anT
-anT
-anT
-anT
-anT
-anT
-aaf
-aaa
-aaa
-aaf
+axY
+axY
+ddO
+anS
+anS
+pVn
+anS
+anS
+anS
+anS
+anS
+anS
+anS
+anS
+anS
+pVn
+anS
+anS
+ddO
+axY
+axY
+mdf
+lMJ
 aaa
 aaa
 aaf
@@ -125126,12 +124229,12 @@ aaf
 aaf
 ack
 aaf
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
+axY
+axY
+axY
+axY
+axY
+axY
 bpu
 bpu
 bpu
@@ -125141,14 +124244,14 @@ bpu
 bpu
 bpu
 bpu
+axY
+axY
+axY
+axY
+axY
+axY
 bpu
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
+lMJ
 aaa
 aaa
 aaa
@@ -125382,30 +124485,30 @@ aaa
 aaa
 aaa
 aaa
+vLD
 aaa
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+trf
+lwB
 aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-anT
-anT
-anT
-anT
-aqB
-anT
-anT
-anT
-anT
-aqB
-aaf
-aaf
-aaf
-aaf
-aaa
-aaf
-aaf
+iRf
+lMJ
 aaa
 aaa
 aaa
@@ -125639,7 +124742,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -125896,26 +124999,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
 aaf
 aai
 aaa

--- a/_maps/cit_map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/cit_map_files/OmegaStation/OmegaStation.dmm
@@ -2574,7 +2574,7 @@
 	c_tag = "AI Vault - Port";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -3515,7 +3515,7 @@
 	c_tag = "AI Vault - Starboard";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4081,8 +4081,7 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
-	c_tag = "Armoury - Internal";
-	network = list("Labor")
+	c_tag = "Armoury - Internal"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -4542,8 +4541,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Cell 1";
-	network = list("MINE")
+	c_tag = "Security - Cell 1"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -4569,8 +4567,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Fore Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -5967,8 +5964,7 @@
 /obj/item/stamp,
 /obj/machinery/camera{
 	c_tag = "Cargo Bay Entrance";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/brown{
 	dir = 8
@@ -6147,8 +6143,7 @@
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Cell 2";
-	network = list("MINE")
+	c_tag = "Security - Cell 2"
 	},
 /turf/open/floor/plasteel/red/side{
 	dir = 5
@@ -6521,8 +6516,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Security - Office";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/red/corner{
 	dir = 1
@@ -6547,8 +6541,7 @@
 "amK" = (
 /obj/machinery/camera{
 	c_tag = "Security - Central";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/side{
 	dir = 8
@@ -6629,8 +6622,7 @@
 "amS" = (
 /obj/machinery/camera{
 	c_tag = "Locker Room Toilets";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/hallway/primary/central)
@@ -8505,8 +8497,7 @@
 /obj/item/shovel,
 /obj/machinery/camera{
 	c_tag = "Mining Dock";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -9015,7 +9006,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 4";
-	network = list("thunder");
 	pixel_x = 10
 	},
 /turf/open/floor/plasteel/green/side{
@@ -9418,8 +9408,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Diner 3";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -10058,8 +10047,7 @@
 "atz" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 1";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -10454,8 +10442,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -10473,8 +10460,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Bar Backroom";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/bar/atrium)
@@ -11736,8 +11722,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/caution{
 	dir = 4
@@ -11956,8 +11941,7 @@
 "axj" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -12059,8 +12043,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/machinery/camera{
 	c_tag = "Atmospherics Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -12634,8 +12617,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Diner 2";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -13466,8 +13448,7 @@
 /obj/structure/bedsheetbin,
 /obj/machinery/camera{
 	c_tag = "Locker Room East";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/arrival{
@@ -14488,8 +14469,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Hallway East";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 1
@@ -15091,8 +15071,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Secure Storage";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -15337,8 +15316,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Locker Room South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault{
@@ -15695,8 +15673,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "SMES Access";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -15739,8 +15716,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Access";
-	dir = 8;
-	network = list("Labor")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -15877,8 +15853,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Central Diner 1";
-	dir = 4;
-	network = list("MINE")
+	dir = 4
 	},
 /turf/open/floor/plasteel/redyellow,
 /area/crew_quarters/bar/atrium)
@@ -16458,8 +16433,7 @@
 "aHg" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot_white/left,
 /turf/open/floor/plasteel/vault{
@@ -16559,7 +16533,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Fore";
 	dir = 2;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /turf/open/floor/engine,
@@ -17184,8 +17158,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Engineering Monitoring";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -18010,7 +17983,7 @@
 /obj/machinery/camera{
 	c_tag = "Kitchen Coldroom";
 	dir = 4;
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen)
@@ -19145,7 +19118,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Port";
 	dir = 4;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -19171,7 +19144,7 @@
 /obj/machinery/camera{
 	c_tag = "Supermatter Chamber";
 	dir = 2;
-	network = list("Engine");
+	network = list("engine");
 	pixel_x = 23
 	},
 /obj/structure/cable{
@@ -19285,7 +19258,7 @@
 	desc = "Used for watching the Engine.";
 	dir = 1;
 	name = "Engine Monitor";
-	network = list("Engine");
+	network = list("engine");
 	pixel_y = -32
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
@@ -19335,8 +19308,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Atmospherics South West";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/neutral/corner{
 	dir = 8;
@@ -19468,8 +19440,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Hydroponics South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -20153,8 +20124,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 4";
-	network = list("SS13","Prison")
+	c_tag = "Aft Primary Hallway 4"
 	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
@@ -20262,8 +20232,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/camera{
-	c_tag = "Aft Primary Hallway 3";
-	network = list("SS13","Prison")
+	c_tag = "Aft Primary Hallway 3"
 	},
 /turf/open/floor/plasteel/green/corner{
 	dir = 1
@@ -21100,7 +21069,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Aft";
 	dir = 2;
-	network = list("SS13","Engine");
+	network = list("ss13","engine");
 	pixel_x = 23
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
@@ -21257,8 +21226,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/yellow/corner{
 	dir = 8
@@ -21535,8 +21503,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library 2";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
@@ -21685,8 +21652,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chemistry";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
@@ -22567,8 +22533,7 @@
 "aUo" = (
 /obj/machinery/camera{
 	c_tag = "Genetics Cloning";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
@@ -23136,7 +23101,7 @@
 /obj/machinery/camera{
 	c_tag = "Server Room";
 	dir = 2;
-	network = list("SS13","RD");
+	network = list("ss13","rd");
 	pixel_x = 22
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
@@ -23645,8 +23610,7 @@
 /obj/structure/closet/crate/bin,
 /obj/machinery/camera{
 	c_tag = "Medbay Morgue";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
@@ -23914,8 +23878,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -24230,8 +24193,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/window/reinforced{
@@ -24495,8 +24457,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Research Division South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/whitepurple/corner,
 /area/science/research)
@@ -25331,7 +25292,7 @@
 /obj/machinery/camera{
 	c_tag = "Robotics Lab";
 	dir = 2;
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side,
@@ -25637,8 +25598,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Foyer";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral,
 /area/hallway/primary/central)
@@ -26708,8 +26668,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay South";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
@@ -27226,8 +27185,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Recovery Room";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 8
@@ -28451,7 +28409,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 4
@@ -28546,7 +28504,7 @@
 /obj/machinery/camera{
 	c_tag = "Crematorium";
 	dir = 4;
-	network = list("MINE")
+	network = list("mine")
 	},
 /turf/open/floor/plasteel/vault/side{
 	dir = 4
@@ -29231,8 +29189,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chaplain's Quarters";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 8
@@ -29278,8 +29235,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/camera{
 	c_tag = "Chapel Office";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /turf/open/floor/wood,
 /area/chapel/main)
@@ -29714,8 +29670,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel South";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -29737,8 +29692,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway 3";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -29825,7 +29779,7 @@
 	c_tag = "Science - Server Room";
 	dir = 8;
 	name = "science camera";
-	network = list("SS13","RD")
+	network = list("ss13","rd")
 	},
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/xenobiology)
@@ -30413,8 +30367,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/camera{
 	c_tag = "Port Primary Hallway";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
@@ -30431,8 +30384,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
@@ -30440,8 +30392,7 @@
 /obj/structure/closet/firecloset,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway 2";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -30464,8 +30415,7 @@
 "blk" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank 3";
-	dir = 4;
-	network = list("SS13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -30478,12 +30428,11 @@
 /obj/machinery/camera{
 	c_tag = "Shuttle Docking Foyer";
 	dir = 8;
-	network = list("MINE")
+	network = list("mine")
 	},
 /obj/machinery/camera{
 	c_tag = "Escape Arm Airlocks";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -30492,8 +30441,7 @@
 /obj/structure/closet/emcloset,
 /obj/machinery/camera{
 	c_tag = "Starboard Primary Hallway";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/vault/side{
@@ -30507,7 +30455,7 @@
 /obj/machinery/camera{
 	c_tag = "Engineering Starboard";
 	dir = 8;
-	network = list("SS13","Engine")
+	network = list("ss13","engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30523,8 +30471,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Research Division Access";
-	dir = 2;
-	network = list("SS13")
+	dir = 2
 	},
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -30538,7 +30485,6 @@
 /obj/machinery/camera{
 	c_tag = "Aft Primary Hallway 1";
 	dir = 8;
-	network = list("SS13");
 	pixel_y = -22
 	},
 /turf/open/floor/plasteel/purple/corner,
@@ -30583,7 +30529,6 @@
 /obj/machinery/camera{
 	c_tag = "Surgery Operating";
 	dir = 1;
-	network = list("SS13");
 	pixel_x = 22
 	},
 /turf/open/floor/plasteel/neutral,
@@ -30592,7 +30537,7 @@
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
 	dir = 2;
-	network = list("Xeno","RD")
+	network = list("xeno","rd")
 	},
 /turf/open/floor/plasteel/vault{
 	dir = 5
@@ -30615,8 +30560,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30627,8 +30571,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway 2";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -30685,8 +30628,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Mass Driver";
-	dir = 8;
-	network = list("SS13")
+	dir = 8
 	},
 /obj/machinery/light/small,
 /obj/machinery/button/massdriver{
@@ -31264,8 +31206,7 @@
 "buU" = (
 /obj/machinery/camera{
 	c_tag = "Communications Relay";
-	dir = 8;
-	network = list("MINE")
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -33064,7 +33005,7 @@
 	c_tag = "AI Chamber - Core";
 	dir = 2;
 	name = "core camera";
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/machinery/cell_charger,
 /turf/open/floor/plasteel/vault/side,
@@ -33247,7 +33188,7 @@
 	c_tag = "AI Chamber - Core";
 	dir = 2;
 	name = "core camera";
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -33384,7 +33325,7 @@
 	c_tag = "AI Chamber - Core";
 	dir = 2;
 	name = "core camera";
-	network = list("RD")
+	network = list("rd")
 	},
 /obj/machinery/light{
 	dir = 1
@@ -33617,7 +33558,7 @@
 	c_tag = "AI Satellite - Access";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault/side{
@@ -33905,7 +33846,7 @@
 	c_tag = "AI Satellite - Maintenance";
 	dir = 8;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -33977,7 +33918,7 @@
 	c_tag = "AI Satellite - Antechamber";
 	dir = 4;
 	name = "ai camera";
-	network = list("Sat");
+	network = list("minisat");
 	start_active = 1
 	},
 /turf/open/floor/plasteel/vault/side{

--- a/_maps/cit_map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/cit_map_files/PubbyStation/PubbyStation.dmm
@@ -12234,6 +12234,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"aEY" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aEZ" = (
 /obj/structure/sink{
 	dir = 8;
@@ -12935,11 +12940,6 @@
 /area/hallway/primary/central)
 "aGV" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"aGW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aGX" = (
@@ -36419,14 +36419,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hallway/primary/aft)
-"bKN" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/preopen{
-	id = "prison release";
-	name = "prisoner processing blast door"
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "bKO" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
@@ -45137,9 +45129,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tesla_coil,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chz" = (
@@ -45147,9 +45136,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tesla_coil,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chA" = (
@@ -45258,10 +45244,6 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chQ" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -45420,14 +45402,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cit" = (
-/obj/machinery/the_singularitygen,
+/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ciu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "civ" = (
@@ -49358,18 +49339,6 @@
 	dir = 1
 	},
 /area/library/lounge)
-"cyr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 29
-	},
-/turf/open/floor/plasteel/red/side{
-	dir = 1
-	},
-/area/security/brig)
 "cyy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -49969,24 +49938,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cBQ" = (
-/obj/machinery/power/rad_collector/anchored,
+/obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cBR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cBS" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -50114,25 +50069,21 @@
 "cDa" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"dTw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-4"
+"dse" = (
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
-/turf/open/floor/carpet,
-/area/library)
-"ecV" = (
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
+"dwC" = (
+/turf/closed/wall/r_wall,
+/area/space)
+"dMB" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "eHp" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
-"eIE" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/library/lounge)
 "eJt" = (
 /obj/machinery/computer/cryopod{
 	pixel_y = 24
@@ -50146,33 +50097,29 @@
 	},
 /turf/open/floor/plasteel/darkpurple,
 /area/crew_quarters/cryopod)
-"fki" = (
+"fwl" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"fyh" = (
+"fWv" = (
+/obj/structure/bookcase/random/religion,
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
+"ick" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
+"ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/carpet,
 /area/library)
-"fID" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/sorting)
-"izp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "Engineering";
-	name = "engineering security door"
-	},
-/turf/open/floor/plating,
-/area/security/checkpoint/engineering)
 "izB" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod"
@@ -50182,7 +50129,7 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/dorms)
-"iCc" = (
+"iKb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
@@ -50209,6 +50156,31 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"jvi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/darkred/side{
+	dir = 1
+	},
+/area/crew_quarters/heads/hos)
+"jFO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/carpet,
+/area/library/lounge)
+"jXh" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
 "jZg" = (
 /obj/machinery/cryopod,
 /turf/open/floor/plasteel/darkpurple,
@@ -50240,12 +50212,10 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"krG" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
+"kMN" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "lqy" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
@@ -50255,50 +50225,37 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"mHo" = (
+"lAs" = (
+/turf/closed/wall,
+/area/quartermaster/sorting)
+"lQQ" = (
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgespace";
+	name = "bridge external shutters"
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/bridge)
+"mdL" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/matter_bin,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stock_parts/micro_laser,
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/lab)
+"mCe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "Engineering";
+	name = "engineering security door"
 	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = 27
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"mLe" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 1
-	},
-/area/crew_quarters/heads/hos)
-"nuB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/carpet,
-/area/library/lounge)
-"opC" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Library APC";
-	pixel_x = 24
-	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/library)
-"oJF" = (
+/turf/open/floor/plating,
+/area/security/checkpoint/engineering)
+"mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
@@ -50325,6 +50282,16 @@
 "pps" = (
 /turf/closed/wall,
 /area/engine/break_room)
+"pXc" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/carpet,
+/area/library)
+"qOE" = (
+/turf/open/floor/plasteel/dark,
+/area/library/lounge)
 "qWK" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50337,10 +50304,30 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"sHK" = (
-/obj/structure/bookcase/random/religion,
-/turf/open/floor/plasteel/dark,
-/area/library/lounge)
+"rxV" = (
+/obj/structure/table,
+/obj/machinery/microwave{
+	pixel_x = -3;
+	pixel_y = 6
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 27
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"sBA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = 29
+	},
+/turf/open/floor/plasteel/red/side{
+	dir = 1
+	},
+/area/security/brig)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -50363,10 +50350,6 @@
 	},
 /turf/open/floor/plasteel/darkpurple,
 /area/crew_quarters/cryopod)
-"tez" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/library/lounge)
 "tjW" = (
 /obj/machinery/light{
 	dir = 8
@@ -50378,15 +50361,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"ufi" = (
-/turf/open/floor/plasteel/dark,
-/area/library/lounge)
-"urZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/library)
 "uyt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -50423,28 +50397,36 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"vTA" = (
+"wxJ" = (
+/obj/effect/turf_decal/delivery,
 /obj/machinery/door/poddoor/preopen{
-	id = "bridgespace";
-	name = "bridge external shutters"
+	id = "prison release";
+	name = "prisoner processing blast door"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"xhj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/library/lounge)
+"xja" = (
+/obj/machinery/light/small{
+	dir = 4
 	},
-/area/bridge)
-"xzr" = (
-/turf/closed/wall,
-/area/quartermaster/sorting)
-"yhZ" = (
-/obj/structure/table,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/matter_bin,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stock_parts/micro_laser,
-/obj/item/stack/cable_coil,
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/whitepurple/side,
-/area/science/lab)
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Library APC";
+	pixel_x = 24
+	},
+/obj/structure/cable,
+/turf/open/floor/plasteel/dark,
+/area/library)
+"xjc" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/library)
 
 (1,1,1) = {"
 aaa
@@ -68110,13 +68092,13 @@ cgG
 cfn
 ckE
 ckT
-tez
-tez
+xhj
+xhj
 cwK
-tez
-tez
+xhj
+xhj
 cxn
-tez
+xhj
 lqy
 cxC
 cxK
@@ -68368,12 +68350,12 @@ cvw
 cvK
 cwg
 cjR
-nuB
+jFO
 ckF
-nuB
+jFO
 cxe
-nuB
-nuB
+jFO
+jFO
 cxz
 cxD
 cxL
@@ -68381,8 +68363,8 @@ cxY
 cym
 cyA
 vOw
-fyh
-dTw
+ijF
+pXc
 ckm
 ckm
 ckm
@@ -68628,7 +68610,7 @@ cwr
 clm
 ckG
 cwU
-eIE
+jXh
 ckU
 cwe
 cwe
@@ -68639,7 +68621,7 @@ cxM
 cyB
 cjp
 cyR
-urZ
+ick
 ckH
 ckH
 ckH
@@ -68882,10 +68864,10 @@ cvy
 cvL
 cwe
 cwe
-sHK
-ufi
+fWv
+qOE
 ckV
-ufi
+qOE
 cln
 cwe
 cfN
@@ -68896,7 +68878,7 @@ aaa
 aaa
 cjp
 cyS
-urZ
+ick
 cyZ
 ckH
 czo
@@ -69139,10 +69121,10 @@ cvc
 cvM
 cfm
 cwe
-sHK
-ufi
-oJF
-ufi
+fWv
+qOE
+mKc
+qOE
 cln
 cwe
 caS
@@ -69153,7 +69135,7 @@ aht
 aht
 cjp
 cko
-urZ
+ick
 ckH
 ckH
 clp
@@ -69410,7 +69392,7 @@ aaa
 aaa
 cjp
 cyT
-urZ
+ick
 cyZ
 ckH
 czp
@@ -69667,8 +69649,8 @@ aht
 aht
 cjp
 cjp
-krG
-opC
+xjc
+xja
 ckH
 czq
 czw
@@ -70574,7 +70556,7 @@ aok
 aoO
 apF
 apE
-bKN
+wxJ
 apE
 bBW
 ajM
@@ -73914,7 +73896,7 @@ anJ
 amX
 aoY
 apN
-cyr
+sBA
 arp
 asB
 atB
@@ -74701,7 +74683,7 @@ aDv
 aBh
 aBh
 aGd
-aGW
+aEY
 aHG
 aIM
 aJG
@@ -77251,7 +77233,7 @@ akW
 alK
 amw
 ani
-mLe
+jvi
 aiR
 aph
 ajM
@@ -79160,8 +79142,8 @@ bXk
 bXk
 bXk
 bXk
-aaa
-aaa
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -79416,9 +79398,9 @@ chR
 cgt
 cjT
 ckq
+ckq
 bXk
-aaa
-aaa
+dwC
 aaa
 aaa
 aaa
@@ -79673,9 +79655,9 @@ chS
 cfV
 cgS
 cfV
+cfV
 bXk
-aaa
-aaa
+dwC
 aaa
 aaa
 aaa
@@ -79858,7 +79840,7 @@ aRN
 aWa
 aRN
 aRN
-mHo
+rxV
 aYS
 cpn
 bch
@@ -79929,10 +79911,10 @@ cfV
 cfV
 cfV
 cgT
+cfV
 ckr
 bXk
-aaa
-aaa
+dwC
 aaa
 aaa
 aaa
@@ -80179,7 +80161,7 @@ cfU
 cgu
 cgU
 chw
-cBR
+chw
 chw
 chw
 chw
@@ -80187,9 +80169,9 @@ chw
 cjs
 cfV
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -80444,9 +80426,9 @@ chQ
 chx
 cfV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -80694,16 +80676,16 @@ cgv
 cgV
 bBW
 bBW
-aaa
 cgV
+aht
 aaa
 bBW
 bBW
 cgV
 cfV
-bTE
-abI
-abI
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -80951,16 +80933,16 @@ cgv
 bBW
 bBW
 bBW
-aaa
+kMN
 abI
 aaa
 bBW
 bBW
 bBW
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -81215,9 +81197,9 @@ aaa
 bBW
 bBW
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -81469,12 +81451,12 @@ cii
 cis
 ciG
 aaa
-aaa
-aaa
+kMN
+cgV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -81719,7 +81701,7 @@ cfd
 cfw
 cfW
 cgw
-cgV
+aht
 abI
 abI
 cij
@@ -81727,11 +81709,11 @@ cit
 ciH
 abI
 abI
-cgV
+aht
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -81976,8 +81958,8 @@ cfe
 cfx
 cfa
 cgv
-aaa
-aaa
+cgV
+kMN
 aaa
 cik
 ciu
@@ -81986,9 +81968,9 @@ aaa
 aaa
 aaa
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -82243,9 +82225,9 @@ aaa
 bBW
 bBW
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -82495,14 +82477,14 @@ bBW
 aaa
 aaa
 abI
-aaa
+kMN
 aaa
 bBW
 bBW
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -82733,7 +82715,7 @@ bUi
 bUV
 bVO
 bWA
-izp
+mCe
 bYj
 bYQ
 bZA
@@ -82751,15 +82733,15 @@ cgV
 bBW
 aaa
 aaa
+aht
 cgV
-aaa
 bBW
 bBW
 cgV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 aaa
 aaa
 aaa
@@ -82990,7 +82972,7 @@ bUj
 bUW
 bVP
 bWB
-izp
+mCe
 bYk
 bYQ
 bZA
@@ -83014,9 +82996,9 @@ cBS
 chz
 cfV
 cfV
-bTE
-abI
-abI
+cfV
+bXk
+dwC
 abI
 abI
 aaa
@@ -83172,7 +83154,7 @@ ahi
 atY
 auU
 atY
-vTA
+lQQ
 ayf
 axf
 aAF
@@ -83247,7 +83229,7 @@ bUk
 bUX
 bVQ
 bWC
-izp
+mCe
 bYl
 bYO
 bZC
@@ -83271,9 +83253,9 @@ chA
 cjt
 cfV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+dwC
 abI
 aaa
 aaa
@@ -83527,10 +83509,10 @@ cfV
 cfV
 cfV
 cgY
+cfV
 cks
 bXk
-abI
-aaa
+dwC
 aaa
 aaa
 aaa
@@ -83785,9 +83767,9 @@ chO
 cfV
 cgZ
 cfV
+cfV
 bXk
-abI
-abI
+dwC
 abI
 aaa
 aaa
@@ -84042,9 +84024,9 @@ chP
 cgt
 cjU
 ckq
+ckq
 bXk
-abI
-aaa
+dwC
 aaa
 aaa
 aaa
@@ -84299,9 +84281,9 @@ bXk
 bXk
 bXk
 bXk
+bXk
 ckJ
-abI
-aaa
+dwC
 aaa
 aaa
 aaa
@@ -85021,7 +85003,7 @@ bsT
 bus
 bvz
 bxg
-yhZ
+mdL
 bAs
 bBu
 bCI
@@ -85752,7 +85734,7 @@ aBI
 aES
 aBI
 aBI
-aGW
+aEY
 aHG
 aBI
 aJX
@@ -85775,7 +85757,7 @@ aMb
 aSX
 aMb
 aBI
-aGW
+aEY
 bgA
 bhe
 aDZ
@@ -87555,13 +87537,13 @@ eHp
 aHN
 aIU
 aJI
-xzr
-xzr
+lAs
+lAs
 aNG
 aOR
-iCc
-xzr
-xzr
+iKb
+lAs
+lAs
 aTb
 aOT
 aVp
@@ -87812,7 +87794,7 @@ aET
 aHN
 aIU
 aJI
-xzr
+lAs
 aMg
 aNH
 aOS
@@ -88069,11 +88051,11 @@ aET
 aHN
 aJh
 bhe
-xzr
+lAs
 aMh
 aNI
-fID
-ecV
+fwl
+dMB
 aRi
 aSf
 aTd
@@ -88326,13 +88308,13 @@ aHn
 aIi
 aJi
 aKe
-xzr
+lAs
 aMi
 aNJ
-fID
+fwl
 aPZ
 aRj
-xzr
+lAs
 aTe
 aUo
 aVs
@@ -88583,13 +88565,13 @@ aET
 aHN
 aIU
 aJI
-xzr
+lAs
 aMj
 aNK
-fID
-ecV
-ecV
-iCc
+fwl
+dMB
+dMB
+iKb
 aTf
 aUp
 aVt
@@ -88840,7 +88822,7 @@ aET
 aHN
 aIU
 aJI
-xzr
+lAs
 aMk
 aNL
 aOU
@@ -89097,10 +89079,10 @@ cos
 coy
 aJj
 aJI
-xzr
+lAs
 aMl
 aNM
-fki
+dse
 aQb
 aRl
 aSh
@@ -89354,13 +89336,13 @@ aDZ
 aDZ
 aJk
 aJH
-xzr
+lAs
 aMm
-xzr
+lAs
 aOW
-xzr
-xzr
-xzr
+lAs
+lAs
+lAs
 aSY
 aUs
 aLf
@@ -89604,18 +89586,18 @@ aAP
 avk
 aDg
 aEc
-aGW
+aEY
 cot
 aBI
 aBI
 aBI
 aJl
 aKf
-xzr
+lAs
 aMn
-xzr
+lAs
 aOX
-xzr
+lAs
 aRm
 aLg
 aTi

--- a/_maps/cit_map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/cit_map_files/PubbyStation/PubbyStation.dmm
@@ -45243,12 +45243,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"chQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "chR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49941,12 +49935,6 @@
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cBS" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cBT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating/airless,
@@ -50075,9 +50063,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"dwC" = (
-/turf/closed/wall/r_wall,
-/area/space)
 "dMB" = (
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
@@ -50212,10 +50197,6 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/AIsatextAP)
-"kMN" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
 "lqy" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Library"
@@ -50370,9 +50351,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uTf" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "vpU" = (
 /turf/open/floor/plasteel/darkpurple,
 /area/crew_quarters/cryopod)
+"vyc" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -79143,7 +79131,7 @@ bXk
 bXk
 bXk
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -79400,7 +79388,7 @@ cjT
 ckq
 ckq
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -79657,7 +79645,7 @@ cgS
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -79914,7 +79902,7 @@ cgT
 cfV
 ckr
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -80161,17 +80149,17 @@ cfU
 cgu
 cgU
 chw
+cgU
 chw
+cgU
 chw
-chw
-chw
-chw
+cgU
 cjs
 cfV
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -80418,17 +80406,17 @@ cfV
 cgv
 cfV
 chx
-chQ
+cfV
 chx
-chQ
+cfV
 chx
-chQ
+cfV
 chx
 cfV
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -80685,7 +80673,7 @@ cgV
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -80933,7 +80921,7 @@ cgv
 bBW
 bBW
 bBW
-kMN
+vyc
 abI
 aaa
 bBW
@@ -80942,7 +80930,7 @@ bBW
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -81199,7 +81187,7 @@ bBW
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -81451,12 +81439,12 @@ cii
 cis
 ciG
 aaa
-kMN
+vyc
 cgV
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -81713,7 +81701,7 @@ aht
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -81959,7 +81947,7 @@ cfx
 cfa
 cgv
 cgV
-kMN
+vyc
 aaa
 cik
 ciu
@@ -81970,7 +81958,7 @@ aaa
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -82227,7 +82215,7 @@ bBW
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -82477,14 +82465,14 @@ bBW
 aaa
 aaa
 abI
-kMN
+vyc
 aaa
 bBW
 bBW
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -82741,7 +82729,7 @@ cgV
 cfV
 cfV
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -82988,17 +82976,17 @@ cfV
 cgv
 cfV
 chz
-cBS
+cfV
 chz
-cBS
+cfV
 chz
-cBS
+cfV
 chz
 cfV
 cfV
 cfV
 bXk
-dwC
+uTf
 abI
 abI
 aaa
@@ -83245,17 +83233,17 @@ cfU
 cgx
 cgU
 chA
+cgU
 chA
+cgU
 chA
-chA
-chA
-chA
+cgU
 cjt
 cfV
 cfV
 cfV
 bXk
-dwC
+uTf
 abI
 aaa
 aaa
@@ -83512,7 +83500,7 @@ cgY
 cfV
 cks
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -83769,7 +83757,7 @@ cgZ
 cfV
 cfV
 bXk
-dwC
+uTf
 abI
 aaa
 aaa
@@ -84026,7 +84014,7 @@ cjU
 ckq
 ckq
 bXk
-dwC
+uTf
 aaa
 aaa
 aaa
@@ -84283,7 +84271,7 @@ bXk
 bXk
 bXk
 ckJ
-dwC
+uTf
 aaa
 aaa
 aaa

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -2439,10 +2439,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/main)
-"agd" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal,
@@ -38079,7 +38075,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("engine");
+	network = list("singularity");
 	pixel_x = 30
 	},
 /turf/open/floor/plasteel/red/side{
@@ -40337,9 +40333,6 @@
 /area/engine/atmos)
 "bWU" = (
 /obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43827,16 +43820,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/chief)
-"cfI" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 4
-	},
-/area/engine/engineering)
 "cfJ" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -44139,13 +44122,13 @@
 /area/engine/engineering)
 "cgw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cgx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgy" = (
 /obj/machinery/light/small{
@@ -44215,32 +44198,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cgI" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cgJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cgL" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cgO" = (
 /obj/structure/rack,
@@ -44254,16 +44227,6 @@
 	dir = 5
 	},
 /area/crew_quarters/heads/chief)
-"cgQ" = (
-/obj/machinery/camera{
-	c_tag = "Engineering East";
-	dir = 8
-	},
-/obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
-	},
-/area/engine/engineering)
 "cgR" = (
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -44624,25 +44587,24 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "chF" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chH" = (
 /obj/structure/closet/firecloset,
@@ -44740,35 +44702,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"chV" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi{
-	pixel_x = 5
-	},
-/obj/item/clothing/gloves/color/black,
-/obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "chX" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "chY" = (
 /obj/machinery/shieldgen,
@@ -44852,24 +44794,6 @@
 "cig" = (
 /turf/closed/wall,
 /area/engine/engineering)
-"cii" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/device/geiger_counter,
-/obj/item/device/geiger_counter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cij" = (
 /obj/machinery/modular_computer/console/preset/engineering,
 /obj/structure/cable{
@@ -44907,15 +44831,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
-"cip" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ciq" = (
 /obj/structure/cable,
 /obj/effect/spawner/structure/window/reinforced,
@@ -44925,13 +44840,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/chief)
-"cir" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cis" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
@@ -45072,14 +44980,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciO" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/book/manual/engineering_singularity_safety{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/engineering_particle_accelerator{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/turf/open/floor/engine,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ciP" = (
 /obj/structure/cable{
@@ -45221,12 +45133,6 @@
 	},
 /turf/open/floor/plasteel/vault,
 /area/crew_quarters/heads/chief)
-"cjh" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cji" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -45459,7 +45365,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
+	},
 /area/engine/engineering)
 "cjP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46730,16 +46638,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/chair/sofa/left{
+	icon_state = "sofaend_left";
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cny" = (
 /obj/effect/landmark/start/station_engineer,
@@ -46973,14 +46876,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -46995,25 +46895,32 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cob" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coc" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/obj/item/stack/cable_coil,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -47182,38 +47089,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "coK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"coL" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"coM" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
+/obj/structure/chair/office/dark,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"coL" = (
+/obj/structure/chair/office/dark,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "coS" = (
 /obj/structure/rack,
@@ -47379,50 +47275,37 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpt" = (
-/obj/structure/table,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/engineering)
+"cpu" = (
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
 /obj/item/clothing/gloves/color/yellow,
-/obj/item/storage/toolbox/electrical{
-	pixel_y = 5
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/table/glass,
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cpx" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cpu" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cpv" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cpx" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cpy" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cpA" = (
 /obj/structure/chair/office/dark{
@@ -47437,19 +47320,17 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "cpD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cpG" = (
 /obj/structure/table/optable,
@@ -47606,133 +47487,72 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cpZ" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/device/flashlight{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cqa" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cqb" = (
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"cqb" = (
+/obj/structure/chair/sofa/right{
+	icon_state = "sofaend_right";
+	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/structure/closet/radiation,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqe" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqf" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqg" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Filter";
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqh" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
 /obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
+	c_tag = "Engineering Center";
+	dir = 2;
 	network = list("ss13","engine");
 	pixel_x = 23
 	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
+/obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqi" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = -24;
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cql" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+"cqh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cqm" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+"cqi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cqn" = (
 /obj/structure/grille,
@@ -47828,54 +47648,39 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cqA" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access = null;
-	req_access_txt = "10;13"
+"cqC" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cqD" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cqB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"cqE" = (
+/obj/structure/particle_accelerator/end_cap,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cqF" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cqC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cqD" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cqE" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cqF" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cqG" = (
 /obj/structure/rack,
 /obj/item/storage/box/rubbershot{
@@ -47963,70 +47768,49 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqS" = (
-/obj/machinery/light/small{
-	dir = 8
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
 	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
 /area/engine/engineering)
 "cqT" = (
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cqU" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 25;
+	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cqY" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cra" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Filter"
-	},
-/obj/machinery/airalarm/engine{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"crb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Gas to Chamber"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"crc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/obj/structure/particle_accelerator/fuel_chamber,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"crd" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+"cra" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crb" = (
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crc" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Fore";
+	dir = 2;
+	network = list("engine")
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crh" = (
 /obj/effect/turf_decal/stripes/line{
@@ -48089,40 +47873,38 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/crowbar,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crt" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/particle_accelerator/power_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cru" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"crv" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/item/screwdriver,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "crw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
 /area/engine/engineering)
 "cry" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48210,43 +47992,34 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"crH" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "crI" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"crJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"crK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/turf/closed/wall/r_wall,
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"crL" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
+"crJ" = (
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#fff4bc"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"crK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crM" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#fff4bc"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "crP" = (
 /obj/machinery/light,
@@ -48259,25 +48032,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crT" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"crU" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
 "crV" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "crW" = (
 /obj/machinery/light/small{
@@ -48297,38 +48057,29 @@
 /obj/structure/transit_tube,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"crZ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "csa" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csb" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csc" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /turf/open/space,
 /area/maintenance/aft)
 "csd" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cse" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csg" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -48347,13 +48098,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"csj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "csk" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating/airless,
@@ -48414,26 +48158,22 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/maintenance/disposal/incinerator)
 "css" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
-"csu" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"csv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csx" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "csy" = (
 /obj/structure/table,
 /obj/item/weldingtool,
@@ -48442,19 +48182,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"csA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
 "csD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -48466,24 +48193,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/solar/starboard/aft)
-"csH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"csI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "csM" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
@@ -48501,27 +48210,9 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "csP" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 1
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"csR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "csT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -50551,18 +50242,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
-"czE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "czF" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "czG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50796,97 +50483,40 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cAl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"cAm" = (
+/obj/item/wirecutters,
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
+	icon_state = "2-8"
 	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cAo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAm" = (
-/obj/machinery/power/supermatter_shard/crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cAo" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop to Gas";
-	on = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAq" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Gas to Mix";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cAu" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAy" = (
 /obj/structure/closet/secure_closet/freezer/kitchen/maintenance,
@@ -51001,9 +50631,17 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cAP" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 25;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cAQ" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
@@ -51417,10 +51055,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cBS" = (
 /obj/structure/cable{
@@ -51596,89 +51231,6 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
-"cCB" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCD" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine";
-	on = 0
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCE" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cCF" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"cCG" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCH" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCI" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"cCP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCQ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cCS" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "cCT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -51698,77 +51250,33 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDe" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cDh" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/device/flashlight,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/pipe_dispenser,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDi" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/table/reinforced,
-/obj/item/clothing/suit/radiation,
-/obj/item/clothing/head/radiation,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDj" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51785,90 +51293,39 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDo" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/pen,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDt" = (
+/obj/structure/table,
+/obj/item/twohanded/rcl/pre_loaded,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cDw" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDv" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDw" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cDx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/chair/sofa{
+	icon_state = "sofamiddle";
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Atmos to Loop";
-	on = 0
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDz" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDB" = (
@@ -51878,102 +51335,23 @@
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDC" = (
-/obj/item/wrench,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cDD" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cDE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "cDF" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "External Gas to Loop"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cDG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cDH" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cDJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cDK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cDL" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cDN" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/engine/engineering)
-"cDY" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+"cDO" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/space,
+/turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cDZ" = (
 /obj/structure/cable{
@@ -51983,824 +51361,139 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cEa" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cEd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
-"cEe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEf" = (
-/obj/machinery/ai_status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cEg" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cEh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEk" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cEl" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "cEm" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"cEr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cEs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Cooling Loop";
-	on = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEt" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEu" = (
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 2;
-	network = list("engine");
-	pixel_x = 23
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEv" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEx" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEy" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEz" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cEA" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Gas";
-	on = 0
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEE" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"cEK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cEL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEM" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cET" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/oil,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
-"cEU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cEW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cFb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cFc" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"cEv" = (
 /obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	icon_state = "pump_map";
-	name = "Cooling Loop Bypass"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFe" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cFh" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cFj" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
-"cFk" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Mix Bypass"
-	},
-/turf/open/floor/engine,
 /area/engine/engineering)
-"cFm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"cFn" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+"cEw" = (
+/obj/structure/particle_accelerator/particle_emitter/left,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEx" = (
+/obj/structure/particle_accelerator/particle_emitter/right,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cEy" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/space,
-/area/space/nearstation)
-"cFo" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"cFu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/meter,
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cFw" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cFy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+"cEK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
-"cFz" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+"cFb" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Fore";
+	dir = 2;
+	network = list("engine")
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cFA" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/dark,
+"cFn" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFJ" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFL" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 2;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cFP" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cFT" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cFU" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGd" = (
-/obj/structure/closet/crate/bin,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGe" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGf" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8;
-	filter_type = "n2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGg" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGh" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGj" = (
-/obj/structure/table,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGk" = (
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGl" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGs" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGt" = (
-/obj/structure/closet/wardrobe/engineering_yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGu" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
-/obj/machinery/meter,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGC" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/components/binary/valve/digital{
-	dir = 4;
-	name = "Output Release";
-	open = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGE" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGH" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGI" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cGK" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cGM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cGR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cGT" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGU" = (
-/obj/structure/reflector/double/anchored{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGV" = (
-/obj/structure/reflector/box/anchored{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGY" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cGZ" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 1;
-	volume_rate = 200
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cHa" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cHb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHc" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHd" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHe" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHg" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHj" = (
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
 	state = 2
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cHn" = (
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cHo" = (
-/obj/structure/reflector/single/anchored{
-	dir = 9
+"cGh" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cHp" = (
-/obj/structure/reflector/single/anchored{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cHr" = (
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGr" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGE" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cGU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cGV" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"cGZ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cHD" = (
 /obj/structure/cable{
@@ -53139,8 +51832,13 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "cMm" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cMC" = (
 /obj/machinery/computer/security/telescreen{
@@ -53148,7 +51846,7 @@
 	dir = 8;
 	layer = 4;
 	name = "Engine Monitor";
-	network = list("engine");
+	network = list("singularity");
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -53159,15 +51857,24 @@
 	},
 /area/engine/engineering)
 "cMD" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"cMH" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"cMN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
-/area/engine/supermatter)
+/area/engine/engineering)
+"cMH" = (
+/obj/structure/particle_accelerator/particle_emitter/center,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cMN" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cMQ" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -53375,6 +52082,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cQZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cSz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53400,41 +52113,23 @@
 /turf/open/floor/plasteel/dark/telecomms/mainframe,
 /area/tcommsat/server)
 "cSG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cSH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cSI" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cSJ" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cSK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "cSL" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -53865,6 +52560,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/brig)
+"ejb" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "ejX" = (
 /obj/machinery/light{
 	dir = 1
@@ -53920,6 +52622,13 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
+"eHD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eRz" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -53978,9 +52687,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
-"fsQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
+"fFB" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "fIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -54045,6 +52761,9 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
+"gre" = (
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "gtB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54148,18 +52867,61 @@
 /obj/structure/closet/bombcloset/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
+"hmW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"hyz" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hCi" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"hDa" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"hMa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access = null;
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"hQd" = (
+/turf/open/space/basic,
+/area/engine/engineering)
 "hSW" = (
 /turf/open/floor/plasteel/red/side,
 /area/security/brig)
-"ijc" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+"ieW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "ilg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
@@ -54176,6 +52938,14 @@
 /obj/machinery/droneDispenser,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"iqO" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "itG" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -54289,6 +53059,10 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"jyX" = (
+/obj/structure/sign/warning/securearea,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "jAD" = (
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
@@ -54333,15 +53107,6 @@
 	dir = 9
 	},
 /area/security/brig)
-"jMY" = (
-/obj/structure/table,
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "jSO" = (
 /obj/machinery/light{
 	dir = 4
@@ -54360,6 +53125,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"jZh" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "khb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -54440,6 +53212,12 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/bar)
+"kNw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -54455,13 +53233,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"kQq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kSb" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -54628,27 +53399,44 @@
 /obj/effect/turf_decal/bot_white,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"mBv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4;
-	name = "Output to Waste"
-	},
-/turf/open/floor/engine,
+"mzz" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "mHd" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"mLm" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"mMg" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "mNi" = (
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"mQs" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "mRe" = (
 /obj/machinery/light{
 	dir = 8
@@ -54671,10 +53459,6 @@
 "nnM" = (
 /turf/closed/wall/r_wall,
 /area/security/armory)
-"noK" = (
-/obj/structure/girder,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nsq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54708,10 +53492,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
-"nzh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "nAv" = (
 /obj/structure/table,
 /obj/item/grenade/barrier{
@@ -54783,6 +53563,13 @@
 /obj/item/device/electropack/shockcollar,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"oaS" = (
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "obC" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -54853,9 +53640,18 @@
 	dir = 10
 	},
 /area/security/brig)
-"oDF" = (
-/obj/machinery/light,
+"oAQ" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
+/area/engine/engineering)
+"oHi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "oHU" = (
 /obj/structure/cable{
@@ -54880,6 +53676,21 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oUs" = (
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -25;
+	req_access_txt = "11"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "oZl" = (
 /turf/open/floor/plasteel/purple/side{
 	tag = "icon-purple (NORTH)";
@@ -54923,6 +53734,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"pmD" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "pzG" = (
 /obj/structure/sign/poster/random{
 	pixel_x = -32
@@ -55089,6 +53903,14 @@
 /obj/item/device/assembly/signaler,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"riY" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -55131,11 +53953,22 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"rNn" = (
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "rWu" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken6"
 	},
 /area/maintenance/bar)
+"rZV" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "saK" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -55148,6 +53981,20 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"spp" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "srd" = (
 /turf/open/floor/plasteel/red/corner{
 	dir = 4
@@ -55170,6 +54017,12 @@
 /obj/item/shovel/spade,
 /turf/open/floor/plasteel/hydrofloor,
 /area/hallway/secondary/service)
+"sAz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sGJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood{
@@ -55236,6 +54089,12 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"sWi" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "sXy" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -55299,6 +54158,12 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/space/nearstation)
+"tHc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
@@ -55329,21 +54194,14 @@
 /obj/item/storage/box/drinkingglasses,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"udp" = (
-/obj/item/crowbar/large,
-/obj/structure/rack,
-/obj/item/device/flashlight,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"uhH" = (
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
+"ugZ" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/structure/rack,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ujc" = (
 /obj/machinery/vending/cigarette,
@@ -55401,6 +54259,20 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
+"uuA" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/wood,
@@ -55408,6 +54280,12 @@
 "uvy" = (
 /turf/closed/wall/r_wall,
 /area/space)
+"uAt" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "uMX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55487,6 +54365,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
+"vie" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vxh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -55517,6 +54401,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vHQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vNJ" = (
 /obj/machinery/vending/clothing,
 /turf/open/floor/wood,
@@ -55740,6 +54631,22 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xJs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"xMh" = (
+/obj/structure/grille,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xTa" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -55768,6 +54675,10 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
+"yam" = (
+/obj/effect/landmark/start/atmospheric_technician,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ycu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -79124,8 +78035,8 @@ aaa
 aaa
 aaa
 aaa
-aaT
-aaT
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -79369,21 +78280,21 @@ cjJ
 aaa
 aaa
 crn
-aaf
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
+pmD
 aaa
-aaf
-ctv
-aaT
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -79626,21 +78537,21 @@ cjJ
 aaa
 aaa
 crn
-aaf
-aaT
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-ctv
-aaT
+pmD
 aaa
-aaf
-ctv
-ctv
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -79883,20 +78794,20 @@ cjJ
 aaf
 aaf
 cig
-aaf
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaT
-aaf
-aaf
-aaf
-aaf
+pmD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80141,17 +79052,17 @@ ccw
 ccw
 ccw
 aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
-aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80398,19 +79309,19 @@ cqw
 cqO
 crp
 aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaa
-aaf
 aaa
 aaa
 aaa
-aaT
-aaT
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80654,20 +79565,20 @@ cgR
 cgR
 cqN
 cro
-cEl
-cEE
-cEl
-cFm
-csx
-cFm
-cFm
-csx
-csv
+pmD
 aaa
 aaa
-aaT
-ctv
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -80911,20 +79822,20 @@ ciN
 cji
 cDZ
 crr
-crJ
-crT
-crJ
-cFn
-css
-csx
-csx
-css
-csb
-aaf
-aaf
-aaT
-ctv
-aaT
+pmD
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81164,24 +80075,24 @@ ccw
 cfL
 coH
 cBO
-cgR
+cnv
 cDB
 cqP
 crq
-crZ
-crT
-crZ
-cFo
-css
-cFm
-cFm
-css
-csv
+pmD
 aaa
 aaa
-aaT
-ctv
-aaT
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81425,21 +80336,21 @@ cgR
 cqx
 cqR
 crp
-crJ
-crT
-crJ
-cFn
-css
-csx
-csx
-css
-csb
-aaf
-aaf
-aaT
-ctv
-aaT
-aaa
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+gXs
+hCi
 aaa
 aaa
 aaa
@@ -81682,22 +80593,22 @@ cpX
 cqz
 cqQ
 ccw
-crH
-crT
-crZ
-cFo
-css
-cFm
-cFm
-css
-csv
+pmD
 aaa
 aaa
-aaT
 ctv
-aaT
+ctv
+ctv
 aaa
 aaa
+aaa
+aaa
+aaa
+ctv
+ctv
+ctv
+hCi
+hCi
 aaa
 aaa
 aaa
@@ -81939,24 +80850,24 @@ clJ
 cig
 cig
 ccw
-crJ
-crT
-crJ
-cFn
-css
-csx
-csx
-css
-csb
-aaf
-aaf
-aaT
+pmD
+pmD
 ctv
-aaT
+ctv
+ctv
+ctv
+ctv
 aaa
 aaa
 aaa
-aaa
+ctv
+ctv
+ctv
+ctv
+uvy
+hCi
+hCi
+hCi
 aaa
 aaa
 aaa
@@ -82190,30 +81101,30 @@ ccw
 ccw
 ccw
 cnZ
-coH
+oHi
 cpt
-cpZ
-cig
+cpt
+cpt
 cqS
 ccw
-crH
-crT
-crZ
-cFo
-css
-cFm
-cFm
-css
-csv
-aaa
-aaa
-aaT
-ctv
-aaT
-aaa
-aaa
-aaf
-aaa
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+cpy
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -82449,27 +81360,27 @@ cnt
 cob
 coL
 cDo
+oaS
 cgR
-cqA
 cqT
-csg
+ccw
 crJ
-crU
+ccw
 csb
 cFn
 css
+cFn
 csx
-csx
-css
-csb
-aaf
-aaf
-aaT
-aaT
-aaT
-gXs
-aaf
-aaf
+ccw
+ccw
+ccw
+cGE
+cFn
+jZh
+mzz
+mzz
+ccw
+uvy
 aaf
 aaa
 aaa
@@ -82707,27 +81618,27 @@ cgw
 coK
 cpu
 cMm
-ccw
-ccw
-ccw
+ckH
+uAt
+hMa
 crK
 cEK
 csa
-csj
-csa
-csa
+gre
+mQs
+gre
 cGr
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+vHQ
+hDa
+vHQ
+mLm
+gre
+mQs
+gre
+gre
+ccw
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -82960,30 +81871,30 @@ ckG
 clJ
 cmF
 cgR
-cgI
+cnZ
 chF
 ciO
-cqc
-cqc
-cqc
-cEd
-cEr
-cEL
+oaS
+cgR
+cqT
+ccw
+cig
+ccw
 cFb
-cFu
+gre
 cFI
-cGd
-cGs
-cGr
+gre
+gre
+gre
+gre
+gre
+gre
+gre
+cFI
+gre
+iqO
 ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-aaa
-eRz
-aaT
+uvy
 eRz
 aaa
 aaa
@@ -83217,30 +82128,30 @@ cTa
 ceZ
 clQ
 cgR
-cgx
-coM
-cpv
-cqb
-cqb
-cqb
-cqb
+cnZ
+oHi
+cgR
+cgR
+cgR
+cqT
+fFB
 cEs
-cqb
-cqb
+gre
+rNn
 cAp
-cqb
+xJs
 cAo
-cGt
-cgx
-jMY
-csd
-cHa
-csd
-uhH
+xJs
+cAo
+xJs
+cAo
+xJs
+cQZ
+gre
+gre
+gre
 ccw
-aaa
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -83475,29 +82386,29 @@ cTd
 ckF
 ckF
 cgK
-cDg
-cDp
-cqe
-cqB
-cqB
-cEe
+oHi
+cgR
+cgR
+cgR
+cqT
+fFB
 csP
-cAl
-cFc
+gre
+gre
 cAq
-cFJ
+aaH
 cSH
-cGu
-cGH
-fsQ
-fsQ
-cGR
-csd
-csd
+aaH
+cSH
+aaH
+cSH
+aaH
+cSH
+aaH
+gre
+gre
 ccw
-aaa
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -83735,26 +82646,26 @@ cgJ
 chG
 cpx
 cqd
-cDC
+cjc
 cqU
-cEf
-cEt
-cEM
-csA
-cEg
+fFB
+csP
+gre
+rNn
+cAq
 cFK
-cGe
-cGv
-cGI
-cGS
-cHb
-cHg
-cHn
-oDF
+aoV
+aoV
+cFK
+gXs
+aaa
+aoV
+aoV
+cFK
+aaH
+gre
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaf
 aaa
@@ -83988,30 +82899,30 @@ cig
 cig
 cTf
 cgR
-ccw
+cnZ
 cDh
 cpy
-cDv
-cDD
-cqU
-cMD
-cEu
-cEz
-cEz
-cMD
-cFL
-cGf
-kQq
-cMm
-ciZ
-cHc
-cAu
-cAu
-ciZ
 ccw
+hyz
+ccw
+ccw
+cqY
+cqY
+cqY
+cAq
+aah
+aoV
+aoV
+hCi
+aaf
 aaa
-aaT
-ctv
+aoV
+aoV
+aoV
+aaH
+gre
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -84245,30 +83156,30 @@ ckI
 clJ
 cmL
 cBO
+cnZ
+cDh
 ccw
-chV
-cpx
 cqf
 cqD
-cMD
+oUs
 crs
 cEv
-cEv
-cFe
-cMD
-cFM
-czE
-kQq
-ccw
-cGT
-csd
-csd
-csd
-csd
-ccw
+ugZ
+cqY
+cAq
+aah
+aoV
+aaa
+aaa
 aaf
-aaT
-ctv
+aaa
+aaa
+aoV
+aoV
+aaH
+gre
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -84502,30 +83413,30 @@ ckK
 clJ
 cmL
 cgR
-cgL
+cnZ
 chX
-cpx
+spp
 cqh
 cqF
 cra
 crI
 cEw
-cEw
-cEw
-cFw
-cFN
-csH
-csR
-cMm
-cGU
-csd
-csd
-cHo
-csd
-ccw
+ejb
+cqY
+cAq
+pmD
 aaa
-aaT
-ctv
+aaa
+cDO
+cGU
+sWi
+aaa
+hCi
+cFK
+aaH
+gre
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -84759,30 +83670,30 @@ ckI
 clJ
 cmL
 cnv
-cMm
-chX
-cpx
+cnZ
+eHD
+ccw
 cqg
 cqE
 cqZ
 crt
 cMH
 cAm
-cMH
+mMg
 cMN
-cFO
-cSI
-cSI
-cMm
+gXs
+aaf
+aaf
+kNw
 cGV
-csd
-cGV
-noK
-csd
+tHc
+aaf
+aaf
+gXs
+aaH
+gre
 ccw
-aaa
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -85016,30 +83927,30 @@ cfb
 ccw
 cmN
 cgR
-cgL
-chX
-cpx
+cnZ
+eHD
+hyz
 cqj
 cSG
 crb
 cru
 cEx
-cEx
-cEx
-cAP
-cFP
-csI
-cAt
-cMm
-csd
-csd
-csd
-cHp
-csd
+oAQ
+cqY
+cAq
+cFK
+hCi
+aaa
+hmW
+sAz
+ieW
+aaa
+aaa
+aaa
+aaH
+gre
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -85273,30 +84184,30 @@ cfb
 clM
 cfz
 cgR
+cnZ
+eHD
 ccw
-cii
-cpx
 cqi
 cMD
 cAP
-crv
-cEy
-cEy
-cFh
 cMD
-cFM
-czE
-kQq
-ccw
-cGT
-csd
-csd
-csd
-csd
-ccw
+cMD
+cEy
+cqY
+cAq
+aah
+aoV
+aaa
+aaa
 aaf
-aaT
-ctv
+aaa
+aaa
+aoV
+aoV
+aaH
+gre
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -85530,30 +84441,30 @@ cfb
 cfa
 cje
 cgR
+cnZ
+eHD
+cpy
 ccw
-cDi
-cDr
-cDw
-cDE
-cEa
-cMD
-cEz
-cEz
-cEz
-cMD
-cFR
-cSJ
-kQq
-cMm
-ciZ
-cHd
-cHj
-cHd
-ciZ
+hyz
 ccw
+ccw
+cqY
+cqY
+cqY
+cAq
+aah
+aoV
 aaa
-aaT
-ctv
+aaa
+aaf
+hCi
+aaa
+aoV
+aoV
+aaH
+gre
+ccw
+uvy
 aaT
 aaa
 aaa
@@ -85787,30 +84698,30 @@ ckL
 cmF
 cje
 cgR
-cMm
-chX
+cnZ
+cjS
 cpD
 cDw
 cDF
 cEa
-cEg
-cEA
-cET
-cFj
-cEf
-cFS
-cGg
-mBv
-cGI
-cGS
-cHe
-cHe
-cHr
-oDF
+fFB
+csP
+gre
+rNn
+cAq
+cFK
+aoV
+aaa
+aaa
+gXs
+cFK
+aoV
+aoV
+cFK
+aaH
+gre
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaf
 aaa
@@ -86044,30 +84955,30 @@ ceq
 clQ
 cje
 cgR
-cMm
-cDj
-cDs
-cql
-cDG
-cDG
-cEh
-cEB
-cEU
-cFk
-cAs
-cFT
+cnZ
+cjS
+cgR
+cgR
+cgR
+cqT
+fFB
+csP
+gre
+gre
+cAq
+aaH
 cSK
-cGx
-cGK
-nzh
-nzh
-cGY
-csd
-csd
+aaH
+cSK
+aaH
+cSK
+aaH
+cSK
+aaH
+gre
+gre
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -86301,30 +85212,30 @@ ckO
 ckH
 cja
 cny
-ccw
-cip
+cnZ
+cjS
 cnx
 cDx
 cqb
-cqb
-cqb
-cEC
-cqb
-cqb
+cqT
+fFB
+cEs
+gre
+rNn
 cAr
-cqb
+xJs
 cGh
-cGC
-cey
-ijc
-csd
-cEk
-csd
-udp
+xJs
+cGh
+xJs
+cGh
+xJs
+vie
+gre
+gre
+gre
 ccw
-aaf
-aaT
-ctv
+uvy
 aaT
 aaa
 aaa
@@ -86558,30 +85469,30 @@ cfb
 clR
 cgR
 cgR
-cMm
-cir
+cnZ
+cjS
 cDt
 cDy
 cqC
+cqT
+ccw
+ccw
+ccw
 crc
-cEi
-cED
-crc
-crc
-cFy
+gre
 cBR
-cGi
-cGD
-cGL
+gre
+gre
+gre
+gre
+gre
+gre
+gre
+cBR
+gre
+riY
 ccw
-ccw
-ccw
-ccw
-ccw
-ccw
-aaa
-aaT
-aaT
+uvy
 aaT
 aaa
 aaa
@@ -86819,27 +85730,27 @@ cDe
 cDk
 coc
 cqa
-cig
-ccw
-ccw
+uuA
+uAt
+hMa
 czF
+cEK
 csd
-csd
-cFz
+gre
 cFU
-cGj
+gre
 cGE
-cGM
+vHQ
 cGZ
-aag
-aaa
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
+vHQ
+csx
+gre
+cFU
+gre
+gre
+ccw
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -87075,27 +85986,27 @@ cgU
 cgU
 cis
 cjN
-cDz
-cDH
-cMm
-csd
-crM
-crV
-crV
-cFA
-csd
-cGk
+cgR
+cgR
+cqT
 ccw
-aag
-aag
-aag
-aaf
-aaf
-aaf
-aaf
-gXs
-aaf
-aaf
+crM
+ccw
+crV
+cFn
+xMh
+cFn
+mLm
+ccw
+ccw
+ccw
+cGr
+cFn
+rZV
+mzz
+mzz
+ccw
+uvy
 aaf
 aaf
 aaa
@@ -87328,32 +86239,32 @@ ccw
 cet
 cfd
 cfB
-cfI
-cgQ
+cfB
+cfB
 cjS
 cjN
-cqm
 cgR
-crd
-cEk
-crL
-cEW
-cse
-cse
-csu
-cGl
+cgR
+cqT
 ccw
-aaa
-aaa
-aaf
-aaa
-aaf
-ctv
-aaT
-aaa
-aaa
-aaf
-aaa
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+cpy
+ccw
+ccw
+ccw
+ccw
+ccw
+ccw
+jyX
+uvy
+hCi
 aaa
 aaa
 aaa
@@ -87589,28 +86500,28 @@ ccw
 ccw
 cDl
 cjN
-cjh
-cDI
+cgR
+cgR
+cgR
+cqS
 ccw
 ccw
 ccw
 ccw
 ccw
-cMm
-cMm
-cMm
 ccw
-aaf
-aaf
-aaf
-aaf
-aaf
+hQd
+pmD
+pmD
+pmD
 ctv
-aaT
-aaa
+ctv
+ctv
+ctv
+uvy
 aaa
 aaf
-aaa
+hCi
 aaa
 aaa
 aaa
@@ -87847,7 +86758,7 @@ ccw
 cDm
 cjP
 ckF
-cDJ
+ckF
 ckF
 cpE
 cjR
@@ -87860,13 +86771,13 @@ aaa
 aaa
 aaa
 aaa
+pmD
 ctv
 ctv
 ctv
-aaT
-aaa
-aaa
-aaa
+hCi
+hCi
+hCi
 aaa
 aaa
 aaa
@@ -88089,7 +87000,7 @@ caE
 cbA
 ccy
 bOd
-bOd
+yam
 bQu
 cfO
 cgW
@@ -88111,17 +87022,17 @@ ccw
 crX
 cfK
 aag
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaT
-aaT
-aaT
-aaT
-aaa
+hCi
+hCi
+hCi
+hCi
+hCi
+hCi
+gXs
+gXs
+gXs
+gXs
+hCi
 aaa
 aaa
 aae
@@ -88334,7 +87245,7 @@ bIF
 bOZ
 bQp
 bRA
-bOd
+yam
 bTO
 bUL
 bVU
@@ -88361,7 +87272,7 @@ ccw
 cpa
 cjc
 cqo
-cDL
+ccw
 cjk
 cjm
 ccw
@@ -88377,7 +87288,7 @@ aaa
 aaa
 aaa
 aaa
-eRz
+gXs
 aaa
 aaa
 aaa
@@ -88618,7 +87529,7 @@ ccw
 ccw
 cpI
 ccw
-cDL
+ccw
 cjl
 cjQ
 cjV
@@ -88875,7 +87786,7 @@ cig
 cpb
 ciZ
 cqp
-cDN
+cig
 cjT
 cgR
 crP
@@ -89132,7 +88043,7 @@ cig
 cig
 czg
 cig
-cDN
+cig
 crh
 crA
 crR
@@ -89389,7 +88300,7 @@ cig
 cpc
 cpJ
 cpc
-cDN
+cig
 cqY
 cqY
 cqY
@@ -89622,7 +88533,7 @@ bRF
 bSM
 bTS
 bUQ
-agd
+bWa
 bUO
 bVZ
 bVZ
@@ -89646,7 +88557,7 @@ cig
 cpd
 czM
 cpd
-cDN
+cig
 aaa
 aaa
 aaa
@@ -89879,8 +88790,8 @@ bRE
 bSJ
 bPe
 bOd
-cCB
-cCC
+bOd
+bOd
 bXT
 bXT
 bXT
@@ -89903,7 +88814,7 @@ ccw
 cpd
 czL
 cpd
-cDL
+ccw
 aaf
 aaa
 aaa
@@ -90137,7 +89048,7 @@ bSM
 bTU
 bUS
 bUS
-cCD
+bUS
 bXU
 bUS
 bUS
@@ -90160,7 +89071,7 @@ aaa
 cpd
 cpM
 cpd
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -90394,7 +89305,7 @@ bSN
 bTT
 bUR
 bWb
-cCE
+bUR
 bTT
 bUR
 bZJ
@@ -90417,7 +89328,7 @@ aaa
 aaa
 czN
 aaa
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -90674,7 +89585,7 @@ aaa
 aaa
 aaa
 aaa
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -90908,7 +89819,7 @@ bSP
 bPh
 bQy
 bRI
-cCF
+bQy
 bPh
 bQy
 bRI
@@ -90931,7 +89842,7 @@ aaa
 aaa
 aaa
 aaa
-cCQ
+aaf
 aaf
 aaa
 aaa
@@ -91165,16 +90076,16 @@ aaf
 bRK
 aaf
 bVv
-cCG
-cCH
-cCI
-cCJ
-cCI
-cCH
-cCI
-cCJ
-cCI
-cCP
+aaf
+bRK
+aaf
+bVv
+aaf
+bRK
+aaf
+bVv
+aaf
+aaf
 bLK
 chg
 bLK
@@ -91188,7 +90099,7 @@ aoV
 aoV
 aoV
 aoV
-cCQ
+aaf
 aoV
 aaa
 aaa
@@ -91431,7 +90342,7 @@ bPj
 bQA
 bPj
 bOh
-cCQ
+aaf
 bLK
 cyG
 bLK
@@ -91445,7 +90356,7 @@ aoV
 aoV
 aoV
 aoV
-cCQ
+aaf
 aoV
 aaa
 aaa
@@ -91688,21 +90599,21 @@ cbI
 ccC
 cdD
 bOh
-cCG
-cCS
-cCS
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cCI
-cDY
+aaf
+aah
+aah
+aaf
+aaf
+aaf
+aaf
+aaf
+aah
+aah
+aah
+aah
+aah
+aah
+aaf
 aaf
 aaf
 aaf

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -243,7 +243,7 @@
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aaU" = (
 /obj/machinery/computer/arcade,
 /turf/open/floor/plasteel/floorgrime,
@@ -52122,14 +52122,14 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cSK" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "cSL" = (
 /obj/machinery/button/door{
 	id = "atmos";
@@ -52644,6 +52644,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
+"fdi" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "fgi" = (
 /turf/closed/wall,
 /area/crew_quarters/cryopod)
@@ -53450,6 +53455,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/fore/secondary)
+"mWO" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "mXj" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/space)
@@ -54679,6 +54687,10 @@
 /obj/effect/landmark/start/atmospheric_technician,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"yck" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "ycu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -77658,10 +77670,10 @@ abc
 abc
 afu
 abc
-aaa
-aaa
-aaa
-aaa
+abc
+abc
+abc
+abc
 aaa
 aaa
 aaa
@@ -80596,17 +80608,17 @@ ccw
 pmD
 aaa
 aaa
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
 aaa
 aaa
 aaa
 aaa
 aaa
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
 hCi
 hCi
 aaa
@@ -80852,18 +80864,18 @@ cig
 ccw
 pmD
 pmD
-ctv
-ctv
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
+uvy
+uvy
 aaa
 aaa
 aaa
-ctv
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
+uvy
 uvy
 hCi
 hCi
@@ -81381,7 +81393,7 @@ mzz
 mzz
 ccw
 uvy
-aaf
+yck
 aaa
 aaa
 aaa
@@ -81895,7 +81907,7 @@ gre
 iqO
 ccw
 uvy
-eRz
+fdi
 aaa
 aaa
 aaa
@@ -82396,15 +82408,15 @@ csP
 gre
 gre
 cAq
-aaH
+mWO
 cSH
-aaH
+mWO
 cSH
-aaH
+mWO
 cSH
-aaH
+mWO
 cSH
-aaH
+mWO
 gre
 gre
 ccw
@@ -82662,7 +82674,7 @@ aaa
 aoV
 aoV
 cFK
-aaH
+mWO
 gre
 ccw
 uvy
@@ -82910,7 +82922,7 @@ cqY
 cqY
 cqY
 cAq
-aah
+aoV
 aoV
 aoV
 hCi
@@ -82919,7 +82931,7 @@ aaa
 aoV
 aoV
 aoV
-aaH
+mWO
 gre
 ccw
 uvy
@@ -83167,7 +83179,7 @@ cEv
 ugZ
 cqY
 cAq
-aah
+aoV
 aoV
 aaa
 aaa
@@ -83176,7 +83188,7 @@ aaa
 aaa
 aoV
 aoV
-aaH
+mWO
 gre
 ccw
 uvy
@@ -83424,7 +83436,7 @@ cEw
 ejb
 cqY
 cAq
-pmD
+aaa
 aaa
 aaa
 cDO
@@ -83433,7 +83445,7 @@ sWi
 aaa
 hCi
 cFK
-aaH
+mWO
 gre
 ccw
 uvy
@@ -83690,7 +83702,7 @@ tHc
 aaf
 aaf
 gXs
-aaH
+mWO
 gre
 ccw
 uvy
@@ -83947,7 +83959,7 @@ ieW
 aaa
 aaa
 aaa
-aaH
+mWO
 gre
 ccw
 uvy
@@ -84195,7 +84207,7 @@ cMD
 cEy
 cqY
 cAq
-aah
+aoV
 aoV
 aaa
 aaa
@@ -84204,7 +84216,7 @@ aaa
 aaa
 aoV
 aoV
-aaH
+mWO
 gre
 ccw
 uvy
@@ -84452,7 +84464,7 @@ cqY
 cqY
 cqY
 cAq
-aah
+aoV
 aoV
 aaa
 aaa
@@ -84461,7 +84473,7 @@ hCi
 aaa
 aoV
 aoV
-aaH
+mWO
 gre
 ccw
 uvy
@@ -84718,7 +84730,7 @@ cFK
 aoV
 aoV
 cFK
-aaH
+mWO
 gre
 ccw
 uvy
@@ -84966,15 +84978,15 @@ csP
 gre
 gre
 cAq
-aaH
+mWO
 cSK
-aaH
+mWO
 cSK
-aaH
+mWO
 cSK
-aaH
+mWO
 cSK
-aaH
+mWO
 gre
 gre
 ccw
@@ -86007,7 +86019,7 @@ mzz
 mzz
 ccw
 uvy
-aaf
+yck
 aaf
 aaa
 aaa
@@ -86514,13 +86526,13 @@ hQd
 pmD
 pmD
 pmD
-ctv
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
+uvy
 uvy
 aaa
-aaf
+yck
 hCi
 aaa
 aaa
@@ -86772,9 +86784,9 @@ aaa
 aaa
 aaa
 pmD
-ctv
-ctv
-ctv
+uvy
+uvy
+uvy
 hCi
 hCi
 hCi

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -9182,10 +9182,6 @@
 	},
 /turf/open/floor/circuit/green,
 /area/engine/supermatter)
-"ayK" = (
-/obj/machinery/power/supermatter_shard/crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "ayL" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
@@ -50251,6 +50247,10 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cdE" = (
@@ -51319,6 +51319,7 @@
 	dir = 8;
 	network = list("singularity")
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cfC" = (
@@ -52290,7 +52291,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "chu" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -53055,10 +53055,10 @@
 "cjb" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -53074,25 +53074,8 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cje" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cjf" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engpa";
-	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -53660,13 +53643,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"ckx" = (
-/obj/structure/cable,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cky" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -53682,6 +53658,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ckA" = (
@@ -53690,34 +53667,10 @@
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"ckB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ckC" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/neutral,
 /area/engine/engineering)
 "ckD" = (
 /obj/effect/decal/cleanable/dirt,
@@ -54289,20 +54242,9 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "clS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /obj/machinery/field/generator{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"clT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/field/generator{
-	anchored = 1
+	anchored = 1;
+	state = 2
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -54315,19 +54257,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"clV" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engpa";
-	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "clW" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -54337,9 +54266,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "clX" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -55205,9 +55131,6 @@
 	id = "engpa";
 	name = "Engineering Chamber Shutters"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
@@ -55893,9 +55816,6 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -56455,6 +56375,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqr" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	icon_state = "emitter_left";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqs" = (
@@ -56463,6 +56387,7 @@
 /area/engine/engineering)
 "cqt" = (
 /obj/structure/cable,
+/obj/machinery/particle_accelerator/control_box,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cqu" = (
@@ -57024,7 +56949,7 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "crJ" = (
-/obj/item/wrench,
+/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "crK" = (
@@ -57065,7 +56990,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crO" = (
-/obj/item/weldingtool/largetank,
+/obj/structure/particle_accelerator/fuel_chamber{
+	icon_state = "fuel_chamber";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "crP" = (
@@ -57843,7 +57771,10 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ctp" = (
-/obj/item/wrench,
+/obj/structure/particle_accelerator/particle_emitter/right{
+	icon_state = "emitter_right";
+	dir = 8
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ctq" = (
@@ -58656,9 +58587,6 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -58713,6 +58641,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cva" = (
@@ -59870,24 +59799,6 @@
 	dir = 4
 	},
 /area/crew_quarters/fitness/recreation)
-"cxA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"cxB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/field/generator{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "cxD" = (
 /obj/structure/rack,
 /obj/item/crowbar,
@@ -60707,13 +60618,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"czp" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "czq" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -60727,33 +60631,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/corner,
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"czs" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engpa";
-	name = "Engineering Chamber Shutters"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"czt" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/neutral,
-/area/engine/engineering)
 "czu" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -61355,10 +61235,10 @@
 "cAI" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-4"
 	},
 /turf/open/space,
 /area/space/nearstation)
@@ -61370,11 +61250,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cAK" = (
-/obj/machinery/power/rad_collector/anchored,
 /obj/effect/decal/cleanable/dirt,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -62960,6 +62836,7 @@
 	dir = 8;
 	network = list("singularity")
 	},
+/obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cDW" = (
@@ -63843,6 +63720,12 @@
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	icon_state = "emitter";
+	state = 2
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cFI" = (
@@ -100913,6 +100796,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
+"gsR" = (
+/turf/open/space,
+/area/space)
 "gKr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -101003,6 +100889,9 @@
 	dir = 9
 	},
 /area/science/circuit)
+"hRG" = (
+/turf/open/space/basic,
+/area/space/nearstation)
 "iQh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -101061,6 +100950,9 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/neutral,
 /area/medical/morgue)
+"jKb" = (
+/turf/open/space,
+/area/space/nearstation)
 "kwx" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/whitepurple/corner,
@@ -101086,6 +100978,9 @@
 	dir = 5
 	},
 /area/crew_quarters/locker)
+"lkn" = (
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "loI" = (
 /obj/machinery/autolathe,
 /obj/machinery/door/window/southleft{
@@ -101101,6 +100996,10 @@
 	dir = 4
 	},
 /area/science/lab)
+"lxv" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lEl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -101145,6 +101044,13 @@
 	dir = 1
 	},
 /area/science/circuit)
+"mqk" = (
+/obj/structure/particle_accelerator/end_cap{
+	icon_state = "end_cap";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -101156,6 +101062,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
+"nJG" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "oZC" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command{
@@ -101169,6 +101079,13 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
+"pfd" = (
+/obj/structure/particle_accelerator/particle_emitter/center{
+	icon_state = "emitter_center";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "pmQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
@@ -101232,6 +101149,12 @@
 "saw" = (
 /turf/closed/wall,
 /area/science/circuit)
+"tdp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "tmi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -101270,6 +101193,9 @@
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel/whitepurple/side,
 /area/science/misc_lab)
+"uDN" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "uYS" = (
 /obj/machinery/door/airlock/atmos/glass{
 	heat_proof = 1;
@@ -101327,6 +101253,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"xwB" = (
+/obj/structure/particle_accelerator/power_box{
+	icon_state = "power_box";
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xwK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -121812,14 +121745,14 @@ aaa
 cja
 ckw
 clS
-aad
-aad
-clR
-aaa
-abj
-aad
-aad
-cxA
+jKb
+jKb
+clS
+nJG
+hRG
+jKb
+jKb
+clS
 ctn
 cja
 aaa
@@ -122067,17 +122000,17 @@ cdC
 cfA
 aad
 cjb
-ckx
+cky
+jKb
+gsR
+gsR
+lxv
 aad
-aaa
-aaa
-abj
-aad
-abj
-aaa
-aaa
-aad
-czp
+hRG
+gsR
+gsR
+jKb
+czq
 cAI
 aad
 cDT
@@ -122325,15 +122258,15 @@ cfA
 aaa
 cja
 ckw
+jKb
+gsR
+hRG
+hRG
 aad
-aaa
-abj
-abj
-abj
-abj
-abj
-aaa
-aad
+hRG
+hRG
+gsR
+jKb
 ctn
 cja
 aaa
@@ -122580,19 +122513,19 @@ car
 cbP
 cfA
 abj
-cja
-ckw
-ckw
-abj
-abj
+cjb
+cky
+hRG
+hRG
+hRG
 cqo
 clR
 ctm
-abj
-abj
-abj
-ctn
-cja
+hRG
+lxv
+clS
+czq
+cAI
 abj
 cDT
 cFJ
@@ -122837,19 +122770,19 @@ car
 cbP
 cdC
 aad
-cjb
-cky
-aaa
+cja
+ckw
+nJG
 aad
-abj
+aad
 ckw
 crJ
-ctn
-abj
+tdp
 aad
-aaa
-czq
-cAI
+aad
+nJG
+ctn
+cja
 aad
 cdC
 cFJ
@@ -123094,19 +123027,19 @@ car
 cbP
 cfA
 abj
-cja
-ckw
-abj
-abj
-abj
+cjb
+cky
+clS
+lxv
+hRG
 cqp
 crK
 cto
-abj
-abj
-ctn
-ctn
-cja
+hRG
+hRG
+hRG
+czq
+cAI
 abj
 cDT
 cFJ
@@ -123353,15 +123286,15 @@ cfA
 aaa
 cja
 ckw
+jKb
+gsR
+hRG
+hRG
 aad
-aaa
-abj
-abj
-abj
-abj
-abj
-aaa
-aad
+hRG
+hRG
+gsR
+jKb
 ctn
 cja
 aaa
@@ -123609,17 +123542,17 @@ cdC
 cfA
 aad
 cjb
-ckx
+cky
+jKb
+gsR
+aaa
+hRG
 aad
+lxv
 aaa
-aaa
-abj
-aad
-abj
-aaa
-aaa
-aad
-czp
+gsR
+jKb
+czq
 cAI
 aad
 cDU
@@ -123867,15 +123800,15 @@ cfA
 aaa
 cja
 ckw
-clT
-aad
-aad
-abj
-aaa
-crK
-aad
-aad
-cxB
+clS
+jKb
+hRG
+hRG
+nJG
+clS
+jKb
+jKb
+clS
 ctn
 cja
 aaa
@@ -124378,8 +124311,8 @@ car
 cbT
 cdG
 cfB
-aaa
-aad
+uDN
+lkn
 aaa
 aad
 cjd
@@ -124391,8 +124324,8 @@ cjd
 cjd
 aad
 aaa
-aad
-aaa
+lkn
+uDN
 cDV
 cFL
 cHg
@@ -124899,7 +124832,7 @@ cje
 cjd
 cpa
 cqr
-cqr
+pfd
 ctp
 cuQ
 cjd
@@ -125150,19 +125083,19 @@ cbV
 cdJ
 car
 chv
-cjf
+chv
 ckA
-clV
+chv
 cnC
 cpa
 cqs
-cqr
+xwB
 ctq
 cuR
 cnC
-cjf
-czs
-clV
+chv
+chv
+chv
 chv
 car
 cFO
@@ -125408,7 +125341,7 @@ cdK
 cfD
 chw
 cjg
-ckB
+chw
 clW
 cnD
 cpb
@@ -125418,7 +125351,7 @@ ctr
 cuS
 cnD
 cxD
-ckB
+chw
 chw
 chw
 cDW
@@ -125665,17 +125598,17 @@ cdL
 cfE
 chx
 cjh
-ckC
+cjn
 clX
 cnE
 cpc
 cqu
-cqr
+mqk
 cts
 cuT
 cnE
 clX
-czt
+cjn
 cAL
 cCs
 cDX
@@ -127152,7 +127085,7 @@ atS
 avb
 awh
 axz
-ayK
+axz
 axz
 aAW
 axz

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -5314,10 +5314,6 @@
 "alq" = (
 /turf/closed/wall,
 /area/maintenance/starboard)
-"alr" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "als" = (
 /obj/machinery/light{
 	dir = 8
@@ -11354,17 +11350,18 @@
 	req_one_access_txt = "0"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/engineering)
 "axV" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "axW" = (
 /obj/structure/disposalpipe/segment,
@@ -11374,10 +11371,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "axX" = (
 /obj/machinery/light_switch{
@@ -11393,41 +11389,21 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 5
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "axY" = (
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"axZ" = (
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"aya" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ayc" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath{
-	pixel_x = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"aye" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "ayf" = (
 /obj/structure/closet/crate,
 /obj/item/stack/sheet/glass{
@@ -11770,46 +11746,59 @@
 	dir = 1;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
 /area/engine/engineering)
 "ayT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ayW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ayX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"aza" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"ayX" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"aza" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "azb" = (
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -11821,13 +11810,18 @@
 	},
 /area/security/brig)
 "azd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aze" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -12455,13 +12449,17 @@
 "aAo" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/engineering)
 "aAp" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/engine/engineering)
 "aAr" = (
 /obj/item/device/radio/intercom{
@@ -12474,15 +12472,12 @@
 	c_tag = "Engineering - Fore";
 	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
@@ -12496,27 +12491,21 @@
 	sortType = 4
 	},
 /obj/effect/landmark/start/station_engineer,
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aAv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aAw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "aAx" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aAz" = (
 /obj/structure/table/wood,
@@ -12540,7 +12529,7 @@
 	id = "mining_home";
 	name = "mining shuttle bay";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/mining/box;
+	roundstart_template = /datum/map_template/shuttle/mining/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -12743,7 +12732,7 @@
 	id = "laborcamp_home";
 	name = "fore bay 1";
 	width = 9;
-	roundstart_template = /datum/map_template/shuttle/labour/box;
+	roundstart_template = /datum/map_template/shuttle/labour/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -13134,17 +13123,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -13157,9 +13142,6 @@
 	},
 /obj/machinery/rnd/circuit_imprinter,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBM" = (
@@ -13169,9 +13151,6 @@
 	},
 /obj/machinery/rnd/protolathe/department/engineering,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBN" = (
@@ -13180,21 +13159,10 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"aBQ" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aBS" = (
 /obj/item/stack/ore/silver,
@@ -13707,9 +13675,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCV" = (
@@ -13719,38 +13684,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"aCX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aCY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aCZ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/structure/cable,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aDa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -14352,10 +14308,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -14378,31 +14333,16 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aEq" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aEr" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Fore Port";
+	dir = 4;
+	network = list("singularity")
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aEt" = (
 /obj/structure/table,
@@ -14940,10 +14880,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 2
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aFw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14961,52 +14900,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aFz" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aFA" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aFB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/structure/rack,
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = -26;
+	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/turf/open/floor/engine,
+/obj/item/clothing/gloves/color/black,
+/obj/item/wrench,
+/obj/item/clothing/glasses/meson/engine,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aFC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aFD" = (
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/meter,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aFE" = (
 /obj/structure/table/wood,
@@ -15753,10 +15666,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aGW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -15767,31 +15679,14 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aGY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aGZ" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "External Gas to Loop"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engpa";
+	name = "Engineering Chamber Shutters"
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"aHa" = (
-/obj/structure/cable/white,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHb" = (
 /obj/machinery/camera{
@@ -16212,42 +16107,21 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aHY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aHZ" = (
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/gloves/color/yellow,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/effect/turf_decal/delivery,
-/obj/structure/table,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aIc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aIe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -16924,34 +16798,13 @@
 /obj/structure/table,
 /obj/item/airlock_painter,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aJp" = (
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/machinery/light{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aJu" = (
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aJv" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "aJB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -17398,12 +17251,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aKA" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aKB" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17417,53 +17264,26 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aKF" = (
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_x = 24;
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aKG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+/obj/structure/particle_accelerator/end_cap{
+	icon_state = "end_cap";
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aKH" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Chamber";
-	on = 0
+/obj/structure/particle_accelerator/fuel_chamber{
+	icon_state = "fuel_chamber";
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aKI" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
+/obj/structure/particle_accelerator/power_box{
+	icon_state = "power_box";
+	dir = 4
 	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"aKL" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Mix Bypass";
-	on = 0
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aKN" = (
 /obj/machinery/door/poddoor{
@@ -18014,12 +17834,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"aMc" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "aMd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
@@ -18040,62 +17854,52 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aMg" = (
-/obj/machinery/door/firedoor,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/plating,
 /area/engine/engineering)
 "aMh" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engpa";
+	name = "Engineering Chamber Shutters"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"aMi" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"aMi" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Gas to Filter"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aMj" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "aMk" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"aMm" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "aMo" = (
-/obj/structure/reflector/box/anchored{
-	dir = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aMq" = (
 /obj/structure/window/reinforced,
 /turf/open/space,
@@ -18542,7 +18346,9 @@
 	maxcharge = 15000
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
 /area/engine/engineering)
 "aNr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18552,17 +18358,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aNu" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Gas to Filter";
-	on = 0
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Particle Accelerator";
+	dir = 1;
+	network = list("singularity")
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "aNv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aNw" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19226,10 +19042,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aOP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -19252,26 +19067,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aOR" = (
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet/firecloset,
-/obj/effect/turf_decal/stripes/line{
+"aOS" = (
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aOS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "aOT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -19815,41 +19616,32 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
+	},
 /area/engine/engineering)
 "aPZ" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aQa" = (
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
 	},
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aQd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/rack,
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = 26;
+	req_access_txt = "11"
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+/obj/item/storage/belt/utility,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aQe" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aQf" = (
 /obj/structure/chair{
@@ -20454,19 +20246,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aRo" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aRp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20477,9 +20259,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -20506,13 +20285,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"aRv" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "aRy" = (
 /turf/closed/wall/r_wall,
@@ -20930,10 +20702,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -20962,9 +20733,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSx" = (
@@ -20975,35 +20744,38 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSz" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/pen,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/glasses/meson,
+/obj/item/paper_bin{
+	layer = 2.9
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/table/glass,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 5
-	},
-/turf/open/floor/engine,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table/glass,
+/obj/item/device/flashlight,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aSB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -21489,10 +21261,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTG" = (
 /obj/structure/disposalpipe/segment{
@@ -21504,26 +21275,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "aTH" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aTI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -21533,9 +21295,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -21549,29 +21308,10 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"aTM" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"aTN" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "aTO" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22178,7 +21918,9 @@
 "aUY" = (
 /obj/effect/turf_decal/delivery,
 /obj/structure/closet/wardrobe/engineering_yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
+	},
 /area/engine/engineering)
 "aUZ" = (
 /obj/structure/disposalpipe/segment,
@@ -22189,8 +21931,8 @@
 /obj/effect/turf_decal/bot{
 	dir = 1
 	},
-/turf/open/floor/plasteel{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
 	},
 /area/engine/engineering)
 "aVa" = (
@@ -22227,31 +21969,13 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/engineering_electrical,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aVe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"aVf" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"aVh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aVk" = (
 /obj/structure/window/reinforced{
@@ -22791,10 +22515,12 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "aWu" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod Four";
+	req_access = null;
+	req_access_txt = "32"
 	},
-/turf/open/floor/plating,
+/turf/open/space/basic,
 /area/maintenance/starboard)
 "aWv" = (
 /turf/closed/wall,
@@ -22880,18 +22606,16 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"aWH" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "aWK" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+/obj/structure/cable/white{
+	icon_state = "2-4"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aWL" = (
 /obj/machinery/ai_status_display{
 	pixel_x = -32
@@ -23788,12 +23512,15 @@
 /turf/closed/wall,
 /area/security/checkpoint/engineering)
 "aYx" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "aYy" = (
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Port";
@@ -38467,7 +38194,6 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/space,
 /area/space/nearstation)
 "bCA" = (
@@ -42921,10 +42647,6 @@
 /obj/machinery/meter,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bMi" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bMj" = (
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -46279,10 +46001,10 @@
 /turf/closed/wall,
 /area/maintenance/solars/port/aft)
 "bTq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bTr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -46858,8 +46580,12 @@
 	},
 /area/maintenance/starboard)
 "bUw" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/dark,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "bUx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -57167,23 +56893,20 @@
 	},
 /area/maintenance/port/aft)
 "cpR" = (
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = -26;
+	req_access_txt = "11"
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 10
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Port";
-	dir = 8;
-	network = list("ss13","engine")
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/machinery/airalarm/engine{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cpS" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -72101,6 +71824,12 @@
 	},
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
+"cWu" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cWA" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -72137,18 +71866,6 @@
 /obj/structure/easel,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"cXz" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 1;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cXA" = (
 /turf/closed/wall/r_wall,
 /area/security/checkpoint/engineering)
@@ -72161,7 +71878,9 @@
 	},
 /area/construction/mining/aux_base)
 "cXI" = (
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cXR" = (
@@ -72173,11 +71892,12 @@
 	},
 /area/construction/mining/aux_base)
 "cXZ" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYc" = (
@@ -72197,8 +71917,9 @@
 	},
 /area/science/robotics/lab)
 "cYj" = (
-/obj/structure/closet/firecloset,
-/obj/effect/spawner/lootdrop/maintenance,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYE" = (
@@ -72505,14 +72226,16 @@
 /turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "daW" = (
+/obj/machinery/button/door{
+	id = "engpa";
+	name = "Engineering Chamber Shutters Control";
+	pixel_y = 26;
+	req_access_txt = "11"
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 9
 	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "daX" = (
 /obj/structure/cable/yellow{
@@ -72522,27 +72245,20 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
-"daY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "daZ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
+/obj/structure/particle_accelerator/particle_emitter/right{
+	icon_state = "emitter_right";
+	dir = 4
 	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dbb" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+/obj/structure/particle_accelerator/particle_emitter/center{
+	icon_state = "emitter_center";
+	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dbd" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -72555,30 +72271,6 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
-"dbg" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dbh" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "dbj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -73775,15 +73467,11 @@
 /turf/open/floor/plating,
 /area/shuttle/auxillary_base)
 "ddO" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ddP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -73798,39 +73486,8 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ddS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddT" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddU" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"ddV" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "ddW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/structure/cable/yellow{
@@ -73845,28 +73502,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ddY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ddZ" = (
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dea" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	volume_rate = 200
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plating/airless,
-/area/engine/engineering)
+/area/space)
 "deb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -73874,644 +73517,153 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"ded" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dee" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "def" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"deh" = (
-/obj/structure/cable/white{
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dei" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dej" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dek" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Mix to Gas"
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"del" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dem" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Mix"
-	},
-/obj/structure/cable/white{
+/obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/turf/open/space,
+/area/space/nearstation)
+"dem" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/turf/open/space,
+/area/space/nearstation)
 "den" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dep" = (
-/obj/machinery/firealarm{
-	pixel_y = 32
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"deq" = (
-/obj/item/device/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
-	name = "Station Intercom (General)";
-	pixel_y = 21
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "der" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"des" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deu" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 10
-	},
-/turf/open/floor/engine,
+/obj/structure/closet/secure_closet/engineering_welding,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "dev" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"dew" = (
+/turf/open/space,
+/area/space/nearstation)
+"deB" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engpa";
+	name = "Engineering Chamber Shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dew" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dex" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dey" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deA" = (
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deB" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deC" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "deD" = (
-/obj/machinery/status_display,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"deI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deK" = (
-/obj/structure/cable/white,
-/obj/machinery/power/emitter/anchored{
-	dir = 2;
-	state = 2
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deL" = (
-/obj/structure/cable/white,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"deM" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"deN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable,
-/obj/structure/window/plasma/reinforced,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"deU" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deV" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"deW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"deY" = (
-/obj/structure/reflector/single/anchored{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfa" = (
-/obj/machinery/power/supermatter_shard/crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfb" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dfc" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dfd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfe" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dff" = (
-/obj/structure/reflector/double/anchored{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dfg" = (
-/obj/structure/reflector/single/anchored{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfh" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dfi" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dfk" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dfp" = (
-/obj/effect/turf_decal/bot{
-	dir = 1
-	},
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 8
-	},
-/obj/machinery/portable_atmospherics/canister,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dfq" = (
-/obj/machinery/camera{
-	c_tag = "Supermatter Chamber";
-	dir = 4;
-	network = list("engine")
-	},
+/obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dft" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"deM" = (
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/machinery/light{
+	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
 	},
-/turf/open/floor/engine,
 /area/engine/engineering)
-"dfu" = (
+"deV" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"deY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	filter_type = "n2"
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"dfa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"dfh" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 10
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"dfp" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/engine/engineering)
 "dfz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfA" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfB" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 1;
-	state = 2
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfC" = (
-/obj/structure/cable/white{
-	icon_state = "0-2"
-	},
-/obj/machinery/power/emitter/anchored{
-	dir = 1;
-	state = 2
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dfD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/item/book/manual/engineering_singularity_safety{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/engineering_particle_accelerator{
+	pixel_x = -3;
+	pixel_y = -3
 	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/meter,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/obj/item/clothing/gloves/color/yellow,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "dfI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Cooling Loop Bypass"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/structure/cable/white{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfJ" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfM" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"dfO" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dfP" = (
 /obj/structure/cable/white{
-	icon_state = "4-8"
+	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Atmos to Loop"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfQ" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -24
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfR" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	name = "Gas to Cold Loop";
-	on = 1
-	},
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfS" = (
-/obj/structure/cable/white{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfT" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfU" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cold Loop to Gas";
-	on = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dfV" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dfW" = (
-/obj/item/wrench,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "dfX" = (
 /obj/structure/disposalpipe/segment,
@@ -74529,272 +73681,88 @@
 	},
 /area/engine/engineering)
 "dfY" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dfZ" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "dga" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"dgb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "dgc" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
+/obj/item/clothing/gloves/color/rainbow,
+/obj/item/clothing/head/soft/rainbow,
+/obj/item/clothing/shoes/sneakers/rainbow,
+/obj/item/clothing/under/color/rainbow,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "dgd" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dge" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
-"dgf" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/cable/white{
+	icon_state = "0-2"
 	},
-/turf/open/space,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/emitter{
+	anchored = 1;
+	dir = 1;
+	icon_state = "emitter";
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/cable/white{
+	icon_state = "4-8"
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
-"dgh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"dgi" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgj" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/obj/structure/grille,
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgk" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgm" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"dgo" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"dgp" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"dgr" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgt" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgu" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/turf/open/space,
-/area/space/nearstation)
-"dgv" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
-"dgw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dgz" = (
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dgA" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgB" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "dgI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 5
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgJ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgK" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 10
-	},
-/turf/open/space,
-/area/space/nearstation)
-"dgN" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dgS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/transit_tube/horizontal,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dha" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dhc" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/space,
-/area/space/nearstation)
-"dhe" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"dhg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"dhh" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Engine";
-	on = 0
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"dhi" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/door/window/northleft{
-	dir = 8;
-	icon_state = "left";
-	name = "Inner Pipe Access";
-	req_access_txt = "24"
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"dhj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/atmos)
-"dhk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
-"dhl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
+/turf/closed/wall/mineral/plastitanium,
 /area/space/nearstation)
 "dhn" = (
 /obj/structure/table,
@@ -75813,26 +74781,18 @@
 /turf/open/space,
 /area/science/xenobiology)
 "djt" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "djx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Port";
+	dir = 4;
+	network = list("singularity")
 	},
-/obj/item/crowbar,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "djz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /obj/machinery/door/airlock/external{
@@ -75870,7 +74830,7 @@
 	id = "arrivals_stationary";
 	name = "arrivals";
 	width = 7;
-	roundstart_template = /datum/map_template/shuttle/arrival/box;
+	roundstart_template = /datum/map_template/shuttle/arrival/box
 	},
 /turf/open/space/basic,
 /area/space)
@@ -75892,12 +74852,11 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "dlI" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dlN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/structure/closet/secure_closet/engineering_electrical,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "dlV" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/department/science/xenobiology)
@@ -76108,6 +75067,14 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/port/fore)
+"drT" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dsg" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76148,6 +75115,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"dtL" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
 "dtP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -76482,45 +75456,23 @@
 /area/engine/gravity_generator)
 "dBw" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dBx" = (
-/obj/effect/turf_decal/delivery,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dBy" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"dBz" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dBA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dBB" = (
-/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
+"dBy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"dBB" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "dBC" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -77200,6 +76152,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"dPf" = (
+/obj/structure/cable/white{
+	icon_state = "1-4"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "dYu" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -77209,6 +76171,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"eln" = (
+/turf/open/space/basic,
+/area/engine/engineering)
+"enN" = (
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eoK" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -77241,6 +76210,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"esV" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "evy" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -77251,6 +76231,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"eEu" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "eFN" = (
 /obj/structure/bodycontainer/crematorium{
 	id = "crematoriumChapel";
@@ -77281,12 +76280,48 @@
 /obj/structure/closet/firecloset,
 /turf/open/floor/plating,
 /area/engine/engineering)
+"fjy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/space)
+"foU" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the Engine.";
+	dir = 8;
+	layer = 4;
+	name = "Engine Monitor";
+	network = list("singularity");
+	pixel_x = 30
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
 "fDD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"fGs" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"fWO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "gfh" = (
 /obj/machinery/libraryscanner,
 /turf/open/floor/plasteel/white,
@@ -77309,6 +76344,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"goZ" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "gEk" = (
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
@@ -77334,6 +76377,14 @@
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"gKb" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Starboard";
+	dir = 8;
+	network = list("singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -77393,6 +76444,33 @@
 	},
 /turf/open/floor/plasteel/whitepurple,
 /area/science/lab)
+"iOa" = (
+/turf/closed/wall/mineral/plastitanium,
+/area/maintenance/starboard)
+"iTS" = (
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/gloves/color/yellow,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/effect/turf_decal/delivery,
+/obj/structure/table,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"jjF" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "jwW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/crew_quarters/fitness/recreation)
@@ -77423,6 +76501,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port/aft)
+"jFx" = (
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard)
+"jIV" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "jKK" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -77537,6 +76630,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"lHL" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"lLj" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 8
+	},
+/area/engine/engineering)
 "lMz" = (
 /obj/structure/falsewall,
 /turf/open/floor/plating,
@@ -77578,6 +76679,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"moI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "mvj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77615,6 +76722,30 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/science/circuit)
+"nte" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"nwU" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "External Containment Access";
+	req_access_txt = "10; 13"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "nyo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -77649,10 +76780,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/storage/wing)
+"nKh" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
+/area/engine/engineering)
 "obb" = (
 /obj/structure/target_stake,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"obN" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
+"ocj" = (
+/obj/structure/cable/white{
+	icon_state = "2-4"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ocT" = (
 /obj/machinery/light{
 	dir = 1
@@ -77679,6 +76833,13 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oiF" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "oub" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
@@ -77767,6 +76928,13 @@
 	dir = 2
 	},
 /area/crew_quarters/locker)
+"pWF" = (
+/obj/effect/decal/cleanable/oil,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "qnJ" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -77820,6 +76988,12 @@
 	dir = 1
 	},
 /area/science/lab)
+"rEi" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77839,6 +77013,29 @@
 /obj/machinery/vending/snack/random,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rTo" = (
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"rVX" = (
+/obj/structure/particle_accelerator/particle_emitter/left{
+	icon_state = "emitter_left";
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"rWa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "sdi" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -77875,6 +77072,9 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"sSU" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "tjH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -77896,22 +77096,19 @@
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "tDM" = (
-/obj/machinery/door/airlock/engineering/glass{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/item/wrench,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
+"tMT" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/engine/engineering)
 "tVY" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -77962,6 +77159,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
+"uQo" = (
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
 "uRM" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -77994,6 +77196,16 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"vSl" = (
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable/white{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wiZ" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -78044,11 +77256,36 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xcM" = (
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/yellow/side{
+	dir = 4
+	},
+/area/engine/engineering)
+"xfK" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "xkG" = (
 /obj/item/device/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xqB" = (
+/obj/structure/cable/white,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/emitter{
+	anchored = 1;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xse" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -78080,6 +77317,19 @@
 /obj/structure/chair/comfy,
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"xLP" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/space,
+/area/space/nearstation)
+"xNI" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xVl" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
@@ -78090,6 +77340,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xWZ" = (
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/obj/structure/grille,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -118297,12 +117557,12 @@ aFu
 aBI
 aBI
 aJn
-aCO
-aFq
+lLj
+lLj
 aNq
 aBI
 aPZ
-aRo
+aSB
 aSu
 aTG
 aUZ
@@ -118553,12 +117813,12 @@ aEn
 aFv
 aGV
 aHX
-aEi
-aKA
-aMc
-aEi
+aBO
+aBO
+aBO
+aBO
 aOO
-aEi
+aBO
 aRp
 aSv
 aTH
@@ -119060,7 +118320,7 @@ avt
 awJ
 axS
 axY
-aCO
+jIV
 ddW
 aCT
 aEp
@@ -119320,16 +118580,16 @@ axY
 aAr
 ddX
 aCU
-aEq
-aTO
+aCW
+aBO
 aGX
-aHZ
-aJp
-aTO
+aBO
+aBO
+aBO
 aSB
-aTO
-aOR
-aQa
+aBO
+aBO
+aBO
 aGX
 aTO
 aTK
@@ -119574,22 +118834,22 @@ avv
 axY
 axU
 ayS
-dCk
-ddY
+enN
+ddX
 deb
-deh
-aFz
-aCZ
+aBO
+aBO
+iTS
 deM
-axY
-aCZ
+uQo
+foU
 aMg
-aCZ
+xcM
 dfh
-deM
-aCZ
-aFz
-deh
+aBO
+aBO
+aTO
+aTK
 aVe
 axY
 aYu
@@ -119834,21 +119094,21 @@ ddP
 aAt
 aBL
 deb
-dei
+aBO
 aFA
+axY
+axY
 deB
-deB
-deB
-deB
+axY
 aMh
-deB
-deB
-deB
-deB
+axY
+axY
+nKh
+aBO
 aSz
-aTM
+aTK
 aVe
-apc
+aJu
 aYu
 aZL
 bbB
@@ -120091,21 +119351,21 @@ aAu
 ddQ
 aBM
 aCV
-aEr
+aBO
 aFB
-aGY
+axY
 daW
 dBw
-aKF
+dBw
 aMi
 cpR
-dfi
+axY
 aQd
-dBA
+aBO
 aSA
-aTN
-aVf
-apc
+aTK
+aVe
+aJu
 aYu
 aZM
 bbC
@@ -120348,21 +119608,21 @@ ayV
 aAv
 aBN
 aCW
-aEr
-aFC
+aBO
+aFA
 aGZ
-aGZ
-dlI
+cWu
+ddO
 aKG
-aMj
+ddO
 dBy
-dlI
-aQe
-aRv
+aGZ
+nKh
+aBO
 dfD
-aTN
-aVe
-apc
+aTK
+rWa
+aJu
 aYu
 aZN
 bbD
@@ -120604,22 +119864,22 @@ axY
 ayW
 bTq
 aBO
-aCX
-dej
+aBO
+aBO
 aFC
-deC
-deC
-dlI
+axY
+cWu
+ddO
 aKH
 aMk
 aNu
-dlI
+axY
 dfp
-dfp
-dfE
+aBO
+aBO
 dfP
 dfY
-dgc
+axY
 aYu
 cXA
 cXA
@@ -120857,30 +120117,30 @@ ath
 ajb
 avA
 axY
-axZ
+axY
 ayX
-ddS
-bUw
-aCY
-dek
+axY
+axY
+aBO
+aBO
 der
-deD
-dlI
-aJv
+axY
+cWu
+ddO
 aKI
 tDM
-dfb
-dfj
+dBy
+axY
 dlI
-deD
-dfF
-aTN
-aVe
-aWH
-dgi
+aBO
+axY
+axY
+ayX
+axY
+atm
 dgc
-aqq
-aqr
+alq
+apc
 aWu
 bif
 bif
@@ -121116,27 +120376,27 @@ avB
 axY
 ddO
 bUw
-ddT
-ddZ
-ded
-del
-des
+ddO
+axY
+axY
+axY
+axY
 djt
-daY
+cWu
 daZ
 dbb
-aMk
-aNv
-dfk
-dfq
+rVX
+dBy
 djt
-dfG
-dfQ
-dfZ
-apc
-apc
-dgo
-apc
+axY
+axY
+axY
+ddO
+bUw
+ddO
+axY
+alq
+alq
 cXZ
 atm
 bfZ
@@ -121371,31 +120631,31 @@ ajb
 ajb
 avC
 axY
-aya
-bUw
-ddU
-aBQ
-dee
+axY
+eEu
+axY
+axY
+ddO
 aEr
-des
+ddO
 djt
-daY
-daZ
-dbb
+cWu
+ddO
+rEi
 dfa
 aNv
-dfk
-daY
+djt
+ddO
 djx
-dfG
-cXz
-aVe
-atm
-alr
-dgp
+axY
+axY
+nwU
+axY
+axY
+alq
 cXI
 cYj
-atm
+iOa
 bga
 big
 bga
@@ -121414,7 +120674,7 @@ bFS
 bHy
 bIV
 bKC
-bMi
+bAQ
 bNU
 bMg
 bQV
@@ -121628,31 +120888,31 @@ dps
 dpL
 avD
 axY
+axY
+xNI
 ddO
-bUw
-ddV
-aBQ
-dee
-aEr
-aKL
+ddO
+ddO
+ddO
+ddO
 djt
-daY
-deS
-dbb
-aMk
-aNv
-dfm
-daY
 djt
-dbg
-dfR
+djt
+oiF
+djt
+djt
+djt
+ddO
+ddO
+ddO
+ddO
 dga
 dgd
 dgj
-dgp
-alr
 atm
-atm
+alq
+jFx
+iOa
 bgb
 cTu
 bgb
@@ -121671,8 +120931,8 @@ bFT
 bHz
 bIW
 bKD
-dhe
-dhg
+bCi
+bCi
 bPu
 bPu
 bPu
@@ -121887,28 +121147,28 @@ avE
 axY
 ayc
 aza
-aAw
-bUw
+ddO
+lHL
 aCY
 dem
-aFD
+dem
 deD
-dlI
-dlI
+deD
+deD
 deV
-dlN
-dfc
-dlI
-dlI
-deD
+dem
+dem
+dem
+dem
+dem
 dfI
-dfS
-aVh
-aaf
+lHL
+ddO
+ddO
 aYx
-dgr
-dgw
-dgA
+bpu
+lHL
+lMJ
 dgI
 bgb
 cTi
@@ -121929,7 +121189,7 @@ bHy
 bIX
 bKE
 bKE
-dhh
+bKE
 bPv
 bKE
 bKE
@@ -122142,31 +121402,31 @@ apm
 dnS
 avB
 axY
-axY
-bTq
+goZ
+ddO
 aAx
-aBO
+aaf
 aIe
 aOS
-deu
-deI
-deN
-deI
-deW
-aMm
-dfd
-deN
-dft
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
+cDu
 dBB
-dbh
-dfT
-aVh
-aaa
+aIe
+aaf
+cWu
+ddO
 aYx
-dgf
-dgj
-ack
-dgJ
+bpu
+lMJ
+lMJ
+lHL
 bgb
 bij
 bgb
@@ -122186,7 +121446,7 @@ bHA
 bIY
 bKF
 bMk
-dhi
+bNV
 bPw
 bQW
 bSj
@@ -122399,31 +121659,31 @@ atk
 aux
 avF
 dqT
-dqT
-aaf
-ack
-dea
-aIc
+esV
+xqB
+aAx
+lHL
+aIe
 den
 dev
-deJ
-deO
-deU
-deX
-dBx
-dfe
-dBz
-dfu
+dew
+dew
+dev
+lMJ
+lHL
+dew
+dew
+dev
 dfz
-dfJ
-dfU
-dga
+aIe
+lHL
+cWu
 dge
 azd
-azd
-azd
-dgB
-dgK
+bpu
+lMJ
+lMJ
+lHL
 aaa
 cUL
 aaa
@@ -122443,7 +121703,7 @@ bHB
 bIZ
 bKG
 bMl
-dhj
+bKG
 bIZ
 bKG
 bMl
@@ -122656,31 +121916,31 @@ atl
 auy
 dnS
 dqT
-dqT
+fGs
+ddO
+aAx
 aaf
-ack
-ack
 def
 aCZ
 dew
-aCZ
-axY
-axY
-aCZ
-aCZ
-aCZ
-axY
-axY
-aCZ
+aav
+aav
+vLD
+aaf
+aaa
+aav
+aav
 dew
-aCZ
-aVe
-dgf
-dgk
-dgt
-dgk
-dgv
-dgJ
+xfK
+obN
+aaf
+cWu
+ddO
+dgg
+bpu
+lMJ
+lHL
+lHL
 anT
 aaf
 aaf
@@ -122700,7 +121960,7 @@ bza
 bJa
 bza
 bFX
-dhk
+bza
 bJa
 bza
 bFX
@@ -122913,51 +122173,51 @@ apm
 dnh
 dnS
 dnz
-dqT
+xWZ
+dPf
+aAx
+lHL
+aIe
+den
+dew
+aav
+aaa
+aaa
 aaf
-aaf
-aaf
-def
-ddZ
-dex
-aJu
-ddZ
-ddZ
-ddZ
-aMo
-dff
-ddZ
-ddZ
-aJu
-dex
-ddZ
-aVe
+aaa
+aaa
+aav
+dew
+dfz
+aIe
+lHL
+cWu
 aWK
 dgk
-dgt
-dgk
-dgB
-dgM
-dgN
-dgO
-dgO
-dgw
-dgO
-dgS
-dgO
-dgO
-dgw
-dgw
-dgw
-dgw
+bpu
+lMJ
+lHL
+lHL
+anT
+dew
+dew
+aaf
+dew
+bpw
+dew
+dew
+aaf
+aaf
+aaf
+aaf
 bCz
-dgw
-dha
-dgw
-dhc
-dgw
-dha
-dhl
+aaf
+bFY
+aaf
+bJb
+aaf
+bFY
+aaf
 bJb
 aaf
 bFY
@@ -123170,31 +122430,31 @@ dnh
 auz
 dqp
 dqT
-dqT
+axY
+fGs
+aAx
+ack
+def
+aCZ
+lHL
 aaa
 aaa
+ddZ
+cDu
+fWO
 aaa
-bTq
-dep
-dey
-aHa
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-ddZ
-dfA
-dfM
-dfV
-dgb
+vLD
+dev
+xfK
+obN
+ack
+cWu
 dgg
-azd
-azd
-azd
-dgv
-aaf
+axY
+bpu
+lMJ
+lHL
+lHL
 anT
 aaa
 aaa
@@ -123427,30 +122687,30 @@ dni
 auA
 dnS
 dqT
-aaa
-aaa
-aaa
-aaa
 axY
-deq
-dey
-deK
-ddZ
-ddZ
-ddZ
+fGs
+ddO
+aaf
+aIe
+den
+lMJ
+aaf
+aaf
+den
+nte
 aMo
-ddZ
-ddZ
-ddZ
-dfB
-dfM
-dfW
+aaf
+aaf
+lMJ
+dfz
+aIe
+aaf
+ddO
+dgg
 axY
-aWK
-dgk
-dgt
-dgk
-dgB
+bpu
+lMJ
+lHL
 aaa
 anT
 aaa
@@ -123684,31 +122944,31 @@ dnh
 auB
 avG
 dqT
-aaa
-aaa
-aaa
-aaa
 axY
-aJu
-deA
-deL
-aJu
-aJu
+fGs
+aAx
+ack
+def
+aCZ
+dev
+vLD
+aaa
+fjy
 deY
+moI
+aaa
+aaa
+lHL
+xfK
+obN
+ack
+cWu
+dgg
 axY
-dfg
-aJu
-aJu
-dfC
-dfO
-ddZ
-axY
-dgh
-dgk
-dgk
-dgk
-dgv
-aaf
+bpu
+lMJ
+lHL
+lHL
 anT
 aaa
 aaa
@@ -123941,30 +123201,30 @@ dnh
 dnh
 jKK
 dqT
+ocj
+rTo
+aAx
+lHL
+aIe
+den
+dew
+aav
+aaa
+aaa
 aaf
 aaa
 aaa
-aaa
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-axY
-aWK
+aav
+dew
+dfz
+aIe
+lHL
+cWu
+jjF
 dgm
-dgu
-dgm
-dgB
+bpu
+lMJ
+lHL
 aaa
 anT
 aaa
@@ -124198,31 +123458,31 @@ atn
 bOY
 avG
 dqT
+fGs
+ddO
+aAx
 aaf
+dtL
+aCZ
+dew
+aav
 aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
 aaa
 aaf
+vLD
 aaa
+aav
+dew
+xfK
+xLP
 aaf
-aaa
-aaf
-aaf
-ack
-ack
-aye
-dgv
-aye
-dgv
-aaf
+pWF
+ddO
+dgg
+bpu
+lMJ
+lHL
+lHL
 anT
 aaf
 aaf
@@ -124455,29 +123715,29 @@ dnh
 dnh
 lNZ
 dqT
-aaf
-aaa
-aaa
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
-aaa
-aaf
-aaa
-aaf
-aaa
-aaa
-aaf
-aaf
-aaf
-aaa
-aaa
-aaf
+drT
+xqB
+aAx
+lHL
+ack
+den
+dev
+dew
+lHL
+lHL
+lMJ
+dev
+dew
+dew
+dev
+dfz
+ack
+lHL
+cWu
+dge
+vSl
+sSU
+lMJ
 aaa
 aaa
 aaf
@@ -124712,29 +123972,29 @@ aaa
 aaf
 ack
 dqT
-aaf
-anT
-anT
-anT
-anT
-aaf
-anT
-anT
-anT
-anT
-anT
-anT
-aqB
-anT
-anT
-anT
-anT
-anT
-anT
-aaf
-aaa
-aaa
-aaf
+axY
+axY
+ddO
+anS
+anS
+gKb
+anS
+anS
+anS
+anS
+anS
+anS
+anS
+anS
+anS
+gKb
+anS
+anS
+ddO
+axY
+axY
+sSU
+lMJ
 aaa
 aaa
 aaf
@@ -124969,12 +124229,12 @@ aaf
 aaf
 ack
 aaf
-aaa
-aaa
-aaa
-aaf
-aaa
-aaa
+axY
+axY
+axY
+axY
+axY
+axY
 bpu
 bpu
 bpu
@@ -124984,14 +124244,14 @@ bpu
 bpu
 bpu
 bpu
+axY
+axY
+axY
+axY
+axY
+axY
 bpu
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
+lMJ
 aaa
 aaa
 aaa
@@ -125225,30 +124485,30 @@ aaa
 aaa
 aaa
 aaa
+vLD
 aaa
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+eln
+tMT
 aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-anT
-anT
-anT
-anT
-aqB
-anT
-anT
-anT
-anT
-aqB
-aaf
-aaf
-aaf
-aaf
-aaa
-aaf
-aaf
+lHL
+lMJ
 aaa
 aaa
 aaa
@@ -125482,7 +124742,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+vLD
 aaa
 aaa
 aaa
@@ -125739,26 +124999,26 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
+vLD
 aaf
 aai
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11247,6 +11247,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "axN" = (
@@ -11359,6 +11362,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -12260,6 +12266,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg2"
 	},
@@ -12457,6 +12466,9 @@
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/item/clothing/suit/hooded/wintercoat/engineering,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 1
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
@@ -16090,6 +16102,9 @@
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
 	name = "2maintenance loot spawner"
+	},
+/obj/machinery/light/small{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
@@ -21282,6 +21297,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/obj/machinery/light,
 /turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "aTI" = (
@@ -22514,9 +22530,7 @@
 	req_access = null;
 	req_access_txt = "32"
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "aWv" = (
 /turf/closed/wall,
@@ -47824,6 +47838,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
 	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bXc" = (
@@ -56896,6 +56913,9 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -71873,9 +71893,10 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/light/small{
+	dir = 1
 	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -71892,9 +71913,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYc" = (
 /obj/structure/table/optable{
@@ -71916,9 +71935,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "cYE" = (
 /obj/structure/closet/toolcloset,
@@ -72232,6 +72249,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
+	},
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -73759,6 +73779,12 @@
 /obj/structure/closet/toolcloset,
 /obj/effect/turf_decal/delivery,
 /obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"dgA" = (
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "dgI" = (
@@ -76162,6 +76188,13 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"dPp" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dYu" = (
 /obj/machinery/door/airlock/external{
 	name = "Auxiliary Airlock"
@@ -76470,6 +76503,10 @@
 	dir = 4
 	},
 /area/engine/engineering)
+"iYY" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jjF" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -76517,9 +76554,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plating,
 /area/maintenance/starboard)
 "jIV" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -76536,6 +76571,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"jYQ" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -76890,11 +76931,6 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oUD" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/engine/break_room)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -77015,6 +77051,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"rFx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/engine/engineering)
 "rQK" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -77100,6 +77142,14 @@
 "sSU" = (
 /turf/closed/wall/r_wall,
 /area/space)
+"tdB" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/starboard/fore)
 "tjH" = (
 /obj/structure/table/reinforced,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -77221,6 +77271,12 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space,
 /area/space)
+"vAk" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -77287,6 +77343,9 @@
 /area/science/misc_lab)
 "xcM" = (
 /obj/structure/closet/firecloset,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
@@ -117840,7 +117899,7 @@ arJ
 arI
 dnh
 dqu
-doh
+tdB
 axO
 axY
 aAo
@@ -118886,8 +118945,8 @@ dfh
 aBO
 aBO
 aBK
-aTK
-aVe
+dPp
+rFx
 axY
 aYu
 aYu
@@ -119900,7 +119959,7 @@ axY
 axY
 ayW
 bTq
-aBO
+dgA
 aBO
 aBO
 aFC
@@ -119913,7 +119972,7 @@ aNu
 axY
 dfp
 aBO
-aBO
+dgA
 dfP
 dfY
 axY
@@ -120177,11 +120236,11 @@ axY
 atm
 dgc
 alq
-apf
+apc
 aWu
-oUD
-oUD
-oUD
+bif
+bif
+bif
 bhT
 bhT
 brK
@@ -120411,7 +120470,7 @@ ati
 ajb
 avB
 axY
-aJu
+jYQ
 bUw
 aJu
 axY
@@ -120430,7 +120489,7 @@ axY
 axY
 aJu
 bUw
-aJu
+iYY
 axY
 alq
 alq
@@ -121436,7 +121495,7 @@ apn
 aqy
 arT
 apm
-dnS
+vAk
 avB
 axY
 goZ

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -11792,7 +11792,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aza" = (
 /obj/structure/cable/white{
@@ -13698,7 +13698,7 @@
 	},
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aCZ" = (
 /obj/structure/cable,
 /obj/effect/turf_decal/stripes/line{
@@ -13706,7 +13706,7 @@
 	},
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aDa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -16121,7 +16121,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "aIf" = (
 /obj/machinery/camera{
 	c_tag = "Auxillary Base Construction";
@@ -17269,21 +17269,21 @@
 	icon_state = "end_cap";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aKH" = (
 /obj/structure/particle_accelerator/fuel_chamber{
 	icon_state = "fuel_chamber";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aKI" = (
 /obj/structure/particle_accelerator/power_box{
 	icon_state = "power_box";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aKN" = (
 /obj/machinery/door/poddoor{
@@ -17884,7 +17884,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMk" = (
 /obj/machinery/particle_accelerator/control_box,
@@ -17892,7 +17892,7 @@
 	icon_state = "0-2";
 	pixel_y = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aMo" = (
 /obj/effect/turf_decal/stripes/line{
@@ -18377,7 +18377,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "aNw" = (
 /obj/structure/window/reinforced{
@@ -19072,7 +19072,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "aOT" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -20744,7 +20744,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21307,12 +21307,6 @@
 "aTK" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"aTO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -22520,7 +22514,9 @@
 	req_access = null;
 	req_access_txt = "32"
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "aWv" = (
 /turf/closed/wall,
@@ -31760,9 +31756,6 @@
 	dir = 6
 	},
 /area/security/checkpoint/customs)
-"bpu" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "bpv" = (
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
@@ -46585,7 +46578,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "bUx" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -47072,7 +47065,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/service)
 "bVA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock{
 	name = "Service Hall";
 	req_access_txt = "null";
@@ -71881,7 +71873,9 @@
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "cXR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -71898,7 +71892,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "cYc" = (
 /obj/structure/table/optable{
@@ -71920,7 +71916,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "cYE" = (
 /obj/structure/closet/toolcloset,
@@ -72250,14 +72248,14 @@
 	icon_state = "emitter_right";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dbb" = (
 /obj/structure/particle_accelerator/particle_emitter/center{
 	icon_state = "emitter_center";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dbd" = (
 /obj/structure/sink/kitchen{
@@ -73528,14 +73526,14 @@
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dem" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "den" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -73575,7 +73573,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "deM" = (
 /obj/structure/table,
 /obj/effect/turf_decal/delivery,
@@ -73600,7 +73598,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "deY" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -73611,7 +73609,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dfh" = (
 /obj/structure/table,
@@ -73637,7 +73635,7 @@
 "dfz" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "dfD" = (
 /obj/item/book/manual/engineering_singularity_safety{
 	pixel_x = 3;
@@ -73658,7 +73656,7 @@
 	},
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "dfP" = (
 /obj/structure/cable/white{
 	icon_state = "2-8"
@@ -73697,7 +73695,9 @@
 /obj/item/clothing/head/soft/rainbow,
 /obj/item/clothing/shoes/sneakers/rainbow,
 /obj/item/clothing/under/color/rainbow,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "dgd" = (
 /obj/structure/cable/white{
@@ -74782,7 +74782,7 @@
 /area/science/xenobiology)
 "djt" = (
 /obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "djx" = (
 /obj/machinery/camera/emp_proof{
@@ -75121,7 +75121,7 @@
 	icon_state = "2-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "dtP" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -75458,21 +75458,21 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dBy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "dBB" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "dBC" = (
 /obj/machinery/meter,
 /obj/structure/grille,
@@ -76171,6 +76171,12 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"dZD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "eln" = (
 /turf/open/space/basic,
 /area/engine/engineering)
@@ -76248,7 +76254,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "eFN" = (
 /obj/structure/bodycontainer/crematorium{
@@ -76379,12 +76385,12 @@
 /area/engine/atmos)
 "gKb" = (
 /obj/machinery/camera/emp_proof{
-	c_tag = "Containment - Aft Starboard";
+	c_tag = "Containment - Fore Starboard";
 	dir = 8;
 	network = list("singularity")
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "gLC" = (
 /obj/structure/reagent_dispensers/water_cooler,
 /turf/open/floor/plasteel,
@@ -76417,6 +76423,9 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hWU" = (
+/turf/open/floor/plating/airless,
+/area/space)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -76508,7 +76517,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
 /area/maintenance/starboard)
 "jIV" = (
 /obj/structure/closet/secure_closet/engineering_personal,
@@ -76694,6 +76705,12 @@
 	},
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"mwK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "mzh" = (
 /obj/machinery/firealarm{
 	dir = 1;
@@ -76744,7 +76761,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "nyo" = (
 /obj/structure/cable/yellow{
@@ -76798,7 +76815,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "ocj" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -76833,13 +76850,6 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"oiF" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "oub" = (
 /obj/structure/sign/poster/official/random,
 /turf/closed/wall,
@@ -76880,6 +76890,11 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"oUD" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/engine/break_room)
 "pvA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -76965,6 +76980,12 @@
 "qBq" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/hallway/secondary/entry)
+"qJG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qJZ" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -76992,7 +77013,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "rQK" = (
 /obj/structure/cable/yellow{
@@ -77028,7 +77049,7 @@
 	icon_state = "emitter_left";
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "rWa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -77072,6 +77093,10 @@
 "sJW" = (
 /turf/closed/wall/mineral/plastitanium,
 /area/engine/break_room)
+"sOW" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "sSU" = (
 /turf/closed/wall/r_wall,
 /area/space)
@@ -77097,7 +77122,7 @@
 /area/science/circuit)
 "tDM" = (
 /obj/item/wrench,
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "tFJ" = (
 /obj/structure/bodycontainer/morgue{
@@ -77192,6 +77217,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/misc_lab)
+"vmz" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space,
+/area/space)
 "vLD" = (
 /obj/structure/lattice,
 /turf/open/space/basic,
@@ -77269,7 +77298,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/space)
 "xkG" = (
 /obj/item/device/integrated_electronics/wirer,
 /obj/structure/table/reinforced,
@@ -77323,7 +77352,7 @@
 	icon_state = "1-8"
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/space)
 "xNI" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -77348,8 +77377,16 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
+"yeY" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Containment - Aft Starboard";
+	dir = 8;
+	network = list("singularity")
+	},
+/turf/open/floor/plating/airless,
+/area/space)
 "ygk" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -118591,7 +118628,7 @@ aBO
 aBO
 aBO
 aGX
-aTO
+aBK
 aTK
 aVd
 aBI
@@ -118848,7 +118885,7 @@ xcM
 dfh
 aBO
 aBO
-aTO
+aBK
 aTK
 aVe
 axY
@@ -119611,10 +119648,10 @@ aCW
 aBO
 aFA
 aGZ
-cWu
-ddO
+qJG
+aJu
 aKG
-ddO
+aJu
 dBy
 aGZ
 nKh
@@ -119868,8 +119905,8 @@ aBO
 aBO
 aFC
 axY
-cWu
-ddO
+qJG
+aJu
 aKH
 aMk
 aNu
@@ -120125,8 +120162,8 @@ aBO
 aBO
 der
 axY
-cWu
-ddO
+qJG
+aJu
 aKI
 tDM
 dBy
@@ -120140,11 +120177,11 @@ axY
 atm
 dgc
 alq
-apc
+apf
 aWu
-bif
-bif
-bif
+oUD
+oUD
+oUD
 bhT
 bhT
 brK
@@ -120374,15 +120411,15 @@ ati
 ajb
 avB
 axY
-ddO
+aJu
 bUw
-ddO
+aJu
 axY
 axY
 axY
 axY
 djt
-cWu
+qJG
 daZ
 dbb
 rVX
@@ -120391,9 +120428,9 @@ djt
 axY
 axY
 axY
-ddO
+aJu
 bUw
-ddO
+aJu
 axY
 alq
 alq
@@ -120639,8 +120676,8 @@ ddO
 aEr
 ddO
 djt
-cWu
-ddO
+qJG
+aJu
 rEi
 dfa
 aNv
@@ -120898,7 +120935,7 @@ ddO
 djt
 djt
 djt
-oiF
+aRm
 djt
 djt
 djt
@@ -121148,7 +121185,7 @@ axY
 ayc
 aza
 ddO
-lHL
+aaa
 aCY
 dem
 dem
@@ -121162,11 +121199,11 @@ dem
 dem
 dem
 dfI
-lHL
+aaa
 ddO
 ddO
 aYx
-bpu
+sSU
 lHL
 lMJ
 dgI
@@ -121405,25 +121442,25 @@ axY
 goZ
 ddO
 aAx
-aaf
+sOW
 aIe
 aOS
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
-cDu
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
+mwK
 dBB
 aIe
-aaf
+sOW
 cWu
 ddO
 aYx
-bpu
+sSU
 lMJ
 lMJ
 lHL
@@ -121662,25 +121699,25 @@ dqT
 esV
 xqB
 aAx
-lHL
+aaa
 aIe
-den
+dZD
 dev
-dew
-dew
+aav
+aav
 dev
 lMJ
-lHL
-dew
-dew
+aaa
+aav
+aav
 dev
 dfz
 aIe
-lHL
+aaa
 cWu
 dge
 azd
-bpu
+sSU
 lMJ
 lMJ
 lHL
@@ -121919,10 +121956,10 @@ dqT
 fGs
 ddO
 aAx
-aaf
+sOW
 def
 aCZ
-dew
+aav
 aav
 aav
 vLD
@@ -121930,14 +121967,14 @@ aaf
 aaa
 aav
 aav
-dew
+aav
 xfK
 obN
-aaf
+sOW
 cWu
 ddO
 dgg
-bpu
+sSU
 lMJ
 lHL
 lHL
@@ -122172,14 +122209,14 @@ apm
 apm
 dnh
 dnS
-dnz
+dqT
 xWZ
 dPf
 aAx
-lHL
+aaa
 aIe
-den
-dew
+dZD
+aav
 aav
 aaa
 aaa
@@ -122187,14 +122224,14 @@ aaf
 aaa
 aaa
 aav
-dew
+aav
 dfz
 aIe
-lHL
+aaa
 cWu
 aWK
 dgk
-bpu
+sSU
 lMJ
 lHL
 lHL
@@ -122433,10 +122470,10 @@ dqT
 axY
 fGs
 aAx
-ack
+vmz
 def
 aCZ
-lHL
+aaa
 aaa
 aaa
 ddZ
@@ -122447,11 +122484,11 @@ vLD
 dev
 xfK
 obN
-ack
+vmz
 cWu
 dgg
 axY
-bpu
+sSU
 lMJ
 lHL
 lHL
@@ -122690,9 +122727,9 @@ dqT
 axY
 fGs
 ddO
-aaf
+sOW
 aIe
-den
+dZD
 lMJ
 aaf
 aaf
@@ -122704,11 +122741,11 @@ aaf
 lMJ
 dfz
 aIe
-aaf
+sOW
 ddO
 dgg
 axY
-bpu
+sSU
 lMJ
 lHL
 aaa
@@ -122947,7 +122984,7 @@ dqT
 axY
 fGs
 aAx
-ack
+vmz
 def
 aCZ
 dev
@@ -122958,14 +122995,14 @@ deY
 moI
 aaa
 aaa
-lHL
+aaa
 xfK
 obN
-ack
+vmz
 cWu
 dgg
 axY
-bpu
+sSU
 lMJ
 lHL
 lHL
@@ -123204,10 +123241,10 @@ dqT
 ocj
 rTo
 aAx
-lHL
+aaa
 aIe
-den
-dew
+dZD
+aav
 aav
 aaa
 aaa
@@ -123215,14 +123252,14 @@ aaf
 aaa
 aaa
 aav
-dew
+aav
 dfz
 aIe
-lHL
+aaa
 cWu
 jjF
 dgm
-bpu
+sSU
 lMJ
 lHL
 aaa
@@ -123461,10 +123498,10 @@ dqT
 fGs
 ddO
 aAx
-aaf
+sOW
 dtL
 aCZ
-dew
+aav
 aav
 aaa
 aaa
@@ -123472,14 +123509,14 @@ aaf
 vLD
 aaa
 aav
-dew
+aav
 xfK
 xLP
-aaf
+sOW
 pWF
 ddO
 dgg
-bpu
+sSU
 lMJ
 lHL
 lHL
@@ -123718,21 +123755,21 @@ dqT
 drT
 xqB
 aAx
-lHL
-ack
-den
+aaa
+vmz
+dZD
 dev
-dew
-lHL
-lHL
+aav
+aaa
+aaa
 lMJ
 dev
-dew
-dew
+aav
+aav
 dev
 dfz
-ack
-lHL
+vmz
+aaa
 cWu
 dge
 vSl
@@ -123975,21 +124012,21 @@ dqT
 axY
 axY
 ddO
-anS
-anS
+hWU
+hWU
 gKb
-anS
-anS
-anS
-anS
-anS
-anS
-anS
-anS
-anS
-gKb
-anS
-anS
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+hWU
+yeY
+hWU
+hWU
 ddO
 axY
 axY
@@ -124235,22 +124272,22 @@ axY
 axY
 axY
 axY
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
-bpu
 axY
 axY
 axY
 axY
 axY
 axY
-bpu
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+axY
+sSU
 lMJ
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45243,12 +45243,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"chQ" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "chR" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49940,12 +49934,6 @@
 "cBQ" = (
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
-/area/engine/engineering)
-"cBS" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cBT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -80161,11 +80149,11 @@ cfU
 cgu
 cgU
 chw
+cgU
 chw
+cgU
 chw
-chw
-chw
-chw
+cgU
 cjs
 cfV
 cfV
@@ -80418,11 +80406,11 @@ cfV
 cgv
 cfV
 chx
-chQ
+cfV
 chx
-chQ
+cfV
 chx
-chQ
+cfV
 chx
 cfV
 cfV
@@ -82988,11 +82976,11 @@ cfV
 cgv
 cfV
 chz
-cBS
+cfV
 chz
-cBS
+cfV
 chz
-cBS
+cfV
 chz
 cfV
 cfV
@@ -83245,11 +83233,11 @@ cfU
 cgx
 cgU
 chA
+cgU
 chA
+cgU
 chA
-chA
-chA
-chA
+cgU
 cjt
 cfV
 cfV

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -45129,9 +45129,6 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/tesla_coil,
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chz" = (
@@ -45139,9 +45136,6 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/tesla_coil,
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chA" = (
@@ -45250,10 +45244,6 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chQ" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -45412,14 +45402,13 @@
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "cit" = (
-/obj/machinery/the_singularitygen,
+/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "ciu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/the_singularitygen/tesla,
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
 "civ" = (
@@ -49952,21 +49941,7 @@
 /obj/machinery/power/rad_collector,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cBR" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cBS" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -50388,9 +50363,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"uTf" = (
+/turf/closed/wall/r_wall,
+/area/space)
 "vpU" = (
 /turf/open/floor/plasteel/darkpurple,
 /area/crew_quarters/cryopod)
+"vyc" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -79160,8 +79142,8 @@ bXk
 bXk
 bXk
 bXk
-aaa
-aaa
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -79416,9 +79398,9 @@ chR
 cgt
 cjT
 ckq
+ckq
 bXk
-aaa
-aaa
+uTf
 aaa
 aaa
 aaa
@@ -79673,9 +79655,9 @@ chS
 cfV
 cgS
 cfV
+cfV
 bXk
-aaa
-aaa
+uTf
 aaa
 aaa
 aaa
@@ -79929,10 +79911,10 @@ cfV
 cfV
 cfV
 cgT
+cfV
 ckr
 bXk
-aaa
-aaa
+uTf
 aaa
 aaa
 aaa
@@ -80179,7 +80161,7 @@ cfU
 cgu
 cgU
 chw
-cBR
+chw
 chw
 chw
 chw
@@ -80187,9 +80169,9 @@ chw
 cjs
 cfV
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -80444,9 +80426,9 @@ chQ
 chx
 cfV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -80694,16 +80676,16 @@ cgv
 cgV
 bBW
 bBW
-aaa
 cgV
+aht
 aaa
 bBW
 bBW
 cgV
 cfV
-bTE
-abI
-abI
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -80951,16 +80933,16 @@ cgv
 bBW
 bBW
 bBW
-aaa
+vyc
 abI
 aaa
 bBW
 bBW
 bBW
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -81215,9 +81197,9 @@ aaa
 bBW
 bBW
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -81469,12 +81451,12 @@ cii
 cis
 ciG
 aaa
-aaa
-aaa
+vyc
+cgV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -81719,7 +81701,7 @@ cfd
 cfw
 cfW
 cgw
-cgV
+aht
 abI
 abI
 cij
@@ -81727,11 +81709,11 @@ cit
 ciH
 abI
 abI
-cgV
+aht
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -81976,8 +81958,8 @@ cfe
 cfx
 cfa
 cgv
-aaa
-aaa
+cgV
+vyc
 aaa
 cik
 ciu
@@ -81986,9 +81968,9 @@ aaa
 aaa
 aaa
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -82243,9 +82225,9 @@ aaa
 bBW
 bBW
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -82495,14 +82477,14 @@ bBW
 aaa
 aaa
 abI
-aaa
+vyc
 aaa
 bBW
 bBW
 cfV
-bTE
-aaa
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -82751,15 +82733,15 @@ cgV
 bBW
 aaa
 aaa
+aht
 cgV
-aaa
 bBW
 bBW
 cgV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 aaa
 aaa
 aaa
@@ -83014,9 +82996,9 @@ cBS
 chz
 cfV
 cfV
-bTE
-abI
-abI
+cfV
+bXk
+uTf
 abI
 abI
 aaa
@@ -83271,9 +83253,9 @@ chA
 cjt
 cfV
 cfV
-bTE
-abI
-aaa
+cfV
+bXk
+uTf
 abI
 aaa
 aaa
@@ -83527,10 +83509,10 @@ cfV
 cfV
 cfV
 cgY
+cfV
 cks
 bXk
-abI
-aaa
+uTf
 aaa
 aaa
 aaa
@@ -83785,9 +83767,9 @@ chO
 cfV
 cgZ
 cfV
+cfV
 bXk
-abI
-abI
+uTf
 abI
 aaa
 aaa
@@ -84042,9 +84024,9 @@ chP
 cgt
 cjU
 ckq
+ckq
 bXk
-abI
-aaa
+uTf
 aaa
 aaa
 aaa
@@ -84299,9 +84281,9 @@ bXk
 bXk
 bXk
 bXk
+bXk
 ckJ
-abI
-aaa
+uTf
 aaa
 aaa
 aaa

--- a/code/modules/power/tesla/coil.dm
+++ b/code/modules/power/tesla/coil.dm
@@ -25,7 +25,7 @@
 
 /obj/machinery/power/tesla_coil/Initialize()
 	. = ..()
-	wires = new /datum/wires/tesla_coil(src)
+//	wires = new /datum/wires/tesla_coil(src) //CITADEL EDIT, Kevinz you cheaty fuccboi.
 	linked_techweb = SSresearch.science_tech
 
 /obj/machinery/power/tesla_coil/RefreshParts()
@@ -79,8 +79,6 @@
 /obj/machinery/power/tesla_coil/tesla_act(var/power)
 	if(anchored && !panel_open)
 		obj_flags |= BEING_SHOCKED
-		//don't lose arc power when it's not connected to anything
-		//please place tesla coils all around the station to maximize effectiveness
 		var/power_produced = powernet ? power / power_loss : power
 		add_avail(power_produced*input_power_multiplier)
 		flick("coilhit", src)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -474,7 +474,6 @@
 #include "code\datums\wires\robot.dm"
 #include "code\datums\wires\suit_storage_unit.dm"
 #include "code\datums\wires\syndicatebomb.dm"
-#include "code\datums\wires\tesla_coil.dm"
 #include "code\datums\wires\vending.dm"
 #include "code\datums\wires\wires.dm"
 #include "code\game\alternate_appearance.dm"


### PR DESCRIPTION
:cl:
add: Tesla Engines are now standard on all but Omega.
fix: fixed a pipe in Meta station that wasn't connected properly.
fix: fixed an exploit related to Tesla wires.
/:cl:

Tesla Engines produce more power and less lag while running, they're also not as temperamental.

Oh, and the Tesla Corona Analyzers so people stop screeching about not having enough points. :v
