### PR TITLE
New vending machine UI

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -334,7 +334,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 			display_records = product_records + hidden_records + coin_records
 		dat += "<table>"
 		for (var/datum/data/vending_product/R in display_records)
-			dat += "<tr><td><img src='data:image/jpeg;base64," + GetIconForProduct(R) + "'/></td>"
+			dat += "<tr><td><img src='data:image/jpeg;base64,[GetIconForProduct(R)]'/></td>"
 			dat += "<td style=\"width: 100%\"><b>[sanitize(R.name)]</b></td>"
 			if(R.amount > 0)
 				dat += "<td><b>[R.amount]&nbsp;</b></td><td><a href='byond://?src=[REF(src)];vend=[REF(R)]'>Vend</a></td>"
@@ -368,7 +368,7 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	if(vending_cache[P.product_path])
 		return vending_cache[P.product_path]
 	var/product = new P.product_path()
-	vending_cache[P.product_path] = icon2base64(getFlatIcon(product))
+	vending_cache[P.product_path] = icon2base64(getFlatIcon(product, no_anim = TRUE))
 	qdel(product)
 	return vending_cache[P.product_path]
 


### PR DESCRIPTION
![it works, right?](https://user-images.githubusercontent.com/15747030/43838835-c1eede60-9b1c-11e8-80e8-4e734610f35b.png)

:cl: Flatty
tweak: The vending machine UI is now prettier.
/:cl:

Originally made by AndrewMontagne for Oracle.

Every typepath will only be rendered once and cached for the rest of the round, meaning every shift all the machines will show up a new, random variety of a screwdriver. Exciting!