### PR TITLE
Adds Loader bot

### DIFF
--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -222,7 +222,7 @@
 
 /obj/item/robot_module/engineering/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
-	var/borg_icon = input(R, "Select an icon!", "Robot Icon", null) as null|anything in list("Default", "Default - Treads","Handy")
+	var/borg_icon = input(R, "Select an icon!", "Robot Icon", null) as null|anything in list("Default","Loader","Default - Treads","Handy")
 	if(!borg_icon)
 		return FALSE
 	switch(borg_icon)


### PR DESCRIPTION
Adds loader bot sprite previously unused. which ive been working on my own loader bot sprite but reee this already exists so all my work meant shit (also first pr so sorry in advance for any mistakes if any)

Add: "Loader" in select icon for engineering cyborg
