### PR TITLE
Makes human tails and human ears save again

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/humans.dm
+++ b/code/modules/mob/living/carbon/human/species_types/humans.dm
@@ -3,8 +3,8 @@
 	id = "human"
 	default_color = "FFFFFF"
 	species_traits = list(EYECOLOR,HAIR,FACEHAIR,LIPS,MUTCOLORS_PARTSONLY)
-	mutant_bodyparts = list("ears", "tail_human", "wings", "taur") // CITADEL EDIT gives humans snowflake parts
-	default_features = list("mcolor" = "FFF", "tail_human" = "None", "ears" = "None", "wings" = "None", "taur" = "None")
+	mutant_bodyparts = list("mam_ears", "mam_tail", "wings", "taur") // CITADEL EDIT gives humans snowflake parts
+	default_features = list("mcolor" = "FFF", "mam_tail" = "None", "mam_ears" = "None", "wings" = "None", "taur" = "None")
 	use_skintones = 1
 	skinned_type = /obj/item/stack/sheet/animalhide/human
 	disliked_food = GROSS | RAW


### PR DESCRIPTION
Grmbl grmbl

:cl: deathride58
fix: Human tails and human ears now save again. Humans now use mam_tail and mam_ears for their snowflake bits instead of tg's equivalent, just as they did prior to human tail and ear saving breaking
/:cl:
