### PR TITLE
Toxins Lab Quality of Life Improvements.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -31432,12 +31432,12 @@
 /area/science/research)
 "bBF" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/item/storage/firstaid/toxin,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
+	},
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -33417,12 +33417,13 @@
 	pixel_y = 10
 	},
 /obj/item/analyzer,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGA" = (
 /obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -33698,10 +33699,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"bHg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
 "bHh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -33816,11 +33813,7 @@
 /area/science/mixing)
 "bHv" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/computer/security/telescreen/toxins{
-	dir = 4;
-	pixel_x = 30
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -34509,9 +34502,7 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bIW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "bIX" = (
@@ -34971,6 +34962,7 @@
 	},
 /obj/item/assembly/timer,
 /obj/structure/table/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bKa" = (
@@ -35522,9 +35514,6 @@
 /obj/structure/sign/warning/nosmoking{
 	pixel_x = -32
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bLj" = (
@@ -36016,7 +36005,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bMz" = (
@@ -36354,12 +36342,10 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "bNu" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
 "bNv" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -36373,7 +36359,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bNy" = (
@@ -36823,7 +36808,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bOH" = (
@@ -37377,6 +37361,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bPM" = (
@@ -37821,6 +37806,7 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bQZ" = (
@@ -39127,6 +39113,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "bUq" = (
@@ -53140,6 +53127,10 @@
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
+"cVK" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "dfh" = (
 /obj/machinery/power/apc{
 	areastring = "/area/science/circuit";
@@ -53164,7 +53155,7 @@
 /area/maintenance/disposal/incinerator)
 "dvO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+	dir = 10
 	},
 /turf/closed/wall,
 /area/science/circuit)
@@ -53366,6 +53357,7 @@
 /obj/machinery/cell_charger{
 	pixel_y = 5
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "iiW" = (
@@ -53493,12 +53485,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"jMF" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall,
-/area/science/circuit)
 "jMY" = (
 /obj/structure/table,
 /obj/item/stack/cable_coil{
@@ -53568,14 +53554,8 @@
 /turf/open/floor/wood,
 /area/maintenance/bar)
 "kzT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
-"kOw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/white,
+/turf/closed/wall/r_wall,
 /area/science/mixing)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -53665,6 +53645,7 @@
 /obj/machinery/light_switch{
 	pixel_x = -20
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "mPE" = (
@@ -53676,6 +53657,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "nfm" = (
@@ -53728,6 +53710,10 @@
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"olr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
 "oDF" = (
 /obj/machinery/light,
 /turf/open/floor/plating,
@@ -53752,6 +53738,15 @@
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"poc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "pHl" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -53846,6 +53841,20 @@
 /obj/effect/decal/cleanable/semen,
 /turf/open/floor/plating,
 /area/maintenance/bar)
+"rNc" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 1;
+	network = list("toxins");
+	pixel_y = -28
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing)
 "saK" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -53973,7 +53982,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "tOq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
@@ -54129,6 +54137,7 @@
 	pixel_x = -24
 	},
 /obj/item/stock_parts/cell/high,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
 "vzO" = (
@@ -54145,6 +54154,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"vHY" = (
+/turf/open/floor/plating,
+/area/science/mixing)
 "vPE" = (
 /obj/machinery/light{
 	dir = 4
@@ -54248,6 +54260,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"ydD" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/plasteel,
+/area/science/mixing)
 
 (1,1,1) = {"
 aaa
@@ -102457,7 +102474,7 @@ aGs
 bvK
 bBF
 bFU
-bFT
+oce
 bGz
 bJZ
 kzT
@@ -102717,7 +102734,7 @@ bFU
 bFT
 bFU
 bJY
-bEM
+bEC
 bMv
 bNv
 bMv
@@ -102971,9 +102988,9 @@ bzO
 bqe
 bEB
 bFW
-oce
+bFT
 tOq
-kOw
+bFU
 bLi
 bMz
 bNy
@@ -102985,9 +103002,9 @@ hRa
 bUp
 mNi
 mRe
-bXs
+olr
 bPL
-bQI
+cVK
 bTo
 eaI
 cbZ
@@ -103230,12 +103247,12 @@ bEA
 bFV
 bFT
 bGA
-bHg
-bHg
+bFU
+bFU
 bMy
 bNx
 bOG
-jMF
+wkN
 uoB
 bSk
 bXs
@@ -105540,11 +105557,11 @@ cNT
 bCm
 bDh
 bEs
-bGd
+ydD
 bHv
 bIW
 bKe
-bLm
+vHY
 bEs
 rmX
 xIa
@@ -105797,11 +105814,11 @@ brG
 brG
 bDg
 bEs
-bGc
-bGc
-bGc
+bGd
+poc
+rNc
 bEs
-bLl
+bLm
 bEs
 cOT
 cOT
@@ -106054,12 +106071,12 @@ byx
 brI
 bky
 bky
-aaf
-aaf
-aaf
-aaf
-aaa
-aaf
+bEs
+bGc
+bGc
+bEs
+bLl
+bEs
 aaf
 aaa
 aaa
@@ -106311,13 +106328,13 @@ bky
 bky
 bky
 aaf
-aaa
-aaa
-aaa
+gXs
+gXs
+gXs
 aaf
 aaa
 aaf
-aaa
+gXs
 aaa
 aaa
 aaf
@@ -111197,9 +111214,9 @@ aaa
 aaa
 aaa
 aaa
-aaf
+gXs
 aaa
-aaf
+gXs
 aaa
 aaa
 aaa
@@ -111453,6 +111470,263 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaf
+aaa
+aaf
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+"}
+(224,1,1) = {"
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaf
 aaf
 aaa
@@ -111560,7 +111834,7 @@ aaa
 aaa
 aaa
 "}
-(224,1,1) = {"
+(225,1,1) = {"
 aaa
 aaa
 aaa
@@ -111817,7 +112091,7 @@ aaa
 aaa
 aaa
 "}
-(225,1,1) = {"
+(226,1,1) = {"
 aaa
 aaa
 aaa
@@ -112074,7 +112348,7 @@ aaa
 aaa
 aaa
 "}
-(226,1,1) = {"
+(227,1,1) = {"
 aaa
 aaa
 aaa
@@ -112331,7 +112605,7 @@ aaa
 aaa
 aaa
 "}
-(227,1,1) = {"
+(228,1,1) = {"
 aaa
 aaa
 aaa
@@ -112588,7 +112862,7 @@ aaa
 aaa
 aaa
 "}
-(228,1,1) = {"
+(229,1,1) = {"
 aaa
 aaa
 aaa
@@ -112845,7 +113119,7 @@ aaa
 aaa
 aaa
 "}
-(229,1,1) = {"
+(230,1,1) = {"
 aaa
 aaa
 aaa
@@ -113102,7 +113376,7 @@ aaa
 aaa
 aaa
 "}
-(230,1,1) = {"
+(231,1,1) = {"
 aaa
 aaa
 aaa
@@ -113359,7 +113633,7 @@ aaa
 aaa
 aaa
 "}
-(231,1,1) = {"
+(232,1,1) = {"
 aaa
 aaa
 aaa
@@ -113616,7 +113890,7 @@ aaa
 aaa
 aaa
 "}
-(232,1,1) = {"
+(233,1,1) = {"
 aaa
 aaa
 aaa
@@ -113772,263 +114046,6 @@ bGe
 bGf
 aaf
 aaf
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-"}
-(233,1,1) = {"
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaf
-aaf
-aaf
-aaf
-aaf
-aaa
 aaa
 aaa
 aaa
@@ -114280,11 +114297,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
 aaf
 aaf
-aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -114538,9 +114555,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
 aaf
-aaa
+aaf
+aaf
 aaa
 aaa
 aaa
@@ -115053,7 +115070,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+aaf
 aaa
 aaa
 aaa

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -60457,6 +60457,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyE" = (
@@ -60480,12 +60481,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
+	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cyG" = (
@@ -61482,9 +61484,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/cable/yellow{
 	icon_state = "2-8"
 	},
@@ -61494,9 +61493,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAE" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/machinery/holopad,
 /obj/effect/landmark/start/scientist,
 /obj/structure/disposalpipe/segment{
@@ -61505,12 +61501,10 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAF" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cAG" = (
@@ -61901,7 +61895,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -61914,9 +61907,7 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBA" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 2
-	},
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBB" = (
@@ -62366,30 +62357,22 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cCA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cCB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cCC" = (
@@ -63763,7 +63746,6 @@
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
 "cFo" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -63775,7 +63757,6 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "cFq" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -64255,10 +64236,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/portable_atmospherics/canister,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cGo" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -30560,8 +30560,8 @@
 /area/science/mixing)
 "bBL" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/airalarm{
-	pixel_y = 22
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -30590,7 +30590,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBQ" = (
@@ -30616,6 +30616,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -30645,6 +30646,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},
@@ -33575,9 +33577,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bIL" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/science/mixing)
 "bIM" = (
@@ -34516,11 +34516,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bLf" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/science/mixing)
 "bLh" = (


### PR DESCRIPTION

:cl: Tupinambis
add: Added an experimental hard suit to toxins bomb test room on Box.
tweak: Increased the size of the toxins bomb test room, moved the telescreen, and added chairs on Box.
tweak: Moved some pipes out of the way on Box and Meta.
add: Two air pumps have been added to the toxins lab on Pubby and Meta.

The following changes apply to Box, Meta, and Pubby:
tweak: Unbolts the toxin burn chamber doors on round start.
tweak: Unlocks the toxins lab air alarm on round start.
/:cl:

[why]: Currently scientists can't modify the burn chamber or gas exchanges without figuring out a method to unlock the air alarm and unbolt the doors. This is inconvenient and can cause toxins workers to have to waste time waiting. This change will allow them to get right to work.

The air pumps have been added so that toxins workers can be guaranteed the ability to pump as much pressure as possible into TTV's.

An experimental hardsuit has been added to box toxins bomb testing room to make it in line with Meta and Pubby.


