### PR TITLE
Tones down particle defender stamina damage

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -193,6 +193,7 @@
 	color = null
 	nodamage = 1
 	knockdown = 100
+	stamina = 5
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'


### PR DESCRIPTION
Title. Point-blank particle defender shots were almost a 1-click stamcrit prior to this nerf. Sec's overrelying on the poor thing because of it.

:cl: deathride58
balance: The warden's particle defender now deals less staminaloss when in stun mode.
/:cl:
