### PR TITLE
The HoS starts with a telebaton instead of a stunbaton.

### DIFF
--- a/code/modules/jobs/job_types/security.dm
+++ b/code/modules/jobs/job_types/security.dm
@@ -51,7 +51,7 @@ Head of Security
 	suit_store = /obj/item/gun/energy/e_gun
 	r_pocket = /obj/item/assembly/flash/handheld
 	l_pocket = /obj/item/restraints/handcuffs
-	backpack_contents = list(/obj/item/melee/baton/loaded=1)
+	backpack_contents = list(/obj/item/melee/classic_baton/telescopic=1)
 
 	backpack = /obj/item/storage/backpack/security
 	satchel = /obj/item/storage/backpack/satchel/sec


### PR DESCRIPTION

:cl: Tupinambis
tweak: By popular request, makes the Head of Security spawn with a telebaton instead of a stun baton. 
/:cl:

[why]: Head of Security players are jealous of the other heads telebatons, and stun batons are easily accessible by the HoS anyway. Telebatons are fun.
