### PR TITLE
Buffs sci correctly this time - 1500 points/3 more core DAs

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -18,11 +18,15 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_nodes_hidden = list()		//Nodes that should be hidden by default.
 	var/list/techweb_point_items = list(		//path = list(point type = value)
 	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000)
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000),   // Cit three more anomalys anomalys
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 7500),   
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 5000),
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 2500)     // End of Cit changes
 	)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list
 	//----------------------------------------------
-	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 20)			//citadel edit - techwebs nerf
+	var/list/single_server_income = list(TECHWEB_POINT_TYPE_GENERIC = 25)			//citadel edit - techwebs nerf
 	var/multiserver_calculation = FALSE
 	var/last_income = 0
 


### PR DESCRIPTION
[Changelogs]: # (Makes slightly more points then before allowing sci to get useful things faster well not being able to max rnd in time before shuttle call
20 * 60 * 141 mins (all the way to auto restart) = 169,200
25*60 * 141 = 211,500
211,500 - 169,200 = 42,300 more points at the end of the day

[why]: # After getting one anomaly core there only useful* for armor and mechs. Sci points are slow and this will speed up early game a tad making AI shells or other nice things quicker, Like Posi Brains!
Done Correctly this time