### PR TITLE
Makes the rev gamemode simply not check for win conditions until the 20 minute mark

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -26,6 +26,7 @@
 	var/finished = 0
 	var/check_counter = 0
 	var/max_headrevs = 3
+	var/completioncheckstart
 	var/datum/team/revolution/revolution
 	var/list/datum/mind/headrev_candidates = list()
 	var/end_when_heads_dead = TRUE
@@ -60,6 +61,8 @@
 	if(headrev_candidates.len < required_enemies)
 		setup_error = "Not enough headrev candidates"
 		return FALSE
+
+	completioncheckstart = world.time + 20 MINUTES
 
 	return TRUE
 
@@ -114,7 +117,7 @@
 /datum/game_mode/revolution/process()
 	check_counter++
 	if(check_counter >= 5)
-		if(!finished)
+		if(!finished && world.time >= completioncheckstart)
 			SSticker.mode.check_win()
 		check_counter = 0
 	return FALSE


### PR DESCRIPTION
Title. Revs ending instantly as soon as the round starts is a bad meme, and it's only made worse by the sheer amount of latejoiners we've got.

:cl: deathride58
tweak: The revolution gamemode now waits until the 20 minute mark before checking for win conditions.
/:cl:
