### PR TITLE
Makes it plausible to join as ghost roles from the latejoin menu

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -5,6 +5,7 @@
 	name = "preserved terrarium"
 	desc = "An ancient machine that seems to be used for storing plant matter. The glass is obstructed by a mat of vines."
 	mob_name = "a lifebringer"
+	job_description = "Lifebringer"
 	icon = 'icons/obj/lavaland/spawners.dmi'
 	icon_state = "terrarium"
 	density = TRUE
@@ -35,6 +36,7 @@
 	name = "ash walker egg"
 	desc = "A man-sized yellow egg, spawned from some unfathomable creature. A humanoid silhouette lurks within."
 	mob_name = "an ash walker"
+	job_description = "Ashwalker"
 	icon = 'icons/mob/lavaland/lavaland_monsters.dmi'
 	icon_state = "large_egg"
 	mob_species = /datum/species/lizard/ashwalker
@@ -77,6 +79,7 @@
 	name = "timeless prison"
 	desc = "Although this stasis pod looks medicinal, it seems as though it's meant to preserve something for a very long time."
 	mob_name = "a penitent exile"
+	job_description = "Exiled Prisoner"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	roundstart = FALSE
@@ -108,6 +111,7 @@
 	name = "inert free golem shell"
 	desc = "A humanoid shape, empty, lifeless, and full of potential."
 	mob_name = "a free golem"
+	job_description = "Free Golem"
 	icon = 'icons/obj/wizard.dmi'
 	icon_state = "construct"
 	mob_species = /datum/species/golem
@@ -180,6 +184,7 @@
 /obj/effect/mob_spawn/human/golem/servant
 	has_owner = TRUE
 	name = "inert servant golem shell"
+	job_description = "Servant Golem"
 
 
 /obj/effect/mob_spawn/human/golem/adamantine
@@ -194,6 +199,7 @@
 	name = "malfunctioning cryostasis sleeper"
 	desc = "A humming sleeper with a silhouetted occupant inside. Its stasis function is broken and it's likely being used as a bed."
 	mob_name = "a stranded hermit"
+	job_description = "Lavaland Hermit"
 	icon = 'icons/obj/lavaland/spawners.dmi'
 	icon_state = "cryostasis_sleeper"
 	roundstart = FALSE
@@ -246,6 +252,7 @@
 /obj/effect/mob_spawn/human/doctor/alive/lavaland
 	name = "broken rejuvenation pod"
 	desc = "A small sleeper typically used to instantly restore minor wounds. This one seems broken, and its occupant is comatose."
+	job_description = "Lavaland Veterinarian"
 	mob_name = "a translocated vet"
 	flavour_text = "<span class='big bold'>What...?</span><b> Where are you? Where are the others? This is still the animal hospital - you should know, you've been an intern here for weeks - but \
 	everyone's gone. One of the cats scratched you just a few minutes ago. That's why you were in the pod - to heal the scratch. The scabs are still fresh; you see them right now. So where is \
@@ -262,6 +269,7 @@
 	name = "prisoner containment sleeper"
 	desc = "A sleeper designed to put its occupant into a deep coma, unbreakable until the sleeper turns off. This one's glass is cracked and you can see a pale, sleeping face staring out."
 	mob_name = "an escaped prisoner"
+	job_description = "Escaped Prisoner"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
 	outfit = /datum/outfit/lavalandprisoner
@@ -299,6 +307,7 @@
 	name = "staff sleeper"
 	desc = "A sleeper designed for long-term stasis between guest visits."
 	mob_name = "hotel staff member"
+	job_description = "Hotel Staff"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
 	objectives = "Cater to visiting guests with your fellow staff. Do not leave your assigned hotel and always remember: The customer is always right!"
@@ -321,6 +330,7 @@
 /obj/effect/mob_spawn/human/hotel_staff/security
 	name = "hotel security sleeper"
 	mob_name = "hotel security member"
+	job_description = "Hotel Security"
 	outfit = /datum/outfit/hotelstaff/security
 	flavour_text = "<span class='big bold'>You are a peacekeeper</span><b> assigned to this hotel to protect the interests of the company while keeping the peace between \
 		guests and the staff. Do <font size=6>NOT</font> leave the hotel, as that is grounds for contract termination.</b>"
@@ -343,6 +353,7 @@
 	name = "Essence of friendship"
 	desc = "Oh boy! Oh boy! A friend!"
 	mob_name = "Demonic friend"
+	job_description = "Demonic Friend"
 	icon = 'icons/obj/cardboard_cutout.dmi'
 	icon_state = "cutout_basic"
 	outfit = /datum/outfit/demonic_friend
@@ -484,6 +495,7 @@
 	id = /obj/item/card/id/away/old/sec
 	r_pocket = /obj/item/restraints/handcuffs
 	l_pocket = /obj/item/assembly/flash/handheld
+	job_description = "Oldstation Crew"
 	assignedrole = "Ancient Crew"
 
 /obj/effect/mob_spawn/human/oldsec/Destroy()
@@ -496,6 +508,7 @@
 	mob_name = "an engineer"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
+	job_description = "Oldstation Crew"
 	roundstart = FALSE
 	death = FALSE
 	random = TRUE
@@ -534,6 +547,7 @@
 	id = /obj/item/card/id/away/old/sci
 	l_pocket = /obj/item/stack/medical/bruise_pack
 	assignedrole = "Ancient Crew"
+	job_description = "Oldstation Crew"
 
 /obj/effect/mob_spawn/human/oldsci/Destroy()
 	new/obj/structure/showcase/machinery/oldpod/used(drop_location())
@@ -542,6 +556,7 @@
 /obj/effect/mob_spawn/human/pirate
 	name = "space pirate sleeper"
 	desc = "A cryo sleeper smelling faintly of rum."
+	job_description = "Space Pirate"
 	random = TRUE
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"

--- a/code/modules/antagonists/swarmer/swarmer.dm
+++ b/code/modules/antagonists/swarmer/swarmer.dm
@@ -16,6 +16,7 @@
 
 	mob_type = /mob/living/simple_animal/hostile/swarmer
 	mob_name = "a swarmer"
+	job_description = "Swarmer"
 	death = FALSE
 	roundstart = FALSE
 	flavour_text = {"

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -6,6 +6,7 @@
 	name = "Unknown"
 	density = TRUE
 	anchored = TRUE
+	var/job_description = null
 	var/mob_type = null
 	var/mob_name = ""
 	var/mob_gender = null
@@ -29,7 +30,7 @@
 	var/ghost_usable = TRUE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
-/obj/effect/mob_spawn/attack_ghost(mob/user)
+/obj/effect/mob_spawn/attack_ghost(mob/user, latejoinercalling)
 	if(!SSticker.HasRoundStarted() || !loc || !ghost_usable)
 		return
 	if(!uses)
@@ -40,11 +41,19 @@
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return
-	var/ghost_role = alert("Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
+	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and is very likely off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
 		return
+	if(QDELETED(src) || QDELETED(user))
+		return
+	if(latejoinercalling)
+		var/mob/dead/new_player/NP = user
+		if(istype(NP))
+			NP.close_spawn_windows()
+			NP.stop_sound_channel(CHANNEL_LOBBYMUSIC)
 	log_game("[key_name(user)] became [mob_name]")
 	create(ckey = user.ckey)
+	return TRUE
 
 /obj/effect/mob_spawn/Initialize(mapload)
 	. = ..()
@@ -52,7 +61,7 @@
 		create()
 	else if(ghost_usable)
 		GLOB.poi_list |= src
-		LAZYADD(GLOB.mob_spawners[name], src)
+		LAZYADD(GLOB.mob_spawners[job_description ? job_description : name], src)
 
 /obj/effect/mob_spawn/Destroy()
 	GLOB.poi_list -= src
@@ -262,6 +271,7 @@
 	mob_type = 	/mob/living/simple_animal/mouse
 	death = FALSE
 	roundstart = FALSE
+	job_description = "Mouse"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 
@@ -270,6 +280,7 @@
 	mob_type = 	/mob/living/simple_animal/cow
 	death = FALSE
 	roundstart = FALSE
+	job_description = "Cow"
 	mob_gender = FEMALE
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
@@ -314,6 +325,7 @@
 	icon_state = "sleeper"
 	flavour_text = "<span class='big bold'>You are a space doctor!</span>"
 	assignedrole = "Space Doctor"
+	job_description = "Off-station Doctor"
 
 /obj/effect/mob_spawn/human/doctor/alive/equip(mob/living/carbon/human/H)
 	..()
@@ -364,6 +376,7 @@
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
+	job_description = "Off-station Bartender"
 	name = "bartender sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
@@ -387,6 +400,7 @@
 	death = FALSE
 	roundstart = FALSE
 	random = TRUE
+	job_description = "Beach Biodome Bum"
 	mob_name = "Beach Bum"
 	name = "beach bum sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -399,6 +413,7 @@
 	mob_gender = "female"
 	name = "lifeguard sleeper"
 	id_job = "Lifeguard"
+	job_description = "Beach Biodome Lifeguard"
 	uniform = /obj/item/clothing/under/shorts/red
 
 /datum/outfit/beachbum
@@ -474,6 +489,7 @@
 /obj/effect/mob_spawn/human/commander/alive
 	death = FALSE
 	roundstart = FALSE
+	job_description = "Nanotrasen Commander"
 	mob_name = "Nanotrasen Commander"
 	name = "sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
@@ -484,6 +500,7 @@
 	death = FALSE
 	roundstart = FALSE
 	mob_name = "Private Security Officer"
+	job_description = "Nanotrasen Security"
 	name = "sleeper"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
@@ -502,6 +519,7 @@
 /obj/effect/mob_spawn/human/skeleton/alive
 	death = FALSE
 	roundstart = FALSE
+	job_description = "Skeleton"
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remains"
 	flavour_text = "<span class='big bold'>By unknown powers, your skeletal remains have been reanimated!</span><b> Walk this mortal plain and terrorize all living adventurers who dare cross your path.</b>"
@@ -516,6 +534,7 @@
 /obj/effect/mob_spawn/human/zombie/alive
 	death = FALSE
 	roundstart = FALSE
+	job_description = "Zombie"
 	icon = 'icons/effects/blood.dmi'
 	icon_state = "remains"
 	flavour_text = "<span class='big bold'>By unknown powers, your rotting remains have been resurrected!</span><b> Walk this mortal plain and terrorize all living adventurers who dare cross your path.</b>"
@@ -542,6 +561,7 @@
 	uses = -1
 	outfit = /datum/outfit/spacebartender
 	assignedrole = "Space Bar Patron"
+	job_description = "Space Bar Patron"
 
 //ATTACK HAND IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/human/alive/space_bar_patron/attack_hand(mob/user)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -41,7 +41,7 @@
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return
-	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and is very likely off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
+	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and as such, it's very likely to be off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
 		return
 	if(QDELETED(src) || QDELETED(user))

--- a/code/modules/awaymissions/mission_code/snowdin.dm
+++ b/code/modules/awaymissions/mission_code/snowdin.dm
@@ -589,6 +589,7 @@
 	icon_state = "sleeper"
 	roundstart = FALSE
 	death = FALSE
+	job_description = "Syndicate Snow Operative"
 	faction = ROLE_SYNDICATE
 	outfit = /datum/outfit/snowsyndie
 	flavour_text = "<span class='big bold'>You are a syndicate operative recently awoken from cryostasis in an underground outpost. Monitor Nanotrasen communications and record information. All intruders should be \

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -461,7 +461,7 @@
 				dat += " [a.title]. </div>"
 
 	dat += "<div class='clearBoth'>Choose from the following open positions:</div><br>"
-	dat += "<small>(G) - Off-station Ghost Role</small><br>"
+	dat += "<small>(G) - Ghost Role</small><br>"
 	dat += "<div class='jobs'><div class='jobsColumn'>"
 	var/job_count = 0
 	for(var/datum/job/job in SSjob.occupations)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -153,6 +153,21 @@
 		AttemptLateSpawn(href_list["SelectedJob"])
 		return
 
+	if(href_list["JoinAsGhostRole"])
+		if(!GLOB.enter_allowed)
+			to_chat(usr, "<span class='notice'> There is an administrative lock on entering the game!</span>")
+
+		if(SSticker.queued_players.len && !(ckey(key) in GLOB.admin_datums))
+			if((living_player_count() >= relevant_cap) || (src != SSticker.queued_players[1]))
+				to_chat(usr, "<span class='warning'>Server is full.</span>")
+				return
+
+		var/obj/effect/mob_spawn/MS = pick(GLOB.mob_spawners[href_list["JoinAsGhostRole"]])
+		if(istype(MS) && MS.attack_ghost(src, latejoinercalling = TRUE))
+			SSticker.queued_players -= src
+			SSticker.queue_delay = 4
+			qdel(src)
+
 	if(!ready && href_list["preference"])
 		if(client)
 			client.prefs.process_link(src, href_list)
@@ -427,6 +442,8 @@
 	for(var/datum/job/job in SSjob.occupations)
 		if(job && IsJobUnavailable(job.title, TRUE) == JOB_AVAILABLE)
 			available_job_count++;
+	for(var/spawner in GLOB.mob_spawners)
+		available_job_count++
 
 	for(var/datum/job/prioritized_job in SSjob.prioritized_jobs)
 		if(prioritized_job.current_positions >= prioritized_job.total_positions)
@@ -444,6 +461,7 @@
 				dat += " [a.title]. </div>"
 
 	dat += "<div class='clearBoth'>Choose from the following open positions:</div><br>"
+	dat += "<small>(G) - Off-station Ghost Role</small><br>"
 	dat += "<div class='jobs'><div class='jobsColumn'>"
 	var/job_count = 0
 	for(var/datum/job/job in SSjob.occupations)
@@ -461,6 +479,10 @@
 				continue
 			dat += "<a class='otherPosition' href='byond://?src=[REF(src)];SelectedJob=[job.title]'>[job.title] ([job.current_positions])</a><br>"
 			break
+	for(var/spawner in GLOB.mob_spawners)
+		job_count++
+		if(job_count > round(available_job_count / 2))
+			dat += "<a class='otherPosition' href='byond://?src=[REF(src)];JoinAsGhostRole=[spawner]'>[spawner] (G)</a><br>"
 	dat += "</div></div>"
 
 	// Removing the old window method but leaving it here for reference

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -96,6 +96,7 @@
 	name = "Syndicate Bioweapon Scientist"
 	roundstart = FALSE
 	death = FALSE
+	job_description = "Off-station Syndicate Scientist"
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper_s"
 	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Continue your research as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> The base is rigged with explosives should the worst happen, do not let the base fall into enemy hands!</b>"
@@ -107,6 +108,7 @@
 
 /datum/outfit/lavaland_syndicate
 	name = "Lavaland Syndicate Agent"
+	name = "Off-station Syndicate Agent"
 	r_hand = /obj/item/gun/ballistic/automatic/sniper_rifle
 	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/toggle/labcoat
@@ -123,6 +125,7 @@
 
 /obj/effect/mob_spawn/human/lavaland_syndicate/comms
 	name = "Syndicate Comms Agent"
+	job_description = "Off-station Syndicate Comms Agent"
 	flavour_text = "<span class='big bold'>You are a syndicate agent,</span><b> employed in a top secret research facility developing biological weapons. Unfortunately, your hated enemy, Nanotrasen, has begun mining in this sector. <b>Monitor enemy activity as best you can, and try to keep a low profile. <font size=6>DON'T</font> abandon the base without good cause.</b> Use the communication equipment to provide support to any field agents, and sow disinformation to throw Nanotrasen off your trail. Do not let the base fall into enemy hands!</b>"
 	outfit = /datum/outfit/lavaland_syndicate/comms
 

--- a/modular_citadel/code/modules/awaymissions/citadel_ghostrole_spawners.dm
+++ b/modular_citadel/code/modules/awaymissions/citadel_ghostrole_spawners.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	roundstart = FALSE
+	job_description = "Cydonian Knight"
 	death = FALSE
 	random = TRUE
 	outfit = /datum/outfit/lavaknight


### PR DESCRIPTION
Title. Here's how it looks
![image](https://user-images.githubusercontent.com/6356337/48613626-47755380-e95a-11e8-96e1-e2bcbda0ffd2.png)

This should hopefully encourage players to play as ghost roles such as ashwalkers, as a lot of ghost roles are far more effective when they have multiple players.

:cl: deathride58
add: You can now access ghost roles from the latejoin menu.
/:cl:
