### PR TITLE
Small combat tweaks - Removes combat rework training wheels, nerfs boxing gloves

### DIFF
--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -34,8 +34,8 @@
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
 	add_logs(A, D, "punched (boxing) ")
-	if(D.getStaminaLoss() > 50)
-		var/knockout_prob = D.getStaminaLoss() + rand(-15,15)
+	if(D.getStaminaLoss() > 100)
+		var/knockout_prob = (D.getStaminaLoss() + rand(-15,15))*0.75
 		if((D.stat != DEAD) && prob(knockout_prob))
 			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \
 								"<span class='userdanger'>[A] has knocked [D] out with a haymaker!</span>")

--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -3,7 +3,7 @@
 		new_owner.resting = TRUE
 		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
 		if(isnull(override_duration) && (set_duration > 80))
-			set_duration = set_duration*0.15
+			set_duration = set_duration*0.01
 			return ..()
 		else if(!isnull(override_duration))
 			set_duration = override_duration


### PR DESCRIPTION
Title. Removing the training wheels from the combat rework is something that's been long overdue. This PR removes the stun entirely from knockdowns, meaning that stunlocks are simply no longer possible with stunbatons and tasers. This comes with an indirect buff in the form of stunbatons and tasers always dealing their full staminaloss, as the bug where stunbatons and tasers don't deal their full stamloss if someone's already knocked down is simply impossible to observe in normal gameplay now.

This also slaps a hard nerf to myself in the form of boxing gloves getting their minimum stamloss required to throw a knockout punch increased from 50 stamloss to 100 stamloss. This means it takes twice the amount of clicks to knock someone out by harm intent spamclicking with boxing gloves.

:cl: deathride58
balance: The combat rework's training wheels have been removed. Knockdowns no longer have any noticeable stun. This indirectly means stunbatons and tasers will always deal their full stamloss on hit.
balance: The stamloss required for boxing gloves to throw a knockout punch has been increased from 50 to 100.
/:cl: