### PR TITLE
Fixing placement and nerfing of Adv Illegal node

### DIFF
--- a/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -14,9 +14,9 @@
 	desc = "A gun magazine."
 	id = "10mm"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 18000)
+	materials = list(MAT_METAL = 55000)
 	build_path = /obj/item/ammo_box/magazine/m10mm
-	category = list("Weapons")
+	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/m10mm/hp
@@ -24,10 +24,10 @@
 	desc = "A gun magazine. Loaded with hollow-point rounds, extremely effective against unarmored targets, but nearly useless against protective clothing."
 	id = "10mmhp"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 18000, MAT_GLASS = 25000)
+	materials = list(MAT_METAL = 40000, MAT_GLASS = 50000)
 	reagents_list = list("sonic_powder" = 280)
 	build_path = /obj/item/ammo_box/magazine/m10mm/hp
-	category = list("Weapons")
+	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
  
  /datum/design/m10mm/ap
@@ -35,9 +35,9 @@
  	desc = "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets."
  	id = "10mmap"
  	build_type = PROTOLATHE
- 	materials = list(MAT_METAL = 18000, MAT_TITANIUM = 22000)
+ 	materials = list(MAT_METAL = 40000, MAT_TITANIUM = 60000)
  	build_path = /obj/item/ammo_box/magazine/m10mm/ap
- 	category = list("Weapons")
+ 	category = list("Ammo")
  	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 	
 /datum/design/bolt_clip
@@ -47,16 +47,16 @@
  	build_type = PROTOLATHE
  	materials = list(MAT_METAL = 8000)
  	build_path = /obj/item/ammo_box/a762
- 	category = list("Weapons")
+ 	category = list("Ammo")
  	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
  
 /datum/design/m45 //Kinda NT in throey
 	name = "handgun magazine (.45)"
 	id = "m45"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 8000)
+	materials = list(MAT_METAL = 80000)
 	build_path = /obj/item/ammo_box/magazine/m45
-	category = list("Weapons")
+	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
 /datum/design/pistolm9mm
@@ -64,7 +64,7 @@
 	desc = "A gun magazine."
 	id = "pistolm9mm"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 16000)
+	materials = list(MAT_METAL = 80000)
 	build_path = /obj/item/ammo_box/magazine/pistolm9mm
-	category = list("Weapons")
+	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
[Changelogs]:  (Just 3-5 times the mats needed to make mags for illegal tec nodes as well as place them under Ammo and not weaponds.)

[why]:  (Feed Back tells me to as well as misplacement needed to be fixed)
