### PR TITLE
Blacklist borg jaws form whetstone's

### DIFF
--- a/code/game/objects/items/sharpener.dm
+++ b/code/game/objects/items/sharpener.dm
@@ -24,6 +24,9 @@
 	if(istype(I, /obj/item/melee/transforming/energy))
 		to_chat(user, "<span class='warning'>You don't think \the [I] will be the thing getting modified if you use it on \the [src]!</span>")
 		return
+	if(istype(I, /obj/item/dogborg/jaws)) // Should not work on Combat Jaws!
+		to_chat(user, "<span class='warning'>Your teeth cant be sharpened with the whetstone!</span>")
+		return
 	if(istype(I, /obj/item/twohanded))//some twohanded items should still be sharpenable, but handle force differently. therefore i need this stuff
 		var/obj/item/twohanded/TH = I
 		if(TH.force_wielded >= max)


### PR DESCRIPTION
[Changelogs]
Makes a blacklist of borg jaws on whetstones
Was told this was the better way of doing it then removing sharp form there jaws - "Metal is sharp" ect ect
[why]
Removing sharp form them was a bad fix! 
Feel there still not ment to sharpen there teeth via magic whetstones to get almost armblade harm or such.