### PR TITLE
Fixes Cit_toggles by sanitizing it with less autism

### DIFF
--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -141,9 +141,10 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	//citadel code
 	S["arousable"]			>> arousable
 	S["screenshake"]		>> screenshake
-	S["damagescreenshake"]		>> damagescreenshake
-	S["widescreenpref"]				>> widescreenpref
+	S["damagescreenshake"]	>> damagescreenshake
+	S["widescreenpref"]		>> widescreenpref
 	S["autostand"]			>> autostand
+	S["cit_toggles"]		>> cit_toggles
 
 	//try to fix any outdated data if necessary
 	if(needs_update >= 0)
@@ -177,6 +178,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	damagescreenshake	= sanitize_integer(damagescreenshake, 0, 2, initial(damagescreenshake))
 	widescreenpref			= sanitize_integer(widescreenpref, 0, 1, initial(widescreenpref))
 	autostand			= sanitize_integer(autostand, 0, 1, initial(autostand))
+	cit_toggles			= sanitize_integer(cit_toggles, 0, 65535, initial(cit_toggles))
 
 	return 1
 
@@ -228,6 +230,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	WRITE_FILE(S["arousable"], arousable)
 	WRITE_FILE(S["widescreenpref"], widescreenpref)
 	WRITE_FILE(S["autostand"], autostand)
+	WRITE_FILE(S["cit_toggles"], cit_toggles)
 
 	return 1
 

--- a/modular_citadel/code/modules/client/preferences_savefile.dm
+++ b/modular_citadel/code/modules/client/preferences_savefile.dm
@@ -3,9 +3,6 @@
 	S["feature_ipc_screen"] >> features["ipc_screen"]
 	S["feature_ipc_antenna"] >> features["ipc_antenna"]
 
-	//Citadel toggles
-	S["cit_toggles"] >> cit_toggles
-
 	features["ipc_screen"] 	= sanitize_inlist(features["ipc_screen"], GLOB.ipc_screens_list)
 	features["ipc_antenna"] 	= sanitize_inlist(features["ipc_antenna"], GLOB.ipc_antennas_list)
 	//Citadel
@@ -16,7 +13,6 @@
 		features["mcolor3"] = pick("FFFFFF","7F7F7F", "7FFF7F", "7F7FFF", "FF7F7F", "7FFFFF", "FF7FFF", "FFFF7F")
 	features["mcolor2"]	= sanitize_hexcolor(features["mcolor2"], 3, 0)
 	features["mcolor3"]	= sanitize_hexcolor(features["mcolor3"], 3, 0)
-	cit_toggles			= sanitize_integer(toggles, 0, 65535, initial(toggles))
 
 	//gear loadout
 	var/text_to_load
@@ -75,8 +71,6 @@
 	WRITE_FILE(S["feature_has_womb"], features["has_womb"])
 	//flavor text
 	WRITE_FILE(S["feature_flavor_text"], features["flavor_text"])
-
-	WRITE_FILE(S["cit_toggles"], cit_toggles)
 
 	//gear loadout
 	if(islist(chosen_gear))


### PR DESCRIPTION
how the fuck did it never go from toggles -> cit_toggles I haven't a clue

:cl: 
fix: Citadel Toggles should save properly now
/:cl:

fixes: #7311