### PR TITLE
changes maint areas near sec

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1129,7 +1129,7 @@
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "acV" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -1333,7 +1333,7 @@
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "ads" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -1912,7 +1912,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "aeG" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -2241,9 +2241,6 @@
 	dir = 5
 	},
 /area/security/main)
-"afn" = (
-/turf/open/floor/plating,
-/area/security/main)
 "afo" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -2252,7 +2249,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "afp" = (
 /obj/docking_port/stationary{
 	dir = 4;
@@ -2516,7 +2513,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "agd" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
@@ -49769,7 +49766,7 @@
 	name = "Escape Pod Three"
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "cxJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -53930,7 +53927,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating,
-/area/security/main)
+/area/maintenance/fore/secondary)
 "sXA" = (
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
@@ -88765,7 +88762,7 @@ acU
 adr
 sXy
 aeC
-afn
+anF
 agc
 abp
 ahk


### PR DESCRIPTION
[Changelogs]: reclassifies a maint area near the sec escape pods, because it realistically seems like an area that should be maint shielded for radiation but isn't.

:cl: nicc
add: see above
/:cl:

[why]: cus it looks and feels like a maint tunnel but is area'd as sec, so it doesnt get rad shielding.