### PR TITLE
Allows anyone to reboot on OOM situations

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -165,6 +165,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	return var_name != NAMEOF(src, holder) && ..()
 
 /client/New(TopicData)
+	world.SetConfig("APP/admin", ckey, "role=admin")			//CITADEL EDIT - Allows admins to reboot in OOM situations
 	var/tdata = TopicData //save this for later use
 	chatOutput = new /datum/chatOutput(src)
 	TopicData = null							//Prevent calls to client.Topic from connect
@@ -179,10 +180,15 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 	var/connecting_admin = FALSE //because de-admined admins connecting should be treated like admins.
 	//Admin Authorisation
 	holder = GLOB.admin_datums[ckey]
+	var/debug_tools_allowed = FALSE			//CITADEL EDIT
 	if(holder)
 		GLOB.admins |= src
 		holder.owner = src
 		connecting_admin = TRUE
+		//CITADEL EDIT
+		if(check_rights_for(src, R_DEBUG))
+			debug_tools_allowed = TRUE
+		//END CITADEL EDIT
 	else if(GLOB.deadmins[ckey])
 		verbs += /client/proc/readmin
 		connecting_admin = TRUE
@@ -197,6 +203,12 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 				to_chat(world, "Autoadmin rank not found")
 			else
 				new /datum/admins(autorank, ckey)
+	//CITADEL EDIT
+	if(check_rights_for(src, R_DEBUG))	//check if autoadmin gave us it
+		debug_tools_allowed = TRUE
+	if(!debug_tools_allowed)
+		world.SetConfig("APP/admin", ckey, null)
+	//END CITADEL EDIT
 	if(CONFIG_GET(flag/enable_localhost_rank) && !connecting_admin)
 		var/localhost_addresses = list("127.0.0.1", "::1")
 		if(isnull(address) || (address in localhost_addresses))


### PR DESCRIPTION
the idea is that GLOB would be gone in an OOM situation so the code that takes away the debug access from nonadmins (admins would be treated as nonadmins when there's no GLOB due to admin datums being stored and referenced there) wouldn't even run as it would runtime from GLOB not existing.
the idea also is that no one would be able to hit the reboot button without actually being an admin, or the server being OOM'd as this runs fast enough in theory so that no one can hit it before the auth checks either complete or runtime due to OOM.