### PR TITLE
Eternalween

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -322,7 +322,7 @@
 
 /datum/holiday/halloween
 	name = HALLOWEEN
-	begin_day = 28
+	begin_day = 1
 	begin_month = OCTOBER
 	end_day = 2
 	end_month = NOVEMBER


### PR DESCRIPTION
Halloween will now last the full month of October instead of starting 3 days before and lasting 2 days after. Maximum spoop.