### PR TITLE
fixes an href exploit in labor camp point claim consoles

### DIFF
--- a/code/modules/mining/laborcamp/laborstacker.dm
+++ b/code/modules/mining/laborcamp/laborstacker.dm
@@ -99,6 +99,8 @@ GLOBAL_LIST(labor_sheet_values)
 		if("move_shuttle")
 			if(!alone_in_area(get_area(src), usr))
 				to_chat(usr, "<span class='warning'>Prisoners are only allowed to be released while alone.</span>")
+			else if(!check_auth())
+				to_chat(usr, "<span class='warning'>Prisoners are only allowed to be released when they reach their point goal.</span>")
 			else
 				switch(SSshuttle.moveShuttle("laborcamp", "laborcamp_home", TRUE))
 					if(1)


### PR DESCRIPTION
Title. Grmbl grmbl. Anyone's free to mirror to TG

:cl: deathride58
fix: You can no longer abuse an href exploit to return from the labor camp before obtaining enough points to satisfy your point goal.
/:cl:
