### PR TITLE
Nerfs gas tank ruptures by reducing the pressure from ^4 to ^3

### DIFF
--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -242,7 +242,6 @@
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react(src)
 		air_contents.react(src)
-		air_contents.react(src)
 		pressure = air_contents.return_pressure()
 		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
 		var/turf/epicenter = get_turf(loc)


### PR DESCRIPTION
If I did my math right, this should nerf bombs that reach the bare minimum to achieve the max cap from 20dev to ~9.6dev. Tritium bombs are still going to have absolutely insane size scaling, but they won't produce as much points. Let's separate the actual toxins nerds from the people who are just following guides blindly, the toxins nerds are going to adapt and make even bigger bombs to 100% rnd, while the folks that're following guides blindly are going to fall behind, at which point I can remove another layer of exponent from the bomb tank rupture until bomb tank ruptures are linear rather than exponential

:cl: deathride58
balance: Reduced the exponent on gas tank ruptures. TTVs and suicide onetanks that were previously 20dev are now approximately 9.6dev. Let's see the actual toxins nerds adapt!
/:cl:
