### PR TITLE
clarifies drone rules when becoming a drone

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -69,7 +69,7 @@
 	var/visualAppearence = MAINTDRONE //What we appear as
 	var/hacked = FALSE //If we have laws to destroy the station
 	var/flavortext = \
-	"\n<big><span class='warning'>DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
+	"\n<big><span class='warning'>UNLESS YOU ARE A FREE DRONE, DO NOT INTERFERE WITH THE ROUND AS A DRONE OR YOU WILL BE DRONE BANNED</span></big>\n"+\
 	"<span class='notify'>Drones are a ghost role that are allowed to fix the station and build things. Interfering with the round as a drone is against the rules.</span>\n"+\
 	"<span class='notify'>Actions that constitute interference include, but are not limited to:</span>\n"+\
 	"<span class='notify'>     - Interacting with round critical objects (IDs, weapons, contraband, powersinks, bombs, etc.)</span>\n"+\


### PR DESCRIPTION
[Changelogs]: Updates drone rule text to add specifics regarding free drones.

:cl: nicc

fix: fixed misleading drone text

/:cl:

[why]: The large red "Do not interfere" text is misleading when transformed into a free drone, which IS allowed to interfere. So this has been added to the text to help out people who aren't familiar.
