### PR TITLE
Makes it plausible to use a list for geargroupid

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -10,7 +10,7 @@
 	name = "Donor item testing bikehorn"
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/bikehorn
-	geargroupID = "DONORTEST"
+	geargroupID = list("DONORTEST") //This is a list mainly for the sake of testing, but geargroupID works just fine with ordinary strings
 
 /datum/gear/kevhorn
 	name = "Airhorn"

--- a/modular_citadel/code/modules/client/loadout/loadout.dm
+++ b/modular_citadel/code/modules/client/loadout/loadout.dm
@@ -33,7 +33,13 @@ GLOBAL_LIST_EMPTY(loadout_whitelist_ids)
 		if(!GLOB.loadout_items[slot_to_string(I.category)])
 			LAZYINITLIST(GLOB.loadout_items[slot_to_string(I.category)])
 		LAZYSET(GLOB.loadout_items[slot_to_string(I.category)], I.name, I)
-		if(I.geargroupID in GLOB.loadout_whitelist_ids)
+		if(islist(I.geargroupID))
+			var/list/ggidlist = I.geargroupID
+			I.ckeywhitelist = list()
+			for(var/entry in ggidlist)
+				if(entry in GLOB.loadout_whitelist_ids)
+					I.ckeywhitelist |= GLOB.loadout_whitelist_ids["[entry]"]
+		else if(I.geargroupID in GLOB.loadout_whitelist_ids)
 			I.ckeywhitelist = GLOB.loadout_whitelist_ids["[I.geargroupID]"]
 
 


### PR DESCRIPTION
Title. This is primarily to reduce copy-pasting with Jay's tiered donor system idea

:cl: deathride58
add: The geargroupID var of loadout entries can now be a list rather than a string. GeargroupID changes are additive when multiple are defined in a single loadout entry.
/:cl:
