### PR TITLE
super turbo lavaland 2 tournament edition (Buffs a bunch of lavaland mobs by increasing their speed)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -33,7 +33,7 @@ Difficulty: Medium
 	movement_type = GROUND
 	speak_emote = list("roars")
 	speed = 1
-	move_to_delay = 3
+	move_to_delay = 2
 	projectiletype = /obj/item/projectile/kinetic/miner
 	projectilesound = 'sound/weapons/kenetic_accel.ogg'
 	ranged = 1

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -40,7 +40,7 @@ Difficulty: Hard
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 6
+	move_to_delay = 10
 	ranged_cooldown_time = 10
 	ranged = 1
 	pixel_x = -32
@@ -61,7 +61,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Life()
 	..()
-	move_to_delay = CLAMP(round((health/maxHealth) * 6), 2, 6)
+	move_to_delay = CLAMP(round((health/maxHealth) * 10), 3, 10)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()
 	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -40,7 +40,8 @@ Difficulty: Hard
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 10
+	move_to_delay = 6
+	ranged_cooldown_time = 10
 	ranged = 1
 	pixel_x = -32
 	del_on_death = 1
@@ -60,7 +61,7 @@ Difficulty: Hard
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/Life()
 	..()
-	move_to_delay = CLAMP(round((health/maxHealth) * 10), 5, 10)
+	move_to_delay = CLAMP(round((health/maxHealth) * 6), 2, 6)
 
 /mob/living/simple_animal/hostile/megafauna/bubblegum/OpenFire()
 	anger_modifier = CLAMP(((maxHealth - health)/50),0,20)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -79,14 +79,14 @@ Difficulty: Very Hard
 			INVOKE_ASYNC(src, .proc/spiral_shoot, pick(TRUE, FALSE))
 
 	else if(prob(20))
-		ranged_cooldown = world.time + 30
+		ranged_cooldown = world.time + 2
 		random_shots()
 	else
 		if(prob(70))
-			ranged_cooldown = world.time + 20
+			ranged_cooldown = world.time + 10
 			blast()
 		else
-			ranged_cooldown = world.time + 40
+			ranged_cooldown = world.time + 20
 			INVOKE_ASYNC(src, .proc/alternating_dir_shots)
 
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/drake.dm
@@ -48,7 +48,7 @@ Difficulty: Medium
 	melee_damage_lower = 40
 	melee_damage_upper = 40
 	speed = 1
-	move_to_delay = 10
+	move_to_delay = 5
 	ranged = 1
 	pixel_x = -16
 	crusher_loot = list(/obj/structure/closet/crate/necropolis/dragon/crusher)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -65,9 +65,9 @@ Difficulty: Hard
 
 	var/burst_range = 3 //range on burst aoe
 	var/beam_range = 5 //range on cross blast beams
-	var/chaser_speed = 3 //how fast chasers are currently
-	var/chaser_cooldown = 101 //base cooldown/cooldown var between spawning chasers
-	var/major_attack_cooldown = 60 //base cooldown for major attacks
+	var/chaser_speed = 2 //how fast chasers are currently
+	var/chaser_cooldown = 50 //base cooldown/cooldown var between spawning chasers
+	var/major_attack_cooldown = 40 //base cooldown for major attacks
 	var/arena_cooldown = 200 //base cooldown/cooldown var for creating an arena
 	var/blinking = FALSE //if we're doing something that requires us to stand still and not attack
 	var/obj/effect/hierophant/spawned_beacon //the beacon we teleport back to
@@ -204,7 +204,7 @@ Difficulty: Hard
 			return
 		target_slowness += L.movement_delay()
 	target_slowness = max(target_slowness, 1)
-	chaser_speed = max(1, (3 - anger_modifier * 0.04) + ((target_slowness - 1) * 0.5))
+	chaser_speed = max(1, (2 - anger_modifier * 0.04) + ((target_slowness - 1) * 0.5))
 
 	arena_trap(target)
 	ranged_cooldown = world.time + max(5, ranged_cooldown_time - anger_modifier * 0.75) //scale cooldown lower with high anger.

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -31,12 +31,13 @@ Difficulty: Medium
 	armour_penetration = 50
 	melee_damage_lower = 25
 	melee_damage_upper = 25
