### PR TITLE
Oldstation but it doesn't lag the server.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -27,7 +27,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/ancientstation/hivebot)
 "af" = (
-/mob/living/simple_animal/hostile/hivebot,
+/mob/living/simple_animal/hostile/hivebot/rapid,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/ancientstation/hivebot)
 "ag" = (
@@ -81,15 +81,9 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/comm)
-"ao" = (
-/obj/effect/decal/cleanable/oil,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/ancientstation/hivebot)
 "ap" = (
 /obj/effect/decal/cleanable/oil,
 /obj/effect/decal/cleanable/robot_debris,
-/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/ancientstation/hivebot)
 "aq" = (
@@ -149,21 +143,7 @@
 /obj/structure/lattice,
 /turf/template_noop,
 /area/template_noop)
-"aB" = (
-/obj/effect/decal/cleanable/robot_debris,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/ancientstation/hivebot)
-"aC" = (
-/mob/living/simple_animal/hostile/hivebot/range,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/ancientstation/hivebot)
 "aD" = (
-/mob/living/simple_animal/hostile/hivebot/strong,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/ancientstation/hivebot)
-"aE" = (
-/obj/effect/decal/cleanable/oil,
 /mob/living/simple_animal/hostile/hivebot/strong,
 /turf/open/floor/plasteel/dark,
 /area/ruin/space/has_grav/ancientstation/hivebot)
@@ -376,11 +356,6 @@
 	},
 /turf/template_noop,
 /area/template_noop)
-"be" = (
-/obj/effect/decal/cleanable/oil,
-/mob/living/simple_animal/hostile/hivebot/range,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/ancientstation/hivebot)
 "bf" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -696,11 +671,6 @@
 /obj/structure/sign/poster/official/science,
 /turf/closed/wall/rust,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"cc" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/closet/crate,
@@ -896,7 +866,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -919,15 +888,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"cC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/range,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -946,8 +906,8 @@
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cF" = (
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "cG" = (
@@ -1075,7 +1035,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -1085,7 +1044,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -1104,8 +1062,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dc" = (
@@ -1113,16 +1071,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"dd" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/hivebot/range,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -1140,14 +1088,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/mob/living/simple_animal/hostile/hivebot/strong,
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"dg" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
-/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/rapid,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dh" = (
@@ -1526,33 +1468,12 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/rnd)
-"ec" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/ancientstation/rnd)
-"ed" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ee" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm/all_access{
 	dir = 8;
 	pixel_x = 24
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -1738,11 +1659,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
-"eC" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
-/turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/ancientstation/rnd)
 "eD" = (
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/decal/cleanable/dirt,
@@ -1919,22 +1835,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"eX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"eY" = (
-/obj/machinery/door/firedoor,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -2129,12 +2029,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
-"fw" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/rnd)
 "fx" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/table,
@@ -2285,22 +2179,6 @@
 	start_charge = 0
 	},
 /turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"fR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"fS" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "fT" = (
 /obj/effect/decal/cleanable/dirt,
@@ -3155,12 +3033,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"hE" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/rnd)
 "hF" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/bottle/aluminium{
@@ -3515,15 +3387,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
-"iq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/hivebot/range,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/rnd)
 "ir" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
@@ -3684,19 +3547,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
-"iC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/airalarm/all_access{
-	dir = 4;
-	pixel_x = -23
-	},
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "iD" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
@@ -4065,15 +3915,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"jt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ju" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/dirt,
@@ -4097,19 +3938,6 @@
 "jw" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/mob/living/simple_animal/hostile/hivebot,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"jx" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -4119,6 +3947,7 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/rapid,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jz" = (
@@ -4205,15 +4034,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
-"jK" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -4944,7 +4764,6 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
@@ -4957,6 +4776,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
+"rn" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/ancientstation/proto)
 "rv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5003,6 +4827,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
+"wr" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "wC" = (
 /obj/structure/particle_accelerator/power_box,
 /obj/effect/decal/cleanable/dirt,
@@ -5015,6 +4846,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
+"yJ" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/engineering,
+/turf/open/floor/plating,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "zh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple,
@@ -5063,6 +4899,15 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/template_noop,
 /area/space/nearstation)
+"Ig" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "It" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -5075,6 +4920,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation)
+"Iu" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/ancientstation/rnd)
 "Ka" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -5155,6 +5005,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation)
