### PR TITLE
Removes the hardcoded species blacklist from mushroompeople (lets us make mushroom people be roundstart)

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -25,10 +25,6 @@
 	mutanteyes = /obj/item/organ/eyes/night_vision/mushroom
 	use_skintones = FALSE
 	var/datum/martial_art/mushpunch/mush
-	blacklisted = TRUE //See comment below about locking it out of roundstart. The species is not intended to be available to players yet - and this means wizards, too.
-
-/datum/species/mush/check_roundstart_eligible()
-	return FALSE //hard locked out of roundstart on the order of design lead kor, this can be removed in the future when planetstation is here OR SOMETHING but right now we have a problem with races.
 
 /datum/species/mush/after_equip_job(datum/job/J, mob/living/carbon/human/H)
 	H.grant_language(/datum/language/mushroom) //pomf pomf


### PR DESCRIPTION
TAKE OFF THE HARDCODED BLACKLIST. STOP HAVING THE SPECIES BE CLOSED

:cl: deathride58
add: mushroom people are now roundstart on live
/:cl: