### PR TITLE
Adds in tracker implant and gas mask to load outs! (Trackers Sec Only) (Masks Engi/Sci Only)

### DIFF
--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -14,7 +14,7 @@ SUBSYSTEM_DEF(traumas)
 	//phobia types is to pull from randomly for brain traumas, e.g. conspiracies is for special assignment only
 	phobia_types = list("spiders", "space", "security", "clowns", "greytide", "lizards",
 						"skeletons", "snakes", "robots", "doctors", "authority", "the supernatural",
-						"aliens", "strangers", "birds", "falling")
+						"aliens", "strangers", "birds", "mimes", "falling")
 
 	phobia_words = list("spiders"   = strings(PHOBIA_FILE, "spiders"),
 						"space"     = strings(PHOBIA_FILE, "space"),
@@ -32,6 +32,7 @@ SUBSYSTEM_DEF(traumas)
 						"strangers"	= strings(PHOBIA_FILE, "strangers"),
 						"conspiracies" = strings(PHOBIA_FILE, "conspiracies"),
 						"birds" = strings(PHOBIA_FILE, "birds"),
+						"mimes" = strings(PHOBIA_FILE, "mimes"),
 						"falling" = strings(PHOBIA_FILE, "falling")
 					   )
 
@@ -41,7 +42,7 @@ SUBSYSTEM_DEF(traumas)
 					   "skeletons" = typecacheof(list(/mob/living/simple_animal/hostile/skeleton)),
 					   "snakes"   = typecacheof(list(/mob/living/simple_animal/hostile/retaliate/poison/snake)),
 					   "robots"   = typecacheof(list(/mob/living/silicon/robot, /mob/living/silicon/ai,
-					   /mob/living/simple_animal/drone, /mob/living/simple_animal/bot, /mob/living/simple_animal/hostile/swarmer)),
+					   /mob/living/simple_animal/drone, /mob/living/simple_animal/bot, /mob/living/simple_animal/hostile/swarmer, /mob/living/simple_animal/bot/honkbot)),
 					   "doctors"   = typecacheof(list(/mob/living/simple_animal/bot/medbot)),
 					   "the supernatural"   = typecacheof(list(/mob/living/simple_animal/hostile/construct,
 					   /mob/living/simple_animal/hostile/clockwork, /mob/living/simple_animal/drone/cogscarab,
@@ -51,31 +52,32 @@ SUBSYSTEM_DEF(traumas)
 					   /mob/living/simple_animal/pet/penguin)),
 					   "birds" = typecacheof(list(/mob/living/simple_animal/parrot, /mob/living/simple_animal/chick, /mob/living/simple_animal/chicken,
 					   /mob/living/simple_animal/pet/penguin))
-					   )
+					  )
+
 
 	phobia_objs = list("snakes" = typecacheof(list(/obj/item/rod_of_asclepius)),
 
-						"spiders"   = typecacheof(list(/obj/structure/spider)),
+					"spiders"   = typecacheof(list(/obj/structure/spider)),
 
-					   "security"  = typecacheof(list(/obj/item/clothing/under/rank/security, /obj/item/clothing/under/rank/warden,
+					"security"  = typecacheof(list(/obj/item/clothing/under/rank/security, /obj/item/clothing/under/rank/warden,
 											 	 /obj/item/clothing/under/rank/head_of_security, /obj/item/clothing/under/rank/det,
 												 /obj/item/melee/baton, /obj/item/gun/energy/taser, /obj/item/restraints/handcuffs,
 												 /obj/machinery/door/airlock/security)),
 
-					  "clowns"    = typecacheof(list(/obj/item/clothing/under/rank/clown, /obj/item/clothing/shoes/clown_shoes,
+					"clowns" = typecacheof(list(/obj/item/clothing/under/rank/clown, /obj/item/clothing/shoes/clown_shoes,
 												 /obj/item/clothing/mask/gas/clown_hat, /obj/item/instrument/bikehorn,
 												 /obj/item/pda/clown, /obj/item/grown/bananapeel)),
 
-					  "greytide"  = typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/cattleprod,
+					"greytide"  = typecacheof(list(/obj/item/clothing/under/color/grey, /obj/item/melee/baton/cattleprod,
 												 /obj/item/twohanded/spear, /obj/item/clothing/mask/gas)),
 
-					  "lizards"   = typecacheof(list(/obj/item/toy/plush/lizardplushie, /obj/item/reagent_containers/food/snacks/kebab/tail,
+					"lizards"   = typecacheof(list(/obj/item/toy/plush/lizardplushie, /obj/item/reagent_containers/food/snacks/kebab/tail,
 												 /obj/item/organ/tail/lizard, /obj/item/reagent_containers/food/drinks/bottle/lizardwine)),
 
-					  "skeletons" = typecacheof(list(/obj/item/organ/tongue/bone, /obj/item/clothing/suit/armor/bone, /obj/item/stack/sheet/bone,
+					"skeletons" = typecacheof(list(/obj/item/organ/tongue/bone, /obj/item/clothing/suit/armor/bone, /obj/item/stack/sheet/bone,
 												 /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
 												 /obj/effect/decal/remains/human)),
-				   "conspiracies" = typecacheof(list(/obj/item/clothing/under/rank/captain, /obj/item/clothing/under/rank/head_of_security,
+				   	"conspiracies" = typecacheof(list(/obj/item/clothing/under/rank/captain, /obj/item/clothing/under/rank/head_of_security,
 												 /obj/item/clothing/under/rank/chief_engineer, /obj/item/clothing/under/rank/chief_medical_officer,
 												 /obj/item/clothing/under/rank/head_of_personnel, /obj/item/clothing/under/rank/research_director,
 												 /obj/item/clothing/under/rank/head_of_security/grey, /obj/item/clothing/under/rank/head_of_security/alt,
@@ -88,10 +90,10 @@ SUBSYSTEM_DEF(traumas)
 												 /obj/item/clothing/suit/space/hardsuit/ert/engi, /obj/item/clothing/suit/space/hardsuit/ert/med,
 												 /obj/item/clothing/suit/space/hardsuit/deathsquad, /obj/item/clothing/head/helmet/space/hardsuit/deathsquad,
 												 /obj/machinery/door/airlock/centcom)),
-						"robots"   = typecacheof(list(/obj/machinery/computer/upload, /obj/item/aiModule/, /obj/machinery/recharge_station,
+					"robots"   = typecacheof(list(/obj/machinery/computer/upload, /obj/item/aiModule/, /obj/machinery/recharge_station,
 						/obj/item/aicard, /obj/item/deactivated_swarmer, /obj/effect/mob_spawn/swarmer)),
 
-						"doctors"   = typecacheof(list(/obj/item/clothing/under/rank/medical, /obj/item/clothing/under/rank/chemist,
+					"doctors"   = typecacheof(list(/obj/item/clothing/under/rank/medical, /obj/item/clothing/under/rank/chemist,
 						/obj/item/clothing/under/rank/nursesuit, /obj/item/clothing/under/rank/chief_medical_officer,
 						/obj/item/reagent_containers/syringe, /obj/item/reagent_containers/pill/, /obj/item/reagent_containers/hypospray,
 						/obj/item/storage/firstaid, /obj/item/storage/pill_bottle, /obj/item/healthanalyzer,
@@ -100,14 +102,14 @@ SUBSYSTEM_DEF(traumas)
 						/obj/item/retractor, /obj/item/hemostat, /obj/item/cautery, /obj/item/surgicaldrill, /obj/item/scalpel, /obj/item/circular_saw,
 						/obj/item/clothing/suit/bio_suit/plaguedoctorsuit, /obj/item/clothing/head/plaguedoctorhat, /obj/item/clothing/mask/gas/plaguedoctor)),
 
-						"authority"   = typecacheof(list(/obj/item/clothing/under/rank/captain,  /obj/item/clothing/under/rank/head_of_personnel,
+					"authority"   = typecacheof(list(/obj/item/clothing/under/rank/captain,  /obj/item/clothing/under/rank/head_of_personnel,
 						/obj/item/clothing/under/rank/head_of_security, /obj/item/clothing/under/rank/research_director,
 						/obj/item/clothing/under/rank/chief_medical_officer, /obj/item/clothing/under/rank/chief_engineer,
 						/obj/item/clothing/under/rank/centcom_officer, /obj/item/clothing/under/rank/centcom_commander,
 						/obj/item/melee/classic_baton/telescopic, /obj/item/card/id/silver, /obj/item/card/id/gold,
 						/obj/item/card/id/captains_spare, /obj/item/card/id/centcom, /obj/machinery/door/airlock/command)),
 
-						"the supernatural"  = typecacheof(list(/obj/structure/destructible/cult, /obj/item/tome,
+					"the supernatural"  = typecacheof(list(/obj/structure/destructible/cult, /obj/item/tome,
 						/obj/item/melee/cultblade, /obj/item/twohanded/required/cult_bastard, /obj/item/restraints/legcuffs/bola/cult,
 						/obj/item/clothing/suit/cultrobes, /obj/item/clothing/suit/space/hardsuit/cult,
 						/obj/item/clothing/suit/hooded/cultrobes, /obj/item/clothing/head/hooded/cult_hoodie, /obj/effect/rune,
@@ -121,7 +123,7 @@ SUBSYSTEM_DEF(traumas)
 						/obj/item/gun/magic/staff, /obj/item/gun/magic/wand,
 						/obj/item/nullrod, /obj/item/clothing/under/rank/chaplain)),
 
-						"aliens"   = typecacheof(list(/obj/item/clothing/mask/facehugger, /obj/item/organ/body_egg/alien_embryo,
+					"aliens"   = typecacheof(list(/obj/item/clothing/mask/facehugger, /obj/item/organ/body_egg/alien_embryo,
 						/obj/structure/alien, /obj/item/toy/toy_xeno,
 						/obj/item/clothing/suit/armor/abductor, /obj/item/abductor, /obj/item/gun/energy/alien,
 						/obj/item/abductor_baton, /obj/item/radio/headset/abductor, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
@@ -130,13 +132,20 @@ SUBSYSTEM_DEF(traumas)
 						/obj/structure/table/abductor, /obj/structure/table/optable/abductor, /obj/structure/closet/abductor, /obj/item/organ/heart/gland,
 						/obj/machinery/abductor, /obj/item/crowbar/abductor, /obj/item/screwdriver/abductor, /obj/item/weldingtool/abductor,
 						/obj/item/wirecutters/abductor, /obj/item/wrench/abductor, /obj/item/stack/sheet/mineral/abductor)),
-						
-						"birds" = typecacheof(list(/obj/item/clothing/mask/gas/plaguedoctor, /obj/item/reagent_containers/food/snacks/cracker,
+
+					"birds" = typecacheof(list(/obj/item/clothing/mask/gas/plaguedoctor, /obj/item/reagent_containers/food/snacks/cracker,
 						/obj/item/clothing/suit/chickensuit, /obj/item/clothing/head/chicken,
 						/obj/item/clothing/suit/toggle/owlwings, /obj/item/clothing/under/owl, /obj/item/clothing/mask/gas/owl_mask,
 						/obj/item/clothing/under/griffin, /obj/item/clothing/shoes/griffin, /obj/item/clothing/head/griffin,
-						/obj/item/clothing/head/helmet/space/freedom, /obj/item/clothing/suit/space/freedom))
-					   )
+						/obj/item/clothing/head/helmet/space/freedom, /obj/item/clothing/suit/space/freedom)),
+
+					"mimes" = typecacheof(list(/obj/item/pda/mime, /obj/item/clothing/under/rank/mime, /obj/item/clothing/mask/gas/mime,
+						/obj/item/clothing/head/frenchberet, /obj/item/clothing/suit/suspenders, /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing,
+						/obj/item/storage/backpack/mime, /obj/item/seeds/banana/mime, /obj/item/reagent_containers/food/snacks/grown/banana/mime,
+						/obj/item/grown/bananapeel/mimanapeel, /obj/item/cartridge/virus/mime, /obj/item/clothing/shoes/sneakers/mime,
+						/obj/item/bedsheet/mime, /obj/item/reagent_containers/food/snacks/burger/mime, /obj/item/clothing/head/beret, /obj/item/clothing/mask/gas/sexymime,
+						/obj/item/clothing/under/sexymime, /obj/item/toy/figure/mime, /obj/item/toy/crayon/mime, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced, /obj/mecha/combat/reticence))
+						)
 
 	phobia_turfs = list("space" = typecacheof(list(/turf/open/space, /turf/open/floor/holofloor/space, /turf/open/floor/fakespace)),
 						"the supernatural" = typecacheof(list(/turf/open/floor/clockwork, /turf/closed/wall/clockwork,

--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -141,7 +141,7 @@ SUBSYSTEM_DEF(traumas)
 
 					"mimes" = typecacheof(list(/obj/item/pda/mime, /obj/item/clothing/under/rank/mime, /obj/item/clothing/mask/gas/mime,
 						/obj/item/clothing/head/frenchberet, /obj/item/clothing/suit/suspenders, /obj/item/reagent_containers/food/drinks/bottle/bottleofnothing,
-						/obj/item/storage/backpack/mime, /obj/item/seeds/banana/mime, /obj/item/reagent_containers/food/snacks/grown/banana/mime,
+						/obj/item/storage/backpack/mime, /obj/item/reagent_containers/food/snacks/grown/banana/mime,
 						/obj/item/grown/bananapeel/mimanapeel, /obj/item/cartridge/virus/mime, /obj/item/clothing/shoes/sneakers/mime,
 						/obj/item/bedsheet/mime, /obj/item/reagent_containers/food/snacks/burger/mime, /obj/item/clothing/head/beret, /obj/item/clothing/mask/gas/sexymime,
 						/obj/item/clothing/under/sexymime, /obj/item/toy/figure/mime, /obj/item/toy/crayon/mime, /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced, /obj/mecha/combat/reticence))

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -62,3 +62,4 @@
 	name = "Tracking Implant"
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/implanter/tracking
+	restricted_roles = list("Head of Security", "Captain", "Warden", "Detective", "Security Officer")

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -56,14 +56,4 @@
 /datum/gear/dildo
 	name = "Customizable dildo"
 	category = SLOT_IN_BACKPACK
-<<<<<<< HEAD
 	path = /obj/item/dildo/custom
-=======
-	path = /obj/item/dildo/custom
-
-/datum/gear/tracking
-	name = "Tracking Implant"
-	category = SLOT_IN_BACKPACK
-	path = /obj/item/implanter/tracking
-	restricted_roles = list("Head of Security", "Captain", "Warden", "Detective", "Security Officer")
->>>>>>> be9d39f31dd805e220cd8d8b7bd34b27a0d776f3

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -57,8 +57,3 @@
 	name = "Customizable dildo"
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/dildo/custom
-
-/datum/gear/tracking
-	name = "Tracking Implant"
-	category = SLOT_IN_BACKPACK
-	path = /obj/item/implanter/tracking

--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -57,3 +57,8 @@
 	name = "Customizable dildo"
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/dildo/custom
+
+/datum/gear/tracking
+	name = "Tracking Implant"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/implanter/tracking

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -7,3 +7,8 @@
 	name = "Fake moustache"
 	category = SLOT_WEAR_MASK
 	path = /obj/item/clothing/mask/fakemoustache
+
+/datum/gear/gas
+	name = "Gas Mask"
+	category = SLOT_WEAR_MASK
+	path = /obj/item/clothing/mask/gas

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -12,3 +12,4 @@
 	name = "Gas Mask"
 	category = SLOT_WEAR_MASK
 	path = /obj/item/clothing/mask/gas
+	restricted_roles = list("Chief Engineer", "Research Director", "Station Engineer", "Atmospheric Technician", "Scientist", "Roboticist")

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -6,14 +6,4 @@
 /datum/gear/moustache
 	name = "Fake moustache"
 	category = SLOT_WEAR_MASK
-<<<<<<< HEAD
 	path = /obj/item/clothing/mask/fakemoustache
-=======
-	path = /obj/item/clothing/mask/fakemoustache
-
-/datum/gear/gas
-	name = "Gas Mask"
-	category = SLOT_WEAR_MASK
-	path = /obj/item/clothing/mask/gas
-	restricted_roles = list("Chief Engineer", "Research Director", "Station Engineer", "Atmospheric Technician", "Scientist", "Roboticist")
->>>>>>> be9d39f31dd805e220cd8d8b7bd34b27a0d776f3

--- a/modular_citadel/code/modules/client/loadout/mask.dm
+++ b/modular_citadel/code/modules/client/loadout/mask.dm
@@ -7,8 +7,3 @@
 	name = "Fake moustache"
 	category = SLOT_WEAR_MASK
 	path = /obj/item/clothing/mask/fakemoustache
-
-/datum/gear/gas
-	name = "Gas Mask"
-	category = SLOT_WEAR_MASK
-	path = /obj/item/clothing/mask/gas

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -68,7 +68,21 @@
 		"banana",
 		"slip",
 		"slipped",
+		"prank",
 		"slipping"
+	],
+
+	"mimes": [
+		"mime",
+		"...",
+		"silence",
+		"mimic",
+		"invisible",
+		"french",
+		"oui oui",
+		"surrender",
+		"pretending",
+		"nothing"
 	],
 
 	"greytide": [

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -79,7 +79,7 @@
 		"mimic",
 		"invisible",
 		"french",
-		"oui oui",
+		"oui",
 		"surrender",
 		"pretending",
 		"nothing"


### PR DESCRIPTION
[Changelogs]:
Adds in Gas Mask to load out Mask! - Engi-Sci
Adds in Tracker Implanter to backpack! - Cap-Sec

[why]: 
Gas masks are only not that hard to get anyways! We can get them in are department easy as well as form are venders
Tracker implanter do to there usefulness and lack of being used by sec force. Lets make them more easy to be gotten, maybe this will make them more usefull