### PR TITLE
Makes shuttles be able to be locked behind Emags properly 

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -421,6 +421,7 @@
 	if(obj_flags & EMAGGED)
 		return
 	obj_flags |= EMAGGED
+	SSshuttle.shuttle_purchase_requirements_met |= "emagged"
 	if(authenticated == 1)
 		authenticated = 2
 	to_chat(user, "<span class='danger'>You scramble the communication routing circuits!</span>")


### PR DESCRIPTION
[Changelogs]: # Makes it so if people want a Traitor shuttle or one that NT don't normal send, be locked behind a Emag

[why]: # (Mostly to lock away the dreaded Scrapheap, but also allow other people to make there own shuttles that can Synda themed and have it be spawn-able by traitors! 

Why have two PRs about locking away scarpheap? First PR is already in, so I dont know what will happen if I change code and its broken,!
