### PR TITLE
Alien ruin space turf fix.

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -116,11 +116,6 @@
 /obj/structure/alien/resin/membrane,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
-"ax" = (
-/obj/structure/alien/resin/wall,
-/obj/structure/alien/weeds,
-/turf/open/space/basic,
-/area/ruin/unpowered/xenonest)
 "aA" = (
 /obj/structure/alien/weeds,
 /obj/item/flamethrower,
@@ -1925,7 +1920,7 @@ ac
 as
 at
 at
-ax
+ac
 ac
 ac
 ac


### PR DESCRIPTION
cl: Tupinambis
fix: replaces a space turf tile in the alien ruin with lavaland turf, as necropolis intended.
/:cl:

[why]: space is bad.