-	speed = 2
+	speed = 1
+	move_to_delay = 2
 	ranged = 1
 	del_on_death = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	ranged_cooldown_time = 20
+	ranged_cooldown_time = 10
 	var/size = 5
 	var/charging = 0
 	medal_type = BOSS_MEDAL_LEGION
@@ -87,6 +88,7 @@ Difficulty: Medium
 			retreat_distance = 0
 			minimum_distance = 0
 			speed = 0
+			move_to_delay = 1
 			charging = 1
 			addtimer(CALLBACK(src, .proc/reset_charge), 50)
 
@@ -94,7 +96,8 @@ Difficulty: Medium
 	ranged = 1
 	retreat_distance = 5
 	minimum_distance = 5
-	speed = 2
+	speed = 1
+	move_to_delay = 2
 	charging = 0
 
 /mob/living/simple_animal/hostile/megafauna/legion/death()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/legion.dm
@@ -45,7 +45,7 @@ Difficulty: Medium
 	pixel_y = -90
 	pixel_x = -75
 	loot = list(/obj/item/stack/sheet/bone = 3)
-	vision_range = 13
+	vision_range = 10
 	wander = FALSE
 	elimination = 1
 	appearance_flags = 0

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -19,8 +19,8 @@
 	damage_coeff = list(BRUTE = 1, BURN = 0.5, TOX = 1, CLONE = 1, STAMINA = 0, OXY = 1)
 	minbodytemp = 0
 	maxbodytemp = INFINITY
-	vision_range = 5
-	aggro_vision_range = 18
+	vision_range = 4
+	aggro_vision_range = 15
 	anchored = TRUE
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -10,9 +10,9 @@
 	icon_gib = "syndicate_gib"
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	move_to_delay = 40
+	move_to_delay = 5
 	ranged = 1
-	ranged_cooldown_time = 120
+	ranged_cooldown_time = 40
 	friendly = "wails at"
 	speak_emote = list("bellows")
 	vision_range = 4
@@ -65,7 +65,7 @@
 		pre_attack = 0
 
 /mob/living/simple_animal/hostile/asteroid/goliath/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	ranged_cooldown -= 10
+	ranged_cooldown -= 5
 	handle_preattack()
 	. = ..()
 
@@ -109,6 +109,7 @@
 	maxHealth = 400
 	health = 400
 	speed = 4
+	ranged_cooldown_time = 60
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"
 	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide) //A throwback to the asteroid days

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -15,7 +15,6 @@
 	ranged_cooldown_time = 60
 	friendly = "wails at"
 	speak_emote = list("bellows")
-	vision_range = 4
 	speed = 3
 	maxHealth = 300
 	health = 300

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -12,7 +12,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	move_to_delay = 5
 	ranged = 1
-	ranged_cooldown_time = 40
+	ranged_cooldown_time = 60
 	friendly = "wails at"
 	speak_emote = list("bellows")
 	vision_range = 4
@@ -21,13 +21,13 @@
 	health = 300
 	harm_intent_damage = 0
 	obj_damage = 100
-	melee_damage_lower = 25
-	melee_damage_upper = 25
+	melee_damage_lower = 18
+	melee_damage_upper = 18
 	attacktext = "pulverizes"
 	attack_sound = 'sound/weapons/punch1.ogg'
 	throw_message = "does nothing to the rocky hide of the"
-	vision_range = 5
-	aggro_vision_range = 9
+	vision_range = 4
+	aggro_vision_range = 7
 	anchored = TRUE //Stays anchored until death as to be unpullable
 	var/pre_attack = 0
 	var/pre_attack_icon = "Goliath_preattack"
@@ -109,7 +109,7 @@
 	maxHealth = 400
 	health = 400
 	speed = 4
