### PR TITLE
flightsuit speed rebalancing

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1234,13 +1234,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			. -= 2
 		else if(istype(T) && T.allow_thrust(0.01, H))
 			. -= 2
-		else if(flightpack && F.allow_thrust(0.01, src))
-			. -= 2
 
 	if(flightpack && F.boost)
 		. -= F.boost_speed
 	else if(flightpack && F.brake)
-		. += 2
+		. += 1
 
 	if(!ignoreslow && !flightpack && gravity)
 		if(H.wear_suit)


### PR DESCRIPTION
:cl:
experimental: flightsuit no longer gives innate jetpack speed in nograv. it already has its own movement processing.
experimenta: flightsuit braking mode is no longer as crappy and might actually be useful now
/:cl:
hopefully cuts down on the unlimited space saxxing.