### PR TITLE
Fixes Defib mount cloning

### DIFF
--- a/code/game/machinery/defibrillator_mount.dm
+++ b/code/game/machinery/defibrillator_mount.dm
@@ -59,10 +59,10 @@
 	if(!defib)
 		to_chat(user, "<span class='warning'>There's no defibrillator unit loaded!</span>")
 		return
-	if(defib.on)
+	if(defib.paddles.loc != defib)
 		to_chat(user, "<span class='warning'>[defib.paddles.loc == user ? "You are already" : "Someone else is"] holding [defib]'s paddles!</span>")
 		return
-	defib.attack_hand(user)
+	user.put_in_hands(defib.paddles)
 
 /obj/machinery/defibrillator_mount/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/defibrillator))
@@ -77,6 +77,9 @@
 		playsound(src, 'sound/machines/click.ogg', 50, TRUE)
 		defib = I
 		update_icon()
+		return
+	else if(I == defib.paddles)
+		defib.paddles.snap_back()
 		return
 	var/obj/item/card/id = I.GetID()
 	if(id)


### PR DESCRIPTION
ORIGINAL PR https://github.com/tgstation/tgstation/pull/39734

🆑Jared-Fogle
fix: Fixes issues with mounted defibrilators.
/🆑

As it turns out, wall mounted defibs become defib units. They have their own code that handles the paddles interactions. This finally makes them work as intended.

The root issue was everything was being send to the defib unit inside of the mount, so when you grabbed the paddles, it'd pull the unit out of its mount and since it can't put_in_hands because the paddles are in the hand it's moving to, it gets dumped out on the floor. It's still registered in said mount, and each mount thereafter gets the same defib's ID registered as what's inside, despite not being contained.

tl;dr Mount tries to be a good boi but a coder tried to be too clever.

fixes #7376