### PR TITLE
Upstream bugfix mirror spree

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1381,6 +1381,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		target.visible_message("<span class='danger'>[user] has [atk_verb]ed [target]!</span>", \
 					"<span class='userdanger'>[user] has [atk_verb]ed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
 
+		target.lastattacker = user.real_name
+		target.lastattackerckey = user.ckey
+
 		if(user.limb_destroyer)
 			target.dismembering_strike(user, affecting.body_zone)
 		target.apply_damage(damage, BRUTE, affecting, armor_block)

--- a/code/modules/mob/living/ventcrawling.dm
+++ b/code/modules/mob/living/ventcrawling.dm
@@ -57,7 +57,7 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 
 			if(iscarbon(src) && ventcrawler < 2)//It must have atleast been 1 to get this far
 				var/failed = 0
-				var/list/items_list = get_equipped_items()
+				var/list/items_list = get_equipped_items(include_pockets = TRUE)
 				if(items_list.len)
 					failed = 1
 				for(var/obj/item/I in held_items)
@@ -120,4 +120,3 @@ GLOBAL_LIST_INIT(ventcrawl_machinery, typecacheof(list(
 		. = new_loc
 	remove_ventcrawl()
 	add_ventcrawl(.)
-

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -256,5 +256,5 @@
 /////////////////////////////////// TEMPERATURE ////////////////////////////////////
 
 /mob/proc/adjust_bodytemperature(amount,min_temp=0,max_temp=INFINITY)
-	if(bodytemperature > min_temp && bodytemperature < max_temp)
+	if(bodytemperature >= min_temp && bodytemperature <= max_temp)
 		bodytemperature = CLAMP(bodytemperature + amount,min_temp,max_temp)

--- a/code/modules/paperwork/photocopier.dm
+++ b/code/modules/paperwork/photocopier.dm
@@ -135,6 +135,8 @@
 					p.pixel_x = rand(-10, 10)
 					p.pixel_y = rand(-10, 10)
 					p.picture = new(null, "You see [ass]'s ass on the photo.", temp_img)
+					p.picture.psize_x = 128
+					p.picture.psize_y = 128
 					p.update_icon()
 					toner -= 5
 					busy = TRUE

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -135,7 +135,7 @@
 	..()
 	if(!automatic_charge_overlays)
 		return
-	var/ratio = CEILING((cell.charge / cell.maxcharge) * charge_sections, 1)
+	var/ratio = CEILING(CLAMP(cell.charge / cell.maxcharge, 0, 1) * charge_sections, 1)
 	if(ratio == old_ratio && !force_update)
 		return
 	old_ratio = ratio

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -539,7 +539,7 @@
 	if(check_pierce(target))
 		permutated += target
 		trajectory_ignore_forcemove = TRUE
-		forceMove(target)
+		forceMove(target.loc)
 		trajectory_ignore_forcemove = FALSE
 		return FALSE
 	if(!QDELETED(target))


### PR DESCRIPTION
This is a PR that mirrors a bunch of bug fixes from upstream. See commits for exact details of what's been mirrored. I strongly, strongly encourage other contributors to also do the same as I'm doing, and go through the code improvement and fixes tags of upstream's github and mirroring PRs that've been merged.

:cl: TGstation contributors
fix: (tgstation/tgstation#40043) - Beam rifles no longer open lockers
fix: (tgstation/tgstation#40061) - Mobs can no longer get stuck at min/max body temperature
fix: (tgstation/tgstation#40041) - Pictures of asses are now properly sized
fix: (tgstation/tgstation#40084) - The lastattacker var now includes unarmed attacks
fix: (tgstation/tgstation#39968) - Plastic golems can no longer ventcrawl with items in their pockets
fix: (tgstation/tgstation#39885) - You can no longer crash the server by overcharging energy guns.
/:cl:
