### PR TITLE
Forces Vore prefs to use rust_g

### DIFF
--- a/modular_citadel/code/modules/vore/eating/vore_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/vore_vr.dm
@@ -151,9 +151,14 @@ V::::::V           V::::::VO:::::::OOO:::::::ORR:::::R     R:::::REE::::::EEEEEE
 		return FALSE
 
 	//Write it out
+#ifdef RUST_G
+	call(RUST_G, "file_write")(json_to_file, path)
+#else
+	// Fall back to using old format if we are not using rust-g
 	if(fexists(path))
 		fdel(path) //Byond only supports APPENDING to files, not replacing.
-	text2file(json_to_file,path)
+	text2file(json_to_file, path)
+#endif
 	if(!fexists(path))
 		testing("Saving: [path] failed file write")
 		return FALSE


### PR DESCRIPTION
This probably fixes vore specific prefs breaking.

:cl: 
fix: Makes vore specific prefs call Rust_g else uses normal stuff.
/:cl: 

next, Cit_prefs