+"NL" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "OA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -5172,7 +5031,6 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/mob/living/simple_animal/hostile/hivebot,
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "Pl" = (
@@ -5186,6 +5044,15 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
+"PF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/ancientstation/rnd)
+"PG" = (
+/mob/living/simple_animal/hostile/hivebot/engineering,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/ancientstation/hivebot)
 "PV" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-25"
@@ -5720,7 +5587,7 @@ aa
 aa
 "}
 (10,1,1) = {"
-ab
+aa
 aa
 aa
 aa
@@ -5770,7 +5637,7 @@ aa
 (11,1,1) = {"
 aa
 aa
-aa
+ab
 aa
 aa
 aa
@@ -5810,7 +5677,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 aa
@@ -5954,7 +5821,7 @@ aa
 aa
 aa
 aa
-aa
+ab
 aa
 aa
 aa
@@ -6290,7 +6157,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 aa
@@ -7683,7 +7550,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 "}
@@ -7779,7 +7646,7 @@ aa
 ac
 aa
 aa
-aa
+ab
 aa
 aa
 "}
@@ -7835,7 +7702,7 @@ aa
 aa
 aa
 aa
-aa
+ab
 aa
 aa
 aa
@@ -7880,7 +7747,7 @@ ac
 aa
 "}
 (55,1,1) = {"
-ab
+aa
 aa
 aa
 aa
@@ -8141,13 +8008,13 @@ dW
 MS
 eW
 ft
-fR
+ey
 gK
 ey
 hC
 ey
 MS
-iC
+dW
 dw
 ey
 ey
@@ -8165,7 +8032,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 "}
 (61,1,1) = {"
 aa
@@ -8186,16 +8053,16 @@ cA
 cZ
 dx
 dX
+wr
+hD
 dX
-eX
 dX
-fS
 gL
 dX
 hD
 dX
 dX
-fS
+dX
 dx
 dX
 dB
@@ -8268,18 +8135,18 @@ aa
 ac
 ad
 ae
-af
-af
+ah
+ah
 ag
 ai
-ao
-af
+aq
+ah
 bo
 ad
 ac
 bD
-cC
-db
+cD
+dc
 dy
 vG
 ez
@@ -8294,8 +8161,8 @@ in
 iD
 iP
 dy
-jt
-jK
+dc
+cD
 jV
 kd
 kt
@@ -8315,19 +8182,19 @@ aa
 aa
 ac
 ad
-af
-ao
-af
+ah
+aq
 ah
 ah
-af
-af
-af
+ah
+PG
+ah
+ah
 ad
 bE
 bD
 cD
-dc
+NL
 dy
 dZ
 eA
@@ -8374,8 +8241,8 @@ ad
 ad
 bG
 bF
-cC
-dd
+cD
+de
 dy
 dZ
 eB
@@ -8384,14 +8251,14 @@ fv
 dZ
 gN
 hg
-hE
+eb
 dY
 gO
 eb
 fV
 dy
 jv
-cD
+Ig
 jV
 kf
 kv
@@ -8411,14 +8278,14 @@ aa
 ac
 ac
 ad
-af
-ap
-af
-aq
 ah
+ap
+ah
+aq
+aD
 ag
-be
-aB
+aq
+ai
 aN
 bG
 lx
@@ -8426,9 +8293,9 @@ cE
 dc
 dy
 fo
-eC
 dZ
 dZ
+Iu
 zh
 gO
 hh
@@ -8439,7 +8306,7 @@ iF
 eb
 dy
 db
-cC
+cD
 jV
 kg
 kw
@@ -8460,29 +8327,29 @@ ac
 ac
 ad
 af
-af
-aB
 ah
 ai
 ah
-aC
-af
+ai
+ah
+ah
+ah
 aN
 bG
 lx
-cF
-db
+ca
+dc
 dz
 eb
 eb
 eb
-fw
+eb
 eb
 gO
 eb
 eb
 ea
-iq
+gO
 eb
 fU
 jc
@@ -8490,7 +8357,7 @@ dc
 jM
 jW
 kh
-kw
+rn
 kw
 kS
 lb
@@ -8535,7 +8402,7 @@ lT
 hi
 jd
 jw
-fS
+dX
 jX
 ki
 ki
@@ -8556,23 +8423,23 @@ ac
 ac
 ad
 ag
-af
-af
-af
-af
-af
-af
+ah
+PG
+ah
+ah
+ah
+ah
 ah
 ad
 bE
 bD
 cF
-db
+dc
 dy
-ec
+vG
 dZ
 dZ
-eC
+dZ
 SJ
 eb
 dy
@@ -8604,12 +8471,12 @@ ac
 ac
 ad
 ah
-af
-af
-aB
-af
+ah
+ah
+ai
+ah
 ag
-af
+ah
 ah
 ad
 ac
@@ -8619,7 +8486,7 @@ de
 dy
 dZ
 eD
-dZ
+PF
 fx
 dZ
 gQ
@@ -8630,7 +8497,7 @@ OA
 nM
 iQ
 dy
-jx
+jv
 py
 jV
 kk
@@ -8652,12 +8519,12 @@ ac
 ac
 ad
 ai
-af
+ah
 ah
 ag
-aC
 ah
-af
+aD
+ah
 aq
 ad
 ac
@@ -8701,17 +8568,17 @@ ac
 ad
 ah
 ag
-aC
-aC
-aC
-aC
+ah
+ah
+ah
+ah
 ag
 ah
 ad
 ac
 bD
-cF
-db
+ca
+dc
 dy
 fo
 eF
@@ -8726,8 +8593,8 @@ iu
 iG
 iS
 dy
-jt
-ed
+dc
+ca
 jV
 kl
 kz
@@ -8750,8 +8617,8 @@ ad
 ah
 ai
 ah
-aD
-aD
+ah
+af
 ah
 ai
 ah
@@ -8797,10 +8664,10 @@ ac
 ad
 ag
 aq
-aD
 ah
 ah
-aD
+ah
+ah
 aq
 ah
 ad
@@ -8809,17 +8676,17 @@ bD
 ca
 df
 dB
-ed
 ca
-eY
 ca
-ed
-ca
-ed
 hI
-ed
 ca
-ed
+ca
+ca
+ca
+hI
+ca
+ca
+ca
 ca
 je
 jy
@@ -8855,17 +8722,17 @@ ad
 ac
 bD
 cH
-dg
+ca
 dC
 ee
 qB
-eY
+hI
 cX
-ed
 ca
-ed
+ca
+ca
 hJ
-ed
+ca
 ca
 ee
 Vs
@@ -8893,10 +8760,10 @@ ac
 ad
 aj
 ai
-aE
-aD
-aD
-aD
+aq
+ah
+ah
+PG
 ah
 bp
 ad
@@ -8941,16 +8808,16 @@ ac
 ac
 ad
 ag
-aD
-aD
-aD
-aD
+ah
+ah
+ah
+ah
 aq
 ad
 ac
 bD
-cc
-cc
+dh
+dh
 dh
 bD
 aa
@@ -8958,16 +8825,16 @@ bD
 eZ
 eZ
 eZ
-dh
+yJ
 dh
 dh
 dh
 td
 tT
 bD
-cc
-cc
-cc
+dh
+dh
+dh
 bD
 aa
 aa
@@ -8978,7 +8845,7 @@ aa
 aa
 aa
 aa
-ab
+aa
 aa
 aa
 aa

--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -1057,15 +1057,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"db" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/range,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "dc" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -3947,7 +3938,6 @@
 	dir = 9
 	},
 /obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/rapid,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "jz" = (
@@ -4720,6 +4710,13 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/sec)
+"ni" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "nk" = (
 /obj/machinery/door/airlock/highsecurity,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4776,11 +4773,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
-"rn" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/strong,
-/turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/ancientstation/proto)
 "rv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4827,13 +4819,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
-"wr" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "wC" = (
 /obj/structure/particle_accelerator/power_box,
 /obj/effect/decal/cleanable/dirt,
@@ -4846,11 +4831,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
-"yJ" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/engineering,
-/turf/open/floor/plating,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "zh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/purple,
@@ -4872,6 +4852,11 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
+"Ax" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/ancientstation/rnd)
 "BH" = (
 /obj/structure/particle_accelerator/particle_emitter/left,
 /obj/effect/decal/cleanable/dirt,
@@ -4883,6 +4868,11 @@
 	},
 /turf/template_noop,
 /area/space/nearstation)
+"Do" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/strong,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/ancientstation/proto)
 "FH" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/mirror{
@@ -4899,15 +4889,6 @@
 /obj/structure/transit_tube/crossing/horizontal,
 /turf/template_noop,
 /area/space/nearstation)
-"Ig" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "It" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/sink{
@@ -4920,11 +4901,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation)
-"Iu" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot/range,
-/turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/ancientstation/rnd)
 "Ka" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -5005,15 +4981,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation)
