### PR TITLE
Adds *dab. Yep. The future is here.

### DIFF
--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -160,3 +160,24 @@
 		user.nextsoundemote = world.time + 7
 		playsound(user, 'modular_citadel/sound/voice/weh.ogg', 50, 1, -1)
 	. = ..()
+
+/datum/emote/living/dab
+	key = "dab"
+	key_third_person = "suddenly hits a dab"
+	message = "suddenly hits a dab!"
+	emote_type = EMOTE_AUDIBLE
+
+
+
+/datum/emote/living/dab/run_emote(mob/living/user, params)
+	if (ishuman(user))
+		var/def_zone = BODY_ZONE_CHEST
+		var/luck = (rand(1,100))
+		if(luck >= 65)
+			user.adjustStaminaLoss(70)
+		if(luck >= 80)
+			def_zone = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
+			user.apply_damage(20, BRUTE, def_zone)
+		if(luck >= 95)
+			user.adjustBrainLoss(100)
+	. = ..()


### PR DESCRIPTION
[Changelogs]: Adds the all new *dab emote. This has a 35% chance of dealing 70 staminaloss, a 20 percent chance of dealing 20 brute to a random arm, (pending change to armbreak with med-rework) and a 5 percent chance to inflict 100 braindamage. Just like real life! I will make balance changes as necessary, if I feel the consequences aren't severe enough. Perhaps a 1% chance of instant dismemberment? Who knows! I am have drink problem!

:cl: nicc
add: *dab

/:cl:

[why]: It felt severely empty playing this wonderful server with no *dab. Now I can *dab, with a chance to be punished for being so shit. Also, a new inventive way for Harold to kill himself.
