### PR TITLE
Removes Low-Pressure Resistance from Cold-Res

### DIFF
--- a/code/datums/mutations/cold_resistance.dm
+++ b/code/datums/mutations/cold_resistance.dm
@@ -18,11 +18,13 @@
 	if(..())
 		return
 	owner.add_trait(TRAIT_RESISTCOLD, "cold_resistance")
+//	owner.add_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
 
 /datum/mutation/human/cold_resistance/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	owner.remove_trait(TRAIT_RESISTCOLD, "cold_resistance")
+//	owner.remove_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
 
 /datum/mutation/human/cold_resistance/on_life(mob/living/carbon/human/owner)
 	if(owner.getFireLoss())

--- a/code/datums/mutations/cold_resistance.dm
+++ b/code/datums/mutations/cold_resistance.dm
@@ -18,13 +18,11 @@
 	if(..())
 		return
 	owner.add_trait(TRAIT_RESISTCOLD, "cold_resistance")
-	owner.add_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
 
 /datum/mutation/human/cold_resistance/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	owner.remove_trait(TRAIT_RESISTCOLD, "cold_resistance")
-	owner.remove_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
 
 /datum/mutation/human/cold_resistance/on_life(mob/living/carbon/human/owner)
 	if(owner.getFireLoss())

--- a/code/datums/mutations/cold_resistance.dm
+++ b/code/datums/mutations/cold_resistance.dm
@@ -18,13 +18,13 @@
 	if(..())
 		return
 	owner.add_trait(TRAIT_RESISTCOLD, "cold_resistance")
-//	owner.add_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
+//	owner.add_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")  CITADEL CHANGE
 
 /datum/mutation/human/cold_resistance/on_losing(mob/living/carbon/human/owner)
 	if(..())
 		return
 	owner.remove_trait(TRAIT_RESISTCOLD, "cold_resistance")
-//	owner.remove_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")
+//	owner.remove_trait(TRAIT_RESISTLOWPRESSURE, "cold_resistance")   CITADEL CHANGE
 
 /datum/mutation/human/cold_resistance/on_life(mob/living/carbon/human/owner)
 	if(owner.getFireLoss())


### PR DESCRIPTION
[Changelogs]: Removes the low-pressure resistance trait for Cold-Res

:cl: nicc

change: see above.

/:cl:

[why]: So, this is a change that I think is becoming needed as a result of certain RD mains :^). Cold-res is a fairly easy to get mutation that allows space-proofing with nothing needed but an oxygen tank. This allows players to use things like teleport armor with EXTREMELY reduced risk, and allows more valid-hunting to occur during high-chaos times. It's all-too-common to see all heads and the entire sec team running around in breached areas with riot gear and full uniforms just because they asked genetics nicely, and all too many geneticists are happy to hand out the powers with no problem. Viro was nerfed into the ground with space-proofing, and now genetics is insane by comparison with the ability to space-proof people within 20 minutes. This doesn't even touch on things like X-Ray/TK combo, but it's a start.

FOR MAINTAINERS; I am a fucking nerd with Byond code, if this isn't the proper way to implement this change please tell me. I have 2 commits because one deleted it, and the other readded it but commented out for easier re-enabling.
