### PR TITLE
New Reagent, Universalizes Survival Medipen

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1067,18 +1067,18 @@
     taste_description = "jelly"
 
 /datum/reagent/medicine/neo_jelly/on_mob_life(mob/living/carbon/M)
-    M.adjustBruteLoss(-1.5REM, 0)
-    M.adjustFireLoss(-1.5REM, 0)
-    M.adjustOxyLoss(-1.5REM, 0)
-    M.adjustToxLoss(-1.5REM, 0, TRUE) //heals TOXINLOVERs
+    M.adjustBruteLoss(-1.5*REM, 0)
+    M.adjustFireLoss(-1.5*REM, 0)
+    M.adjustOxyLoss(-1.5*REM, 0)
+    M.adjustToxLoss(-1.5*REM, 0, TRUE) //heals TOXINLOVERs
     . = 1
     ..()
 
 /datum/reagent/medicine/neo_jelly/overdose_process(mob/living/M)
-    M.adjustToxLoss(0REM, 0)
-    M.adjustOxyLoss(2.6REM, 0)
-    M.adjustBruteLoss(3.5REM, 0)
-    M.adjustFireLoss(3.5REM, 0)
+    M.adjustToxLoss(0*REM, 0)
+    M.adjustOxyLoss(2.6*REM, 0)
+    M.adjustBruteLoss(3.5*REM, 0)
+    M.adjustFireLoss(3.5*REM, 0)
     ..()
     . = 1
 

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1056,6 +1056,32 @@
 	..()
 	. = 1
 
+/datum/reagent/medicine/neo_jelly
+    name = "Neo Jelly"
+    id = "neo_jelly"
+    description = "Gradually regenerates all types of damage, without harming slime anatomy.Can OD"
+    reagent_state = LIQUID
+    metabolization_rate = 1 * REAGENTS_METABOLISM
+    color = "#91D865"
+    overdose_threshold = 30
+    taste_description = "jelly"
+
+/datum/reagent/medicine/neo_jelly/on_mob_life(mob/living/carbon/M)
+    M.adjustBruteLoss(-1.5REM, 0)
+    M.adjustFireLoss(-1.5REM, 0)
+    M.adjustOxyLoss(-1.5REM, 0)
+    M.adjustToxLoss(-1.5REM, 0, TRUE) //heals TOXINLOVERs
+    . = 1
+    ..()
+
+/datum/reagent/medicine/neo_jelly/overdose_process(mob/living/M)
+    M.adjustToxLoss(0REM, 0)
+    M.adjustOxyLoss(2.6REM, 0)
+    M.adjustBruteLoss(3.5REM, 0)
+    M.adjustFireLoss(3.5REM, 0)
+    ..()
+    . = 1
+
 /datum/reagent/medicine/earthsblood //Created by ambrosia gaia plants
 	name = "Earthsblood"
 	id = "earthsblood"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1075,7 +1075,6 @@
     ..()
 
 /datum/reagent/medicine/neo_jelly/overdose_process(mob/living/M)
-    M.adjustToxLoss(0*REM, 0)
     M.adjustOxyLoss(2.6*REM, 0)
     M.adjustBruteLoss(3.5*REM, 0)
     M.adjustFireLoss(3.5*REM, 0)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -158,7 +158,7 @@
 	icon_state = "stimpen"
 	volume = 57
 	amount_per_transfer_from_this = 57
-	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "tricordrazine" = 15, "epinephrine" = 10, "lavaland_extract" = 2, "omnizine" = 5)
+	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "neo_jelly" = 15, "epinephrine" = 10, "lavaland_extract" = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/species_mutator
 	name = "species mutator medipen"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -156,8 +156,8 @@
 	name = "survival medipen"
 	desc = "A medipen for surviving in the harshest of environments, heals and protects from environmental hazards. WARNING: Do not inject more than one pen in quick succession."
 	icon_state = "stimpen"
-	volume = 57
-	amount_per_transfer_from_this = 57
+	volume = 52
+	amount_per_transfer_from_this = 52
 	list_reagents = list("salbutamol" = 10, "leporazine" = 15, "neo_jelly" = 15, "epinephrine" = 10, "lavaland_extract" = 2)
 
 /obj/item/reagent_containers/hypospray/medipen/species_mutator


### PR DESCRIPTION
Adds an alternate regenerative jelly for the survival medipens used in mining. Replaces the tricord and omnizine in medipens with 15u of Neo Jelly. Makes medipens finally useful for slime miners. When ODed on Neo Jelly, causes heavy brute/burn and minor oxyloss and causes no toxin damage.

add: new reagent: Neo Jelly, is almost exactly like Regenerative Jelly, except has an OD threshold of 30u to prevent abuse.
balance: With the removal of tricord and omnizine and replacement with Neo Jelly, this allows for slime miners to have a reason to value medipens just the same as other non slime miners would.
code: removed tricord and omnizine from survival medipens and replaces it with 15u of Neo Jelly.
why: Several slime players who mine have admitted that medipens are functionally useless to them, and instead would kill them if used. This fixes it so slimes heal just like the other miners.
