### PR TITLE
Buffs jukeboxes - gives music played by jukeboxes double the falloff

### DIFF
--- a/code/controllers/subsystem/jukeboxes.dm
+++ b/code/controllers/subsystem/jukeboxes.dm
@@ -18,14 +18,14 @@ SUBSYSTEM_DEF(jukeboxes)
 	song_beat = beat
 	song_associated_id = assocID
 
-/datum/controller/subsystem/jukeboxes/proc/addjukebox(obj/jukebox, datum/track/T)
+/datum/controller/subsystem/jukeboxes/proc/addjukebox(obj/jukebox, datum/track/T, jukefalloff = 1)
 	if(!istype(T))
 		CRASH("[src] tried to play a song with a nonexistant track")
 	var/channeltoreserve = CHANNEL_JUKEBOX_START + activejukeboxes.len - 1
 	if(channeltoreserve > CHANNEL_JUKEBOX)
 		return FALSE
 	activejukeboxes.len++
-	activejukeboxes[activejukeboxes.len] = list(T, channeltoreserve, jukebox)
+	activejukeboxes[activejukeboxes.len] = list(T, channeltoreserve, jukebox, jukefalloff)
 	return activejukeboxes.len
 
 /datum/controller/subsystem/jukeboxes/proc/removejukebox(IDtoremove)
@@ -77,6 +77,8 @@ SUBSYSTEM_DEF(jukeboxes)
 		var/area/currentarea = get_area(jukebox)
 		var/turf/currentturf = get_turf(jukebox)
 		var/list/hearerscache = hearers(7, jukebox)
+
+		song_played.falloff = jukeinfo[4]
 
 		for(var/mob/M in GLOB.player_list)
 			if(!M.client)

--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -121,7 +121,7 @@
 			updateUsrDialog()
 
 /obj/machinery/jukebox/proc/activate_music()
-	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, selection)
+	var/jukeboxslottotake = SSjukeboxes.addjukebox(src, selection, 2)
 	if(jukeboxslottotake)
 		active = TRUE
 		update_icon()


### PR DESCRIPTION
Title. You're supposed to be able to reasonably hear the jukebox booming inside the bar while standing outside from the main hallway, or walking near the bar in maint, but all you can hear is an extremely muffled, distant version of the song playing from the jukebox. This fixes that. With this PR, you will be able to reliably hear the jukebox while passing by the bar, just as I showed off in the initial teaser I tossed around for the jukebox rework.

:cl: deathride58
balance: The jukebox now falls off over a greater distance. You can now actually hear the jukebox while sitting in a far corner of the bar, or while passing through the main hallways.
/:cl:
