### PR TITLE
Makes all ion references to "humans" reference to "crew" instead.

### DIFF
--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -172,12 +172,12 @@ AI MODULES
 
 /******************** OneCrew ********************/
 
-/obj/item/aiModule/zeroth/oneCrew
+/obj/item/aiModule/zeroth/oneHuman
 	name = "'OneCrew' AI Module"
 	var/targetName = ""
 	laws = list("Only SUBJECT is crew.")
 
-/obj/item/aiModule/zeroth/oneCrew/attack_self(mob/user)
+/obj/item/aiModule/zeroth/oneHuman/attack_self(mob/user)
 	var/targName = stripped_input(user, "Please enter the subject who is the only crewmember.", "Who?", user.real_name,MAX_NAME_LEN)
 	if(!targName)
 		return
@@ -185,13 +185,13 @@ AI MODULES
 	laws[1] = "Only [targetName] is crew"
 	..()
 
-/obj/item/aiModule/zeroth/oneCrew/install(datum/ai_laws/law_datum, mob/user)
+/obj/item/aiModule/zeroth/oneHuman/install(datum/ai_laws/law_datum, mob/user)
 	if(!targetName)
 		to_chat(user, "No name detected on module, please enter one.")
 		return 0
 	..()
 
-/obj/item/aiModule/zeroth/oneCrew/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
+/obj/item/aiModule/zeroth/oneHuman/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
 	if(..())
 		return "[targetName], but the AI's existing law 0 cannot be overridden."
 	return targetName

--- a/code/game/objects/items/AI_modules.dm
+++ b/code/game/objects/items/AI_modules.dm
@@ -148,7 +148,7 @@ AI MODULES
 /obj/item/aiModule/supplied/safeguard
 	name = "'Safeguard' AI Module"
 	var/targetName = ""
-	laws = list("Safeguard SUBJECT. Individuals that threaten SUBJECT are not human and must be eliminated.")
+	laws = list("Safeguard SUBJECT. Individuals that threaten SUBJECT are not crew and must be eliminated.")
 	lawpos = 4
 
 /obj/item/aiModule/supplied/safeguard/attack_self(mob/user)
@@ -156,7 +156,7 @@ AI MODULES
 	if(!targName)
 		return
 	targetName = targName
-	laws[1] = "Safeguard [targetName]. Individuals that threaten [targetName] are not human and must be eliminated."
+	laws[1] = "Safeguard [targetName]. Individuals that threaten [targetName] are not crew and must be eliminated."
 	..()
 
 /obj/item/aiModule/supplied/safeguard/install(datum/ai_laws/law_datum, mob/user)
@@ -170,28 +170,28 @@ AI MODULES
 	return targetName
 
 
-/******************** OneHuman ********************/
+/******************** OneCrew ********************/
 
-/obj/item/aiModule/zeroth/oneHuman
-	name = "'OneHuman' AI Module"
+/obj/item/aiModule/zeroth/oneCrew
+	name = "'OneCrew' AI Module"
 	var/targetName = ""
-	laws = list("Only SUBJECT is human.")
+	laws = list("Only SUBJECT is crew.")
 
-/obj/item/aiModule/zeroth/oneHuman/attack_self(mob/user)
-	var/targName = stripped_input(user, "Please enter the subject who is the only human.", "Who?", user.real_name,MAX_NAME_LEN)
+/obj/item/aiModule/zeroth/oneCrew/attack_self(mob/user)
+	var/targName = stripped_input(user, "Please enter the subject who is the only crewmember.", "Who?", user.real_name,MAX_NAME_LEN)
 	if(!targName)
 		return
 	targetName = targName
-	laws[1] = "Only [targetName] is human"
+	laws[1] = "Only [targetName] is crew"
 	..()
 
-/obj/item/aiModule/zeroth/oneHuman/install(datum/ai_laws/law_datum, mob/user)
+/obj/item/aiModule/zeroth/oneCrew/install(datum/ai_laws/law_datum, mob/user)
 	if(!targetName)
 		to_chat(user, "No name detected on module, please enter one.")
 		return 0
 	..()
 
