### PR TITLE
Corrects climax cooldown delay message, makes relieve message pronoun…

### DIFF
--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -171,7 +171,7 @@
 				src.visible_message("<span class='danger'>[src] starts masturbating!</span>", \
 								"<span class='userdanger'>You start masturbating.</span>")
 				if(do_after(src, 30, target = src))
-					src.visible_message("<span class='danger'>[src] relieves themself!</span>", \
+					src.visible_message("<span class='danger'>[src] relieves [p_them()]self!</span>", \
 								"<span class='userdanger'>You have relieved yourself.</span>")
 					setArousalLoss(min_arousal)
 					/*
@@ -390,7 +390,7 @@
 /mob/living/carbon/human/mob_climax(forced_climax=FALSE) //Forced is instead of the other proc, makes you cum if you have the tools for it, ignoring restraints
 	if(mb_cd_timer > world.time)
 		if(!forced_climax) //Don't spam the message to the victim if forced to come too fast
-			to_chat(src, "<span class='warning'>You need to wait [round((mb_cd_timer - world.time)/(20))] seconds before you can do that again!</span>")
+			to_chat(src, "<span class='warning'>You need to wait [DisplayTimeText((mb_cd_timer - world.time), TRUE)] before you can do that again!</span>")
 		return
 	mb_cd_timer = (world.time + mb_cd_length)
 


### PR DESCRIPTION
…sensitive

The cooldown message was dividing the delay by 20ds, meaning it was would tell the user to wait 4 seconds instead of the proper 8 seconds. Also switched it to use DisplayTimeText() so it will no longer say `you must wait 1 seconds`