### PR TITLE
Removes the old hypospray from CMO closet, updates tator objective

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -63,7 +63,7 @@
 
 /datum/objective_item/steal/hypo
 	name = "the hypospray."
-	targetitem = /obj/item/reagent_containers/hypospray/CMO
+	targetitem = /obj/item/hypospray/mkii/CMO //CITADEL EDIT, changing theft objective for the Hypo MK II
 	difficulty = 5
 	excludefromjob = list("Chief Medical Officer")
 

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -69,7 +69,7 @@
 	new /obj/item/storage/belt/medical(src)
 	new /obj/item/device/healthanalyzer/advanced(src)
 	new /obj/item/device/assembly/flash/handheld(src)
-	new /obj/item/reagent_containers/hypospray/CMO(src)
+//	new /obj/item/reagent_containers/hypospray/CMO(src) // CITADEL EDIT comments out the hypospray mk I. the MK II kit is modularized
 	new /obj/item/device/autosurgeon/cmo(src)
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/clothing/neck/petcollar(src)


### PR DESCRIPTION
:cl: Poojawa
del: The Mark I hypospray has been recalled! Something about prototype status or patent breaks whatever.
balance: Syndicate Agents will now be encouraged to get the latest iphone 99 err, MK II Hypospray!
/:cl:

The Future is here. 