### PR TITLE
Mostly fixes stamina by making knockdown() apply its staminaloss to the chest, giving adjuststaminaloss() new args, disabling limb-specific stamina regen for the chest, and disabling head stamina

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -163,7 +163,7 @@
 			return 0
 
 	L.Knockdown(stunforce)
-	L.adjustStaminaLoss(stunforce*0.1)//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
+	L.adjustStaminaLoss(stunforce*0.1, affected_zone = (istype(user) ? user.zone_selected : BODY_ZONE_CHEST))//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -18,13 +18,13 @@
 	switch(damagetype)
 		if(BRUTE)
 			if(BP)
-				if(damage < 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(damage * hit_percent, 0))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(!damage * hit_percent, 0))
 					update_damage_overlays()
 			else //no bodypart, we deal damage with a more general method.
 				adjustBruteLoss(damage * hit_percent)
 		if(BURN)
 			if(BP)
-				if(damage < 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, damage * hit_percent))
+				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, !damage * hit_percent))
 					update_damage_overlays()
 			else
 				adjustFireLoss(damage * hit_percent)
@@ -36,7 +36,7 @@
 			adjustCloneLoss(damage * hit_percent)
 		if(STAMINA)
 			if(BP)
-				if(damage < 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, damage * hit_percent))
+				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, !damage * hit_percent))
 					update_damage_overlays()
 			else
 				adjustStaminaLoss(damage * hit_percent)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -2,7 +2,7 @@
 
 /mob/living/carbon/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked = FALSE)
 	var/hit_percent = (100-blocked)/100
-	if(!damage || hit_percent <= 0)
+	if(hit_percent <= 0)
 		return 0
 
 	var/obj/item/bodypart/BP = null
@@ -18,13 +18,13 @@
 	switch(damagetype)
 		if(BRUTE)
 			if(BP)
-				if(BP.receive_damage(damage * hit_percent, 0))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(damage * hit_percent, 0))
 					update_damage_overlays()
 			else //no bodypart, we deal damage with a more general method.
 				adjustBruteLoss(damage * hit_percent)
 		if(BURN)
 			if(BP)
-				if(BP.receive_damage(0, damage * hit_percent))
+				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, damage * hit_percent))
 					update_damage_overlays()
 			else
 				adjustFireLoss(damage * hit_percent)
@@ -36,7 +36,7 @@
 			adjustCloneLoss(damage * hit_percent)
 		if(STAMINA)
 			if(BP)
-				if(BP.receive_damage(0, 0, damage * hit_percent))
+				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, damage * hit_percent))
 					update_damage_overlays()
 			else
 				adjustStaminaLoss(damage * hit_percent)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -18,7 +18,7 @@
 	switch(damagetype)
 		if(BRUTE)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(abs(damage * hit_percent, 0)))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(abs(damage * hit_percent), 0))
 					update_damage_overlays()
 			else //no bodypart, we deal damage with a more general method.
 				adjustBruteLoss(damage * hit_percent)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -18,13 +18,13 @@
 	switch(damagetype)
 		if(BRUTE)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(!damage * hit_percent, 0))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(abs(damage * hit_percent, 0)))
 					update_damage_overlays()
 			else //no bodypart, we deal damage with a more general method.
 				adjustBruteLoss(damage * hit_percent)
 		if(BURN)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, !damage * hit_percent))
+				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, abs(damage * hit_percent)))
 					update_damage_overlays()
 			else
 				adjustFireLoss(damage * hit_percent)
@@ -36,7 +36,7 @@
 			adjustCloneLoss(damage * hit_percent)
 		if(STAMINA)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, !damage * hit_percent))
+				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, abs(damage * hit_percent)))
 					update_damage_overlays()
 			else
 				adjustStaminaLoss(damage * hit_percent)

--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -18,13 +18,13 @@
 	switch(damagetype)
 		if(BRUTE)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(damage * hit_percent, 0))
+				if(damage < 0 ? BP.receive_damage(damage * hit_percent, 0) : BP.heal_damage(damage * hit_percent, 0))
 					update_damage_overlays()
 			else //no bodypart, we deal damage with a more general method.
 				adjustBruteLoss(damage * hit_percent)
 		if(BURN)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, damage * hit_percent))
+				if(damage < 0 ? BP.receive_damage(0, damage * hit_percent) : BP.heal_damage(0, damage * hit_percent))
 					update_damage_overlays()
 			else
 				adjustFireLoss(damage * hit_percent)
@@ -36,7 +36,7 @@
 			adjustCloneLoss(damage * hit_percent)
 		if(STAMINA)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, damage * hit_percent))
+				if(damage < 0 ? BP.receive_damage(0, 0, damage * hit_percent) : BP.heal_damage(0, 0, damage * hit_percent))
 					update_damage_overlays()
 			else
 				adjustStaminaLoss(damage * hit_percent)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1612,14 +1612,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(BRUTE)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(!damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(abs(damage * hit_percent * brutemod * H.physiology.brute_mod), 0))
 					H.update_damage_overlays()
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage * hit_percent * brutemod * H.physiology.brute_mod)
 		if(BURN)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, !damage * hit_percent * burnmod * H.physiology.burn_mod))
+				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, abs(damage * hit_percent * burnmod * H.physiology.burn_mod)))
 					H.update_damage_overlays()
 			else
 				H.adjustFireLoss(damage * hit_percent * burnmod * H.physiology.burn_mod)
@@ -1631,7 +1631,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.adjustCloneLoss(damage * hit_percent * H.physiology.clone_mod)
 		if(STAMINA)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, !damage * hit_percent * H.physiology.stamina_mod))
+				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, abs(damage * hit_percent * H.physiology.stamina_mod)))
 					H.update_stamina()
 			else
 				H.adjustStaminaLoss(damage * hit_percent * H.physiology.stamina_mod)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1595,7 +1595,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 /datum/species/proc/apply_damage(damage, damagetype = BRUTE, def_zone = null, blocked, mob/living/carbon/human/H)
 	var/hit_percent = (100-(blocked+armor))/100
 	hit_percent = (hit_percent * (100-H.physiology.damage_resistance))/100
-	if(!damage || hit_percent <= 0)
+	if(hit_percent <= 0)
 		return 0
 
 	var/obj/item/bodypart/BP = null
@@ -1612,14 +1612,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(BRUTE)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
 					H.update_damage_overlays()
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage * hit_percent * brutemod * H.physiology.brute_mod)
 		if(BURN)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod))
+				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod))
 					H.update_damage_overlays()
 			else
 				H.adjustFireLoss(damage * hit_percent * burnmod * H.physiology.burn_mod)
@@ -1631,7 +1631,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.adjustCloneLoss(damage * hit_percent * H.physiology.clone_mod)
 		if(STAMINA)
 			if(BP)
-				if(BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod))
+				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod))
 					H.update_stamina()
 			else
 				H.adjustStaminaLoss(damage * hit_percent * H.physiology.stamina_mod)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1612,14 +1612,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(BRUTE)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
+				if(damage < 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
 					H.update_damage_overlays()
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage * hit_percent * brutemod * H.physiology.brute_mod)
 		if(BURN)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod))
+				if(damage < 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod))
 					H.update_damage_overlays()
 			else
 				H.adjustFireLoss(damage * hit_percent * burnmod * H.physiology.burn_mod)
@@ -1631,7 +1631,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.adjustCloneLoss(damage * hit_percent * H.physiology.clone_mod)
 		if(STAMINA)
 			if(BP)
-				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod))
+				if(damage < 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod))
 					H.update_stamina()
 			else
 				H.adjustStaminaLoss(damage * hit_percent * H.physiology.stamina_mod)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1612,14 +1612,14 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(BRUTE)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(damage < 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
+				if(damage > 0 ? BP.receive_damage(damage * hit_percent * brutemod * H.physiology.brute_mod, 0) : BP.heal_damage(!damage * hit_percent * brutemod * H.physiology.brute_mod, 0))
 					H.update_damage_overlays()
 			else//no bodypart, we deal damage with a more general method.
 				H.adjustBruteLoss(damage * hit_percent * brutemod * H.physiology.brute_mod)
 		if(BURN)
 			H.damageoverlaytemp = 20
 			if(BP)
-				if(damage < 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod))
+				if(damage > 0 ? BP.receive_damage(0, damage * hit_percent * burnmod * H.physiology.burn_mod) : BP.heal_damage(0, !damage * hit_percent * burnmod * H.physiology.burn_mod))
 					H.update_damage_overlays()
 			else
 				H.adjustFireLoss(damage * hit_percent * burnmod * H.physiology.burn_mod)
@@ -1631,7 +1631,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.adjustCloneLoss(damage * hit_percent * H.physiology.clone_mod)
 		if(STAMINA)
 			if(BP)
-				if(damage < 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod))
+				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, !damage * hit_percent * H.physiology.stamina_mod))
 					H.update_stamina()
 			else
 				H.adjustStaminaLoss(damage * hit_percent * H.physiology.stamina_mod)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -31,7 +31,7 @@
 	var/stamina_dam = 0
 	var/max_stamina_damage = 0
 	var/max_damage = 0
-	var/stam_heal_tick = 3		//per Life().
+	var/stam_heal_tick = 0		//per Life(). Defaults to 0 due to citadel changes
 
 	var/brute_reduction = 0 //Subtracted to brute damage taken
 	var/burn_reduction = 0	//Subtracted to burn damage taken
@@ -135,7 +135,7 @@
 
 //Return TRUE to get whatever mob this is in to update health.
 /obj/item/bodypart/proc/on_life()
-	if(stamina_dam > DAMAGE_PRECISION)					//DO NOT update health here, it'll be done in the carbon's life.
+	if(stam_heal_tick && stamina_dam > DAMAGE_PRECISION)					//DO NOT update health here, it'll be done in the carbon's life.
 		if(heal_damage(brute = 0, burn = 0, stamina = stam_heal_tick, only_robotic = FALSE, only_organic = FALSE, updating_health = FALSE))
 			. |= BODYPART_LIFE_UPDATE_HEALTH
 
@@ -441,7 +441,7 @@
 	px_x = 0
 	px_y = 0
 	stam_damage_coeff = 1
-	max_stamina_damage = 100
+	max_stamina_damage = 200
 	var/obj/item/cavity_item
 
 /obj/item/bodypart/chest/Destroy()

--- a/code/modules/surgery/bodyparts/head.dm
+++ b/code/modules/surgery/bodyparts/head.dm
@@ -12,7 +12,7 @@
 	px_x = 0
 	px_y = -8
 	stam_damage_coeff = 1
-	max_stamina_damage = 100
+	max_stamina_damage = 0 //Setting this to 0 since this has the same exact effects as the chest when disabled
 
 	var/mob/living/brain/brainmob = null //The current occupant.
 	var/obj/item/organ/brain/brain = null //The brain organ

--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -1,7 +1,7 @@
 /datum/status_effect/incapacitating/knockdown/on_creation(mob/living/new_owner, set_duration, updating_canmove, override_duration, override_stam)
 	if(iscarbon(new_owner) && (isnum(set_duration) || isnum(override_duration)))
 		new_owner.resting = TRUE
-		new_owner.apply_damage(isnull(override_stam)? set_duration*0.25 : override_stam, STAMINA, BODY_ZONE_CHEST)
+		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
 		if(isnull(override_duration) && (set_duration > 80))
 			set_duration = set_duration*0.01
 			return ..()

--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -1,7 +1,7 @@
 /datum/status_effect/incapacitating/knockdown/on_creation(mob/living/new_owner, set_duration, updating_canmove, override_duration, override_stam)
 	if(iscarbon(new_owner) && (isnum(set_duration) || isnum(override_duration)))
 		new_owner.resting = TRUE
-		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
+		new_owner.apply_damage(isnull(override_stam)? set_duration*0.25 : override_stam, STAMINA, BODY_ZONE_CHEST)
 		if(isnull(override_duration) && (set_duration > 80))
 			set_duration = set_duration*0.01
 			return ..()

--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -9,12 +9,8 @@
 	if(updating_stamina)
 		update_health_hud()
 
-/mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
+/mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE, affected_zone = BODY_ZONE_CHEST)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	if(amount > 0)
-		amount = CLAMP(amount, 0, 200 - getStaminaLoss())
-		take_overall_damage(0, 0, amount, updating_health)
-	else
-		heal_overall_damage(0, 0, abs(amount), FALSE, FALSE, updating_health)
+	apply_damage(amount, STAMINA, affected_zone)
 	return amount


### PR DESCRIPTION
Title. I still need to fix staminaloss from swinging items and all the other stambuffered actions.
:cl: deathride58
fix: Stamina no longer regenerates at hyper speeds.
tweak: To accommodate for upstream's stamina changes, knockdown() now applies staminaloss only to the chest.
tweak: adjuststaminaloss() now has a new argument that allows you to specify a zone to apply staminaloss to. This defaults to the chest
tweak: apply_damage() is now capable of healing carbon mobs and human mobs.
tweak: Since the head has the same exact effects as the chest when disabled, and doesn't really make much sense to be affected by stamina, the head no longer has stamina.
tweak: The chest now has a stamina cap of 200 stamina due to the above.
/:cl:
