### PR TITLE
changes the name of iron ore to metal ore

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -648,6 +648,7 @@
 /area/ruin/powered/clownplanet)
 "bV" = (
 /obj/structure/table/glass,
+/obj/item/gun/magic/staff/honk,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bW" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -648,7 +648,6 @@
 /area/ruin/powered/clownplanet)
 "bV" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/staff/honk,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bW" = (

--- a/code/modules/mining/ores_coins.dm
+++ b/code/modules/mining/ores_coins.dm
@@ -73,10 +73,10 @@
 	refined_type = /obj/item/stack/sheet/mineral/uranium
 
 /obj/item/stack/ore/iron
-	name = "iron ore"
+	name = "metal ore"
 	icon_state = "Iron ore"
 	item_state = "Iron ore"
-	singular_name = "iron ore chunk"
+	singular_name = "metal ore chunk"
 	points = 1
 	materials = list(MAT_METAL=MINERAL_MATERIAL_AMOUNT)
 	refined_type = /obj/item/stack/sheet/metal
@@ -378,7 +378,7 @@ GLOBAL_LIST_INIT(sand_recipes, list(\
 	grind_results = list("carbon" = 4)
 
 /obj/item/coin/iron
-	name = "iron coin"
+	name = "metal coin"
 	cmineral = "iron"
 	icon_state = "coin_iron_heads"
 	value = 1


### PR DESCRIPTION
[Changelogs]: iron ore is now called metal ore.

:cl: nicc
tweak: changed iron ore to metal ore
/:cl:

[why]: Because it makes slightly more sense than iron ore magically becoming other metals for things like wall plating. Now 'metal ore' is just a catch-all term for the various metals that would make sense for the metal sheet items various uses. IE, The walls of the station that may be steel/aluminum, metal circuitry that would more likely use copper, chairs which could be steel, aluminum, who knows, bullets which could be lead or steel or fuck even tungsten who knows man future.
