### PR TITLE
Buffs WT-550 rubber shot

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/ballistic/rifles.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/rifles.dm
@@ -32,7 +32,7 @@
 /obj/item/projectile/bullet/c46x30mm/rubber
 	name = "4.6x30mm bullet"
 	damage = 5
-	stamina = 20
+	stamina = 30
 
 ///toy memes///
 


### PR DESCRIPTION
[Changelogs]: # (buffs WT-550 rubber shot to 30 stam damg so there useful

[why]: # 20 stam damg is pathetic and takes more all most 10 rounds to place them into stam crit, making them a wast of metal and useless