### PR TITLE
makes it impossible to resist/move out of grabs while resting (though disarming your way out of the grab still works)

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1422,6 +1422,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(target.pulling == user)
 			target.visible_message("<span class='warning'>[user] wrestles out of [target]'s grip!</span>")
 			target.stop_pulling()
+			playsound(target, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+			log_combat(user, target, "disarmed out of grab from")
+			return
 		//var/obj/item/bodypart/affecting = target.get_bodypart(randomized_zone) CIT CHANGE - comments this out to prevent compile errors due to the below commented out bit
 		var/randn = rand(1, 100)
 		/*if(randn <= 25) CITADEL CHANGE - moves disarm push attempts to right click

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1419,6 +1419,9 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			target.w_uniform.add_fingerprint(user)
 		//var/randomized_zone = ran_zone(user.zone_selected) CIT CHANGE - comments out to prevent compiling errors
 		SEND_SIGNAL(target, COMSIG_HUMAN_DISARM_HIT, user, user.zone_selected)
+		if(target.pulling == user)
+			target.visible_message("<span class='warning'>[user] wrestles out of [target]'s grip!</span>")
+			target.stop_pulling()
 		//var/obj/item/bodypart/affecting = target.get_bodypart(randomized_zone) CIT CHANGE - comments this out to prevent compile errors due to the below commented out bit
 		var/randn = rand(1, 100)
 		/*if(randn <= 25) CITADEL CHANGE - moves disarm push attempts to right click

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -631,7 +631,7 @@
 /mob/living/resist_grab(moving_resist)
 	. = 1
 	if(pulledby.grab_state)
-		if(prob(30/pulledby.grab_state))
+		if(!resting && prob(30/pulledby.grab_state))
 			visible_message("<span class='danger'>[src] has broken free of [pulledby]'s grip!</span>")
 			log_combat(pulledby, src, "broke grab")
 			pulledby.stop_pulling()


### PR DESCRIPTION
Title. For the laymen, this means sec will no longer have to push perps into hard stamcrit to actually arrest someone. For those that know what they're doing, this means that combat with non-sec will be a lot more lethal. This partially emulates the upcoming grab rework's restraining/pinning with the current grab system, which will make it a lot easier for those who know what they're doing to end a fight.

:cl: deathride58
balance: You can no longer resist/move out of grabs while you're resting. Disarming your way out still works, though.
/:cl:
