### PR TITLE
Changes bomb scaling formula, tier 2 tritium bomb rush nerfed to ~100+k from ~200+k points

### DIFF
--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -129,4 +129,4 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	linked_techweb = SSresearch.science_tech
 
 /proc/techweb_scale_bomb(lightradius)
-	return (lightradius ** 0.5) * 3000
+	return lightradius ** 1.36


### PR DESCRIPTION
:clap:
Why: I guess finishing research in 20 minutes was bad