### PR TITLE
Adds support for manipulating gear entries via config

### DIFF
--- a/config/loadout_config.txt
+++ b/config/loadout_config.txt
@@ -1,0 +1,1 @@
+DONORTEST|WHITELIST=jayehh,deathride58,poojawa

--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -10,7 +10,7 @@
 	name = "Donor item testing bikehorn"
 	category = slot_in_backpack
 	path = /obj/item/bikehorn
-	ckeywhitelist = list("jayehh","deathride58")
+	geargroupID = "DONORTEST"
 
 /datum/gear/kevhorn
 	name = "Airhorn"

--- a/modular_citadel/code/modules/client/loadout/loadout.dm
+++ b/modular_citadel/code/modules/client/loadout/loadout.dm
@@ -5,14 +5,36 @@
 // and lastly, restricted_roles list allows you to let someone spawn with certain items only if the job they spawned with is on the list.
 
 GLOBAL_LIST_EMPTY(loadout_items)
+GLOBAL_LIST_EMPTY(loadout_whitelist_ids)
+
+/proc/load_loadout_config(loadout_config)
+	if(!loadout_config)
+		loadout_config = "config/loadout_config.txt"
+	LAZYINITLIST(GLOB.loadout_whitelist_ids)
+	var/list/file_lines = world.file2list(loadout_config)
+	for(var/line in file_lines)
+		if(!line || findtextEx(line,"#",1,2))
+			continue
+		var/list/lineinfo = splittext(line, "|")
+		var/lineID = lineinfo[1]
+		for(var/subline in lineinfo)
+			var/sublinetypedef = findtext(subline, "=")
+			if(sublinetypedef)
+				var/sublinetype = copytext(subline, 1, sublinetypedef)
+				var/list/sublinecontent = splittext(copytext(subline, sublinetypedef+1), ",")
+				if(sublinetype == "WHITELIST")
+					GLOB.loadout_whitelist_ids["[lineID]"] = sublinecontent
 
 /proc/initialize_global_loadout_items()
 	LAZYINITLIST(GLOB.loadout_items)
+	load_loadout_config()
 	for(var/item in subtypesof(/datum/gear))
 		var/datum/gear/I = new item
 		if(!GLOB.loadout_items[slot_to_string(I.category)])
 			LAZYINITLIST(GLOB.loadout_items[slot_to_string(I.category)])
 		LAZYSET(GLOB.loadout_items[slot_to_string(I.category)], I.name, I)
+		if(I.geargroupID in GLOB.loadout_whitelist_ids)
+			I.ckeywhitelist = GLOB.loadout_whitelist_ids["[I.geargroupID]"]
 
 
 /datum/gear
@@ -21,6 +43,7 @@ GLOBAL_LIST_EMPTY(loadout_items)
 	var/description
 	var/path //item-to-spawn path
 	var/cost = 1 //normally, each loadout costs a single point.
+	var/geargroupID //defines the ID that the gear inherits from the config
 	var/list/restricted_roles
 	var/list/ckeywhitelist
 


### PR DESCRIPTION
Title. See loadout_config.txt for a sample of how it works. Right now, the only thing supported is defining whitelist values via config, but the system is built for expansion.

This is primarily designed to make the planned rework of how donations are handled a lot easier to roll out.

:cl: deathride58
code: It's now possible to assign an ID to a gear entry to manipulate it via config options. Right now, you can only use this to modify the whitelist.
/:cl:
