### PR TITLE
makes footsteps sound less like ass by shoving cit's original values into the new system

### DIFF
--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -27,11 +27,11 @@
 			v /= 2
 			e -= 5
 	steps++
-	if(steps >= 6)
+	if(steps >= 3)
 		steps = 0
-	if(steps % 2)
+	else
 		return
-	if(!LM.has_gravity(T) && steps != 0) // don't need to step as often when you hop around
+	if(prob(80) && !LM.has_gravity(T)) // don't need to step as often when you hop around
 		return
 	playsound(T, pick(GLOB.footstep[T.footstep][1]),
 		GLOB.footstep[T.footstep][2] * v,

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -20,7 +20,7 @@
 	GLOB.carbon_list -= src
 
 /mob/living/carbon/initialize_footstep()
-	AddComponent(/datum/component/footstep, 1, 2)
+	AddComponent(/datum/component/footstep, 0.6, 2)
 
 /mob/living/carbon/relaymove(mob/user, direction)
 	if(user in src.stomach_contents)


### PR DESCRIPTION
the new footsteps sound overly loud and obnoxious. this fixes that
:cl: deathride58
tweak: Footsteps now sound mostly the same as they did before the hard sync
/:cl:
