### PR TITLE
Removes clowncar from the uplink until someone wants to make it less broken.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1487,7 +1487,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	restricted_roles = list("Clown")
-
+/*
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"
 	desc = "The Clown Car is the ultimate transportation method for any worthy clown! \
@@ -1498,7 +1498,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/vehicle/sealed/car/clowncar
 	cost = 15
 	restricted_roles = list("Clown")
-
+*/
 // Pointless
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"


### PR DESCRIPTION
[Changelogs]: This thing is actually insane, moves fast, can stuff people in who have already moved away, and generally is just insanely unbalanced. Removed from uplink until someone thinks it's worth balancing.

:cl: nicc

del: Removed stupid item

/:cl:

[why]: see CL