### PR TITLE
[Grammar] [Ready] Makes Space Queens men pirate gear have better item descriptions 

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -129,7 +129,7 @@ Contains:
 	//Space pirate outfit
 /obj/item/clothing/head/helmet/space/pirate
 	name = "royal tricorne"
-	desc = "A tricorne form the Space Queen herself, that is space proof as well as made with padded armor."
+	desc = "A tricorne form the Honorable Space Queen herself, that is space proof as well as made with padded armor."
 	icon_state = "pirate"
 	item_state = "pirate"
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 60, "acid" = 75)

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -128,8 +128,8 @@ Contains:
 
 	//Space pirate outfit
 /obj/item/clothing/head/helmet/space/pirate
-	name = "pirate hat"
-	desc = "Yarr."
+	name = "royal tricorne"
+	desc = "A tricorne form the Space Queen herself, that is space proof as well as made with padded armor."
 	icon_state = "pirate"
 	item_state = "pirate"
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 60, "acid" = 75)
@@ -139,13 +139,14 @@ Contains:
 	flags_cover = HEADCOVERSEYES
 
 /obj/item/clothing/head/helmet/space/pirate/bandana
-	name = "pirate bandana"
+	name = "royal bandana"
+	desc = "A special bandana that is space proof as well as made with padded armor."
 	icon_state = "bandana"
 	item_state = "bandana"
 
 /obj/item/clothing/suit/space/pirate
-	name = "pirate coat"
-	desc = "Yarr."
+	name = "royal waistcoat "
+	desc = "A royal waistcoat made to be spaceproof as well as padded with armor."
 	icon_state = "pirate"
 	item_state = "pirate"
 	w_class = WEIGHT_CLASS_NORMAL

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -129,7 +129,7 @@ Contains:
 	//Space pirate outfit
 /obj/item/clothing/head/helmet/space/pirate
 	name = "royal tricorne"
-	desc = "A tricorne form the Honorable Space Queen herself, that is space proof as well as made with padded armor."
+	desc = "A thick, space-proof tricorne from the royal Space Queen. It's lined with a layer of reflective kevlar."
 	icon_state = "pirate"
 	item_state = "pirate"
 	armor = list("melee" = 30, "bullet" = 50, "laser" = 30,"energy" = 15, "bomb" = 30, "bio" = 30, "rad" = 30, "fire" = 60, "acid" = 75)
@@ -140,13 +140,13 @@ Contains:
 
 /obj/item/clothing/head/helmet/space/pirate/bandana
 	name = "royal bandana"
-	desc = "A special bandana that is space proof as well as made with padded armor."
+	desc = "A space-proof bandanna crafted with reflective kevlar."
 	icon_state = "bandana"
 	item_state = "bandana"
 
 /obj/item/clothing/suit/space/pirate
 	name = "royal waistcoat "
-	desc = "A royal waistcoat made to be spaceproof as well as padded with armor."
+	desc = "A royal, space-proof waistcoat. The inside of it is lined with reflective kevlar."
 	icon_state = "pirate"
 	item_state = "pirate"
 	w_class = WEIGHT_CLASS_NORMAL


### PR DESCRIPTION
[Changelogs]
Makes all the Space Pirate gear have there own descriptions and new names!
[why]
_Bhijn (deathride58)Today at 11:46 AM
what happened is that people got confused as to whether the pirate suits were spaceproof or not, so pirates ended up sending only one person out in the only space suit the ship had, only for the rest of the pirates to end up ghosting_
Fixes that.