### PR TITLE
Adds in stim pillls to Medical department vendors! [Coin only to get stim pills]

### DIFF
--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -21,7 +21,8 @@
 					/obj/item/clothing/under/pants/khaki = 3)
 	premium = list(/obj/item/clothing/under/rank/security/navyblue = 3,
 					/obj/item/clothing/suit/security/officer = 3,
-					/obj/item/clothing/head/beret/sec/navyofficer = 3)
+					/obj/item/clothing/head/beret/sec/navyofficer = 3,
+					/obj/item/reagent_containers/pill/stimulant = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/sec_wardrobe
 
 /obj/item/vending_refill/wardrobe/sec_wardrobe
@@ -50,6 +51,7 @@
 					/obj/item/clothing/head/soft/emt = 3,
 					/obj/item/clothing/suit/apron/surgical = 1,
 					/obj/item/clothing/mask/surgical = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/medi_wardrobe
 
 /obj/item/vending_refill/wardrobe/medi_wardrobe
@@ -70,6 +72,7 @@
 					/obj/item/clothing/suit/hazardvest = 3,
 					/obj/item/clothing/shoes/workboots = 3,
 					/obj/item/clothing/head/hardhat = 3)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 
 /obj/item/vending_refill/wardrobe/engi_wardrobe
@@ -88,6 +91,7 @@
 					/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos = 3,
 					/obj/item/clothing/under/rank/atmospheric_technician = 3,
 					/obj/item/clothing/shoes/sneakers/black = 3)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe
 
 /obj/item/vending_refill/wardrobe/atmos_wardrobe
@@ -105,6 +109,7 @@
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft = 3,
 					/obj/item/radio/headset/headset_cargo = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/cargo_wardrobe
 
 /obj/item/vending_refill/wardrobe/cargo_wardrobe
@@ -123,6 +128,7 @@
 					/obj/item/clothing/gloves/fingerless = 2,
 					/obj/item/clothing/head/soft/black = 2,
 					/obj/item/clothing/mask/bandana/skull = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
 
 /obj/item/vending_refill/wardrobe/robo_wardrobe
@@ -143,6 +149,7 @@
 					/obj/item/clothing/shoes/sneakers/white = 3,
 					/obj/item/radio/headset/headset_sci = 2,
 					/obj/item/clothing/mask/gas = 3)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 
 /obj/item/vending_refill/wardrobe/science_wardrobe
@@ -161,6 +168,7 @@
 					/obj/item/clothing/suit/apron/overalls = 3,
 					/obj/item/clothing/under/rank/hydroponics = 3,
 					/obj/item/clothing/mask/bandana = 3)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/hydro_wardrobe
 
 /obj/item/vending_refill/wardrobe/hydro_wardrobe
@@ -178,6 +186,7 @@
 					/obj/item/clothing/shoes/workboots/mining = 1,
 					/obj/item/storage/backpack/satchel/explorer = 1,
 					/obj/item/storage/bag/books = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/curator_wardrobe
 
 /obj/item/vending_refill/wardrobe/curator_wardrobe
@@ -205,6 +214,7 @@
 					/obj/item/clothing/glasses/sunglasses/reagent = 1,
 					/obj/item/clothing/neck/petcollar = 1,
 					/obj/item/storage/belt/bandolier = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/bar_wardrobe
 
 /obj/item/vending_refill/wardrobe/bar_wardrobe
@@ -227,6 +237,7 @@
 					/obj/item/clothing/under/rank/chef = 1,
 					/obj/item/clothing/head/chefhat = 1,
 					/obj/item/reagent_containers/glass/rag = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chef_wardrobe
 
 /obj/item/vending_refill/wardrobe/chef_wardrobe
@@ -253,6 +264,7 @@
 					/obj/item/clothing/shoes/galoshes = 1,
 					/obj/item/watertank/janitor = 1,
 					/obj/item/storage/belt/janitor = 1)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 
 /obj/item/vending_refill/wardrobe/jani_wardrobe
@@ -275,6 +287,7 @@
 					/obj/item/clothing/suit/toggle/lawyer/black = 1,
 					/obj/item/clothing/shoes/laceup = 2,
 					/obj/item/clothing/accessory/lawyers_badge = 2)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/law_wardrobe
 
 /obj/item/vending_refill/wardrobe/law_wardrobe
@@ -295,6 +308,7 @@
 					/obj/item/clothing/head/nun_hood = 1,
 					/obj/item/clothing/suit/holidaypriest = 1,
 					/obj/item/storage/fancy/candle_box = 2)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chap_wardrobe
 
 /obj/item/vending_refill/wardrobe/chap_wardrobe
@@ -312,6 +326,7 @@
 					/obj/item/storage/backpack/chemistry = 2,
 					/obj/item/storage/backpack/satchel/chem = 2,
 					/obj/item/storage/bag/chemistry = 2)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chem_wardrobe
 
 /obj/item/vending_refill/wardrobe/chem_wardrobe
@@ -328,6 +343,7 @@
 					/obj/item/clothing/suit/toggle/labcoat/genetics = 2,
 					/obj/item/storage/backpack/genetics = 2,
 					/obj/item/storage/backpack/satchel/gen = 2)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/gene_wardrobe
 
 /obj/item/vending_refill/wardrobe/gene_wardrobe
@@ -345,6 +361,7 @@
 					/obj/item/clothing/mask/surgical = 2,
 					/obj/item/storage/backpack/virology = 2,
 					/obj/item/storage/backpack/satchel/vir = 2)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/viro_wardrobe
 
 /obj/item/vending_refill/wardrobe/viro_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -21,8 +21,7 @@
 					/obj/item/clothing/under/pants/khaki = 3)
 	premium = list(/obj/item/clothing/under/rank/security/navyblue = 3,
 					/obj/item/clothing/suit/security/officer = 3,
-					/obj/item/clothing/head/beret/sec/navyofficer = 3,
-					/obj/item/reagent_containers/pill/stimulant = 2)
+					/obj/item/clothing/head/beret/sec/navyofficer = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/sec_wardrobe
 
 /obj/item/vending_refill/wardrobe/sec_wardrobe
@@ -51,7 +50,7 @@
 					/obj/item/clothing/head/soft/emt = 3,
 					/obj/item/clothing/suit/apron/surgical = 1,
 					/obj/item/clothing/mask/surgical = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 2)
+	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/medi_wardrobe
 
 /obj/item/vending_refill/wardrobe/medi_wardrobe
@@ -72,7 +71,6 @@
 					/obj/item/clothing/suit/hazardvest = 3,
 					/obj/item/clothing/shoes/workboots = 3,
 					/obj/item/clothing/head/hardhat = 3)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/engi_wardrobe
 
 /obj/item/vending_refill/wardrobe/engi_wardrobe
@@ -109,7 +107,6 @@
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft = 3,
 					/obj/item/radio/headset/headset_cargo = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/cargo_wardrobe
 
 /obj/item/vending_refill/wardrobe/cargo_wardrobe
@@ -128,7 +125,6 @@
 					/obj/item/clothing/gloves/fingerless = 2,
 					/obj/item/clothing/head/soft/black = 2,
 					/obj/item/clothing/mask/bandana/skull = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
 
 /obj/item/vending_refill/wardrobe/robo_wardrobe
@@ -149,7 +145,6 @@
 					/obj/item/clothing/shoes/sneakers/white = 3,
 					/obj/item/radio/headset/headset_sci = 2,
 					/obj/item/clothing/mask/gas = 3)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 3)
 	refill_canister = /obj/item/vending_refill/wardrobe/science_wardrobe
 
 /obj/item/vending_refill/wardrobe/science_wardrobe
@@ -168,7 +163,6 @@
 					/obj/item/clothing/suit/apron/overalls = 3,
 					/obj/item/clothing/under/rank/hydroponics = 3,
 					/obj/item/clothing/mask/bandana = 3)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/hydro_wardrobe
 
 /obj/item/vending_refill/wardrobe/hydro_wardrobe
@@ -186,7 +180,6 @@
 					/obj/item/clothing/shoes/workboots/mining = 1,
 					/obj/item/storage/backpack/satchel/explorer = 1,
 					/obj/item/storage/bag/books = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/curator_wardrobe
 
 /obj/item/vending_refill/wardrobe/curator_wardrobe
@@ -214,7 +207,6 @@
 					/obj/item/clothing/glasses/sunglasses/reagent = 1,
 					/obj/item/clothing/neck/petcollar = 1,
 					/obj/item/storage/belt/bandolier = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/bar_wardrobe
 
 /obj/item/vending_refill/wardrobe/bar_wardrobe
@@ -237,7 +229,6 @@
 					/obj/item/clothing/under/rank/chef = 1,
 					/obj/item/clothing/head/chefhat = 1,
 					/obj/item/reagent_containers/glass/rag = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chef_wardrobe
 
 /obj/item/vending_refill/wardrobe/chef_wardrobe
@@ -264,7 +255,6 @@
 					/obj/item/clothing/shoes/galoshes = 1,
 					/obj/item/watertank/janitor = 1,
 					/obj/item/storage/belt/janitor = 1)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/jani_wardrobe
 
 /obj/item/vending_refill/wardrobe/jani_wardrobe
@@ -287,7 +277,6 @@
 					/obj/item/clothing/suit/toggle/lawyer/black = 1,
 					/obj/item/clothing/shoes/laceup = 2,
 					/obj/item/clothing/accessory/lawyers_badge = 2)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/law_wardrobe
 
 /obj/item/vending_refill/wardrobe/law_wardrobe
@@ -308,7 +297,6 @@
 					/obj/item/clothing/head/nun_hood = 1,
 					/obj/item/clothing/suit/holidaypriest = 1,
 					/obj/item/storage/fancy/candle_box = 2)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/chap_wardrobe
 
 /obj/item/vending_refill/wardrobe/chap_wardrobe

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -89,7 +89,6 @@
 					/obj/item/clothing/suit/hooded/wintercoat/engineering/atmos = 3,
 					/obj/item/clothing/under/rank/atmospheric_technician = 3,
 					/obj/item/clothing/shoes/sneakers/black = 3)
-	premium = list(/obj/item/reagent_containers/pill/stimulant = 1)
 	refill_canister = /obj/item/vending_refill/wardrobe/atmos_wardrobe
 
 /obj/item/vending_refill/wardrobe/atmos_wardrobe


### PR DESCRIPTION
[Changelogs]: 
Adds in 1-3 stim pills into each medical vendor that is used for item/clothing for departments 

[why]:
Long hard work days now are slightly less horrible, NT has teamed up once more with Med-Co to add in marked up stim pills to get there workers to pay even more to there own employer!
There coin only and can give people the little bit of speed they need to be able to do what needs to be done before [ EVERYONE DIES AND WERE ALL SAD EVENT]!
Now medics can get to dieing/dead people faster