### PR TITLE
Fixes norko's donor item being in the wrong category

### DIFF
--- a/modular_citadel/code/modules/client/loadout/__donator.dm
+++ b/modular_citadel/code/modules/client/loadout/__donator.dm
@@ -335,7 +335,7 @@ datum/gear/darksabresheath
 	
 /datum/gear/gothcoat
 	name = "Goth Coat"
-	category = SLOT_W_UNIFORM
+	category = SLOT_WEAR_SUIT
 	path = /obj/item/clothing/suit/gothcoat
 	ckeywhitelist = list("norko")
 	


### PR DESCRIPTION
Title
:cl: deathride58
fix: Norko's donor item is now listed in the right category
/:cl:
