### PR TITLE
PR to reduce goliath stuntime (Meant for merge alongside Bhijn's mob changes)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goliath.dm
@@ -182,7 +182,7 @@
 		if((!QDELETED(spawner) && spawner.faction_check_mob(L)) || L.stat == DEAD)
 			continue
 		visible_message("<span class='danger'>[src] grabs hold of [L]!</span>")
-		L.Stun(100)
+		L.Stun(60)
 		L.adjustBruteLoss(rand(10,15))
 		latched = TRUE
 	if(!latched)


### PR DESCRIPTION
[Changelogs]: Reduce goliath stuntime.

:cl: nicc

tweak: Goliath stuntime reduced, 100 down to 60.

/:cl:

[why]: This will make it much less likely to be instantly fucking ruined by an unlucky goliath stun from incoming changes with Bhijns mobr PR.
