### PR TITLE
Adds antag OOC, off by default.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -261,6 +261,7 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 
 //Color Defines
 #define OOC_COLOR  "#002eb8"
+#define AOOC_COLOR "#b8002e"
 
 /////////////////////////////////////
 // atom.appearence_flags shortcuts //

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -10,6 +10,7 @@ GLOBAL_VAR_INIT(hub_visibility, FALSE)
 
 GLOBAL_VAR_INIT(ooc_allowed, TRUE)	// used with admin verbs to disable ooc - not a config option apparently
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
+GLOBAL_VAR_INIT(aooc_allowed, FALSE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)
 GLOBAL_VAR_INIT(shuttle_frozen, FALSE)
 GLOBAL_VAR_INIT(shuttle_left, FALSE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -190,9 +190,9 @@
 		body += "<A href='?_src_=holder;[HrefToken()];tdome2=[REF(M)]'>Thunderdome 2</A> | "
 		body += "<A href='?_src_=holder;[HrefToken()];tdomeadmin=[REF(M)]'>Thunderdome Admin</A> | "
 		body += "<A href='?_src_=holder;[HrefToken()];tdomeobserve=[REF(M)]'>Thunderdome Observer</A> | "
-	
+
 	body += usr.client.citaPPoptions(M) // CITADEL
-	
+
 	body += "<br>"
 	body += "</body></html>"
 
@@ -543,6 +543,15 @@
 	log_admin("[key_name(usr)] toggled OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/datum/admins/proc/toggleaooc()
+	set category = "Server"
+	set desc="Toggle dis bitch"
+	set name="Toggle Antag OOC"
+	toggle_aooc()
+	log_admin("[key_name(usr)] toggled Antagonist OOC.")
+	message_admins("[key_name_admin(usr)] toggled Antagonist OOC.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Antag OOC", "[GLOB.aooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
 /datum/admins/proc/startnow()
 	set category = "Server"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -25,6 +25,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
+	/datum/admins/proc/toggleaooc,		/*toggles antag ooc on/off*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/
 	/datum/admins/proc/toggleguests,	/*toggles whether guests can join the current game*/
 	/datum/admins/proc/announce,		/*priority announce something to all clients.*/
@@ -183,7 +184,7 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/client/proc/admin_ghost,
 	/client/proc/toggle_view_range,
 	/client/proc/cmd_admin_subtle_message,
-	/client/proc/cmd_admin_headset_message,	
+	/client/proc/cmd_admin_headset_message,
 	/client/proc/cmd_admin_check_contents,
 	/datum/admins/proc/access_news_network,
 	/client/proc/admin_call_shuttle,

--- a/code/modules/client/verbs/aooc.dm
+++ b/code/modules/client/verbs/aooc.dm
@@ -1,0 +1,119 @@
+/client/verb/aooc(msg as text)
+	set name = "AOOC"
+	set desc = "An OOC channel exclusive to antagonists."
+	set category = "OOC"
+
+	if(GLOB.say_disabled)	//This is here to try to identify lag problems
+		to_chat(usr, "<span class='danger'>Speech is currently admin-disabled.</span>")
+		return
+
+	if(!mob)
+		return
+
+	if(!holder)
+		if(mob.stat == DEAD)
+			to_chat(usr, "<span class='danger'>You cannot use AOOC while dead.</span>")
+			return
+		if(!is_special_character(mob))
+			to_chat(usr, "<span class='danger'>You aren't an antagonist!</span>")
+		if(prefs.muted & MUTE_OOC)
+			to_chat(src, "<span class='danger'>You cannot use AOOC (muted).</span>")
+			return
+		if(jobban_isbanned(src.mob, "OOC"))
+			to_chat(src, "<span class='danger'>You are banned from OOC.</span>")
+			return
+		if(!GLOB.aooc_allowed)
+			to_chat(src, "<span class='danger'>AOOC is currently muted.</span>")
+			return
+	if(QDELETED(src))
+		return
+
+	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)
+	var/raw_msg = msg
+
+	if(!msg)
+		return
+
+	msg = emoji_parse(msg)
+
+	if(!holder)
+		if(handle_spam_prevention(msg,MUTE_OOC))
+			return
+		if(findtext(msg, "byond://"))
+			to_chat(src, "<B>Advertising other servers is not allowed.</B>")
+			log_admin("[key_name(src)] has attempted to advertise in AOOC: [msg]")
+			message_admins("[key_name_admin(src)] has attempted to advertise in AOOC: [msg]")
+			return
+
+	log_talk(mob,"(AOOC) [key_name(src)] : [raw_msg]",LOGOOC)
+	mob.log_message("(AOOC) [key]: [raw_msg]", INDIVIDUAL_OOC_LOG)
+
+	var/keyname = key
+	if(prefs.unlock_content)
+		if(prefs.toggles & MEMBER_PUBLIC)
+			keyname = "<font color='[prefs.ooccolor ? prefs.ooccolor : GLOB.antag_ooc_colour]'>[icon2html('icons/member_content.dmi', world, "blag")][keyname]</font>"
+	//The linkify span classes and linkify=TRUE below make ooc text get clickable chat href links if you pass in something resembling a url
+
+	var/antaglisting = list()
+
+	for(var/datum/mind/M in get_antag_minds(/datum/antagonist))
+		if(!M.current || !M.current.client)
+			continue
+		antaglisting |= M.current.client
+
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && (M.stat == DEAD || M.client.holder))
+			antaglisting |= M.client
+
+	for(var/client/C in antaglisting)
+		if(!C || !istype(C))
+			continue
+		if(holder)
+			if(!holder.fakekey || C.holder)
+				if(check_rights_for(src, R_ADMIN))
+					to_chat(C, "<span class='adminooc'>[CONFIG_GET(flag/allow_admin_ooccolor) && prefs.ooccolor ? "<font color=[prefs.ooccolor]>" :"" ]<span class='prefix'>Antag OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></span></font>")
+				else
+					to_chat(C, "<span class='adminobserverooc'><span class='prefix'>Antag OOC:</span> <EM>[keyname][holder.fakekey ? "/([holder.fakekey])" : ""]:</EM> <span class='message linkify'>[msg]</span></span>")
+			else
+				to_chat(C, "<font color='[GLOB.antag_ooc_colour]'><span class='ooc'><span class='prefix'>Antag OOC:</span> <EM>[holder.fakekey ? holder.fakekey : key]:</EM> <span class='message linkify'>[msg]</span></span></font>")
+		else if(!(key in C.prefs.ignoring))
+			to_chat(C, "<font color='[GLOB.antag_ooc_colour]'><span class='ooc'><span class='prefix'>Antag OOC:</span> <EM>[keyname]:</EM> <span class='message linkify'>[msg]</span></span></font>")
+
+GLOBAL_VAR_INIT(antag_ooc_colour, AOOC_COLOR)
+
+/client/proc/set_aooc(newColor as color)
+	set name = "Set Antag OOC Color"
+	set desc = "Modifies antag OOC Color"
+	set category = "Fun"
+	GLOB.antag_ooc_colour = sanitize_ooccolor(newColor)
+
+/client/proc/reset_aooc()
+	set name = "Reset Antag OOC Color"
+	set desc = "Returns antag OOC Color to default"
+	set category = "Fun"
+	GLOB.antag_ooc_colour = AOOC_COLOR
+
+/proc/toggle_aooc(toggle = null)
+	if(toggle != null) //if we're specifically en/disabling ooc
+		if(toggle != GLOB.aooc_allowed)
+			GLOB.aooc_allowed = toggle
+		else
+			return
+	else //otherwise just toggle it
+		GLOB.aooc_allowed = !GLOB.aooc_allowed
+
+	var/antaglisting = list()	//Only those who have access to AOOC need to know if it's enabled or not.
+
+	for(var/datum/mind/M in get_antag_minds(/datum/antagonist))
+		if(!M.current || !M.current.client)
+			continue
+		antaglisting |= M.current.client
+
+	for(var/mob/M in GLOB.player_list)
+		if(M.client && (M.stat == DEAD || M.client.holder))
+			antaglisting |= M.client
+
+	for(var/client/C in antaglisting)
+		if(!C || !istype(C))
+			continue
+		to_chat(C, "<B>The Antagonist OOC channel has been [GLOB.aooc_allowed ? "enabled. If you're an antagonist, you can access it through the \"AOOC\" verb." : "disabled"].</B>")

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -46,6 +46,8 @@
 			to_chat(src, "<span class='danger'>You cannot use LOOC while ghosting.</span>")
 			return
 
+	msg = emoji_parse(msg)
+
 	log_ooc("(LOCAL) [mob.name]/[key] : [msg]")
 	mob.log_message("(LOCAL): [msg]", INDIVIDUAL_OOC_LOG)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1402,6 +1402,7 @@
 #include "code\modules\client\preferences_savefile.dm"
 #include "code\modules\client\preferences_toggles.dm"
 #include "code\modules\client\preferences_vr.dm"
+#include "code\modules\client\verbs\aooc.dm"
 #include "code\modules\client\verbs\etips.dm"
 #include "code\modules\client\verbs\looc.dm"
 #include "code\modules\client\verbs\ooc.dm"


### PR DESCRIPTION
Title. This is an insanely useful verb to have as a staff member, especially during conversion gamemodes like revolution or cult. This is off by default to ensure AOOC doesn't get misused as an ingame metacomms feature for antags. Admins, antags, and dead players/ghosts can all see AOOC. However, only admins and antags may chat in AOOC.
To admins: Please enable antag OOC frequently during the testmerge! This PR is very untested and may have some pretty weird bugs. Enabling AOOC often during the testmerge will help make sure any bugs get brought to light.

:cl: deathride58
add: Added antag OOC. This is disabled by default, but you can access it with the "AOOC" verb as an antagonist when an administrator enables it.
tweak: LOOC now supports emojis
/:cl: