### PR TITLE
adds lavaknight corpses to legion drops

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -267,7 +267,7 @@
 	H.dna.add_mutation(DWARFISM)
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist")) = 4))
+	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist", "Lavaknight")) = 4)) //CIT CHANGE: Lavaknights
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -366,6 +366,15 @@
 			l_pocket = /obj/item/melee/cultblade/dagger
 			glasses =  /obj/item/clothing/glasses/night/cultblind
 			backpack_contents = list(/obj/item/reagent_containers/glass/beaker/unholywater = 1, /obj/item/device/cult_shift = 1, /obj/item/device/flashlight/flare/culttorch = 1, /obj/item/stack/sheet/runed_metal = 15)
+		if("Lavaknight") //START OF CIT CHANGE
+			uniform = /obj/item/clothing/under/assistantformal
+			mask = /obj/item/clothing/mask/breath
+			shoes = /obj/item/clothing/shoes/sneakers/black
+			r_pocket = /obj/item/melee/transforming/energy/sword/cx/broken
+			suit = /obj/item/clothing/suit/space/hardsuit/lavaknight
+			suit_store = /obj/item/tank/internals/oxygen
+			id = /obj/item/card/id/knight //END OF CIT CHANGE
+			id_job = "Knight"
 	. = ..()
 
 

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -111,6 +111,11 @@
 			var/mutable_appearance/blade_inhand = mutable_appearance(icon_file, "cxsword_blade")
 			blade_inhand.color = light_color
 			. += blade_inhand
+//Broken version. Not a toy, but not as strong.
+/obj/item/melee/transforming/energy/sword/cx/broken
+	name = "misaligned non-eutactic blade"
+	desc = "The Non-Eutactic Blade utilizes a hardlight blade that is dynamically 'forged' on demand to create a deadly sharp edge that is unbreakable. This one seems to have a damaged hardlight emitter and a misalgined magnet, causing the blade to be unstable at best"
+	force_on = 15 //As strong a survival knife/bone dagger
 
 //OBLIGATORY TOY MEMES	/////////////////////////////////////
 

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -114,7 +114,7 @@
 //Broken version. Not a toy, but not as strong.
 /obj/item/melee/transforming/energy/sword/cx/broken
 	name = "misaligned non-eutactic blade"
-	desc = "The Non-Eutactic Blade utilizes a hardlight blade that is dynamically 'forged' on demand to create a deadly sharp edge that is unbreakable. This one seems to have a damaged hardlight emitter and a misalgined magnet, causing the blade to be unstable at best"
+	desc = "The Non-Eutactic Blade utilizes a hardlight blade that is dynamically 'forged' on demand to create a deadly sharp edge that is unbreakable. This one seems to have a damaged handle and misaligned components, causing the blade to be unstable at best"
 	force_on = 15 //As strong a survival knife/bone dagger
 
 //OBLIGATORY TOY MEMES	/////////////////////////////////////


### PR DESCRIPTION

:cl: Cebutris
add: A small band of knights have been seen getting eaten by legions down on Lavaland. Maybe you can find their bodies!
/:cl:

This adds a a small chance for lavaknights to be found as corpses from legions on lavaland. They have the neat badges, and broken NEBs.

Ready as-is, but I would like to know if it's possible to modularize (I don't know how) and if it's possible to give the bodies cat ears