### PR TITLE
Nuclear Operatives are no longer exclusively human

### DIFF
--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -35,7 +35,7 @@
 	H.equipOutfit(nukeop_outfit)
 
 	if(!isplasmaman(owner.current))
-		return
+		return TRUE
 	var/mob/living/carbon/human/plasma = owner.current
 
 	plasma.set_species(/datum/species/human) //Plasmamen burn up otherwise.

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -32,9 +32,14 @@
 		return
 	var/mob/living/carbon/human/H = owner.current
 
-	H.set_species(/datum/species/human) //Plasamen burn up otherwise, and lizards are vulnerable to asimov AIs
-
 	H.equipOutfit(nukeop_outfit)
+
+	if(!isplasmaman(owner.current))
+		return
+	var/mob/living/carbon/human/plasma = owner.current
+
+	plasma.set_species(/datum/species/human) //Plasmamen burn up otherwise.
+
 	return TRUE
 
 /datum/antagonist/nukeop/greet()


### PR DESCRIPTION

:cl: Tupinambis
tweak: When spawned as a nuclear operative, you keep your characters race instead of being changed into a human. Plasmamen are an exception to this change.
/:cl:

[why]: The original reason that the players race was always changed to human was because of tg's default Asimov lawset. On citadel crewsimov is followed instead. This should also make stealth ops more effective, as a group of unknown pure humans on cit is a lot more suspicious than it would be on tg. 
