### PR TITLE
Xenomicrobes now randomly transform you into one of three castes.

### DIFF
--- a/code/datums/diseases/transformation.dm
+++ b/code/datums/diseases/transformation.dm
@@ -167,36 +167,6 @@
 			if (prob(20))
 				affected_mob.say(pick("beep, beep!", "Boop bop boop beep.", "kkkiiiill mmme", "I wwwaaannntt tttoo dddiiieeee..."))
 
-
-/datum/disease/transformation/xeno
-
-	name = "Xenomorph Transformation"
-	cure_text = "Spaceacillin & Glycerol"
-	cures = list("spaceacillin", "glycerol")
-	cure_chance = 5
-	agent = "Rip-LEY Alien Microbes"
-	desc = "This disease changes the victim into a xenomorph."
-	severity = DISEASE_SEVERITY_BIOHAZARD
-	visibility_flags = 0
-	stage1	= list()
-	stage2	= list("Your throat feels scratchy.", "<span class='danger'>Kill...</span>")
-	stage3	= list("<span class='danger'>Your throat feels very scratchy.</span>", "Your skin feels tight.", "<span class='danger'>You can feel something move...inside.</span>")
-	stage4	= list("<span class='danger'>Your skin feels very tight.</span>", "<span class='danger'>Your blood boils!</span>", "<span class='danger'>You can feel... something...inside you.</span>")
-	stage5	= list("<span class='danger'>Your skin feels as if it's about to burst off!</span>")
-	new_form = /mob/living/carbon/alien/humanoid/hunter
-
-/datum/disease/transformation/xeno/stage_act()
-	..()
-	switch(stage)
-		if(3)
-			if (prob(4))
-				to_chat(affected_mob, "<span class='danger'>You feel a stabbing pain in your head.</span>")
-				affected_mob.Unconscious(40)
-		if(4)
-			if (prob(20))
-				affected_mob.say(pick("You look delicious.", "Going to... devour you...", "Hsssshhhhh!"))
-
-
 /datum/disease/transformation/slime
 	name = "Advanced Mutation Transformation"
 	cure_text = "frost oil"

--- a/code/datums/diseases/xenomicrobes.dm
+++ b/code/datums/diseases/xenomicrobes.dm
@@ -1,0 +1,72 @@
+/datum/disease/xenomicrobes
+	name = "Xenomorph Cytogenetic Transformation Vector"
+	max_stages = 5
+	spread_text = "Acute"
+	spread_flags = DISEASE_SPREAD_SPECIAL
+	cure_text = "Spaceacillin & Glycerol"
+	cures = list("spaceacillin", "glycerol")
+	agent = "Rip-LEY Alien Microbes"
+	viable_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
+	cure_chance = 5
+	desc = "A cellular infection that transforms the victim into a Xenomorph."
+	severity = DISEASE_SEVERITY_BIOHAZARD
+	stage_prob = 10
+
+/datum/disease/xenomicrobes/stage_act()
+	..()
+	switch(stage)
+		if(2)
+			if (prob(8))
+				to_chat(affected_mob, "Your throat feels scratchy.")
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>Kill...</span>")
+		if(3)
+			if (prob(4))
+				to_chat(affected_mob, "<span class='danger'>You feel a stabbing pain in your head.</span>")
+				affected_mob.Unconscious(40)
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>Your throat feels very scratchy.</span>")
+			if (prob(8))
+				to_chat(affected_mob, "Your skin feels tight.")
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>You can feel something shift from...within.</span>")
+		if(4)
+			if (prob(20))
+				affected_mob.say(pick("You look delicious.", "Going to... devour you...", "SSssSssss!", "You will... serve as... a host... for the hive..."))
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>Your skin feels very tight.</span>")
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>Your blood boils!</span>")
+			if (prob(8))
+				to_chat(affected_mob, "<span class='danger'>You can feel... something shifting... within you.</span>")
+		if(5)
+			to_chat(affected_mob, "<span class='danger'>Your skin feels as though it's about to burst off!</span>")
+			if (prob(50))
+				var/mob/living/new_mob
+
+				for(var/obj/item/W in affected_mob.get_equipped_items(TRUE))
+					affected_mob.dropItemToGround(W)
+				for(var/obj/item/I in affected_mob.held_items)
+					affected_mob.dropItemToGround(I)
+
+				var/randomize = pick("sentinel","hunter","drone")
+				switch(randomize)
+					if("sentinel")
+						to_chat(affected_mob, "<span class='danger'>You burst from your old body, being reborn. You feel a tingling sensation within your throat.</span>")
+						new_mob = new /mob/living/carbon/alien/humanoid/sentinel(affected_mob.loc)
+
+					if("hunter")
+						to_chat(affected_mob, "<span class='danger'>You burst from your old body, being reborn. You feel... stronger.</span>")
+						new_mob = new /mob/living/carbon/alien/humanoid/hunter(affected_mob.loc)
+
+					if("drone")
+						to_chat(affected_mob, "<span class='danger'>You burst from your old body, being reborn. An incessant desire to expand the hive reverberates within you.</span>")
+						new_mob = new /mob/living/carbon/alien/humanoid/drone(affected_mob.loc)
+
+				if(affected_mob.mind)
+					affected_mob.mind.transfer_to(new_mob)
+				else
+					new_mob.key = affected_mob.key
+				qdel(affected_mob)
+				return new_mob
+	return

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1113,7 +1113,7 @@
 
 /datum/reagent/xenomicrobes/reaction_mob(mob/living/L, method=TOUCH, reac_volume, show_message = 1, touch_protection = 0)
 	if(method==PATCH || method==INGEST || method==INJECT || (method == VAPOR && prob(min(reac_volume,100)*(1 - touch_protection))))
-		L.ForceContractDisease(new /datum/disease/transformation/xeno(), FALSE, TRUE)
+		L.ForceContractDisease(new /datum/disease/xenomicrobes(), FALSE, TRUE)
 
 /datum/reagent/fungalspores
 	name = "Tubercle bacillus Cosmosis microbes"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -393,6 +393,7 @@
 #include "code\datums\diseases\transformation.dm"
 #include "code\datums\diseases\tuberculosis.dm"
 #include "code\datums\diseases\wizarditis.dm"
+#include "code\datums\diseases\xenomicrobes.dm"
 #include "code\datums\diseases\advance\advance.dm"
 #include "code\datums\diseases\advance\presets.dm"
 #include "code\datums\diseases\advance\symptoms\beard.dm"


### PR DESCRIPTION

:cl: Tupinambis
tweak: Xenomicrobes will now have a random chance of transforming you into either a drone, hunter, or sentinel.
tweak: Flavor text for the xenomicrobe infection has been modified.
note: In order for this to work xenomicrobes had to be removed from the transforming diseases file.
/:cl:

[why]: Since xenomicrobes are currently only obtainable via a lavaland ruin, it is worthwhile to update them to be more robust, allowing the user to potentially become a drone and even a queen.
