### PR TITLE
Changes Survival medipens to be safe for slimes.

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -158,7 +158,7 @@
 	icon_state = "stimpen"
 	volume = 57
 	amount_per_transfer_from_this = 57
-	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "miningnanites" = 2, "omnizine" = 5)
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "epinephrine" = 10, "miningnanites" = 2, "regen_jelly" = 15)
 
 /obj/item/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"


### PR DESCRIPTION
[Changelogs]: 15/5u of Tricord/Omni replaced with 15u of Regenerative Jelly.

:cl: nicc

tweak: tweaked drugs in regen jelly
/:cl:

[why]: cus slimes can't fucking use survival pens. In my short bit of testing, this seemed to heal at a comparable rate and last a similar amount of time. Will adjust as needed. This is to make way for a new reward suit currently in development by Coldstorm.
