### PR TITLE
okay, let's watch the population drop - adds a config option that makes all stamina buffer actions free (TG-style gameplay)

### DIFF
--- a/code/_onclick/hud/human.dm
+++ b/code/_onclick/hud/human.dm
@@ -312,8 +312,9 @@
 	staminas = new /obj/screen/staminas()
 	infodisplay += staminas
 
-	staminabuffer = new /obj/screen/staminabuffer()
-	infodisplay += staminabuffer
+	if(!CONFIG_GET(flag/disable_stambuffer))
+		staminabuffer = new /obj/screen/staminabuffer()
+		infodisplay += staminabuffer
 	//END OF CIT CHANGES
 
 	healthdoll = new /obj/screen/healthdoll()

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -350,3 +350,5 @@
 /datum/config_entry/number/monkeycap
 	config_entry_value = 64
 	min_val = 0
+
+/datum/config_entry/flag/disable_stambuffer

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -28,6 +28,9 @@
 
 	. = ..()
 
+	if(CONFIG_GET(flag/disable_stambuffer))
+		togglesprint()
+
 	AddComponent(/datum/component/redirect, list(COMSIG_COMPONENT_CLEAN_ACT = CALLBACK(src, .proc/clean_blood)))
 
 

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -37,7 +37,7 @@ WALK_DELAY 4
 
 ## The variables below affect the movement of specific mob types. THIS AFFECTS ALL SUBTYPES OF THE TYPE YOU CHOOSE!
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.
-## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and 
+## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and
 ## /mob/living/carbon/human on the last entry, the last entry will override the first.
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/silicon/robot 0
@@ -135,10 +135,10 @@ MIDROUND_ANTAG CHANGELING
 MIDROUND_ANTAG WIZARD
 #MIDROUND_ANTAG  MONKEY
 
-## Uncomment these for overrides of the minimum / maximum number of players in a round type. 
+## Uncomment these for overrides of the minimum / maximum number of players in a round type.
 ## If you set any of these occasionally check to see if you still need them as the modes
 ## will still be actively rebalanced around the SUGGESTED populations, not your overrides.
-## Notes: For maximum number of players a value of -1 means no maximum. Setting minimums to 
+## Notes: For maximum number of players a value of -1 means no maximum. Setting minimums to
 ## VERY low numbers (< 5) can lead to errors if the roundtypes were not designed for that.
 
 #MIN_POP TRAITOR 0
@@ -542,3 +542,6 @@ ROUNDSTART_TRAITS
 
 ## A cap on how many monkeys may be created via monkey cubes
 MONKEYCAP 64
+
+## Uncomment to use TG-style combat
+#DISABLE_STAMBUFFER

--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -1,6 +1,8 @@
 /mob/living/carbon/adjustStaminaLossBuffered(amount, updating_stamina = 1)
 	if(status_flags & GODMODE)
 		return 0
+	if(CONFIG_GET(flag/disable_stambuffer))
+		return
 	var/directstamloss = (bufferedstam + amount) - stambuffer
 	if(directstamloss > 0)
 		adjustStaminaLoss(directstamloss)


### PR DESCRIPTION
The majority of people who complain incessantly about stamina have already gone their own way, but they're still persistently loud about it regardless. Since I'm getting sick and tired of hearing "jUS fUKCIN REVER STAMINNA!", let's go ahead and show the reason why most game devs ditch and laugh at non-constructive feedback. The stats for server population are at https://ss13.se/server/03d7647d3f1584bf461de3e5af31fd1f2c14f6047ba4458871ffbfd4fbc698e6 , and I urge everyone to take a screenshot of the weekly population graph when the config option introduced in this PR gets enabled, and another screenshot a week after it's been enabled. You'll know when it's enabled when the stamina buffer display simply doesn't show up when you spawn in, and when you're sprinting by default when you spawn in. I can guarantee that the server's population will drop over the week it's enabled, as we'd more or less be a straight-up clone of TG without the stamina buffer.

This PR targets only the stamina buffer primarily to keep performance costs at a minimum, as the stamina buffer specifically is what most complainers choose to focus on when ranting about the combat rework.

:cl: deathride58
add: Server operators and badmins can now make the server play like TG by toggling the stamina buffer on/off using the DISABLE_STAMBUFFER config option.
/:cl:
