### PR TITLE
removes honkstaff temporarily

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_clown_planet.dmm
@@ -648,7 +648,6 @@
 /area/ruin/powered/clownplanet)
 "bV" = (
 /obj/structure/table/glass,
-/obj/item/gun/magic/staff/honk,
 /turf/open/floor/carpet,
 /area/ruin/powered/clownplanet)
 "bW" = (


### PR DESCRIPTION
[Changelogs]: temporarily removes the honkmother staff from the lavaland ruin


:cl: nicc

del: honkstaff

/:cl:

[why]: The staff currently has a bug where it will get stuck between two turfs and spam the fuck out of anyone nearby with several hundred bullet strikes, and has been known to cause crashes. Temporary removal until fix is found.
