### PR TITLE
Makes slime cores be able to be made into sci points (Once per color type)

### DIFF
--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -18,26 +18,26 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_nodes_hidden = list()		//Nodes that should be hidden by default.
 	var/list/techweb_point_items = list(		//path = list(point type = value)
 	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000),   // Adds in slime core deconing
-	/obj/item/slime_extract/grey = (TECHWEB_POINT_TYPE_GENERIC = 500),
-	/obj/item/slime_extract/metal = (TECHWEB_POINT_TYPE_GENERIC = 750),
-	/obj/item/slime_extract/purple = (TECHWEB_POINT_TYPE_GENERIC = 750),
-	/obj/item/slime_extract/orange = (TECHWEB_POINT_TYPE_GENERIC = 750),
-	/obj/item/slime_extract/blue = (TECHWEB_POINT_TYPE_GENERIC = 750),
-	/obj/item/slime_extract/yellow = (TECHWEB_POINT_TYPE_GENERIC = 1000),
-	/obj/item/slime_extract/silver = (TECHWEB_POINT_TYPE_GENERIC = 1000),
-	/obj/item/slime_extract/darkblue = (TECHWEB_POINT_TYPE_GENERIC = 1000),
-	/obj/item/slime_extract/darkpurple = (TECHWEB_POINT_TYPE_GENERIC = 1000),
-	/obj/item/slime_extract/bluespace = (TECHWEB_POINT_TYPE_GENERIC = 1250),
-	/obj/item/slime_extract/cerulean = (TECHWEB_POINT_TYPE_GENERIC = 1250),
-	/obj/item/slime_extract/pyrite = (TECHWEB_POINT_TYPE_GENERIC = 1250),
-	/obj/item/slime_extract/green = (TECHWEB_POINT_TYPE_GENERIC = 1250),
-	/obj/item/slime_extract/pink = (TECHWEB_POINT_TYPE_GENERIC = 1250),
-	/obj/item/slime_extract/gold = (TECHWEB_POINT_TYPE_GENERIC = 1250),
-	/obj/item/slime_extract/black = (TECHWEB_POINT_TYPE_GENERIC = 1500),
-	/obj/item/slime_extract/adamantine = (TECHWEB_POINT_TYPE_GENERIC = 1500),
-	/obj/item/slime_extract/oil = (TECHWEB_POINT_TYPE_GENERIC = 1500),
-	/obj/item/slime_extract/lightpink = (TECHWEB_POINT_TYPE_GENERIC = 1500),
-	/obj/item/slime_extract/rainbow = (TECHWEB_POINT_TYPE_GENERIC = 2500)      // End of Cit changes	
+	/obj/item/slime_extract/grey = list(TECHWEB_POINT_TYPE_GENERIC = 500),
+	/obj/item/slime_extract/metal = list(TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/purple = list(TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/orange = list(TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/blue = list(TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/yellow = list(TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/silver = list(TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/darkblue = list(TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/darkpurple = list(TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/bluespace = list(TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/cerulean = list(TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/pyrite = list(TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/green = list(TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/pink = list(TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/gold = list(TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/black = list(TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/adamantine =list (TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/oil = list(TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/lightpink = list(TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/rainbow = list(TECHWEB_POINT_TYPE_GENERIC = 2500)      // End of Cit changes	
 	)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -17,8 +17,11 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_boost_items = list()		//associative double-layer path = list(id = list(point_type = point_discount))
 	var/list/techweb_nodes_hidden = list()		//Nodes that should be hidden by default.
 	var/list/techweb_point_items = list(		//path = list(point type = value)
-	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000),   // Adds in slime core deconing
-	/obj/item/slime_extract/grey = list(TECHWEB_POINT_TYPE_GENERIC = 500),
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 2500),   
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 5000),   // Cit three more anomalys anomalys
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 7500),   
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000),
+	/obj/item/slime_extract/grey = list(TECHWEB_POINT_TYPE_GENERIC = 500),    // Adds in slime core deconing
 	/obj/item/slime_extract/metal = list(TECHWEB_POINT_TYPE_GENERIC = 750),
 	/obj/item/slime_extract/purple = list(TECHWEB_POINT_TYPE_GENERIC = 750),
 	/obj/item/slime_extract/orange = list(TECHWEB_POINT_TYPE_GENERIC = 750),

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -35,6 +35,7 @@ SUBSYSTEM_DEF(research)
 	/obj/item/slime_extract/gold = (TECHWEB_POINT_TYPE_GENERIC = 1250),
 	/obj/item/slime_extract/black = (TECHWEB_POINT_TYPE_GENERIC = 1500),
 	/obj/item/slime_extract/adamantine = (TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/oil = (TECHWEB_POINT_TYPE_GENERIC = 1500),
 	/obj/item/slime_extract/lightpink = (TECHWEB_POINT_TYPE_GENERIC = 1500),
 	/obj/item/slime_extract/rainbow = (TECHWEB_POINT_TYPE_GENERIC = 2500)      // End of Cit changes	
 	)

--- a/code/controllers/subsystem/research.dm
+++ b/code/controllers/subsystem/research.dm
@@ -17,10 +17,26 @@ SUBSYSTEM_DEF(research)
 	var/list/techweb_boost_items = list()		//associative double-layer path = list(id = list(point_type = point_discount))
 	var/list/techweb_nodes_hidden = list()		//Nodes that should be hidden by default.
 	var/list/techweb_point_items = list(		//path = list(point type = value)
-	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000),   // Cit three more anomalys anomalys
-	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 7500),   
-	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 5000),
-	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 2500)     // End of Cit changes
+	/obj/item/assembly/signaler/anomaly = list(TECHWEB_POINT_TYPE_GENERIC = 10000),   // Adds in slime core deconing
+	/obj/item/slime_extract/grey = (TECHWEB_POINT_TYPE_GENERIC = 500),
+	/obj/item/slime_extract/metal = (TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/purple = (TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/orange = (TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/blue = (TECHWEB_POINT_TYPE_GENERIC = 750),
+	/obj/item/slime_extract/yellow = (TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/silver = (TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/darkblue = (TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/darkpurple = (TECHWEB_POINT_TYPE_GENERIC = 1000),
+	/obj/item/slime_extract/bluespace = (TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/cerulean = (TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/pyrite = (TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/green = (TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/pink = (TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/gold = (TECHWEB_POINT_TYPE_GENERIC = 1250),
+	/obj/item/slime_extract/black = (TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/adamantine = (TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/lightpink = (TECHWEB_POINT_TYPE_GENERIC = 1500),
+	/obj/item/slime_extract/rainbow = (TECHWEB_POINT_TYPE_GENERIC = 2500)      // End of Cit changes	
 	)
 	var/list/errored_datums = list()
 	var/list/point_types = list()				//typecache style type = TRUE list


### PR DESCRIPTION
 **REMOVES THE 3 OTHER ANOMALY TO POINTS DA**
Adds in slime cores being able to be made into tec points, can only do this ONCE per core type
TODO
Make Crossbreading cores into points
Relabel and add in different core DA listings
[why]: # (Most slime are useless to non-antags and never gotten with intent. 
