### PR TITLE
Nerf Mining Armor (FEEDBACK NEEDED.)

### DIFF
--- a/code/modules/jobs/job_types/cargo_service.dm
+++ b/code/modules/jobs/job_types/cargo_service.dm
@@ -93,6 +93,7 @@ Shaft Miner
 		/obj/item/storage/bag/ore=1,\
 		/obj/item/kitchen/knife/combat/survival=1,\
 		/obj/item/mining_voucher=1,\
+		/obj/item/suit_voucher=1,\
 		/obj/item/stack/marker_beacon/ten=1)
 
 	backpack = /obj/item/storage/backpack/explorer

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -152,7 +152,7 @@
 	desc = "A robust suit for exploring dangerous environments."
 	icon_state = "exo"
 	item_state = "exo"
-	w-_class = WEIGHT_CLASS_BULKY
+	w_class = WEIGHT_CLASS_BULKY
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	cold_protection = CHEST|GROIN|LEGS|ARMS

--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -125,6 +125,7 @@
 	desc = "A fire-proof suit for exploring hot environments."
 	icon_state = "seva"
 	item_state = "seva"
+	w_class = WEIGHT_CLASS_BULKY
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
@@ -151,6 +152,7 @@
 	desc = "A robust suit for exploring dangerous environments."
 	icon_state = "exo"
 	item_state = "exo"
+	w-_class = WEIGHT_CLASS_BULKY
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	min_cold_protection_temperature = FIRE_SUIT_MIN_TEMP_PROTECT
 	cold_protection = CHEST|GROIN|LEGS|ARMS

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -60,7 +60,6 @@
 	new /obj/item/gun/energy/kinetic_accelerator(src)
 	new /obj/item/clothing/glasses/meson(src)
 	new /obj/item/survivalcapsule(src)
-	new /obj/item/suit_voucher(src)
 	new /obj/item/assault_pod/mining(src)
 
 


### PR DESCRIPTION
[Changelogs]: Reclasses new gear as bulky, and changes the voucher spawn situation.

:cl: nicc

tweak: suit vouchers now spawn on miners and not in lockers
balance: new suits are now bulky, and won't fit in backpacks

/:cl:

[why]: stops having a SEVA in your backpack and an exo on you to meme ash-storms, and makes the suits a bit harder to get more than one of to further quell the issue. I haven't yet gotten any other feedback on them other than minor OOC reeing, and those people didn't wanna DM me so I could get actual issues to fix, so please comment below if more needs doing. thx