### PR TITLE
[!EXPERIMENTAL!] [NON-MODULAR] Makes atmos process 2.5x faster, and makes it a lot more violent

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -10,7 +10,7 @@ SUBSYSTEM_DEF(air)
 	name = "Atmospherics"
 	init_order = INIT_ORDER_AIR
 	priority = FIRE_PRIORITY_AIR
-	wait = 5
+	wait = 2
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -253,7 +253,7 @@
 	if (pressure_resistance > 0)
 		move_prob = (pressure_difference/pressure_resistance*PROBABILITY_BASE_PRECENT)-PROBABILITY_OFFSET
 	move_prob += pressure_resistance_prob_delta
-	if(pressure_difference >= throw_pressure_limit && move_prob > PROBABILITY_OFFSET && prob(move_prob))
+	if(pressure_difference >= throw_pressure_limit && move_prob > PROBABILITY_OFFSET && prob(move_prob/throw_pressure_limit))
 		to_chat(src, "<span class='warning'>You feel a sudden push from the air around you.</span>")
 		if(iscarbon(src))
 			var/mob/living/carbon/C = src

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -253,7 +253,7 @@
 	if (pressure_resistance > 0)
 		move_prob = (pressure_difference/pressure_resistance*PROBABILITY_BASE_PRECENT)-PROBABILITY_OFFSET
 	move_prob += pressure_resistance_prob_delta
-	if(pressure_difference >= throw_pressure_limit && move_prob > PROBABILITY_OFFSET && prob(move_prob/throw_pressure_limit))
+	if(!is_mining_level(z) && pressure_difference >= throw_pressure_limit && move_prob > PROBABILITY_OFFSET && prob(move_prob/throw_pressure_limit))
 		to_chat(src, "<span class='warning'>You feel a sudden push from the air around you.</span>")
 		if(iscarbon(src))
 			var/mob/living/carbon/C = src

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -257,9 +257,9 @@
 		to_chat(src, "<span class='warning'>You feel a sudden push from the air around you.</span>")
 		if(iscarbon(src))
 			var/mob/living/carbon/C = src
-			C.Knockdown(20)
+			C.Knockdown(5)
 		throw_at(get_edge_target_turf(src, direction), pressure_difference / 10, pressure_difference / 200, null, FALSE)
-	else if (move_prob > 10 && prob(move_prob))
+	else if (move_prob > 20 && prob(move_prob))
 		step(src, direction)
 		last_high_pressure_movement_air_cycle = SSair.times_fired
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -240,8 +240,9 @@
 
 /turf/closed/proc/high_pressure_movements()
 	return
-	
-/atom/movable/var/pressure_resistance = 10
+
+/atom/movable/var/pressure_resistance = 5
+/atom/movable/var/throw_pressure_limit = 15
 /atom/movable/var/last_high_pressure_movement_air_cycle = 0
 
 /atom/movable/proc/experience_pressure_difference(pressure_difference, direction, pressure_resistance_prob_delta = 0)
@@ -252,7 +253,13 @@
 	if (pressure_resistance > 0)
 		move_prob = (pressure_difference/pressure_resistance*PROBABILITY_BASE_PRECENT)-PROBABILITY_OFFSET
 	move_prob += pressure_resistance_prob_delta
-	if (move_prob > PROBABILITY_OFFSET && prob(move_prob))
+	if(pressure_difference >= throw_pressure_limit && move_prob > PROBABILITY_OFFSET && prob(move_prob))
+		to_chat(src, "<span class='warning'>You feel a sudden push from the air around you.</span>")
+		if(iscarbon(src))
+			var/mob/living/carbon/C = src
+			C.Knockdown(20)
+		throw_at(get_edge_target_turf(src, direction), pressure_difference / 10, pressure_difference / 200, null, FALSE)
+	else if (move_prob > 10 && prob(move_prob))
 		step(src, direction)
 		last_high_pressure_movement_air_cycle = SSair.times_fired
 

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon
 	gender = MALE
-	pressure_resistance = 15
+	pressure_resistance = 8
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD,GLAND_HUD)
 	has_limbs = 1

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -1,6 +1,6 @@
 /mob/living/carbon
 	gender = MALE
-	pressure_resistance = 8
+	pressure_resistance = 10
 	possible_a_intents = list(INTENT_HELP, INTENT_HARM)
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ANTAG_HUD,GLAND_HUD)
 	has_limbs = 1

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD,GLAND_HUD,SENTIENT_DISEASE_HUD)
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
-	pressure_resistance = 8
+	pressure_resistance = 15
 	can_buckle = TRUE
 	buckle_lying = FALSE
 	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -2,6 +2,7 @@
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD,GLAND_HUD,SENTIENT_DISEASE_HUD)
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
 	pressure_resistance = 15
+	throw_pressure_limit = 20
 	can_buckle = TRUE
 	buckle_lying = FALSE
 	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -1,7 +1,7 @@
 /mob/living/carbon/human
 	hud_possible = list(HEALTH_HUD,STATUS_HUD,ID_HUD,WANTED_HUD,IMPLOYAL_HUD,IMPCHEM_HUD,IMPTRACK_HUD,ANTAG_HUD,GLAND_HUD,SENTIENT_DISEASE_HUD)
 	possible_a_intents = list(INTENT_HELP, INTENT_DISARM, INTENT_GRAB, INTENT_HARM)
-	pressure_resistance = 25
+	pressure_resistance = 8
 	can_buckle = TRUE
 	buckle_lying = FALSE
 	mob_biotypes = list(MOB_ORGANIC, MOB_HUMANOID)


### PR DESCRIPTION
Title. This change isn't modular yet. It's purely experimental. For testmerge only right now, to collect feedback and make sure the server won't explode from it.

:cl: deathride58
add: Atmos now has the ability to throw people and objects around (ported from para)
tweak: Humans now have a pressure resistance of 8, reduced from the original value of 25.
tweak: Atmos now processes once every 2 ticks instead of once per 5 ticks.
tweak: The minimum amount of pressure for objects to move as a result of atmos has been reduced. The original threshold is now used to determine if an object can be thrown.
/:cl:
