### PR TITLE
Deep Storage Suit Loot Update. (Alternative to PR #7402)

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2165,7 +2165,7 @@
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/space/has_grav/deepstorage/power)
 "fo" = (
-/obj/machinery/suit_storage_unit/syndicate,
+/obj/machinery/suit_storage_unit/mining/eva,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/space/has_grav/deepstorage/power)
 "fp" = (

--- a/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
+++ b/_maps/RandomRuins/SpaceRuins/deepstorage.dmm
@@ -2166,6 +2166,7 @@
 /area/ruin/space/has_grav/deepstorage/power)
 "fo" = (
 /obj/machinery/suit_storage_unit/mining/eva,
+/obj/item/tank/jetpack/oxygen,
 /turf/open/floor/plasteel/floorgrime,
 /area/ruin/space/has_grav/deepstorage/power)
 "fp" = (


### PR DESCRIPTION

:cl: Tupinambis
tweak: Replaces the blood-red hardsuit in Deep Storage with a mining EVA hardsuit, and an included oxygen jetpack.
/:cl:

[why]: Being able to get an eight TC traitor/syndicate item for free, without any challenge to whoever wishes to acquire it, is over powered. This change should remedy that while still giving players a potential upgrade to their space gear.