-"NL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plasteel,
-/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "OA" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -5044,15 +5011,6 @@
 	},
 /turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation)
-"PF" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/hivebot,
-/turf/open/floor/plasteel/white,
-/area/ruin/space/has_grav/ancientstation/rnd)
-"PG" = (
-/mob/living/simple_animal/hostile/hivebot/engineering,
-/turf/open/floor/plasteel/dark,
-/area/ruin/space/has_grav/ancientstation/hivebot)
 "PV" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-25"
@@ -5101,6 +5059,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation)
+"Un" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
+"UF" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/range,
+/turf/open/floor/plasteel/white,
+/area/ruin/space/has_grav/ancientstation/rnd)
 "Vs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -5112,6 +5084,15 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
+"Wq" = (
+/mob/living/simple_animal/hostile/hivebot/engineering,
+/turf/open/floor/plasteel/dark,
+/area/ruin/space/has_grav/ancientstation/hivebot)
+"Xk" = (
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/engineering,
+/turf/open/floor/plating,
 /area/ruin/space/has_grav/ancientstation/deltacorridor)
 "XJ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -5144,6 +5125,15 @@
 /obj/item/soap/nanotrasen,
 /turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation)
+"Zk" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot/rapid,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 "ZE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/firealarm{
@@ -5153,6 +5143,15 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/ancientstation)
+"ZY" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/mob/living/simple_animal/hostile/hivebot,
+/turf/open/floor/plasteel,
+/area/ruin/space/has_grav/ancientstation/deltacorridor)
 
 (1,1,1) = {"
 aa
@@ -8053,7 +8052,7 @@ cA
 cZ
 dx
 dX
-wr
+ni
 hD
 dX
 dX
@@ -8062,7 +8061,7 @@ dX
 hD
 dX
 dX
-dX
+ni
 dx
 dX
 dB
@@ -8187,14 +8186,14 @@ aq
 ah
 ah
 ah
-PG
+Wq
 ah
 ah
 ad
 bE
 bD
 cD
-NL
+ZY
 dy
 dZ
 eA
@@ -8258,7 +8257,7 @@ eb
 fV
 dy
 jv
-Ig
+Un
 jV
 kf
 kv
@@ -8295,7 +8294,7 @@ dy
 fo
 dZ
 dZ
-Iu
+UF
 zh
 gO
 hh
@@ -8305,7 +8304,7 @@ ip
 iF
 eb
 dy
-db
+dc
 cD
 jV
 kg
@@ -8353,11 +8352,11 @@ gO
 eb
 fU
 jc
-dc
+Zk
 jM
 jW
 kh
-rn
+Do
 kw
 kS
 lb
@@ -8424,7 +8423,7 @@ ac
 ad
 ag
 ah
-PG
+Wq
 ah
 ah
 ah
@@ -8486,7 +8485,7 @@ de
 dy
 dZ
 eD
-PF
+Ax
 fx
 dZ
 gQ
@@ -8687,7 +8686,7 @@ hI
 ca
 ca
 ca
-ca
+cF
 je
 jy
 ca
@@ -8763,7 +8762,7 @@ ai
 aq
 ah
 ah
-PG
+Wq
 ah
 bp
 ad
@@ -8825,7 +8824,7 @@ bD
 eZ
 eZ
 eZ
-yJ
+Xk
 dh
 dh
 dh

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -1,5 +1,5 @@
 /obj/item/projectile/hivebotbullet
-	damage = 10
+	damage = 15
 	damage_type = BRUTE
 
 /mob/living/simple_animal/hostile/hivebot
@@ -11,11 +11,11 @@
 	icon_dead = "basic"
 	gender = NEUTER
 	mob_biotypes = list(MOB_ROBOTIC)
-	health = 40
-	maxHealth = 40
+	health = 50
+	maxHealth = 50
 	healable = 0
-	melee_damage_lower = 8
-	melee_damage_upper = 8
+	melee_damage_lower = 10
+	melee_damage_upper = 10
 	attacktext = "saw"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	projectilesound = 'sound/weapons/gunshot.ogg'
@@ -61,8 +61,8 @@
 	icon_living = "EngBot"
 	icon_dead = "EngBot"
 	desc = "A strange engineering robot that does not seem pleased to meet you."
-	health = 60
-	maxHealth = 60
+	health = 75
+	maxHealth = 75
 
 /mob/living/simple_animal/hostile/hivebot/strong
 	name = "elite hivebot"
@@ -70,8 +70,8 @@
 	icon_living = "strong"
 	icon_dead = "strong"
 	desc = "A heavily armed and armored robot that does not seem pleased to meet you."
-	health = 95
-	maxHealth = 95
+	health = 100
+	maxHealth = 100
 	ranged = 1
 
 /mob/living/simple_animal/hostile/hivebot/death(gibbed)

--- a/code/modules/mob/living/simple_animal/hostile/hivebot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hivebot.dm
@@ -4,19 +4,19 @@
 
 /mob/living/simple_animal/hostile/hivebot
 	name = "hivebot"
-	desc = "A small robot."
+	desc = "A strange robot that does not seem pleased to meet you."
 	icon = 'icons/mob/hivebot.dmi'
 	icon_state = "basic"
 	icon_living = "basic"
 	icon_dead = "basic"
 	gender = NEUTER
 	mob_biotypes = list(MOB_ROBOTIC)
-	health = 15
-	maxHealth = 15
+	health = 40
+	maxHealth = 40
 	healable = 0
-	melee_damage_lower = 2
-	melee_damage_upper = 3
-	attacktext = "claws"
+	melee_damage_lower = 8
+	melee_damage_upper = 8
+	attacktext = "saw"
 	attack_sound = 'sound/weapons/bladeslice.ogg'
 	projectilesound = 'sound/weapons/gunshot.ogg'
 	projectiletype = /obj/item/projectile/hivebotbullet
@@ -36,8 +36,8 @@
 	deathmessage = "[src] blows apart!"
 
 /mob/living/simple_animal/hostile/hivebot/range
-	name = "hivebot"
-	desc = "A smallish robot, this one is armed!"
+	name = "combat hivebot"
+	desc = "An armed robot that does not seem pleased to meet you."
 	icon_state = "ranged"
 	icon_living = "ranged"
 	icon_dead = "ranged"
@@ -46,6 +46,7 @@
 	minimum_distance = 5
 
 /mob/living/simple_animal/hostile/hivebot/rapid
+	name = "gunner hivebot"
 	icon_state = "ranged"
 	icon_living = "ranged"
 	icon_dead = "ranged"
@@ -54,14 +55,23 @@
 	retreat_distance = 5
 	minimum_distance = 5
 
+/mob/living/simple_animal/hostile/hivebot/engineering
+	name = "engineering hivebot"
+	icon_state = "EngBot"
+	icon_living = "EngBot"
+	icon_dead = "EngBot"
+	desc = "A strange engineering robot that does not seem pleased to meet you."
+	health = 60
+	maxHealth = 60
+
 /mob/living/simple_animal/hostile/hivebot/strong
-	name = "strong hivebot"
+	name = "elite hivebot"
 	icon_state = "strong"
 	icon_living = "strong"
 	icon_dead = "strong"
-	desc = "A robot, this one is armed and looks tough!"
-	health = 80
-	maxHealth = 80
+	desc = "A heavily armed and armored robot that does not seem pleased to meet you."
+	health = 95
+	maxHealth = 95
 	ranged = 1
 
 /mob/living/simple_animal/hostile/hivebot/death(gibbed)


### PR DESCRIPTION

:cl: Tupinambis
add: New engineering hivebot. Has a bit more health but otherwise aesthetic.
tweak: Oldstation no longer has an excessive amounts of hivebots within it, however the bots that remain are individually a larger threat.
balance: Hivebots are now more robust, with a higher melee damage output and health.
server: Remove this ruin from the blacklist or this PR is pointless.
/:cl:

[why]: Oldstation is arguably one of the best ghost spawns and ruins, but it suffers from being blacklisted because of the lag it causes. This PR should solve that.

P.S. REMOVE THE RUIN FROM THE BLACKLIST IF THIS PR IS MERGED PLEASE AND THANK YOU.
