### PR TITLE
[s] nerfs smuggler satchels cus wtf

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -247,7 +247,7 @@
 	name = "smuggler's satchel"
 	desc = "A very slim satchel that can easily fit into tight spaces."
 	icon_state = "satchel-flat"
-	w_class = WEIGHT_CLASS_NORMAL //Can fit in backpacks itself.
+	w_class = WEIGHT_CLASS_BULKY //Can fit in backpacks itself.
 	level = 1
 	component_type = /datum/component/storage/concrete/secret_satchel
 

--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -258,7 +258,7 @@
 /obj/item/storage/backpack/satchel/flat/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_combined_w_class = 15
+	STR.max_combined_w_class = 6
 	STR.cant_hold = typecacheof(list(/obj/item/storage/backpack/satchel/flat)) //muh recursive backpacks
 
 /obj/item/storage/backpack/satchel/flat/hide(intact)


### PR DESCRIPTION
[Changelogs]: Reduces carry capacity of smuggler satchels

:cl: nicc

balance: reduces weight cap of smuggler satchel

/:cl:

[why]: at the moment you can put like 5 guns in them and then throw them in your backpack, so unless one of the better coders wants to just make it so you can't put guns in or something, this is the easy way to solve that massive powergame.