-	ranged_cooldown_time = 60
+	ranged_cooldown_time = 80
 	pre_attack_icon = "Goliath_preattack"
 	throw_message = "does nothing to the rocky hide of the"
 	loot = list(/obj/item/stack/sheet/animalhide/goliath_hide) //A throwback to the asteroid days

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -10,7 +10,7 @@
 	icon_gib = "syndicate_gib"
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
-	move_to_delay = 5
+	move_to_delay = 10
 	ranged = 1
 	ranged_cooldown_time = 60
 	friendly = "wails at"

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -11,8 +11,8 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	move_to_delay = 14
 	ranged = 1
-	vision_range = 5
-	aggro_vision_range = 9
+	vision_range = 4
+	aggro_vision_range = 7
 	speed = 3
 	maxHealth = 75
 	health = 75

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -24,7 +24,7 @@
 	attack_sound = 'sound/weapons/pierce.ogg'
 	throw_message = "falls right through the strange body of the"
 	ranged_cooldown = 0
-	ranged_cooldown_time = 20
+	ranged_cooldown_time = 15
 	obj_damage = 0
 	environment_smash = ENVIRONMENT_SMASH_NONE
 	retreat_distance = 3
@@ -131,6 +131,7 @@
 	maxHealth = 60
 	health = 60
 	speed = 2 //faster!
+	move_to_delay = 10 //actually faster!
 	crusher_drop_mod = 20
 	dwarf_mob = TRUE
 
@@ -377,7 +378,3 @@
 			id = /obj/item/card/id/knight //END OF CIT CHANGE
 			id_job = "Knight"
 	. = ..()
-
-
-
-


### PR DESCRIPTION
Title. This PR is entirely untested as of the time of this writing because I made this entire PR on my lunch break.

This PR buffs lavaland mobs not by increasing their damage, not by increasing their health, not by giving them new complex attack patterns, not by making their attack patterns even more random, but rather by simply increasing the rate of their attacks and their movement speed. Full details of everything is listed in the diff, it's easy enough to interpret if you know how to codedive. If they're too fast for you now, then git gud or bring a buddy. Leave feedback regarding these adjustments on this PR!

:cl: deathride58
balance: Most of Lavaland's mobs are now on crack.
balance: Blood drunk miners now move once every two ticks, rather than once every three ticks.
balance: Bubblegum now has a maximum movement speed of once every three ticks. Buffed from the original value of once per 5 ticks.
balance: The minimum time for the Colossus to attack again after firing a random shot is two deciseconds, Sped up from the original value of three seconds. The minimum time for the Colossus to attack again after performing a blast is now one second, with the original value being two seconds. The minimum time for it to attack again after performing its alternating shot pattern is now two seconds, original value being four seconds.
balance: Ashdrakes now move once every five ticks, rather than once every ten ticks.
balance: Heirophant chasers now move once every two ticks rather than three ticks by default, and the chaser cooldown has been reduced from 10 seconds to 5 seconds. The cooldown for the Heirophant's major attacks has also been sped up to 4 seconds from the original value of 6 seconds.
balance: The Legion (megafauna) now moves at two ticks per second rather than three ticks. It additionally now actually moves faster while charging. The cooldown timer for it's special attacks has been reduced from 2 seconds to 1 second. Additionally, The Legion's view range has been decreased from 13 tiles to 10 tiles.
balance: All megafauna now have a default view range of 4 tiles, decreased from the original of 5 tiles, and an aggro'd view range of 15 tiles, decreased from the original of 18
balance: Goliaths now move once every ten ticks, sped up from the original value of 40(!!!) ticks. Additionally, their cooldown for their tentacles has been reduced from 12 seconds to 6 seconds. To compensate, their cooldown now only decreases by 5 deciseconds every time they're attacked, rather than 10 deciseconds, their melee damage has been reduced to 18 per hit from 25 per hit, and their vision range has been decreased from 5 tiles unaggroed, 9 tiles when aggroed, to 4 tiles and 7 tiles respectively. Ancient goliaths have a default attack cooldown of 8 seconds, sped up from the original value of 12 seconds.
balance: Legion (the common mob) now has a cooldown of 1.5 seconds on their skull attack, sped up from the original value of 2 seconds. Additionally, their view range has been decreased from 5 tiles, 9 tiles when aggroed, to 4 tiles, 7 tiles when aggroed.
/:cl:
