### PR TITLE
Fire Alarms are visible in the dark

### DIFF
--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -141,7 +141,7 @@
 
 	flash_lighting_fx(FLASH_LIGHT_RANGE, flash_power, flash_color)
 	if(!timerid)
-		timerid = addtimer(CALLBACK(src, .proc/flash, world.time), 30, TIMER_STOPPABLE | TIMER_LOOP)
+		timerid = addtimer(CALLBACK(src, .proc/flash, world.time), 30, TIMER_UNIQUE | TIMER_STOPPABLE | TIMER_LOOP)
 
 /obj/machinery/firealarm/proc/reset()
 	if(!is_operational())

--- a/code/game/machinery/firealarm.dm
+++ b/code/game/machinery/firealarm.dm
@@ -29,10 +29,6 @@
 	light_range = 7
 	light_color = "#ff3232"
 
-	var/timerid
-	var/flash_power = FLASH_LIGHT_POWER
-	var/flash_color = LIGHT_COLOR_HALOGEN
-
 	var/detecting = 1
 	var/buildstage = 2 // 2 = complete, 1 = no wires, 0 = circuit gone
 	var/last_alarm = 0
@@ -80,17 +76,9 @@
 	if(is_station_level(z))
 		add_overlay("overlay_[GLOB.security_level]")
 		SSvis_overlays.add_vis_overlay(src, icon, "overlay_[GLOB.security_level]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
-		if(GLOB.security_level == SEC_LEVEL_DELTA)
-			if(!timerid)
-				flash()
-		else if(GLOB.security_level <= SEC_LEVEL_RED)
-			if(timerid)
-				deltimer(timerid)
-				timerid = null
 	else
 		add_overlay("overlay_[SEC_LEVEL_GREEN]")
 		SSvis_overlays.add_vis_overlay(src, icon, "overlay_[SEC_LEVEL_GREEN]", ABOVE_LIGHTING_LAYER, ABOVE_LIGHTING_PLANE, dir)
-
 
 	if(detecting)
 		add_overlay("overlay_[A.fire ? "fire" : "clear"]")
@@ -129,29 +117,12 @@
 	var/area/A = get_area(src)
 	A.firealert(src)
 	playsound(src.loc, 'goon/sound/machinery/FireAlarm.ogg', 75)
-	if(timerid)
-		return
-	flash()
-
-/obj/machinery/firealarm/proc/flash()
-	if (!powered())
-		return
-	if(!is_operational())
-		return
-
-	flash_lighting_fx(FLASH_LIGHT_RANGE, flash_power, flash_color)
-	if(!timerid)
-		timerid = addtimer(CALLBACK(src, .proc/flash, world.time), 30, TIMER_UNIQUE | TIMER_STOPPABLE | TIMER_LOOP)
 
 /obj/machinery/firealarm/proc/reset()
 	if(!is_operational())
 		return
 	var/area/A = get_area(src)
 	A.firereset(src)
-	if(!timerid)
-		return
-	deltimer(timerid)
-	timerid = null
 
 /obj/machinery/firealarm/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)


### PR DESCRIPTION
:cl: Poojawa
add: Fire Alarms are visible in low light situations
/:cl:

like air alarms , fire alarms were also something that would be helpful to see in the dark, and were far easier to shift because they're already initialized and the sprites were already overlays. 


![](https://i.gyazo.com/4bade442700952c53418ec621258c635.png)
