### PR TITLE
Adds loader engineering cyborg sprite.

### DIFF
--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -223,7 +223,7 @@
 
 /obj/item/robot_module/engineering/be_transformed_to(obj/item/robot_module/old_module)
 	var/mob/living/silicon/robot/R = loc
-	var/borg_icon = input(R, "Select an icon!", "Robot Icon", null) as null|anything in list("Default", "Default - Treads","Handy")
+	var/borg_icon = input(R, "Select an icon!", "Robot Icon", null) as null|anything in list("Default", "Default - Treads","Loader","Handy")
 	if(!borg_icon)
 		return FALSE
 	switch(borg_icon)
@@ -234,7 +234,7 @@
 			special_light_key = "engineer"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
 		if("Loader")
-			cyborg_base_icon = "loader"
+			cyborg_base_icon = "loaderborg"
 			cyborg_icon_override = 'modular_citadel/icons/mob/robots.dmi'
 			has_snowflake_deadsprite = TRUE
 		if("Handy")


### PR DESCRIPTION

:cl: Tupinambis
add: You can now choose the pre-exisiting "loader" sprite as an appearance for your engineering borg.
/:cl:

[why]: This nice sprite has been sitting in the gamefiles unused, now it shall be used. Enjoy.
