### PR TITLE
Rebalances pump-action energy shotguns

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -143,7 +143,7 @@
 /obj/item/ammo_casing/energy/laser/scatter/disabler/pump
 	projectile_type = /obj/item/projectile/beam/disabler/weak
 	e_cost = 150
-	pellets = 5
+	pellets = 4
 	variance = 30
 	fire_sound = 'modular_citadel/sound/weapons/ParticleBlaster.ogg'
 	select_name  = "disable"
@@ -151,7 +151,7 @@
 /obj/item/ammo_casing/energy/disabler/slug
 	projectile_type = /obj/item/projectile/beam/disabler/slug
 	select_name  = "overdrive"
-	e_cost = 200
+	e_cost = 250
 	fire_sound = 'modular_citadel/sound/weapons/LaserSlugv3.ogg'
 
 /obj/item/ammo_casing/energy/laser/pump
@@ -174,13 +174,13 @@
 
 /obj/item/projectile/beam/disabler/weak
 	name = "particle blast"
-	damage = 18
+	damage = 13
 	icon_state = "disablerpellet"
 	icon = 'modular_citadel/icons/obj/projectiles.dmi'
 
 /obj/item/projectile/beam/disabler/slug
 	name = "positron blast"
-	damage = 60
+	damage = 80
 	range = 14
 	speed = 0.6
 	icon_state = "disablerslug"

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -151,7 +151,7 @@
 /obj/item/ammo_casing/energy/disabler/slug
 	projectile_type = /obj/item/projectile/beam/disabler/slug
 	select_name  = "overdrive"
-	e_cost = 250
+	e_cost = 210
 	fire_sound = 'modular_citadel/sound/weapons/LaserSlugv3.ogg'
 
 /obj/item/ammo_casing/energy/laser/pump

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -151,7 +151,7 @@
 /obj/item/ammo_casing/energy/disabler/slug
 	projectile_type = /obj/item/projectile/beam/disabler/slug
 	select_name  = "overdrive"
-	e_cost = 210
+	e_cost = 200
 	fire_sound = 'modular_citadel/sound/weapons/LaserSlugv3.ogg'
 
 /obj/item/ammo_casing/energy/laser/pump


### PR DESCRIPTION
I was wondering why sec officers were screeching autistically at the warden every round for disabler shotguns. Turns out disabler shotguns are broken

:cl: deathride58
balance: The disabler shotgun's spread mode has been nerfed from firing 5 pellets at 18 staminaloss each, to only firing 4 pellets at 13 staminaloss each. That brings the total staminaloss from a pointblank disabler shotgun blast from 90 to 52.
balance: The disabler shotgun's slug mode has been buffed heavily from only dealing 60 staminaloss to dealing a whopping 80 staminaloss.
/:cl:
