### PR TITLE
Makes the captain's spare easy for acting captains to access.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -22131,7 +22131,13 @@
 "bfB" = (
 /obj/structure/table/wood,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/item/card/id/captains_spare,
+/obj/item/storage/box/matches{
+	pixel_x = -3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/cigarette/cigar{
+	pixel_y = 6
+	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfC" = (
@@ -26100,13 +26106,12 @@
 /area/crew_quarters/heads/captain)
 "bpl" = (
 /obj/structure/table/wood,
-/obj/item/storage/box/matches,
 /obj/item/razor{
 	pixel_x = -4;
 	pixel_y = 2
 	},
-/obj/item/clothing/mask/cigarette/cigar,
 /obj/item/reagent_containers/food/drinks/flask/gold,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bpm" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -20756,6 +20756,8 @@
 /area/bridge/meeting_room)
 "bbZ" = (
 /obj/structure/table/wood,
+/obj/item/folder/blue,
+/obj/item/stamp/captain,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bca" = (
@@ -22128,9 +22130,8 @@
 /area/crew_quarters/heads/captain)
 "bfB" = (
 /obj/structure/table/wood,
-/obj/item/folder/blue,
-/obj/item/stamp/captain,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfC" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39930,6 +39930,7 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/captain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bKM" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -39930,7 +39930,6 @@
 /obj/item/clipboard,
 /obj/item/toy/figure/captain,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/card/id/captains_spare,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bKM" = (
@@ -43799,6 +43798,7 @@
 	dir = 1;
 	layer = 2.9
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bSO" = (
@@ -82123,11 +82123,11 @@
 	},
 /area/science/explab)
 "duF" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
-	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = -23
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "duG" = (
@@ -89453,6 +89453,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJO" = (
@@ -99649,7 +99650,6 @@
 /area/crew_quarters/abandoned_gambling_den)
 "fpQ" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine,
 /area/science/mixing)
 "fGq" = (
@@ -100180,7 +100180,6 @@
 /area/science/mixing)
 "oIE" = (
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
-/obj/effect/mapping_helpers/airlock/locked,
 /turf/open/floor/engine,
 /area/science/mixing)
 "oMw" = (
@@ -100196,6 +100195,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/vault{
 	dir = 5
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26783,7 +26783,9 @@
 	pixel_x = -30;
 	pixel_y = 1
 	},
-/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/melee/chainofcommand,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/coin/plasma,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bfz" = (
@@ -32299,7 +32301,6 @@
 /area/bridge)
 "bqV" = (
 /obj/structure/table/wood,
-/obj/item/book/manual/wiki/security_space_law,
 /obj/machinery/power/apc{
 	dir = 8;
 	name = "Captain's Quarters APC";
@@ -32312,9 +32313,8 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/item/card/id/captains_spare,
 /obj/item/paper/fluff/gateway,
-/obj/item/coin/plasma,
-/obj/item/melee/chainofcommand,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
 "bqW" = (
@@ -35947,7 +35947,7 @@
 /area/crew_quarters/heads/captain/private)
 "byr" = (
 /obj/structure/table/wood,
-/obj/item/card/id/captains_spare,
+/obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bys" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -26783,6 +26783,7 @@
 	pixel_x = -30;
 	pixel_y = 1
 	},
+/obj/item/reagent_containers/food/drinks/shaker,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bfz" = (
@@ -35946,7 +35947,7 @@
 /area/crew_quarters/heads/captain/private)
 "byr" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/drinks/shaker,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bys" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3373,6 +3373,7 @@
 	},
 /obj/item/melee/chainofcommand,
 /obj/item/stamp/captain,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "agS" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1057,6 +1057,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain/private)
 "acd" = (
@@ -3373,7 +3374,6 @@
 	},
 /obj/item/melee/chainofcommand,
 /obj/item/stamp/captain,
-/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "agS" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9866,6 +9866,7 @@
 "aAs" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/fork,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "aAt" = (
@@ -9894,7 +9895,6 @@
 /area/crew_quarters/heads/captain)
 "aAx" = (
 /obj/structure/table/wood,
-/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAy" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -9894,6 +9894,7 @@
 /area/crew_quarters/heads/captain)
 "aAx" = (
 /obj/structure/table/wood,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "aAy" = (

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -32,7 +32,6 @@
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
-	new /obj/item/card/id/captains_spare(src)
 	new /obj/item/storage/photo_album/Captain(src)
 
 /obj/structure/closet/secure_closet/hop


### PR DESCRIPTION
:cl: Tupinambis
tweak: Removes the captain's spare from the locker and places it on a table within the captain's rooms. Applies to all stations.
tweak: Unlock air alarm and door bolts for Toxins. Adds scrubber and bomb hardsuit. Just updating it to be in line with the other stations.
/:cl:

[why]: As an acting captain, going through the process of grabbing an axe or ion rifle to access the captain's spare is frustrating. This change should allow heads of staff  to more easily take over as acting captain, should no HoP or Captain be available round start.