### PR TITLE
Reduces the stamina buffer regen timer to 1 second

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -5,7 +5,7 @@
 	if(directstamloss > 0)
 		adjustStaminaLoss(directstamloss)
 	bufferedstam = CLAMP(bufferedstam + amount, 0, stambuffer)
-	stambufferregentime = world.time + 2 SECONDS
+	stambufferregentime = world.time + 10
 	if(updating_stamina)
 		update_health_hud()
 


### PR DESCRIPTION
Old value was 2 seconds. The stamina buffer will be fleshed out a little bit more with med reworks but this is a pretty good hold-over until then.

:cl: deathride58
balance: The stamina buffer now only takes 1 second to start regenerating.
/:cl:
