### PR TITLE
Nerfs round start nanites memes (Soft gates)

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -837,7 +837,7 @@
 	id = "nanite_base"
 	display_name = "Basic Nanite Programming"
 	description = "The basics of nanite construction and programming."
-	prereq_ids = list("datatheory","robotics")
+	prereq_ids = list("datatheory","robotics","high_efficiency", "emp_adv")
 	design_ids = list("nanite_disk","nanite_remote","nanite_scanner",\
 						"nanite_chamber","public_nanite_chamber","nanite_chamber_control","nanite_programmer","nanite_program_hub","nanite_cloud_control",\
 						"relay_nanites", "monitoring_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -837,7 +837,7 @@
 	id = "nanite_base"
 	display_name = "Basic Nanite Programming"
 	description = "The basics of nanite construction and programming."
-	prereq_ids = list("datatheory","robotics","high_efficiency", "emp_adv")
+	prereq_ids = list("datatheory","robotics","high_efficiency", "emp_adv", "adv_biotech")
 	design_ids = list("nanite_disk","nanite_remote","nanite_scanner",\
 						"nanite_chamber","public_nanite_chamber","nanite_chamber_control","nanite_programmer","nanite_program_hub","nanite_cloud_control",\
 						"relay_nanites", "monitoring_nanites", "access_nanites", "repairing_nanites","sensor_nanite_volume", "repeater_nanites", "relay_repeater_nanites")
@@ -848,7 +848,7 @@
 	id = "nanite_smart"
 	display_name = "Smart Nanite Programming"
 	description = "Nanite programs that require nanites to perform complex actions, act independently, roam or seek targets."
-	prereq_ids = list("nanite_base","adv_robotics")
+	prereq_ids = list("nanite_base","adv_robotics", "adv_datatheory")
 	design_ids = list("purging_nanites", "metabolic_nanites", "stealth_nanites", "memleak_nanites","sensor_voice_nanites", "voice_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 4000
@@ -866,7 +866,7 @@
 	id = "nanite_bio"
 	display_name = "Biological Nanite Programming"
 	description = "Nanite programs that require complex biological interaction."
-	prereq_ids = list("nanite_base","biotech")
+	prereq_ids = list("nanite_base","adv_datatheory", "adv_surgery")
 	design_ids = list("regenerative_nanites", "bloodheal_nanites", "coagulating_nanites","poison_nanites","flesheating_nanites",\
 					"sensor_crit_nanites","sensor_death_nanites", "sensor_health_nanites", "sensor_damage_nanites")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)


### PR DESCRIPTION
[Changelogs]:
Helps gate off nanite memes behind t3 parts so we get things that make are life not hell and wait for 1 hour befor getting basic blue space
[What dose this do?]
Added in soft gates(I.e being tec needing basic other nodes that are related to the tec in the node) 
Added in gates to help node progression more evenly with other departments
[Why]
Not gating them behind parts was a horrible idea for power gamers that just want to walk on lava well being hit with bomb spears well drinking plasma. Also removes round start mindshield factories or other crazy Anit-Fun things. This also helps node progression for other departments, so nanaits are not solo sci gear 
