### PR TITLE
Makes the eyeblur effect scale depending on how much eyeblur you have

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -459,7 +459,7 @@ GLOBAL_LIST_INIT(pda_styles, list(MONO, VT, ORBITRON, SHARE))
 
 //Filters
 #define AMBIENT_OCCLUSION list("type"="drop_shadow","x"=0,"y"=-2,"size"=4,"border"=4,"color"="#04080FAA")
-#define EYE_BLUR list("type"="blur", "size"=3)
+#define EYE_BLUR(size) list("type"="blur", "size"=size)
 #define GRAVITY_MOTION_BLUR list("type"="motion_blur","x"=0,"y"=0)
 
 #define STANDARD_GRAVITY 1 //Anything above this is high gravity, anything below no grav

--- a/code/modules/mob/living/life.dm
+++ b/code/modules/mob/living/life.dm
@@ -135,8 +135,11 @@
 			eye_blind = max(eye_blind-1,1)
 	else if(eye_blurry)			//blurry eyes heal slowly
 		eye_blurry = max(eye_blurry-1, 0)
-		if(client && !eye_blurry)
-			remove_eyeblur()
+		if(client)
+			if(!eye_blurry)
+				remove_eyeblur()
+			else
+				update_eyeblur()
 
 /mob/living/proc/update_damage_hud()
 	return

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -206,6 +206,8 @@
 		eye_blurry = max(amount, eye_blurry)
 		if(!old_eye_blurry)
 			add_eyeblur() //Citadel edit blurry eye memes entailed. syncs beware
+		else if(eye_blurry > 0)
+			update_eyeblur()
 
 /mob/proc/adjust_blurriness(amount)
 	var/old_eye_blurry = eye_blurry
@@ -213,6 +215,8 @@
 	if(amount>0)
 		if(!old_eye_blurry)
 			add_eyeblur()
+	else if(eye_blurry > 0)
+		update_eyeblur()
 	else if(old_eye_blurry && !eye_blurry)
 		remove_eyeblur()
 
@@ -222,14 +226,20 @@
 	if(amount>0)
 		if(!old_eye_blurry)
 			add_eyeblur()
+	else if(eye_blurry > 0)
+		update_eyeblur()
 	else if(old_eye_blurry)
 		remove_eyeblur()
 
 /mob/proc/add_eyeblur()
 	var/obj/screen/plane_master/game_world/GW = locate(/obj/screen/plane_master/game_world) in client.screen
 	var/obj/screen/plane_master/floor/F = locate(/obj/screen/plane_master/floor) in client.screen
-	GW.add_filter("blurry_eyes", 2, EYE_BLUR)
-	F.add_filter("blurry_eyes", 2, EYE_BLUR)
+	GW.add_filter("blurry_eyes", 2, EYE_BLUR(CLAMP(eye_blurry*0.1,0.6,3)))
+	F.add_filter("blurry_eyes", 2, EYE_BLUR(CLAMP(eye_blurry*0.1,0.6,3)))
+
+/mob/proc/update_eyeblur()
+	remove_eyeblur()
+	add_eyeblur()
 
 /mob/proc/remove_eyeblur()
 	var/obj/screen/plane_master/game_world/GW = locate(/obj/screen/plane_master/game_world) in client.screen


### PR DESCRIPTION
Title. This means that getting shot with a laser one single time won't make your sight equivalent to that of someone who just lost their glasses, as the blur effect with an `eye_blurry` value of 2 only applies a 0.6 pixel wide blur, which is pretty subtle. However, if you manage to stack up quite a bit of eyeblur, you'll find yourself with a screen just as blurry as eyeblur originally was before this PR, which is a total of 3 pixels wide.

:cl: deathride58
add: Eyeblur now scales depending on how much actual eyeblur you actually have.
/:cl:
