### PR TITLE
Makes teleporters viable - Buffs launchpads across the board (18 max launchpad range to 60 max launchpad range)

### DIFF
--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -18,11 +18,10 @@
 	var/y_offset = 0
 
 /obj/machinery/launchpad/RefreshParts()
-	var/E = -1 //to make default parts have the base value
+	var/E = 0
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
-		E += M.rating
-	range = initial(range)
-	range += E
+		E += M.rating*15
+	range = E
 
 /obj/machinery/launchpad/attackby(obj/item/I, mob/user, params)
 	if(stationary)
@@ -148,7 +147,7 @@
 	idle_power_usage = 0
 	active_power_usage = 0
 	teleport_speed = 20
-	range = 8
+	range = 20
 	stationary = FALSE
 	var/closed = TRUE
 	var/obj/item/storage/briefcase/launchpad/briefcase

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1053,7 +1053,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/device_tools/briefcase_launchpad
 	name = "Briefcase Launchpad"
-	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to eight tiles away from the briefcase. \
+	desc = "A briefcase containing a launchpad, a device able to teleport items and people to and from targets up to twenty tiles away from the briefcase. \
 			Also includes a remote control, disguised as an ordinary folder. Touch the briefcase with the remote to link it."
 	surplus = 0
 	item = /obj/item/storage/briefcase/launchpad


### PR DESCRIPTION
Title. This PR increases launchpad part scaling quite a bit, each tier grants you a flat 15 tile range. T1 parts have a range of 15 tiles, T2 parts have a range of 30 tiles, T3 parts have a range of 45 tiles, and T4 parts have a range of 60 tiles. Briefcase launchpads were also buffed, from a pitiful range of 8 tiles to a range of 20 tiles. This PR makes it launchpads viable to use on-station, though they still aren't as strong as telesci was.

:cl: deathride58
balance: Telepads have been buffed across the board. T1 parts on a launchpad still grants you a range of 15 tiles, but T4 parts now grant you a pretty large 60 tile range (up from their original 18 tile range). Briefcase launchpads were also buffed, they now have a range of 20 tiles, up from their previous laughable 8 tiles.
/:cl:
