### PR TITLE
Brings back nonlethal 38 bullets in a semi-nerfed state, keeps the current lethal variant in as a brand new sec autolathe printable ammo box

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/revolver.dm
+++ b/code/modules/projectiles/ammunition/ballistic/revolver.dm
@@ -17,7 +17,12 @@
 // .38 (Detective's Gun)
 
 /obj/item/ammo_casing/c38
-	name = ".38 bullet casing"
-	desc = "A .38 bullet casing."
+	name = ".38 rubber bullet casing"
+	desc = "A .38 rubber bullet casing."
 	caliber = "38"
 	projectile_type = /obj/item/projectile/bullet/c38
+
+/obj/item/ammo_casing/c38/lethal
+	name = ".38 bullet casing"
+	desc = "A .38 bullet casing"
+	projectile_type = /obj/item/projectile/bullet/c38lethal

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -7,13 +7,17 @@
 	multiple_sprites = 1
 
 /obj/item/ammo_box/c38
-	name = "speed loader (.38)"
+	name = "speed loader (.38 rubber)"
 	desc = "Designed to quickly reload revolvers."
 	icon_state = "38"
 	ammo_type = /obj/item/ammo_casing/c38
 	max_ammo = 6
 	multiple_sprites = 1
 	materials = list(MAT_METAL = 20000)
+
+/obj/item/ammo_box/c38/lethal
+	name = "speed loader (.38)"
+	ammo_type = /obj/item/ammo_casing/c38/lethal
 
 /obj/item/ammo_box/c9mm
 	name = "ammo box (9mm)"

--- a/code/modules/projectiles/projectile/bullets/revolver.dm
+++ b/code/modules/projectiles/projectile/bullets/revolver.dm
@@ -13,6 +13,11 @@
 // .38 (Detective's Gun)
 
 /obj/item/projectile/bullet/c38
+	name = ".38 rubber bullet"
+	damage = 15
+	stamina = 48
+
+/obj/item/projectile/bullet/c38lethal
 	name = ".38 bullet"
 	damage = 25
 

--- a/code/modules/research/designs/autolathe_designs.dm
+++ b/code/modules/research/designs/autolathe_designs.dm
@@ -462,7 +462,7 @@
 	category = list("initial", "Security")
 
 /datum/design/c38
-	name = "Speed Loader (.38)"
+	name = "Speed Loader (.38 rubber)"
 	id = "c38"
 	build_type = AUTOLATHE
 	materials = list(MAT_METAL = 20000)

--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -8,6 +8,11 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
+/datum/design/c38/sec/lethal
+	name = "Speed Loader (.38)"
+	id = "sec_38lethal"
+	build_path = /obj/item/ammo_box/c38/lethal
+
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
 	build_type = PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -10,7 +10,7 @@
 	// Default research tech, prevents bricking
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani",
 	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab",
-	"space_heater", "xlarge_beaker", "sec_rshot", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "sec_38lethal"
+	"space_heater", "xlarge_beaker", "sec_rshot", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "sec_38lethal",
 	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass")
 
 /datum/techweb_node/mmi

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -10,7 +10,7 @@
 	// Default research tech, prevents bricking
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani",
 	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab",
-	"space_heater", "xlarge_beaker", "sec_rshot", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38",
+	"space_heater", "xlarge_beaker", "sec_rshot", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "sec_38lethal"
 	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass")
 
 /datum/techweb_node/mmi


### PR DESCRIPTION
Title. This increases the number of shots required to hard stamcrit for the nonlethal 38 bullets to 3 shots minimum, but still take 7 whole shots to healthcrit someone. The original values were absolute cancer to deal with. This PR also keeps the current lethal variant in, available at sec protolathes.

:cl: deathride58
balance: The detective revolver's .38 bullets are now non-lethal again, but now require 3 shots to hard stamcrit
add: The current lethal variant of the .38 bullets can still be printed at sec protolathes.
/:cl:
