### PR TITLE
Fixes items spawning on top of rather than inside closets

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -36,11 +36,11 @@
 
 
 /obj/structure/closet/Initialize(mapload)
-	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
-		addtimer(CALLBACK(src, .proc/take_contents), 0)
 	. = ..()
 	update_icon()
 	PopulateContents()
+	if(mapload && !opened)
+		take_contents()
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()
@@ -167,6 +167,8 @@
 			var/obj/item/I = AM
 			if (I.item_flags & NODROP)
 				return
+		else if(istype(AM, /obj/effect))
+			return
 		else if(!allow_objects && !istype(AM, /obj/effect/dummy/chameleon))
 			return
 		if(!allow_dense && AM.density)


### PR DESCRIPTION
Why the fuck. Why the ***FUCK*** do closets use timers to store items? Seriously, why in the actual flying ***fuck***

:cl: deathride58
fix: Items now spawn on top of, rather than inside, closets and other storage structures
/:cl:
