### PR TITLE
Adds table slamming as a right click interaction for tables

### DIFF
--- a/modular_citadel/code/game/objects/structures/tables_racks.dm
+++ b/modular_citadel/code/game/objects/structures/tables_racks.dm
@@ -1,5 +1,5 @@
 /obj/structure/table/alt_attack_hand(mob/user)
-	if(user && adjacent(user) && !incapacitated(user))
+	if(user && Adjacent(user) && !user.incapacitated())
 		if(istype(user) && user.a_intent == INTENT_HARM)
 			user.visible_message("<span class='warning'>[user] slams [p_their()] palms down on [src].</span>", "<span class='warning'>You slam your palms down on [src].</span>")
 			playsound(src, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)

--- a/modular_citadel/code/game/objects/structures/tables_racks.dm
+++ b/modular_citadel/code/game/objects/structures/tables_racks.dm
@@ -1,0 +1,10 @@
+/obj/structure/table/alt_attack_hand(mob/user)
+	if(user && adjacent(user) && !incapacitated(user))
+		if(istype(user) && user.a_intent == INTENT_HARM)
+			user.visible_message("<span class='warning'>[user] slams [p_their()] palms down on [src].</span>", "<span class='warning'>You slam your palms down on [src].</span>")
+			playsound(src, 'sound/weapons/sonic_jackhammer.ogg', 50, 1)
+		else
+			user.visible_message("<span class='notice'>[user] slaps [p_their()] hands on [src].</span>", "<span class='notice'>You slap your hands on [src].</span>")
+			playsound(src, 'sound/weapons/tap.ogg', 50, 1)
+		user.do_attack_animation(src)
+		return TRUE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2726,6 +2726,7 @@
 #include "modular_citadel\code\game\objects\items\melee\eutactic_blades.dm"
 #include "modular_citadel\code\game\objects\items\melee\transforming.dm"
 #include "modular_citadel\code\game\objects\items\storage\firstaid.dm"
+#include "modular_citadel\code\game\objects\structures\tables_racks.dm"
 #include "modular_citadel\code\game\objects\structures\beds_chairs\chair.dm"
 #include "modular_citadel\code\game\objects\structures\beds_chairs\sofa.dm"
 #include "modular_citadel\code\game\objects\structures\crates_lockers\closets\fitness.dm"


### PR DESCRIPTION
Title. Inspired by table slamming from 5th port, but not an exact port of it.
Being on harm intent will slam your palms hard down on the table, while any other intent will just slap your hands on the table.

:cl: deathride58
add: You can now slam or slap your hands onto tables by right clicking them in combat mode.
/:cl:
