### PR TITLE
Increases arousal performance, bandaid patch

### DIFF
--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -48,9 +48,8 @@
 					if(getorganslot("vagina"))
 						amt_nude++
 				if(amt_nude)
-					var/mob/living/M
 					var/watchers = 0
-					for(M in view(world.view, src))
+					for(var/mob/living/M in view(world.view, src))
 						if(M.client && !M.stat && !M.eye_blind && (locate(src) in viewers(world.view,M)))
 							watchers++
 					if(watchers)

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -33,12 +33,12 @@
 
 
 /mob/living/carbon/handle_arousal()
-	if(canbearoused && dna && client)
+	if(canbearoused && dna)
 		var/datum/species/S
 		S = dna.species
-		if(S && SSmobs.times_fired%36==2 && getArousalLoss() < max_arousal)//Totally stolen from breathing code. Do this every 36 ticks.
+		if(S && !(SSmobs.times_fired % 36) && getArousalLoss() < max_arousal)//Totally stolen from breathing code. Do this every 36 ticks.
 			adjustArousalLoss(arousal_rate * S.arousal_gain_rate)
-			if(dna.features["exhibitionist"])
+			if(dna.features["exhibitionist"] && client)
 				var/amt_nude = 0
 				if(is_chest_exposed() && (gender == FEMALE || getorganslot("breasts")))
 					amt_nude++

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -49,7 +49,10 @@
 						amt_nude++
 				if(amt_nude)
 					var/watchers = 0
-					for(var/mob/living/M in view(world.view, src))
+					for(var/mob/_M in view(world.view, src))
+						var/mob/living/M = _M
+						if(!istype(M))
+							continue
 						if(M.client && !M.stat && !M.eye_blind && (locate(src) in viewers(world.view,M)))
 							watchers++
 					if(watchers)

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -33,7 +33,7 @@
 
 
 /mob/living/carbon/handle_arousal()
-	if(canbearoused && dna)
+	if(canbearoused && dna && client)
 		var/datum/species/S
 		S = dna.species
 		if(S && SSmobs.times_fired%36==2 && getArousalLoss() < max_arousal)//Totally stolen from breathing code. Do this every 36 ticks.
@@ -47,13 +47,14 @@
 						amt_nude++
 					if(getorganslot("vagina"))
 						amt_nude++
-				var/mob/living/M
-				var/watchers = 0
-				for(M in view(world.view, src))
-					if(M.client && !M.stat && !M.eye_blind && (locate(src) in viewers(world.view,M)))
-						watchers++
-				if(watchers && amt_nude)
-					adjustArousalLoss((amt_nude * watchers) + S.arousal_gain_rate)
+				if(amt_nude)
+					var/mob/living/M
+					var/watchers = 0
+					for(M in view(world.view, src))
+						if(M.client && !M.stat && !M.eye_blind && (locate(src) in viewers(world.view,M)))
+							watchers++
+					if(watchers)
+						adjustArousalLoss((amt_nude * watchers) + S.arousal_gain_rate)
 
 
 /mob/living/proc/getArousalLoss()


### PR DESCRIPTION
One of the most expensive procs possible is now no longer going to be run on handle arousal unless there is a reason to run them.
Clientless mobs no longer get aroused from being looked at because they're braindead/SSD.