### PR TITLE
Prevents the vast majority of IC in LOOC cases

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -39,6 +39,12 @@
 			to_chat(src, "<B>Advertising other servers is not allowed.</B>")
 			log_admin("[key_name(src)] has attempted to advertise in LOOC: [msg]")
 			return
+		if(mob.stat)
+			to_chat(src, "<span class='danger'>You cannot salt in LOOC while unconscious or dead.</span>")
+			return
+		if(istype(mob, /mob/dead))
+			to_chat(src, "<span class='danger'>You cannot use LOOC while ghosting.</span>")
+			return
 
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
 	mob.log_message("(LOCAL): [msg]", INDIVIDUAL_OOC_LOG)


### PR DESCRIPTION
Title. This PR will *only* be affecting those who break the "no IC in OOC" rule via LOOC.

:cl: deathride58
tweak: Non-admins can no longer use LOOC while dead, unconscious, in crit, or while ghosting.
/:cl:
