### PR TITLE
Makes staminaloss taken while in hard stamcrit decrease the amount of staminaloss you'll take until you're out of stamcrit, and adds scrambling while in stamcrit

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -13,6 +13,15 @@
 	if(wet)
 		AddComponent(/datum/component/wet_floor, wet, INFINITY, 0, INFINITY, TRUE)
 
+/turf/open/MouseDrop_T(atom/dropping, mob/user)
+	. = ..()
+	if(dropping == user && isliving(user))
+		var/mob/living/L = user
+		if(L.resting && do_after(L, max(10, L.getStaminaLoss()*0.5), 0, src))
+			if(Adjacent(L, src))
+				L.forceMove(src)
+				playsound(L, "rustle", 25, 1)
+
 /turf/open/indestructible
 	name = "floor"
 	icon = 'icons/turf/floors.dmi'

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -454,6 +454,9 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(getStaminaLoss() && !combatmode)//CIT CHANGE - prevents stamina regen while combat mode is active
 		adjustStaminaLoss(resting ? (recoveringstam ? -7.5 : -3) : -1.5)//CIT CHANGE - decreases adjuststaminaloss to stop stamina damage from being such a joke
 
+	if(!recoveringstam && incomingstammult != 1)
+		incomingstammult = min(1, incomingstammult*2)
+
 	//CIT CHANGES START HERE. STAMINA BUFFER STUFF
 	if(bufferedstam && world.time > stambufferregentime)
 		var/drainrate = max((bufferedstam*(bufferedstam/(5)))*0.1,1)

--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -12,5 +12,7 @@
 /mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE, affected_zone = BODY_ZONE_CHEST)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	apply_damage(amount, STAMINA, affected_zone)
+	apply_damage(amount > 0 ? amount*incomingstammult : amount, STAMINA, affected_zone)
+	if(recoveringstam && amount > 20)
+		incomingstammult = max(0.01, incomingstammult/(amount*0.05))
 	return amount

--- a/modular_citadel/code/modules/mob/living/living.dm
+++ b/modular_citadel/code/modules/mob/living/living.dm
@@ -1,5 +1,6 @@
 /mob/living
 	var/recoveringstam = FALSE
+	var/incomingstammult = 1
 	var/bufferedstam = 0
 	var/stambuffer = 20
 	var/stambufferregentime


### PR DESCRIPTION
Title. This makes it so that it's much, much, *much* harder to keep someone in stamcrit for an extended period of time, and gives people a little bit of a grace period once they finally do get out of stamcrit. The diminishing returns multiplier has a minimum of 0.01 and it doesn't reset until the person's out of stamcrit. This means that a single security officer with an infinite cell stunbaton cannot keep a single person down on their own. It takes a maximum of 7 mob process ticks to get back to taking normal staminaloss, which is about 14 seconds. This PR also adds the ability to scramble on the ground while resting, even while in staminacrit. The amount of time you'll need in order to successfully scramble depends on your total staminaloss, up to a maximum of 10 seconds and with a minimum of 1 second. This can be done by dragging your character onto an adjacent open turf.

:cl: deathride58
add: Stamina damage now has diminishing returns on people who are in hard staminacrit with the addition of a new multiplier. When you take staminaloss while in hard staminacrit, you'll be under the effects of the new multiplier, which reduces the amount of staminaloss you take from all sources of staminaloss. The diminishing returns multiplier will steadily return to 1 once you're out of staminacrit.
add: You can now scramble while resting. You can do this by dragging your spaceman onto an adjacent turf. This works even if you're in staminacrit, but the timer depends entirely on your staminaloss.
/:cl:
