### PR TITLE
Fixes autolathes not building shockcollars

### DIFF
--- a/modular_citadel/code/game/objects/items/devices/radio/shockcollar.dm
+++ b/modular_citadel/code/game/objects/items/devices/radio/shockcollar.dm
@@ -16,6 +16,7 @@
 	name = "Shockcollar"
 	id = "shockcollar"
 	build_type = AUTOLATHE
+	build_path = /obj/item/device/electropack/shockcollar
 	materials = list(MAT_METAL=5000, MAT_GLASS=2000)
 	category = list("hacked", "Misc")
 	


### PR DESCRIPTION
:cl: Jay
fix: Shockcollars are now printed instead of electropacks.
/:cl:

It was using the electropack buildpath.

Fixes #5998 