### PR TITLE
[Ready] Makes PDA notes have basic ship terms that relate to the NSEW form PFBSQ

### DIFF
--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/lock_code = "" // Lockcode to unlock uplink
 	var/honkamt = 0 //How many honks left when infected with honk.exe
 	var/mimeamt = 0 //How many silence left when infected with mime.exe
-	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!" //Current note in the notepad function
+	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant! To help with navigation we have provided the following definitions! Port, also known as West. Bow also known as North. Starboard, also known as East. Quarter also known as South." //Current note in the notepad function
 	var/notehtml = ""
 	var/notescanned = FALSE // True if what is in the notekeeper was from a paper.
 	var/detonatable = TRUE // Can the PDA be blown up?

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/lock_code = "" // Lockcode to unlock uplink
 	var/honkamt = 0 //How many honks left when infected with honk.exe
 	var/mimeamt = 0 //How many silence left when infected with mime.exe
-	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant! To help with navigation we have provided the following definitions! Port, also known as West. Bow also known as North. Starboard, also known as East. Quarter also known as South." //Current note in the notepad function
+	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant! To help with navigation we have provided the following definitions! North: Fore. South: Aft. West: Port. East: Starboard. Quarter is either side of aft." //Current note in the notepad function
 	var/notehtml = ""
 	var/notescanned = FALSE // True if what is in the notekeeper was from a paper.
 	var/detonatable = TRUE // Can the PDA be blown up?

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -59,7 +59,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/lock_code = "" // Lockcode to unlock uplink
 	var/honkamt = 0 //How many honks left when infected with honk.exe
 	var/mimeamt = 0 //How many silence left when infected with mime.exe
-	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant!Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant! To help with navigation we have provided the following definitions! North: Fore. South: Aft. West: Port. East: Starboard. Quarter is either side of aft." //Current note in the notepad function
+	var/note = "Congratulations, your station has chosen the Thinktronic 5230 Personal Data Assistant! To help with navigation, we have provided the following definitions. North: Fore. South: Aft. West: Port. East: Starboard. Quarter is either side of aft." //Current note in the notepad function
 	var/notehtml = ""
 	var/notescanned = FALSE // True if what is in the notekeeper was from a paper.
 	var/detonatable = TRUE // Can the PDA be blown up?


### PR DESCRIPTION
[Changelogs]
PDAs now define based of NSEW the PBSQ, this also is based off GPS locations. Being in the senter of the station and having GPS on each labeled PBSQ will give you a NSEW to go off

[why]
`Flux Anomaly detected in maints on the Port Quarter`