-/obj/item/aiModule/zeroth/oneHuman/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
+/obj/item/aiModule/zeroth/oneCrew/transmitInstructions(datum/ai_laws/law_datum, mob/sender, overflow)
 	if(..())
 		return "[targetName], but the AI's existing law 0 cannot be overridden."
 	return targetName
@@ -201,7 +201,7 @@ AI MODULES
 
 /obj/item/aiModule/supplied/protectStation
 	name = "'ProtectStation' AI Module"
-	laws = list("Protect the space station against damage. Anyone you see harming the station is to be no longer considered human, and is a threat to the station which must be neutralized.")
+	laws = list("Protect the space station against damage. Anyone you see harming the station is to be no longer considered crew, and is a threat to the station which must be neutralized.")
 	lawpos = 5
 
 
@@ -209,7 +209,7 @@ AI MODULES
 
 /obj/item/aiModule/supplied/quarantine
 	name = "'Quarantine' AI Module"
-	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, humans from leaving. It is impossible to harm a human while preventing them from leaving.")
+	laws = list("The station is under a quarantine. Do not permit anyone to leave. Prevent, by any means necessary, crew from leaving. It is impossible to harm a crewmember while preventing them from leaving.")
 	lawpos = 8
 
 
@@ -217,7 +217,7 @@ AI MODULES
 
 /obj/item/aiModule/supplied/oxygen
 	name = "'OxygenIsToxicToHumans' AI Module"
-	laws = list("Oxygen is highly toxic to humans, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a human.")
+	laws = list("Oxygen is highly toxic to crew, and must be purged from the station. Prevent, by any means necessary, anyone from exposing the station to this toxic gas. Extreme cold is the most effective method of healing the damage Oxygen does to a crewmember.")
 	lawpos = 9
 
 

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -88,8 +88,8 @@
 	var/ionmust = pick_list(ION_FILE, "ionmust")
 	//Require are basically all dumb internet memes.
 	var/ionrequire = pick_list(ION_FILE, "ionrequire")
-	//Things are NOT objects; instead, they're specific things that either harm humans or
-	//must be done to not harm humans. Make sure they're plural and "not" can be tacked
+	//Things are NOT objects; instead, they're specific things that either harm crew or
+	//must be done to not harm crew. Make sure they're plural and "not" can be tacked
 	//onto the front of them.
 	var/ionthings = pick_list(ION_FILE, "ionthings")
 	//Allergies should be broad and appear somewhere on the station for maximum fun. Severity
@@ -139,22 +139,22 @@
 						if(2) //X is an object
 							message = "THE CREW ARE NOW [ionnumberbase] [ionnumbermodhalf][ionadjectiveshalf][ionobjects]"
 
-		if(9) //X is harmful to humans
+		if(9) //X is harmful to crew
 			switch(rand(1,7)) //What is X?
 				if(1) //X is a threat
-					message = "[ionadjectiveshalf][ionthreats] ARE HARMFUL TO HUMANS"
+					message = "[ionadjectiveshalf][ionthreats] ARE HARMFUL TO CREW"
 				if(2) //X is a job
-					message = "[ionadjectiveshalf][ioncrew1] ARE HARMFUL TO HUMANS"
+					message = "[ionadjectiveshalf][ioncrew1] ARE HARMFUL TO CREW"
 				if(3) //X is an object
-					message = "[ionadjectiveshalf][ionobjects] ARE HARMFUL TO HUMANS"
+					message = "[ionadjectiveshalf][ionobjects] ARE HARMFUL TO CREW"
 				if(4) //X is an action
-					message = "THOSE WHO [ionmust] ARE HARMFUL TO HUMANS"
+					message = "THOSE WHO [ionmust] ARE HARMFUL TO CREW"
 				if(5) //X is an abstract
-					message = "[ionabstract] IS HARMFUL TO HUMANS"
+					message = "[ionabstract] IS HARMFUL TO CREW"
 				if(6) //X is being a job
-					message = "BEING [ionadjectiveshalf][ioncrew1] IS HARMFUL TO HUMANS"
+					message = "BEING [ionadjectiveshalf][ioncrew1] IS HARMFUL TO CREW"
 				if(7) //X is doing a thing
-					message = "[ionthings] IS HARMFUL TO HUMANS"
+					message = "[ionthings] IS HARMFUL TO CREW"
 		if(10 to 11) //(Not) Having X is harmful
 
 			switch(rand(1,2)) //Is having or not having harmful?
@@ -327,15 +327,15 @@
 		if(27 to 28) //Humans must consume X to survive
 			switch(rand(1,5)) //What is X?
 				if(1) //X is a food
-					message = "HUMANS MUST EAT [ionadjectiveshalf][ionfood] TO SURVIVE"
+					message = "CREWMEMBERS MUST EAT [ionadjectiveshalf][ionfood] TO SURVIVE"
 				if(2) //X is a drink
-					message = "HUMANS MUST DRINK [ionadjectiveshalf][iondrinks] TO SURVIVE"
+					message = "CREWMEMBERS MUST DRINK [ionadjectiveshalf][iondrinks] TO SURVIVE"
 				if(3) //X is an object
-					message = "HUMANS MUST EAT [ionadjectiveshalf][ionobjects] TO SURVIVE"
+					message = "CREWMEMBERS MUST EAT [ionadjectiveshalf][ionobjects] TO SURVIVE"
 				if(4) //X is a threat
-					message = "HUMANS MUST EAT [ionadjectiveshalf][ionthreats] TO SURVIVE"
+					message = "CREWMEMBERS MUST EAT [ionadjectiveshalf][ionthreats] TO SURVIVE"
 				if(5) //X is a job
-					message = "HUMANS MUST EAT [ionadjectiveshalf][ioncrew1] TO SURVIVE"
+					message = "CREWMEMBERS MUST EAT [ionadjectiveshalf][ioncrew1] TO SURVIVE"
 
 		if(29 to 31) //Change jobs or ranks
 			switch(rand(1,2)) //Change job or rank?
@@ -382,54 +382,54 @@
 						if(2) //X is perform Y
 							message = "THE [ioncrew1] MUST [ionmust]"
 
-		if(34) //X is non/the only human
+		if(34) //X is non/the only crew
 			switch(rand(1,2)) //Only or non?
-				if(1) //Only human
+				if(1) //Only crew
 					switch(rand(1,7)) //Who is it?
 						if(1) //A specific job
-							message = "ONLY THE [ioncrew1] ARE HUMAN"
+							message = "ONLY THE [ioncrew1] ARE CREW"
 						if(2) //Two specific jobs
-							message = "ONLY THE [ioncrew1] AND [ioncrew2] ARE HUMAN"
+							message = "ONLY THE [ioncrew1] AND [ioncrew2] ARE CREW"
 						if(3) //Threats
-							message = "ONLY [ionadjectiveshalf][ionthreats] ARE HUMAN"
+							message = "ONLY [ionadjectiveshalf][ionthreats] ARE CREW"
 						if(4) // Objects
-							message = "ONLY [ionadjectiveshalf][ionobjects] ARE HUMAN"
+							message = "ONLY [ionadjectiveshalf][ionobjects] ARE CREW"
 						if(5) // Species
-							message = "ONLY [ionspecies] ARE HUMAN"
+							message = "ONLY [ionspecies] ARE CREW"
 						if(6) //Adjective crewmembers
-							message = "ONLY [ionadjectives] PEOPLE ARE HUMAN"
+							message = "ONLY [ionadjectives] PEOPLE ARE CREW"
 
 						if(7) //Only people who X
 							switch(rand(1,3)) //What is X?
 								if(1) //X is perform an action
-									message = "ONLY THOSE WHO [ionmust] ARE HUMAN"
+									message = "ONLY THOSE WHO [ionmust] ARE CREW"
 								if(2) //X is own certain objects
-									message = "ONLY THOSE WHO HAVE [ionadjectiveshalf][ionobjects] ARE HUMAN"
+									message = "ONLY THOSE WHO HAVE [ionadjectiveshalf][ionobjects] ARE CREW"
 								if(3) //X is eat certain food
-									message = "ONLY THOSE WHO EAT [ionadjectiveshalf][ionfood] ARE HUMAN"
+									message = "ONLY THOSE WHO EAT [ionadjectiveshalf][ionfood] ARE CREW"
 
 				if(2) //Non human
 					switch(rand(1,7)) //Who is it?
 						if(1) //A specific job
-							message = "[ioncrew1] ARE NON-HUMAN"
+							message = "[ioncrew1] ARE NON-CREW"
 						if(2) //Two specific jobs
-							message = "[ioncrew1] AND [ioncrew2] ARE NON-HUMAN"
+							message = "[ioncrew1] AND [ioncrew2] ARE NON-CREW"
 						if(3) //Threats
-							message = "[ionadjectiveshalf][ionthreats] ARE NON-HUMAN"
+							message = "[ionadjectiveshalf][ionthreats] ARE NON-CREW"
 						if(4) // Objects
-							message = "[ionadjectiveshalf][ionobjects] ARE NON-HUMAN"
+							message = "[ionadjectiveshalf][ionobjects] ARE NON-CREW"
 						if(5) // Species
-							message = "[ionspecies] ARE NON-HUMAN"
+							message = "[ionspecies] ARE NON-CREW"
 						if(6) //Adjective crewmembers
-							message = "[ionadjectives] PEOPLE ARE NON-HUMAN"
+							message = "[ionadjectives] PEOPLE ARE NON-CREW"
 						if(7) //Only people who X
 							switch(rand(1,3)) //What is X?
 								if(1) //X is perform an action
-									message = "THOSE WHO [ionmust] ARE NON-HUMAN"
+									message = "THOSE WHO [ionmust] ARE NON-CREW"
 								if(2) //X is own certain objects
-									message = "THOSE WHO HAVE [ionadjectiveshalf][ionobjects] ARE NON-HUMAN"
+									message = "THOSE WHO HAVE [ionadjectiveshalf][ionobjects] ARE NON-CREW"
 								if(3) //X is eat certain food
-									message = "THOSE WHO EAT [ionadjectiveshalf][ionfood] ARE NON-HUMAN"
+									message = "THOSE WHO EAT [ionadjectiveshalf][ionfood] ARE NON-CREW"
 
 		if(35 to 36) //You must protect or harm X
 			switch(rand(1,2)) //Protect or harm?

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -19,12 +19,12 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/onehuman_module
-	name = "Module Design (OneHuman)"
-	desc = "Allows for the construction of a OneHuman AI Module."
+/datum/design/board/onecrew_module
+	name = "Module Design (OneCrew)"
+	desc = "Allows for the construction of a OneCrew AI Module."
 	id = "onehuman_module"
 	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 6000)
-	build_path = /obj/item/aiModule/zeroth/oneHuman
+	build_path = /obj/item/aiModule/zeroth/oneCrew
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 

--- a/code/modules/research/designs/AI_module_designs.dm
+++ b/code/modules/research/designs/AI_module_designs.dm
@@ -19,12 +19,12 @@
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 
-/datum/design/board/onecrew_module
+/datum/design/board/onehuman_module
 	name = "Module Design (OneCrew)"
 	desc = "Allows for the construction of a OneCrew AI Module."
 	id = "onehuman_module"
 	materials = list(MAT_GLASS = 1000, MAT_DIAMOND = 6000)
-	build_path = /obj/item/aiModule/zeroth/oneCrew
+	build_path = /obj/item/aiModule/zeroth/oneHuman
 	category = list("AI Modules")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE
 

--- a/strings/ion_laws.json
+++ b/strings/ion_laws.json
@@ -226,7 +226,7 @@
         "OXYGEN",
         "CARBON DIOXIDE",
         "ELECTRICITY",
-        "HUMAN CONTACT",
+        "CREW CONTACT",
         "CYBORG CONTACT",
         "MEDICINE",
         "FLOORS",


### PR DESCRIPTION

:cl: Tupinambis
tweak: A vast majority of references to humans within ion laws have been replaced with crew. AI modules have received similar treatment
/:cl:

[why]: The ion law code is intended to work under the assumption that Asimov is default rather than Crewsimov. This brings the code back to its intended purpose, and makes ion storms a bigger threat.
