### PR TITLE
Adds Cryo Sleepers to Permabrig

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -250,6 +250,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/cryopod,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaH" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -18861,6 +18861,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/machinery/cryopod,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMl" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -911,6 +911,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
+/obj/machinery/cryopod,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "acy" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1685,8 +1685,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Unisex Showers"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1757,12 +1760,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ago" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
+/obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "right";
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -56014,6 +56014,10 @@
 /obj/item/stack/ore/iron,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"jXF" = (
+/obj/machinery/cryopod,
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "jXV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -82805,7 +82809,7 @@ lGp
 aeU
 afI
 aeU
-aeU
+jXF
 agy
 agN
 agY


### PR DESCRIPTION

:cl: Tupinambis
add: Cryo Sleepers have been added to Perma on all four maps in rotation. the bathroom windoor and window have switched places to accommodate this change.
/:cl:

[why]: New "don't suicide to escape punishment" rules, and allows perma'd players to leave the round non=disruptively 
