### PR TITLE
You're too exhausted to be lifted up - makes it much harder to force stamcritted spacemen to stand

### DIFF
--- a/code/game/objects/items/robot/robot_items.dm
+++ b/code/game/objects/items/robot/robot_items.dm
@@ -82,7 +82,7 @@
 					else
 						user.visible_message("<span class='notice'>[user] hugs [M] to make [M.p_them()] feel better!</span>", \
 								"<span class='notice'>You hug [M] to make [M.p_them()] feel better!</span>")
-					if(M.resting)
+					if(M.resting && !M.recoveringstam)
 						M.resting = FALSE
 						M.update_canmove()
 				else
@@ -102,7 +102,7 @@
 					else
 						user.visible_message("<span class='warning'>[user] hugs [M] in a firm bear-hug! [M] looks uncomfortable...</span>", \
 								"<span class='warning'>You hug [M] firmly to make [M.p_them()] feel better! [M] looks uncomfortable...</span>")
-					if(M.resting)
+					if(M.resting && !M.recoveringstam)
 						M.resting = FALSE
 						M.update_canmove()
 				else

--- a/code/modules/mob/living/carbon/alien/alien_defense.dm
+++ b/code/modules/mob/living/carbon/alien/alien_defense.dm
@@ -21,7 +21,8 @@ In all, this is a lot like the monkey code. /N
 	switch(M.a_intent)
 
 		if ("help")
-			resting = 0
+			if(!recoveringstam)
+				resting = 0
 			AdjustStun(-60)
 			AdjustKnockdown(-60)
 			AdjustUnconscious(-60)

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -26,7 +26,8 @@
 		else
 			if(stat == UNCONSCIOUS)
 				stat = CONSCIOUS
-				resting = 0
+				if(!recoveringstam)
+					resting = 0
 				adjust_blindness(-1)
 				update_canmove()
 	update_damage_hud()

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -311,7 +311,7 @@
 		AdjustKnockdown(-60)
 		AdjustUnconscious(-60)
 		AdjustSleeping(-100)
-		if(resting)
+		if(resting && !recoveringstam)
 			resting = 0
 			update_canmove()
 


### PR DESCRIPTION
Title. Help intent no longer makes it easy to meme stamcritted people by forcing them to stand, as standing counteracts the stamina regeneration gained by being in hard stamcrit

:cl: deathride58
fix: You can no longer force a hard stamcritted spaceman to stand by clicking them with help intent. Get more creative if you want to torture someone that's in hard stamcrit.
/:cl:
