### PR TITLE
Makes portal guns spawn without firing pins

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -177,6 +177,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/wormhole, /obj/item/ammo_casing/energy/wormhole/orange)
 	item_state = null
 	icon_state = "wormhole_projector"
+	pin = null
 	var/obj/effect/portal/p_blue
 	var/obj/effect/portal/p_orange
 	var/atmos_link = FALSE


### PR DESCRIPTION
Go prod sec or cargo if you want your mass-produced 0-effort all access.

:cl: deathride58
balance: Portal guns now spawn without firing pins.
/:cl:
