### PR TITLE
Adds more to the Autodrobe coin slot!

### DIFF
--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -119,7 +119,15 @@
 		           /obj/item/clothing/under/roman = 1,
 		           /obj/item/clothing/shoes/roman = 1,
 		           /obj/item/shield/riot/roman/fake = 1,
-		           /obj/item/skub = 1)
+		           /obj/item/skub = 1,
+		           /obj/item/clothing/under/lobster = 1,	 // CIT CHANGES	           
+		           /obj/item/clothing/head/lobsterhat = 1,
+		           /obj/item/clothing/head/drfreezehat = 1,
+		           /obj/item/clothing/suit/dracula = 1,
+		           /obj/item/clothing/suit/drfreeze_coat = 1,
+		           /obj/item/clothing/suit/gothcoat = 2,
+		           /obj/item/clothing/under/draculass = 1,
+                   /obj/item/clothing/under/drfreeze = 1)    //End of Cit Changes
 	refill_canister = /obj/item/vending_refill/autodrobe
 
 /obj/item/vending_refill/autodrobe


### PR DESCRIPTION
Adds in more clothing for gimmicks or to look fancy! None of those outfits have any armor or usefulness other then to look good or cover your face if its a mask similar to the chicken hat. All items need a coin to get to keep it balanced! 

[Changelogs]: # Adds in more clothing for gimmicks or to look fancy! None of those outfits have any armor or usefulness other then to look good or cover your face if its a mask similar to the chicken 
adds in
dracula coat
doctor freeze's labcoat
gothic coat
draculass coat
doctor freeze's jumpsuit
doctor freeze's wig
foam lobster suit

[why]: # These outfits look nice and have no real in-game affect for Power-gamers, Whats the point in having them if there going to be unused! 
