### PR TITLE
NPC Space Pirate Heath Buff 100 -> 115 (Yarr)

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/pirate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/pirate.dm
@@ -12,8 +12,8 @@
 	response_disarm = "shoves"
 	response_harm = "hits"
 	speed = 0
-	maxHealth = 100
-	health = 100
+	maxHealth = 115
+	health = 115
 	spacewalk = TRUE
 
 	harm_intent_damage = 5


### PR DESCRIPTION
**For the away mission**
[Changelogs]: 
Raises the NPC Space Pirates health by 15 hp
*I mean we could give them their suits armor as well but that is retarded seeings how their not the space people as Space Queen's men.. And if we did give them those armor that the real space queen people have then it would make that loot op for nukie level armor that is space proof*


[why]:
Their still a joke to fight for free laser guns and a e-sword with 50% block. Maybe give them basic space suit armor or something latter