### PR TITLE
Gives a prompt for people to see who is replying to an mhelp

### DIFF
--- a/modular_citadel/code/modules/mentor/mentorpm.dm
+++ b/modular_citadel/code/modules/mentor/mentorpm.dm
@@ -31,11 +31,15 @@
 		else		mentorhelp(msg)	//Mentor we are replying to left. Mentorhelp instead(check below)
 		return
 
+	if(is_mentor(whom))
+		to_chat(GLOB.admins | GLOB.mentors, "<font color='purple'>[src] has started replying to [whom]'s mhelp.</font color>")
+
 	//get message text, limit it's length.and clean/escape html
 	if(!msg)
 		msg = input(src,"Message:", "Private message") as text|null
-
-		if(!msg)
+		
+		if(!msg && is_mentor(whom))
+			to_chat(GLOB.admins | GLOB.mentors, "<font color='purple'>[src] has stopped their reply to [whom]'s mhelp.</font color>")
 			return
 
 		if(!C)
@@ -50,7 +54,9 @@
 			return
 
 	msg = sanitize(copytext(msg,1,MAX_MESSAGE_LEN))
-	if(!msg)	return
+	if(!msg && is_mentor(whom))	
+		to_chat(GLOB.admins | GLOB.mentors, "<font color='purple'>[src] has stopped their reply to [whom]'s mhelp.</font color>")
+		return
 
 	log_mentor("Mentor PM: [key_name(src)]->[key_name(C)]: [msg]")
 


### PR DESCRIPTION
because dogpiling on mhelps seems silly.

This only shows to people who are mentor status of whom is replying to an mhelp, it'll also say if someone cancels their reply so people don't do the awkward 'no you message, I insist' politeness, like likes of which are comparable to two people in a doorway.