### PR TITLE
Legit power creep

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/goldgrub.dm
@@ -15,6 +15,7 @@
 	friendly = "harmlessly rolls into"
 	maxHealth = 45
 	health = 45
+	gold_core_spawnable = HOSTILE_SPAWN
 	harm_intent_damage = 5
 	melee_damage_lower = 0
 	melee_damage_upper = 0
@@ -27,7 +28,7 @@
 	status_flags = CANPUSH
 	search_objects = 1
 	wanted_objects = list(/obj/item/stack/ore/diamond, /obj/item/stack/ore/gold, /obj/item/stack/ore/silver,
-						  /obj/item/stack/ore/uranium)
+						  /obj/item/stack/ore/uranium, /obj/item/stack/ore/titanium)
 
 	var/chase_time = 100
 	var/will_burrow = TRUE


### PR DESCRIPTION
[Changelogs]
Legit power creep, cant even hide it at this point.
HEY TEENS! Sick of Miners being LAZY or DEAD! Well now do to slime bullshit magic you can make "Goldgrumps" a Monster form lava land for sci, when killed drop mats! NOW they have been seen in the wild eating titanium ore, so you know what to do! Mass produce gold slimes, kill them and get mats for free! WAIT THEIRS MORE! you can make a orm and get points, then make a Pointer Miner vender, get 1000 points and get CARGO AND MINER ACCESS To do there job for them! Or get Miner items that are frankly just OP and allready Power Creep!

[why]
Power creep