### PR TITLE
Syndicate Basic Encryption Key's: Teamwork makes the dream work.

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -17,7 +17,7 @@
 	syndie = 1//Signifies that it de-crypts Syndicate transmissions
 
 /obj/item/encryptionkey/syndicate/basic
-	name = "syndicate encryption key"
+	name = "syndicate basic encryption key"
 	desc = "An encryption key for a radio headset. To access the syndicate channel, use :t."
 	icon_state = "syn_cypherkey"
 	channels = list("Syndicate" = 1)

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -16,6 +16,12 @@
 	channels = list("Syndicate" = 1)
 	syndie = 1//Signifies that it de-crypts Syndicate transmissions
 
+/obj/item/encryptionkey/syndicate/basic
+	name = "syndicate encryption key"
+	desc = "An encryption key for a radio headset. To access the syndicate channel, use :t."
+	icon_state = "syn_cypherkey"
+	channels = list("Syndicate" = 1)
+
 /obj/item/encryptionkey/binary
 	name = "binary translator key"
 	desc = "An encryption key for a radio headset.  To access the binary channel, use :b."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -109,6 +109,22 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/discounts
 	category = "Discounted Gear"
 
+// Standard Issue Gear
+/datum/uplink_item/standard_issue
+	category = "Standard Issue Gear"
+	surplus = 0
+	cost = 0
+	limited_stock = 1
+	restricted = TRUE
+	cant_discount = TRUE
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/standard_issue/headset
+	name = "Syndicate Basic Encryption Key"
+	desc = "A key that, when inserted into a radio headset, allows you to talk on an encrypted Syndicate channel with other agents that also have access to the channel. \
+			Be warned, if Nanotrasen personnel discover this key, it could compromise your mission and the communications of other agents. Purchase with caution."
+	item = /obj/item/encryptionkey/syndicate/basic
+
 // Nuclear Operative (Special Offers)
 /datum/uplink_item/nukeoffer
 	category = "Special Offers"
@@ -994,9 +1010,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/device_tools/encryptionkey
 	name = "Syndicate Encryption Key"
 	desc = "A key that, when inserted into a radio headset, allows you to listen to all station department channels \
-			as well as talk on an encrypted Syndicate channel with other agents that have the same key."
+			as well as talk on an encrypted Syndicate channel with other agents that also have access to the channel."
 	item = /obj/item/encryptionkey/syndicate
-	cost = 2
+	cost = 1
 	surplus = 75
 	restricted = TRUE
 


### PR DESCRIPTION
LISTEN UP AGENTS: We have noticed that success rates among our agents increases when there is a line of communications between them. Sadly, this is a rarity when every TC counts. In order to ensure that our agents can more effectively operate in the field, we have added an encryption key in your uplink for the low low price of FREE. Get yours today agent and be badass as a TEAM!

:cl: Tupinambis
add: Adds an all new syndicate basic encryption key, which allows you to use the syndicate channel on your headset. This can be purchased for free under "Standard Issue Gear" from the uplink, but only once.
balance: Reduces the cost of the normal syndicate encryption key to 1 TC from 2 TC.
/:cl:

[why]: Currently, security can very easily face a traitor in a one versus one scenario in most situations. Part of this, is that traitors often work alone. Private radio communications will encourage traitors to work as a team and coordinate to complete their objectives (which unlike in lings, usually won't result in betrayal) will not only encourage teamplay and RP, but also give sec more of a challenge, and give traitors who have been caught by sec (or validhunters) a chance to escape with the help of their allies.
