### PR TITLE
Lone Ops but they are an actual threat (hopefully)

### DIFF
--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -175,3 +175,20 @@
 		/obj/item/tank/jetpack/oxygen/harness=1,\
 		/obj/item/gun/ballistic/automatic/pistol=1,\
 		/obj/item/kitchen/knife/combat/survival)
+
+/datum/outfit/syndicate/lone
+	name = "Syndicate Operative - Lone"
+
+	glasses = /obj/item/clothing/glasses/night
+	mask = /obj/item/clothing/mask/gas/syndicate
+	suit = /obj/item/clothing/suit/space/syndicate/black/red
+	head = /obj/item/clothing/head/helmet/space/syndicate/black/red
+	r_pocket = /obj/item/tank/internals/emergency_oxygen/engi
+	internals_slot = SLOT_R_STORE
+	belt = /obj/item/storage/belt/military
+	backpack_contents = list(/obj/item/storage/box/syndie=1,\
+	/obj/item/tank/jetpack/oxygen/harness=1,\
+	/obj/item/gun/ballistic/automatic/pistol=1,\
+	/obj/item/kitchen/knife/combat/survival)
+
+	tc = 40

--- a/code/modules/antagonists/nukeop/nukeop.dm
+++ b/code/modules/antagonists/nukeop/nukeop.dm
@@ -208,7 +208,7 @@
 	name = "Lone Operative"
 	always_new_team = TRUE
 	send_to_spawnpoint = FALSE //Handled by event
-	nukeop_outfit = /datum/outfit/syndicate/full
+	nukeop_outfit = /datum/outfit/syndicate/lone
 
 /datum/antagonist/nukeop/lone/assign_nuke()
 	if(nuke_team && !nuke_team.tracked_nuke)


### PR DESCRIPTION
:cl: Tupinambis
balance: Lone operatives no longer spawn with a syndicate hardsuit and a bulldog. They instead spawn with a black and red EVA suit and an extra 15 TC (40 in total)
![image](https://user-images.githubusercontent.com/42078130/48308065-c44e9a80-e520-11e8-8d60-cec8ff23d61d.png)

/:cl:

[why]: Currently, lone ops have a very small chance (read: 0% chance) of succeeding unless either A: the disk was never secured or B: there is no security or greytide threat. This is because they are very limited in how they can attack the station. They start with a syndie hardsuit and if they dare be seen, people will immediately scream "NUKE OPS!" over radio. Ops are also forced to use a bulldog, which not everyone prefers, and which puts you right in the range that security wants you (taser, stunbatons, bolas, and more!). They don't currently have enough TC to change things up or get creative in their approach. They also don't get any of the free gear that comes with the syndicate infiltrator and base. The extra TC (effectively 7 extra, as syndie hardsuits are free by default) should hopefully allow lone ops to attack the station with more confidence and with greater odds of success.
