### PR TITLE
Makes the syndicate suspicous toolbox not be called "suspicous anymore" but just black and red striped instead.

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -113,8 +113,9 @@
 		new /obj/item/stack/cable_coil(src,30,pickedcolor)
 
 /obj/item/storage/toolbox/syndicate
-	name = "suspicious looking toolbox"
+	name = "black and red striped toolbox"
 	icon_state = "syndicate"
+	desc = "A toolbox painted black with a red stripe. It looks more heavy then normal toolboxes."
 	item_state = "toolbox_syndi"
 	force = 15
 	throwforce = 18

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -113,9 +113,9 @@
 		new /obj/item/stack/cable_coil(src,30,pickedcolor)
 
 /obj/item/storage/toolbox/syndicate
-	name = "black and red striped toolbox"
+	name = "black and red toolbox"
 	icon_state = "syndicate"
-	desc = "A toolbox painted black with a red stripe. It looks more heavy then normal toolboxes."
+	desc = "A toolbox painted black with a red stripe. It looks more heavier then normal toolboxes."
 	item_state = "toolbox_syndi"
 	force = 15
 	throwforce = 18

--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -115,7 +115,7 @@
 /obj/item/storage/toolbox/syndicate
 	name = "black and red toolbox"
 	icon_state = "syndicate"
-	desc = "A toolbox painted black with a red stripe. It looks more heavier then normal toolboxes."
+	desc = "A toolbox painted black with a red stripe. It looks more heavier than normal toolboxes."
 	item_state = "toolbox_syndi"
 	force = 15
 	throwforce = 18


### PR DESCRIPTION
UHHH BLACK TOOLBUX LOOKS SUSPICUS

:cl: Improvedgay
balance: Naming immerions
/:cl:
