### PR TITLE
Reduces the default space ruin z-level count to 1

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -18,7 +18,7 @@
 	var/map_file = "BoxStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 7
+	var/space_ruin_levels = 1 //Citadel edit - reduces the default space ruin z-level count to 1
 	var/space_empty_levels = 1
 
 	var/minetype = "lavaland"


### PR DESCRIPTION
The original value was 7 z-levels reserved for specifically for space ruin generation. This should let us have a lot more memory for things like [SECRET SIDE PROJECT] and my idea to add a jungle mining area. This will also mean the space ruin z-level will be a little more heavily populated, since the ruins will all be present on only one single z-level instead of 7 separate z-levels. Space is something that is rarely, *rarely* ever explored, so this PR won't be affecting a lot of players.

:cl: deathride58
tweak: The default amount of z-levels reserved specifically for space ruin generation has been reduced from 7 to 1
/:cl:
