### PR TITLE
Buffs ebows by making them deal 50 drowsiness

### DIFF
--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -6,6 +6,7 @@
 	nodamage = 0
 	knockdown = 100
 	stutter = 5
+	drowsy = 50
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"


### PR DESCRIPTION
Title. This makes it so that, when you get hit by an ebow, you'll have a 5% chance every single process cycle to fall asleep for a total of 50 process cycles, and will have 1 eye blurriness added to you every process cycle. Combined with the ebow's lack of messages and sounds to everyone except the victim, this makes it excellent for getting rid of targets that're in the middle of large crowds.

:cl: deathride58
balance: Ebows now induce 50 drowsiness on whatever they hit.
/:cl:
