### PR TITLE
(HOPEFULLY) Fixes autostand making item dropping wait for stand attempts to finish

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1020,7 +1020,7 @@
 			client.move_delay = world.time + movement_delay()
 	lying_prev = lying
 	if(canmove && !intentionalresting && iscarbon(src) && client && client.prefs && client.prefs.autostand)//CIT CHANGE - adds autostanding as a preference
-		resist_a_rest(TRUE)//CIT CHANGE - ditto
+		addtimer(CALLBACK(src, .proc/resist_a_rest, TRUE), 0) //CIT CHANGE - ditto
 	return canmove
 
 /mob/living/proc/AddAbility(obj/effect/proc_holder/A)


### PR DESCRIPTION
Reason number 3189235981239 why game devs hate unconstructive feedback with a passion. Shit like this never gets reported. At all.

:cl: deathride58
fix: Autostand no longer makes you invulnerable to dropping items when being knocked down with a force greater than 80
/:cl:
