### PR TITLE
Allows players to commit seppuku with any katana, adds SFX for seppuku

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -348,6 +348,11 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced")
 	hitsound = 'sound/weapons/bladeslice.ogg'
 
+/obj/item/toy/katana/suicide_act(mob/living/carbon/user)
+	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku!</span>")
+	playsound(src, 'sound/weapons/bladeslice.ogg', 50, 1)
+	return(BRUTELOSS)
+
 /*
  * Snap pops
  */

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -223,6 +223,7 @@
 
 /obj/item/katana/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit seppuku!</span>")
+	playsound(src, 'sound/weapons/bladeslice.ogg', 50, 1)
 	return(BRUTELOSS)
 
 /obj/item/wirerod

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -32,6 +32,11 @@
 	dash_toggled = !dash_toggled
 	to_chat(user, "<span class='notice'>You [dash_toggled ? "enable" : "disable"] the dash function on [src].</span>")
 
+/obj/item/energy_katana/suicide_act(mob/living/carbon/user)
+	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] stomach open with [src]! It looks like [user.p_theyre()] trying to commit cyber-seppuku!</span>")
+	playsound(src, 'sound/weapons/blade1.ogg', 50, 1)
+	return(BRUTELOSS)
+
 /obj/item/energy_katana/afterattack(atom/target, mob/user, proximity_flag, click_parameters)
 	if(dash_toggled)
 		jaunt.Teleport(user, target)


### PR DESCRIPTION
Title says it all; special messages for commiting suicide with replica katanas/energy katanas

[Changelogs]: # (Your PR should contain a detailed changelog of notable changes, titled and categorized appropriately. This includes, new features, sprites, sounds, balance changes, admin tools, map edits, removals, big refactors, config changes, hosting changes and important fixes. An example changelog has been provided below for you to edit. If you need additional help, read https://github.com/tgstation/tgstation/wiki/Changelogs)

:cl:
add: SFX for seppuku (on all katanas)
add: suicide message for energy katanas ("cyber-seppuku")
add: suicide message for replica katanas ("seppuku")
/:cl:

[why]: In a game like SS13, where the unofficial motto is "the developers thought of everything", I found it annoying that you don't get a special suicide message if you have a replica katana or an energy katana.  It just seems like such an obvious interaction, I figured it would already be in the game by now.  However, the interaction only exists with the base katana, not the toy or energy version.  This PR fixes that.

This change does not affect gameplay at all, just flavor text.
