### PR TITLE
Metastation Cleanup

### DIFF
--- a/_maps/cit_map_files/MetaStation/MetaStation.dmm
+++ b/_maps/cit_map_files/MetaStation/MetaStation.dmm
@@ -24357,7 +24357,6 @@
 /area/quartermaster/office)
 "bax" = (
 /obj/structure/table/reinforced,
-/obj/machinery/computer/stockexchange,
 /turf/open/floor/plasteel/brown{
 	dir = 5
 	},
@@ -29047,7 +29046,6 @@
 /area/quartermaster/sorting)
 "bkn" = (
 /obj/structure/table,
-/obj/machinery/computer/stockexchange,
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -26


### PR DESCRIPTION
Making it so that MetaStation doesn't have null objects (the Stock
Exchange computer previously located at
/obj/machinery/computer/stockexchange) and is usuable/editable with FastDMM.