### PR TITLE
Bombspear tweaks + embedded item tweaks

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -108,7 +108,7 @@
 #define EMBEDDED_IMPACT_PAIN_MULTIPLIER			4	//Coefficient of multiplication for the damage the item does when it first embeds (this*item.w_class)
 #define EMBED_THROWSPEED_THRESHOLD				4	//The minimum value of an item's throw_speed for it to embed (Unless it has embedded_ignore_throwspeed_threshold set to 1)
 #define EMBEDDED_UNSAFE_REMOVAL_PAIN_MULTIPLIER 8	//Coefficient of multiplication for the damage the item does when removed without a surgery (this*item.w_class)
-#define EMBEDDED_UNSAFE_REMOVAL_TIME			30	//A Time in ticks, total removal time = (this*item.w_class)
+#define EMBEDDED_UNSAFE_REMOVAL_TIME			150	//A Time in ticks, total removal time = (this/item.w_class)
 
 //Gun weapon weight
 #define WEAPON_LIGHT 1

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -794,3 +794,6 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if (item_flags & NODROP)
 		return
 	return ..()
+
+/obj/item/proc/grenade_prime_react(obj/item/grenade/nade)
+	return

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -87,6 +87,9 @@
 	if(ismob(loc))
 		var/mob/M = loc
 		M.dropItemToGround(src)
+	else if(isitem(loc))
+		var/obj/item/I = loc
+		I.grenade_prime_react(src)
 
 
 /obj/item/grenade/attackby(obj/item/W, mob/user, params)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -463,7 +463,7 @@
 	force_wielded = 18
 	throwforce = 20
 	throw_speed = 4
-	embedding = list("embedded_impact_pain_multiplier" = 3)
+	embedding = list("embedded_impact_pain_multiplier" = 3, "embed_chance" = 90)
 	armour_penetration = 10
 	materials = list(MAT_METAL=1150, MAT_GLASS=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -478,14 +478,25 @@
 	. = ..()
 	AddComponent(/datum/component/butchering, 100, 70) //decent in a pinch, but pretty bad.
 
+/obj/item/twohanded/spear/attack_self(mob/user)
+	if(explosive)
+		explosive.attack_self(user)
+		return
+	. = ..()
+
+/obj/item/twohanded/rightclick_attack_self(mob/user)
+	if(wielded) //Trying to unwield it
+		unwield(user)
+	else //Trying to wield it
+		wield(user)
+	return TRUE
+
 /obj/item/twohanded/spear/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to sword-swallow \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	if(explosive)
 		user.say("[war_cry]")
-		explosive.forceMove(user)
 		explosive.prime()
 		user.gib()
-		qdel(src)
 		return BRUTELOSS
 	return BRUTELOSS
 
@@ -496,7 +507,7 @@
 /obj/item/twohanded/spear/examine(mob/user)
 	..()
 	if(explosive)
-		to_chat(user, "<span class='notice'>Alt-click to set your war cry.</span>")
+		to_chat(user, "<span class='notice'>Use in your hands to activate the attached explosive.</span><br><span class='notice'>Alt-click to set your war cry.</span><br><span class='notice'>Right-click in combat mode to wield</span>")
 
 /obj/item/twohanded/spear/update_icon()
 	if(explosive)
@@ -511,17 +522,11 @@
 		return
 	if(explosive && wielded)
 		user.say("[war_cry]")
-		explosive.forceMove(AM)
 		explosive.prime()
-		qdel(src)
 
- //THIS MIGHT BE UNBALANCED SO I DUNNO // it totally is.
-/obj/item/twohanded/spear/throw_impact(atom/target)
-	. = ..()
-	if(!.) //not caught
-		if(explosive)
-			explosive.prime()
-			qdel(src)
+/obj/item/twohanded/spear/grenade_prime_react(obj/item/grenade/nade)
+	nade.forceMove(get_turf(src))
+	qdel(src)
 
 /obj/item/twohanded/spear/AltClick(mob/user)
 	if(user.canUseTopic(src, BE_CLOSE))

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -207,6 +207,33 @@
 
 	spreadFire(AM)
 
+/mob/living/carbon/human/resist()
+	. = ..()
+	if(wear_suit && wear_suit.breakouttime)//added in human cuff breakout proc
+		return
+	if(.)
+		if(canmove && !on_fire)
+			for(var/obj/item/bodypart/L in bodyparts)
+				if(istype(L) && L.embedded_objects.len)
+					for(var/obj/item/I in L.embedded_objects)
+						if(istype(I) && I.w_class >= WEIGHT_CLASS_NORMAL)	//minimum weight class to insta-ripout via resist
+							remove_embedded_unsafe(L, I, src, 1.5)	//forcefully call the remove embedded unsafe proc but with extra pain multiplier. if you want to remove it less painfully, examine and remove it carefully.
+							return FALSE //Hands are occupied
+	return .
+
+/mob/living/carbon/human/proc/remove_embedded_unsafe(obj/item/bodypart/L, obj/item/I, mob/user, painmul = 1)
+	if(!I || !L || I.loc != src || !(I in L.embedded_objects))
+		return
+	L.embedded_objects -= I
+	L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class*painmul)//It hurts to rip it out, get surgery you dingus. And if you're ripping it out quickly via resist, it's gonna hurt even more
+	I.forceMove(get_turf(src))
+	user.put_in_hands(I)
+	user.emote("scream")
+	user.visible_message("[user] rips [I] out of [user.p_their()] [L.name]!","<span class='notice'>You remove [I] from your [L.name].</span>")
+	if(!has_embedded_objects())
+		clear_alert("embeddedobject")
+		SEND_SIGNAL(user, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+	return
 
 /mob/living/carbon/human/Topic(href, href_list)
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
@@ -217,20 +244,10 @@
 			var/obj/item/I = locate(href_list["embedded_object"]) in L.embedded_objects
 			if(!I || I.loc != src) //no item, no limb, or item is not in limb or in the person anymore
 				return
-			var/time_taken = I.embedding.embedded_unsafe_removal_time*I.w_class
+			var/time_taken = I.embedding.embedded_unsafe_removal_time/I.w_class
 			usr.visible_message("<span class='warning'>[usr] attempts to remove [I] from [usr.p_their()] [L.name].</span>","<span class='notice'>You attempt to remove [I] from your [L.name]... (It will take [DisplayTimeText(time_taken)].)</span>")
 			if(do_after(usr, time_taken, needhand = 1, target = src))
-				if(!I || !L || I.loc != src || !(I in L.embedded_objects))
-					return
-				L.embedded_objects -= I
-				L.receive_damage(I.embedding.embedded_unsafe_removal_pain_multiplier*I.w_class)//It hurts to rip it out, get surgery you dingus.
-				I.forceMove(get_turf(src))
-				usr.put_in_hands(I)
-				usr.emote("scream")
-				usr.visible_message("[usr] successfully rips [I] out of [usr.p_their()] [L.name]!","<span class='notice'>You successfully remove [I] from your [L.name].</span>")
-				if(!has_embedded_objects())
-					clear_alert("embeddedobject")
-					SEND_SIGNAL(usr, COMSIG_CLEAR_MOOD_EVENT, "embedded")
+				remove_embedded_unsafe(L, I, usr)
 			return
 
 		if(href_list["item"])

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -614,6 +614,10 @@
 			resist_fire() //stop, drop, and roll
 		else if(resting) //cit change - allows resisting out of resting
 			resist_a_rest() // ditto
+		else if(istype(src, /mob/living/carbon))
+			var/mob/living/carbon/C = src
+			if(!C.handcuffed && !C.legcuffed)
+				return TRUE
 		else if(last_special <= world.time)
 			resist_restraints() //trying to remove cuffs.
 


### PR DESCRIPTION
Bombspears are pretty strong in that they're able to instantly gib someone in only one single click with only 10 seconds of setup, all without putting yourself at danger at all. This tweaks bombspears by giving them a higher embed chance, making it possible to prime the grenade on the bombspear, and removing the ability for the grenade on the bombspear to explode on impact. You can still force the grenade on your bombspear to explode by attacking with the bombspear while wielding it, which will still leave them pretty viable for completing "die a glorious death" objectives. This PR also makes it so that embedded items are easier to pull out if they're larger, and adds the ability to instantly pull out embedded objects via the resist button if the embedded object is normal sized or larger, at the cost of the item dealing 1.5x more damage on tearout.

:cl: deathride58
add: You can now prime the grenade on bombspears by using them in your hand. The wield hotkey is moved to combat mode rightclick while a spear has a grenade on it. This is explained in the examine text.
balance: Bombspears no longer instantly explode on impact when thrown. They now have to be primed to explode when thrown.
balance: Bombspears now have 90% embed chance.
add: If an embedded item is normal sized or larger, you can take it out instantly by pressing resist.
balance: Embedded items are now much harder to pull out the smaller they are, rather than the other way around. It's much easier to rip out a sword from your chest than it is a shard of glass in your face.
/:cl:
