### PR TITLE
Adds Particle Blasters to armories

### DIFF
--- a/_maps/cit_map_files/BoxStation/BoxStation.dmm
+++ b/_maps/cit_map_files/BoxStation/BoxStation.dmm
@@ -52947,6 +52947,8 @@
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/effect/turf_decal/bot_white,
+/obj/item/gun/energy/pumpaction/blaster,
+/obj/item/gun/energy/pumpaction/blaster,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ipA" = (

--- a/_maps/cit_map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/cit_map_files/Deltastation/DeltaStation2.dmm
@@ -47348,6 +47348,7 @@
 /obj/item/gun/energy/ionrifle,
 /obj/item/clothing/suit/armor/laserproof,
 /obj/item/gun/energy/temperature/security,
+/obj/item/gun/energy/pumpaction/blaster,
 /turf/open/floor/plasteel/vault{
 	dir = 8
 	},

--- a/_maps/cit_map_files/MetaStation/MetaStation.dmm
+++ b/_maps/cit_map_files/MetaStation/MetaStation.dmm
@@ -3218,6 +3218,8 @@
 /obj/item/storage/fancy/donut_box,
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/pumpaction/blaster,
+/obj/item/gun/energy/pumpaction/blaster,
 /turf/open/floor/plasteel/vault{
 	dir = 1
 	},

--- a/_maps/cit_map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/cit_map_files/OmegaStation/OmegaStation.dmm
@@ -6902,6 +6902,8 @@
 	},
 /obj/item/gun/energy/e_gun/dragnet,
 /obj/item/gun/energy/e_gun/dragnet,
+/obj/item/gun/energy/pumpaction/blaster,
+/obj/item/gun/energy/pumpaction/blaster,
 /turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},

--- a/_maps/cit_map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/cit_map_files/PubbyStation/PubbyStation.dmm
@@ -2937,6 +2937,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/item/gun/energy/pumpaction/blaster,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajh" = (


### PR DESCRIPTION
:cl: Toriate
add: Centcom has just approved a procurement order for new pump action particle blasters. Armories will be stocked with them.
/:cl:


This PR maps in pump action disablers because they are straight out adminspawn only right now. Two are placed where DRAGnets spawn, and if the map doesn't have them, one is placed on the ion rifle/temp gun/reflective vest rack.