### PR TITLE
Tweaks/rebalances disarms and disarm pushes

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1431,9 +1431,11 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(!target.combatmode) // CITADEL CHANGE
 			randn += -10 //CITADEL CHANGE - being out of combat mode makes it easier for you to get disarmed
 		if(user.resting) //CITADEL CHANGE
-			randn += 60 //CITADEL CHANGE - No kosher disarming if you're resting
+			randn += 100 //CITADEL CHANGE - No kosher disarming if you're resting
 		if(!user.combatmode) //CITADEL CHANGE
 			randn += 25 //CITADEL CHANGE - Makes it harder to disarm outside of combat mode
+		if(user.pulling == target)
+			randn += -20 //If you have the time to get someone in a grab, you should have a greater chance at snatching the thing in their hand. Will be made completely obsolete by the grab rework but i've got a poor track record for releasing big projects on time so w/e i guess
 
 		if(randn <= 35)//CIT CHANGE - changes this back to a 35% chance to accomodate for the above being commented out in favor of right-click pushing
 			var/obj/item/I = null

--- a/modular_citadel/code/modules/mob/living/carbon/human/species.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species.dm
@@ -37,24 +37,22 @@
 		var/randomized_zone = ran_zone(user.zone_selected)
 		SEND_SIGNAL(target, COMSIG_HUMAN_DISARM_HIT, user, user.zone_selected)
 		var/obj/item/bodypart/affecting = target.get_bodypart(randomized_zone)
-		var/randn = rand(1, 100)
-		if(user.resting)
-			randn += 20 //Makes it plausible, but unlikely, to push someone over while resting
-		if(!user.combatmode)
-			randn += 25 //Makes it impossible to push actually push someone outside of combat mode
 
-		if(randn <= 25)
+		if(!target.combatmode && user.combatmode || prob(target.getStaminaLoss()*(user.resting ? 0.25 : 1)*(user.combatmode ? 1 : 0.05))) //probability depends on staminaloss. it's plausible, but unlikely that you'll be able to push someone over while resting, and pretty rare to successfully push someone outside of combat mode. The few people that even know how to right-click outside of combat mode are a rarity but let's take that into account regardless.
 			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-			target.visible_message("<span class='danger'>[user] has pushed [target]!</span>",
+			target.visible_message("<span class='danger'>[user] [user.combatmode ? "has" : "gently"] pushed [target]!</span>",
 				"<span class='userdanger'>[user] has pushed [target]!</span>", null, COMBAT_MESSAGE_RANGE)
 			target.apply_effect(40, EFFECT_KNOCKDOWN, target.run_armor_check(affecting, "melee", "Your armor prevents your fall!", "Your armor softens your fall!"))
 			target.forcesay(GLOB.hit_appends)
 			log_combat(user, target, "disarmed", " pushing them to the ground")
 			return
 
-		playsound(target, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-		target.visible_message("<span class='danger'>[user] attempted to push [target]!</span>", \
-						"<span class='userdanger'>[user] attemped to push [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+		playsound(target, 'sound/weapons/thudswoosh.ogg', 25, 1, -1)
+		target.visible_message("<span class='danger'>[user] [user.combatmode ? "attempted to push" : "tries to gently push"] [target] over!</span>", \
+						"<span class='userdanger'>[user] [user.combatmode ? "attempted to push" : "tries to gently push"] [target] over!</span>", null, COMBAT_MESSAGE_RANGE)
+		if(!target.resting && !user.resting && user.combatmode)
+			target.adjustStaminaLoss(rand(1,5)) //This is the absolute most inefficient way to get someone into soft stamcrit, but if you've got a crowd trying to shove you over, you've no option but to get knocked down and accept fate
+		log_combat(user, target, "attempted to disarm push")
 
 ////////////////////
 /////BODYPARTS/////


### PR DESCRIPTION
This is an overall buff to melee combat, which has been particularly uninteresting as of lately since the majority of players don't give a shit about managing their stamina when engaging in one-on-one fights against opponents who don't have equipment that deals stamloss. This changes that by giving direct incentive for players to manage their stamina well, with disarm pushing becoming a very, very inefficient, but readily available option to quickly punish those that don't know how to manage their stamina, giving players a little more motivation to get good.

:cl: deathride58
balance: The thing you're currently grabbing is now taken into account when left-click disarming. Things you have grabbed now roughly have a 45% chance to be disarmed.
balance: Disarm push rolls are now determined by the target's staminaloss rather than a flat number.
balance: When you're in combat mode, pushing someone who isn't in combat mode is a guaranteed knockdown. Hard counter to stam regen squeezing in melee combat.
balance: Failed disarm push attempts now deals light staminaloss to the target so long as both the attacker and target are standing. The total stamloss dealt to the target is random, clocking in at a very inefficient 1-5 stamloss per unsuccessful push attempt.
tweak: Disarm pushes now play the thudswoosh sound regardless if they're successful or not. Had it not been for copyright, I would've used L4D's melee sound.
tweak: Disarm push attempts are now logged
/:cl:
