### PR TITLE
Adds custom say verbs, makes yelling echo and penetrate walls, makes distant voices have small text

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -241,9 +241,18 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		eavesdrop_range = EAVESDROP_EXTRA_RANGE
 	var/list/listening = get_hearers_in_view(message_range+eavesdrop_range, source)
 	var/list/the_dead = list()
+
+	var/list/yellareas	//CIT CHANGE - adds the ability for yelling to penetrate walls and echo throughout areas
+	if(say_test(message) == "2")	//CIT CHANGE - ditto
+		yellareas = get_areas_in_range(message_range*0.5,src)	//CIT CHANGE - ditto
+
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(M.stat != DEAD) //not dead, not important
+			if(yellareas)	//CIT CHANGE - see above. makes yelling penetrate walls
+				var/area/A = get_area(M)	//CIT CHANGE - ditto
+				if(istype(A) && A in yellareas)	//CIT CHANGE - ditto
+				listening |= M	//CIT CHANGE - ditto
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(M.stat != DEAD) //not dead, not important
-			if(yellareas.len)	//CIT CHANGE - see above. makes yelling penetrate walls
+			if(yellareas)	//CIT CHANGE - see above. makes yelling penetrate walls
 				var/area/A = get_area(M)	//CIT CHANGE - ditto
 				if(istype(A) && A in yellareas)	//CIT CHANGE - ditto
 					listening |= M	//CIT CHANGE - ditto

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	for(var/_M in GLOB.player_list)
 		var/mob/M = _M
 		if(M.stat != DEAD) //not dead, not important
-			if(yellareas)	//CIT CHANGE - see above. makes yelling penetrate walls
+			if(yellareas.len)	//CIT CHANGE - see above. makes yelling penetrate walls
 				var/area/A = get_area(M)	//CIT CHANGE - ditto
 				if(istype(A) && A in yellareas)	//CIT CHANGE - ditto
 				listening |= M	//CIT CHANGE - ditto

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -252,7 +252,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			if(yellareas.len)	//CIT CHANGE - see above. makes yelling penetrate walls
 				var/area/A = get_area(M)	//CIT CHANGE - ditto
 				if(istype(A) && A in yellareas)	//CIT CHANGE - ditto
-				listening |= M	//CIT CHANGE - ditto
+					listening |= M	//CIT CHANGE - ditto
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice
 			continue

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -251,7 +251,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		if(M.stat != DEAD) //not dead, not important
 			if(yellareas)	//CIT CHANGE - see above. makes yelling penetrate walls
 				var/area/A = get_area(M)	//CIT CHANGE - ditto
-				if(istype(A) && A in yellareas)	//CIT CHANGE - ditto
+				if(istype(A) && A.ambientsounds != SPACE && A in yellareas)	//CIT CHANGE - ditto
 					listening |= M	//CIT CHANGE - ditto
 			continue
 		if(!M.client || !client) //client is so that ghosts don't have to listen to mice

--- a/modular_citadel/code/modules/mob/mob.dm
+++ b/modular_citadel/code/modules/mob/mob.dm
@@ -15,5 +15,8 @@
 
 /mob/living/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode, face_name = FALSE)
 	. = ..()
-	if(istype(speaker, /mob/living) && !(speaker in get_hear(5, src)))
-		. = "<citspan class='small'>[.]</citspan>" //Don't ask how the fuck this works. It just does.
+	if(istype(speaker, /mob/living))
+		var/turf/speakturf = get_turf(speaker)
+		var/turf/sourceturf = get_turf(src)
+		if(istype(speakturf) && istype(sourceturf) && !(speakturf in get_hear(5, sourceturf)))
+			. = "<citspan class='small'>[.]</citspan>" //Don't ask how the fuck this works. It just does.

--- a/modular_citadel/code/modules/mob/mob.dm
+++ b/modular_citadel/code/modules/mob/mob.dm
@@ -1,2 +1,19 @@
 /mob/proc/use_that_empty_hand() //currently unused proc so i can implement 2-handing any item a lot easier in the future.
 	return
+
+/mob/say_mod(input, message_mode)
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		return lowertext(copytext(input, 1, customsayverb))
+	. = ..()
+
+/atom/movable/proc/attach_spans(input, list/spans)
+	var/customsayverb = findtext(input, "*")
+	if(customsayverb)
+		input = capitalize(copytext(input, customsayverb+1))
+	return "[message_spans_start(spans)][input]</span>"
+
+/mob/living/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode, face_name = FALSE)
+	. = ..()
+	if(istype(speaker, /mob/living) && !(speaker in get_hear(5, src)))
+		. = "<citspan class='small'>[.]</citspan>" //Don't ask how the fuck this works. It just does.


### PR DESCRIPTION
Title.

Custom say verbs can be used via the `say verb*message` format. Inspiration for this feature comes from Lifeweb.
`say verb*message` will result in `Urist McTestman say verb, "Message"`
`desperately moans*Harder!` will result in `Lewdster Lewdus desperately moans, "Harder!"`

This also adds the ability for yells to penetrate walls, and echo throughout areas. Any spoken message with an exclamation point at the end of it will be heard by everybody in the area, and will also penetrate nearby walls, echoing throughout any area it reaches. This makes it plausible to cry out for help if you got your headset stolen, as your voice will end up echoing throughout maint.

This also makes distant voices have smaller text.

:cl: deathride58
add: You can now make use of custom say verbs with the [say verb*message] format
add: Yelling will now echo and penetrate walls
tweak: Distant voices now have smaller text
/:cl:
