### PR TITLE
Replaces random airlock wires with departmental airlock wires

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -99,7 +99,7 @@
 
 /obj/machinery/door/airlock/Initialize()
 	. = ..()
-	wires = new /datum/wires/airlock(src)
+	wires = new wiretypepath(src) //CIT CHANGE - makes it possible for airlocks to have different wire datums
 	if(frequency)
 		set_frequency(frequency)
 

--- a/modular_citadel/code/datums/wires/airlock.dm
+++ b/modular_citadel/code/datums/wires/airlock.dm
@@ -1,2 +1,40 @@
 /datum/wires/airlock
-	randomize = TRUE
+	proper_name = "Generic Airlock"
+	var/wiretype
+
+/datum/wires/airlock/command
+	proper_name = "Command Airlock"
+	wiretype = "commandairlock"
+
+/datum/wires/airlock/security
+	proper_name = "Security Airlock"
+	wiretype = "securityairlock"
+
+/datum/wires/airlock/engineering
+	proper_name = "Engineering Airlock"
+	wiretype = "engineeringairlock"
+
+/datum/wires/airlock/science
+	proper_name = "Science Airlock"
+	wiretype = "scienceairlock"
+
+/datum/wires/airlock/medical
+	proper_name = "Medical Airlock"
+	wiretype = "medicalairlock"
+
+/datum/wires/airlock/cargo
+	proper_name = "Cargo Airlock"
+	wiretype = "cargoairlock"
+
+/datum/wires/airlock/New(atom/holder)
+	. = ..()
+	if(randomize)
+		return
+	if(wiretype)
+		if(!GLOB.wire_color_directory[wiretype])
+			colors = list()
+			randomize()
+			GLOB.wire_color_directory[wiretype] = colors
+			GLOB.wire_name_directory[wiretype] = proper_name
+		else
+			colors = GLOB.wire_color_directory[wiretype]

--- a/modular_citadel/code/game/machinery/doors/airlock.dm
+++ b/modular_citadel/code/game/machinery/doors/airlock.dm
@@ -1,0 +1,2 @@
+/obj/machinery/door/airlock
+	var/wiretypepath = /datum/wires/airlock

--- a/modular_citadel/code/game/machinery/doors/airlock_types.dm
+++ b/modular_citadel/code/game/machinery/doors/airlock_types.dm
@@ -1,0 +1,29 @@
+/obj/machinery/door/airlock/command
+	wiretypepath = /datum/wires/airlock/command
+
+/obj/machinery/door/airlock/security
+	wiretypepath = /datum/wires/airlock/security
+
+/obj/machinery/door/airlock/engineering
+	wiretypepath = /datum/wires/airlock/engineering
+
+/obj/machinery/door/airlock/medical
+	wiretypepath = /datum/wires/airlock/medical
+
+/obj/machinery/door/airlock/mining
+	wiretypepath = /datum/wires/airlock/cargo
+
+/obj/machinery/door/airlock/atmos
+	wiretypepath = /datum/wires/airlock/engineering
+
+/obj/machinery/door/airlock/research
+	wiretypepath = /datum/wires/airlock/science
+
+/obj/machinery/door/airlock/science
+	wiretypepath = /datum/wires/airlock/science
+
+/obj/machinery/door/airlock/virology
+	wiretypepath = /datum/wires/airlock/medical
+
+/obj/machinery/door/airlock/vault
+	wiretypepath = /datum/wires/airlock/secure

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2670,6 +2670,8 @@
 #include "modular_citadel\code\game\machinery\vending.dm"
 #include "modular_citadel\code\game\machinery\wishgranter.dm"
 #include "modular_citadel\code\game\machinery\computer\card.dm"
+#include "modular_citadel\code\game\machinery\doors\airlock.dm"
+#include "modular_citadel\code\game\machinery\doors\airlock_types.dm"
 #include "modular_citadel\code\game\objects\ids.dm"
 #include "modular_citadel\code\game\objects\items.dm"
 #include "modular_citadel\code\game\objects\tools.dm"


### PR DESCRIPTION
Title. This idea is much more well-received than the current system of making airlock wires 100% random.

:cl: deathride58
tweak: Airlocks are no longer 100% random. Instead, their wires are randomized depending on their department.
/:cl:
