### PR TITLE
changes to pubby secpod/bridge

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -202,6 +202,3 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 
 #Jukebox audio files
 /config/jukebox_music/**/*
-*.dmm
-_maps/nanostation.dm
-_maps/nanotstation.json

--- a/.gitignore
+++ b/.gitignore
@@ -202,3 +202,6 @@ tools/MapAtmosFixer/MapAtmosFixer/bin/*
 
 #Jukebox audio files
 /config/jukebox_music/**/*
+*.dmm
+_maps/nanostation.dm
+_maps/nanotstation.json

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -48539,6 +48539,15 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"gDR" = (
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Escape";
+	dir = 4
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "gDZ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -53279,6 +53288,10 @@
 /obj/structure/chair{
 	dir = 8;
 	name = "Defense"
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Starboard";
+	dir = 8
 	},
 /turf/open/floor/plasteel/purple/side{
 	icon_state = "purplecorner"
@@ -86824,7 +86837,7 @@ aBI
 bmB
 vKq
 nTr
-nTr
+gDR
 vzA
 bvu
 hIZ

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -47836,7 +47836,7 @@
 	dir = 1
 	},
 /turf/open/floor/plasteel/neutral,
-/area/maintenance/department/security/brig)
+/area/hallway/secondary/exit/departure_lounge)
 "eCw" = (
 /obj/structure/cable{
 	icon_state = "1-2"

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -16023,21 +16023,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"aQA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aQB" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -26307,23 +26298,22 @@
 "brl" = (
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
-/obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
+/obj/structure/table,
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
 /area/medical/chemistry)
 "brm" = (
 /obj/machinery/chem_master,
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Shutters Control";
-	pixel_x = 26;
-	pixel_y = 4;
-	req_access_txt = "5; 33"
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = 32;
+	receive_ore_updates = 1
 	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 5
@@ -26900,7 +26890,7 @@
 /area/medical/chemistry)
 "bsL" = (
 /obj/item/storage/box/beakers,
-/obj/structure/table/glass,
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsM" = (
@@ -28453,18 +28443,12 @@
 /obj/item/hand_labeler,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/machinery/light_switch{
-	pixel_x = 25
-	},
 /turf/open/floor/plasteel/whiteyellow/side{
 	dir = 6
 	},
 /area/medical/chemistry)
 "bxa" = (
 /obj/structure/table/glass,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
 /obj/item/book/manual/research_and_development,
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
@@ -47590,6 +47574,22 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"dHZ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "Shutters Control";
+	pixel_x = 26;
+	pixel_y = 4;
+	req_access_txt = "5; 33"
+	},
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 1
+	},
+/area/medical/chemistry)
 "dJm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -48583,12 +48583,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gGA" = (
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49539,9 +49533,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17"
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
@@ -49688,6 +49679,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"jZG" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/medical/chemistry)
 "kfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -50054,6 +50049,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"kYM" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "lcU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -50384,6 +50387,9 @@
 /area/engine/engineering)
 "mhn" = (
 /obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel/purple/side{
 	icon_state = "purplecorner"
 	},
@@ -51613,7 +51619,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/closed/wall,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
 /area/medical/chemistry)
 "pBD" = (
 /obj/structure/cable{
@@ -51786,6 +51793,9 @@
 "pYw" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-03"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
@@ -52047,6 +52057,15 @@
 /obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"qTV" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "qUw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/neutral,
@@ -52957,6 +52976,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"tzH" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/science/lab)
 "tAK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -53635,6 +53658,9 @@
 /area/maintenance/department/security/brig)
 "vKq" = (
 /obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
@@ -78290,7 +78316,7 @@ aAL
 aMR
 aAL
 aAL
-aQA
+aHE
 aAL
 aAL
 aTO
@@ -85512,7 +85538,7 @@ bmz
 bnG
 boN
 bpW
-brk
+dHZ
 bsK
 buk
 bvs
@@ -86544,7 +86570,7 @@ bpY
 bpY
 bpY
 pxD
-bpY
+jZG
 bpY
 bpY
 bpY
@@ -86806,7 +86832,7 @@ tqO
 mqp
 cKV
 iwe
-nTr
+qTV
 xDj
 blt
 jCv
@@ -87317,7 +87343,7 @@ ltE
 ltE
 ltE
 imE
-ltE
+kYM
 bmC
 fdQ
 bmD
@@ -87571,8 +87597,8 @@ cCl
 cCl
 cCl
 tJr
-cCl
-cCl
+tzH
+tzH
 byD
 bAm
 dhz

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -29192,6 +29192,9 @@
 	req_one_access_txt = "7;29;30"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
 /turf/open/floor/plasteel,
 /area/science/lab)
 "byE" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -50403,6 +50403,10 @@
 	icon_state = "purplecorner"
 	},
 /area/hallway/primary/aft)
+"mjn" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -86302,7 +86306,7 @@ aSS
 aUg
 aVf
 aWi
-bah
+mjn
 aYe
 aZb
 bag

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -24471,18 +24471,11 @@
 	},
 /area/medical/medbay/central)
 "bmB" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
 	},
 /area/hallway/primary/central)
 "bmC" = (
@@ -26336,17 +26329,6 @@
 	dir = 5
 	},
 /area/medical/chemistry)
-"bro" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/maintenance/department/engine)
-"brp" = (
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 1
-	},
-/area/science/lab)
 "brq" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -26354,6 +26336,7 @@
 	pixel_y = 28
 	},
 /obj/item/stack/cable_coil/orange,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
@@ -27453,7 +27436,6 @@
 /turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "buj" = (
-/obj/machinery/chem_heater,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -27464,21 +27446,22 @@
 	c_tag = "Chemistry";
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
 	},
 /area/medical/chemistry)
 "buk" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bul" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bum" = (
@@ -27486,8 +27469,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bun" = (
-/turf/open/floor/plasteel/whiteyellow/corner{
-	dir = 4
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 5
 	},
 /area/medical/chemistry)
 "bup" = (
@@ -27894,11 +27881,13 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/turf/closed/wall,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "bvw" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -29174,14 +29163,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"byy" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 4
-	},
-/area/medical/chemistry)
 "byz" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -29215,28 +29196,31 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byD" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
+/obj/machinery/door/airlock/research{
+	name = "R&D Lab";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29;30"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "byE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/lab)
 "byF" = (
 /obj/structure/chair/office/light{
@@ -29905,21 +29889,14 @@
 	},
 /obj/item/stack/cable_coil/random,
 /obj/item/book/manual/wiki/chemistry,
-/turf/open/floor/plasteel/whiteyellow/side,
-/area/medical/chemistry)
-"bAh" = (
-/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 2;
 	layer = 2.9
 	},
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
 /obj/item/screwdriver,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 6
-	},
+/turf/open/floor/plasteel/whiteyellow/side,
 /area/medical/chemistry)
 "bAi" = (
 /obj/machinery/smoke_machine,
@@ -29935,24 +29912,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "7;29"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/aft)
 "bAo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -31333,8 +31302,10 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "bDB" = (
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -31946,8 +31917,10 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "bER" = (
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -33900,6 +33873,7 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJE" = (
@@ -46330,13 +46304,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"cwP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/turf/closed/wall,
-/area/medical/chemistry)
 "cwR" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -47248,6 +47215,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"cKV" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -47386,8 +47363,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dgz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47415,8 +47392,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -47739,14 +47722,8 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "eeF" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
 	},
 /area/hallway/primary/central)
 "eeQ" = (
@@ -47966,6 +47943,11 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"eRp" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "eSL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/beacon,
@@ -48026,8 +48008,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fdS" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -48423,8 +48405,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gkX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage";
@@ -48919,6 +48901,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hIZ" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -49108,6 +49098,12 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"imE" = (
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purple";
+	dir = 4
+	},
+/area/hallway/primary/aft)
 "ioj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -49151,6 +49147,12 @@
 	dir = 8
 	},
 /area/science/xenobiology)
+"iwe" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "iyg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49537,9 +49539,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-17"
 	},
@@ -49624,10 +49623,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"jSA" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/maintenance/department/engine)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -50127,6 +50122,11 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"ltE" = (
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -50221,6 +50221,12 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lJI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lKL" = (
 /obj/machinery/door/airlock/abandoned{
 	name = "Starboard Emergency Storage";
@@ -50347,12 +50353,6 @@
 	dir = 1
 	},
 /area/engine/engineering)
-"mcf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "mci" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/structure/disposalpipe/segment{
@@ -50382,6 +50382,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mhn" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -50423,6 +50429,18 @@
 	dir = 1
 	},
 /area/science/xenobiology)
+"mqp" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -50696,9 +50714,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"nnf" = (
-/turf/open/floor/plasteel/whiteyellow/side,
-/area/medical/chemistry)
 "nnh" = (
 /obj/structure/chair{
 	dir = 8
@@ -50981,6 +50996,11 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
+"nTr" = (
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "nVU" = (
 /obj/item/twohanded/spear,
 /turf/open/floor/plating,
@@ -51518,8 +51538,8 @@
 "phJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "pjH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -51589,6 +51609,12 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pxD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/medical/chemistry)
 "pBD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -51691,12 +51717,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"pSc" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 5
-	},
-/area/medical/chemistry)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -52683,6 +52703,16 @@
 	},
 /turf/open/space,
 /area/engine/engineering)
+"sYQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "sZh" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -52843,6 +52873,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"tqO" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "tqX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -52951,6 +52989,11 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"tJr" = (
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/science/lab)
 "tPm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52970,8 +53013,8 @@
 /area/maintenance/department/science)
 "tTl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -53200,6 +53243,24 @@
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uxP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purplecorner"
+	},
+/area/hallway/primary/aft)
 "uzn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
@@ -53440,6 +53501,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"vsG" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/neutral/corner{
@@ -53495,6 +53570,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
+"vzA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "vzP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -53550,6 +53633,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"vKq" = (
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -54121,12 +54210,10 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "xje" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xjK" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -54276,11 +54363,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel/blue/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
@@ -85942,8 +86031,8 @@ bsM
 bum
 bvt
 bwV
-byy
-bAh
+byz
+ooh
 bpY
 bCA
 bDy
@@ -86197,10 +86286,10 @@ bpV
 brm
 bsN
 bun
-mcf
-nnf
-byz
-ooh
+gGA
+bwW
+byA
+bAi
 bpY
 bCB
 bDz
@@ -86452,14 +86541,14 @@ bmA
 bjd
 bpY
 bpY
-cwP
-pSc
-gGA
-bwW
-byA
-bAi
 bpY
-pwj
+bpY
+pxD
+bpY
+bpY
+bpY
+bpY
+vsG
 bva
 bva
 bva
@@ -86707,19 +86796,19 @@ bls
 aBI
 aBI
 bmB
-bva
-bsn
-bva
-bva
+vKq
+nTr
+nTr
+vzA
 bvu
-bva
-bva
-bva
-bva
-pwj
-hVx
+hIZ
+tqO
+mqp
+cKV
+iwe
+nTr
 xDj
-bva
+blt
 jCv
 bOK
 bEN
@@ -86976,7 +87065,7 @@ tTl
 dgg
 phJ
 phJ
-xje
+lJI
 bAk
 bIt
 bJB
@@ -87221,19 +87310,19 @@ blu
 aDZ
 aDZ
 eeF
-bBX
-bBX
-bBX
-bro
-bBX
-bBX
-bBX
-bBX
-bva
+mhn
+ltE
+ltE
+ltE
+ltE
+ltE
+imE
+ltE
+bmC
 fdQ
-npE
-npE
-bFZ
+bmD
+bmD
+eRp
 bAl
 bIu
 bJC
@@ -87479,20 +87568,20 @@ blt
 cqh
 bKM
 cCl
-pYw
-gFo
-cSK
-duF
-bxa
+cCl
+cCl
+tJr
+cCl
+cCl
 byD
 bAm
 dhz
-bCD
+uxP
 bDA
 bEQ
-jSA
-bHg
-bIv
+bGa
+bHp
+sYQ
 bJD
 bBo
 bBo
@@ -87736,11 +87825,11 @@ bmC
 cqi
 boP
 bqb
-brp
-byF
-cCt
-byF
-cCt
+pYw
+gFo
+cSK
+duF
+bxa
 byE
 bBp
 bBp
@@ -87994,9 +88083,9 @@ cqi
 boQ
 cCl
 brq
+byF
 cCt
-cCt
-cCt
+byF
 bxc
 nIU
 bAo

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30219,14 +30219,19 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
 /area/medical/medbay/central)
 "bBf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27217,6 +27217,9 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
+"btG" = (
+/turf/open/space/basic,
+/area)
 "btK" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -47963,6 +47966,15 @@
 	dir = 5
 	},
 /area/science/explab)
+"eUT" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -48236,6 +48248,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/engine/engineering)
+"fGQ" = (
+/obj/docking_port/stationary{
+	dir = 4;
+	dwidth = 1;
+	height = 4;
+	name = "escape pod loader";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/turf/open/space/basic,
+/area/space)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48968,6 +48991,9 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
+"hRK" = (
+/turf/closed/wall/r_wall,
+/area/security/main)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50585,6 +50611,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"mGq" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 4
+	},
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod 1"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -51086,6 +51121,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
+"ofS" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#706891"
+	},
+/turf/open/floor/plating,
+/area/security/main)
 "ofX" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -51573,6 +51615,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pjW" = (
+/obj/docking_port/stationary/random{
+	dir = 4;
+	id = "pod_lavaland4";
+	name = "lavaland"
+	},
+/turf/open/space,
+/area/space)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
@@ -80870,9 +80920,9 @@ aaa
 aby
 abI
 agP
-agQ
-agQ
-agQ
+hRK
+mGq
+hRK
 agP
 agP
 agP
@@ -81127,9 +81177,9 @@ aaa
 aaa
 aaa
 aaa
-abI
-abI
-abI
+agQ
+ofS
+agQ
 abI
 abI
 abI
@@ -81384,9 +81434,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+hRK
+eUT
+hRK
 aaa
 aaa
 abI
@@ -81642,8 +81692,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-afJ
+fGQ
+mZE
 aaa
 aaa
 abI
@@ -82670,7 +82720,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+pjW
 aaa
 aaa
 aaa
@@ -93988,7 +94038,7 @@ akn
 alg
 aaa
 aaa
-aaa
+btG
 aaa
 aaa
 aaa

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -7198,7 +7198,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "atN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -7278,7 +7278,7 @@
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aua" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -8052,7 +8052,7 @@
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "avR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -8136,7 +8136,7 @@
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "awd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8967,7 +8967,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ayf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -27217,9 +27217,6 @@
 	},
 /turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
-"btG" = (
-/turf/open/space/basic,
-/area)
 "btK" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -47966,15 +47963,6 @@
 	dir = 5
 	},
 /area/science/explab)
-"eUT" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
 	dir = 8
@@ -48248,17 +48236,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/engine/engineering)
-"fGQ" = (
-/obj/docking_port/stationary{
-	dir = 4;
-	dwidth = 1;
-	height = 4;
-	name = "escape pod loader";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/turf/open/space/basic,
-/area/space)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -48991,9 +48968,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"hRK" = (
-/turf/closed/wall/r_wall,
-/area/security/main)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -50611,15 +50585,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mGq" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod 1"
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -51121,13 +51086,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
-"ofS" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#706891"
-	},
-/turf/open/floor/plating,
-/area/security/main)
 "ofX" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -51615,14 +51573,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"pjW" = (
-/obj/docking_port/stationary/random{
-	dir = 4;
-	id = "pod_lavaland4";
-	name = "lavaland"
-	},
-/turf/open/space,
-/area/space)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
@@ -80920,9 +80870,9 @@ aaa
 aby
 abI
 agP
-hRK
-mGq
-hRK
+agQ
+agQ
+agQ
 agP
 agP
 agP
@@ -81177,9 +81127,9 @@ aaa
 aaa
 aaa
 aaa
-agQ
-ofS
-agQ
+abI
+abI
+abI
 abI
 abI
 abI
@@ -81434,9 +81384,9 @@ aaa
 aaa
 aaa
 aaa
-hRK
-eUT
-hRK
+aaa
+aaa
+aaa
 aaa
 aaa
 abI
@@ -81692,8 +81642,8 @@ aaa
 aaa
 aaa
 aaa
-fGQ
-mZE
+aaa
+afJ
 aaa
 aaa
 abI
@@ -82720,7 +82670,7 @@ aaa
 aaa
 aaa
 aaa
-pjW
+aaa
 aaa
 aaa
 aaa
@@ -94038,7 +93988,7 @@ akn
 alg
 aaa
 aaa
-btG
+aaa
 aaa
 aaa
 aaa


### PR DESCRIPTION
[Changelogs]: Changes a few doors area types on command to make fixing them easier without an AI during greytide events.
Also adds an escape pod to security.

:cl: nicc
tweak: area alterations
add: escape pod
/:cl:

[why]: Bridge greytide opens a few airlocks that can't actually be worked by the command door remotes, which seems like a bit of an oversight. Changing the areas of said doors, which are the AI sat access doors, to AI sat area, means bridge won't get vented, and command staff would be struggling to hack doors closed when the command remote refuses to work. The alternative was changing the doors access levels, or the remotes levels, which seemed more game changing. So I opted for this change instead.
Pubby seems to be the only map lacking alternate escape, aside from the iffy monastery pod which can be in one of two places on opposite ends of the station. This should add an alternate escape for crafty antags, or good sec/command players.
