### PR TITLE
Nerfs disablers, buffs tasers

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -67,7 +67,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 36
+	damage = 24
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'

--- a/modular_citadel/code/modules/projectiles/projectile/energy.dm
+++ b/modular_citadel/code/modules/projectiles/projectile/energy.dm
@@ -1,2 +1,2 @@
 /obj/item/projectile/energy/electrode
-	stamina = 30
+	stamina = 36


### PR DESCRIPTION
Title. Nerfs disablers from 36 stamloss on hit to 24 stamloss on hit, increasing the number of shots to hard stamcrit someone from 4 shots to 6.
Also buffs tasers from 30 flat stamloss to 36 flat stamloss, bringing the total staminaloss dealt by tasers from 55 stamloss to 61 stamloss.

:cl: deathride58
balance: Disablers have had their damage reduced from 36 stamloss to 24 stamloss, increasing their shots to stamcrit from 4 to 6.
balance: Tasers have had their damage increased from 55 stamloss total to 61 stamloss total. Shots required to stamcrit are unaffected.
/:cl:

Should make combat with sec a little more interesting. Disablers are no longer nearly as superior to tasers as they once were, making tasers have a little more of a use.