### PR TITLE
Makes blood cult combat rework compatible.

### DIFF
--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -139,9 +139,8 @@
 	name = "Stun"
 	desc = "A potent spell that will stun and mute victims upon contact."
 	button_icon_state = "hand"
-	charges = 4
 	magic_path = "/obj/item/melee/blood_magic/stun"
-	health_cost = 3
+	health_cost = 10
 
 /datum/action/innate/cult/blood_spell/teleport
 	name = "Teleport"

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -139,8 +139,9 @@
 	name = "Stun"
 	desc = "A potent spell that will stun and mute victims upon contact."
 	button_icon_state = "hand"
+	charges = 4
 	magic_path = "/obj/item/melee/blood_magic/stun"
-	health_cost = 10
+	health_cost = 3
 
 /datum/action/innate/cult/blood_spell/teleport
 	name = "Teleport"

--- a/modular_citadel/code/modules/antagonists/cult/blood_magic.dm
+++ b/modular_citadel/code/modules/antagonists/cult/blood_magic.dm
@@ -1,0 +1,3 @@
+/datum/action/innate/cult/blood_spell/stun
+	charges = 4
+	health_cost = 10

--- a/modular_citadel/code/modules/antagonists/cult/blood_magic.dm
+++ b/modular_citadel/code/modules/antagonists/cult/blood_magic.dm
@@ -1,3 +1,3 @@
 /datum/action/innate/cult/blood_spell/stun
 	charges = 4
-	health_cost = 10
+	health_cost = 3

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2688,6 +2688,7 @@
 #include "modular_citadel\code\modules\admin\topic.dm"
 #include "modular_citadel\code\modules\antagonists\cit_crewobjectives.dm"
 #include "modular_citadel\code\modules\antagonists\cit_miscreants.dm"
+#include "modular_citadel/code/modules/antagonists/cult/blood_magic.dm"
 #include "modular_citadel\code\modules\antagonists\crew_objectives\cit_crewobjectives_cargo.dm"
 #include "modular_citadel\code\modules\antagonists\crew_objectives\cit_crewobjectives_civilian.dm"
 #include "modular_citadel\code\modules\antagonists\crew_objectives\cit_crewobjectives_command.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2688,7 +2688,7 @@
 #include "modular_citadel\code\modules\admin\topic.dm"
 #include "modular_citadel\code\modules\antagonists\cit_crewobjectives.dm"
 #include "modular_citadel\code\modules\antagonists\cit_miscreants.dm"
-#include "modular_citadel/code/modules/antagonists/cult/blood_magic.dm"
+#include "modular_citadel\code\modules\antagonists\cult\blood_magic.dm"
 #include "modular_citadel\code\modules\antagonists\crew_objectives\cit_crewobjectives_cargo.dm"
 #include "modular_citadel\code\modules\antagonists\crew_objectives\cit_crewobjectives_civilian.dm"
 #include "modular_citadel\code\modules\antagonists\crew_objectives\cit_crewobjectives_command.dm"


### PR DESCRIPTION
[Changelogs]: # Changes the amount of stuns blood cult has each time they are carved onto the body, each use is a 1.6 second knockdown and gives out 40 points of stamina damage. One or two uses will knockdown and slow but your target would still be able to crawl away. Three uses will knock them down longer and staminacrit them briefly. Four uses is a guaranteed stun for a while, note that each use will deal 3 points of brute damage to the arm you are using the stun on.

:cl:
balance: Blood cult stun now has 4 stun charges instead of one. Three uses will give you 120 stamina damage and a 4.8 second knockdown and 9 point of damage. Four uses will give you 160 stamina damage and a 6.4 second knockdown and 12 points of damage. 

/:cl:

[why]: # Because they can't stun anyone right now.