### PR TITLE
It's a feature now - makes it plausible to use custom say verbs in place of emotes (allows proper non-buggy emotes over radio)

### DIFF
--- a/code/game/say.dm
+++ b/code/game/say.dm
@@ -95,7 +95,7 @@ GLOBAL_LIST_INIT(freqtospan, list(
 		spans |= SPAN_YELL
 
 	var/spanned = attach_spans(input, spans)
-	return "[say_mod(input, message_mode)], \"[spanned]\""
+	return "[say_mod(input, message_mode)][spanned ? ", \"[spanned]\"" : ""]"
 
 /atom/movable/proc/lang_treat(atom/movable/speaker, datum/language/language, raw_message, list/spans, message_mode)
 	if(has_language(language))

--- a/modular_citadel/code/modules/mob/mob.dm
+++ b/modular_citadel/code/modules/mob/mob.dm
@@ -11,7 +11,10 @@
 	var/customsayverb = findtext(input, "*")
 	if(customsayverb)
 		input = capitalize(copytext(input, customsayverb+1))
-	return "[message_spans_start(spans)][input]</span>"
+	if(input)
+		return "[message_spans_start(spans)][input]</span>"
+	else
+		return
 
 /mob/living/compose_message(atom/movable/speaker, datum/language/message_language, raw_message, radio_freq, list/spans, message_mode, face_name = FALSE)
 	. = ..()


### PR DESCRIPTION
Title. It's a feature now.

:cl: deathride58
tweak: When a custom say verb message is spoken without any actual words, the text will render without a `, ""` at the end of it.
/:cl:
