### PR TITLE
Nerfs nanite pools

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -2,10 +2,10 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 	var/mob/living/host_mob
-	var/nanite_volume = 25		//amount of nanites in the system, used as fuel for nanite programs
-	var/max_nanites = 125		//maximum amount of nanites in the system
+	var/nanite_volume = 50		//amount of nanites in the system, used as fuel for nanite programs
+	var/max_nanites = 250		//maximum amount of nanites in the system
 	var/regen_rate = 0.5		//nanites generated per second
-	var/safety_threshold = 12	//how low nanites will get before they stop processing/triggering
+	var/safety_threshold = 25	//how low nanites will get before they stop processing/triggering
 	var/cloud_id = 0 			//0 if not connected to the cloud, 1-100 to set a determined cloud backup to draw from
 	var/next_sync = 0
 	var/list/datum/nanite_program/programs = list()

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -5,7 +5,7 @@
 	var/nanite_volume = 25		//amount of nanites in the system, used as fuel for nanite programs
 	var/max_nanites = 125		//maximum amount of nanites in the system
 	var/regen_rate = 0.5		//nanites generated per second
-	var/safety_threshold = 50	//how low nanites will get before they stop processing/triggering
+	var/safety_threshold = 12	//how low nanites will get before they stop processing/triggering
 	var/cloud_id = 0 			//0 if not connected to the cloud, 1-100 to set a determined cloud backup to draw from
 	var/next_sync = 0
 	var/list/datum/nanite_program/programs = list()

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -2,8 +2,8 @@
 	dupe_mode = COMPONENT_DUPE_UNIQUE_PASSARGS
 
 	var/mob/living/host_mob
-	var/nanite_volume = 100		//amount of nanites in the system, used as fuel for nanite programs
-	var/max_nanites = 500		//maximum amount of nanites in the system
+	var/nanite_volume = 25		//amount of nanites in the system, used as fuel for nanite programs
+	var/max_nanites = 125		//maximum amount of nanites in the system
 	var/regen_rate = 0.5		//nanites generated per second
 	var/safety_threshold = 50	//how low nanites will get before they stop processing/triggering
 	var/cloud_id = 0 			//0 if not connected to the cloud, 1-100 to set a determined cloud backup to draw from


### PR DESCRIPTION
Title. This PR nerfs the baseline/default nanite pool from 100 nanites to 25 nanites, and nerfs the maximum nanite amount from 500 nanites to 125 nanites. The safety threshold has been reduced from 50 nanites to 12 nanites.

:cl: deathride58
balance: Reduced the default/baseline nanite pool amount from 100 nanites to 25 nanites, and reduced the maximum nanite amount from 500 nanites to 125 nanites. The safety threshold was reduced from 50 nanites to 12 nanites.
/:cl:

This PR should make nanites a lot less powerful by making it so that it's entirely plausible for nanites to actually run out if they're used for prolonged periods of time. So instead of your nervous support lasting for 5.5 minutes (!!!) on it's own, it'll only last roughly one minute.