### PR TITLE
Makes Revs have a min pop needed

### DIFF
--- a/modular_citadel/code/game/gamemodes/revolution/revolution.dm
+++ b/modular_citadel/code/game/gamemodes/revolution/revolution.dm
@@ -1,2 +1,5 @@
 /datum/game_mode/revolution
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer", "Quartermaster")
+	false_report_weight = 10
+	required_players = 20
+	required_enemies = 1


### PR DESCRIPTION
Needs 20 players min to make sure there is a Head and at lest one sec officer more then likely

[Changelogs]: # Changes Rev game mode to have a min requirement of players to be played

[why]: # You can have min pop and have one head or none! Why have a low pop round end befor anyone even moves is byond me...