### PR TITLE
Removes armor form Fed Officer Cap

### DIFF
--- a/modular_citadel/code/modules/clothing/under/trek_under.dm
+++ b/modular_citadel/code/modules/clothing/under/trek_under.dm
@@ -240,7 +240,6 @@
 	icon_state = "fedcapofficer"
 	icon_override = 'modular_citadel/icons/mob/clothing/trek_mob_icon.dmi'
 	item_state = "fedcapofficer_mob"
-	armor = list("melee" = 10, "bullet" = 10, "laser" = 10,"energy" = 10, "bomb" = 0, "bio" = 10, "rad" = 10, "fire" = 0, "acid" = 0)
 
 	//Variants
 /obj/item/clothing/head/caphat/formal/fedcover/medsci


### PR DESCRIPTION
_*Lets give everone armor at shift start!*_

[Changelogs]:
Removes armor form Fed Officer Cap, do to load out having it

[why]
Giving people round start armor is bad, and could easily give the upper hand in Combat