### PR TITLE
adds windoor to atmos flaps

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -36955,6 +36955,12 @@
 	location = "Atmospherics"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	dir = 4;
+	icon_state = "left";
+	name = "Atmospherics Desk";
+	req_access_txt = "24"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOU" = (


### PR DESCRIPTION
[Changelogs]: suggest change to make atmos just that little bit harder to break into.

:cl: nicc
add: adds windoor to the plastic flaps in the atmos lobby
/:cl:

[why]: currently, in order to break into atmos to steal a hardsuit, you need a welder and a wrench. Crawl under flaps, jump into and out of the disposals unit, rip the wall open. GG 30 seconds or less. This makes that less of an easy thing to do.
