### PR TITLE
Reduces the revolution win condition check grace period to 10 minutes

### DIFF
--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -62,7 +62,7 @@
 		setup_error = "Not enough headrev candidates"
 		return FALSE
 
-	completioncheckstart = world.time + 20 MINUTES
+	completioncheckstart = world.time + 10 MINUTES
 
 	return TRUE
 


### PR DESCRIPTION
Title. Should make those rev rounds where no heads join at all a little more bearable

:cl: deathride58
tweak: The grace period for the revolution win condition check has been reduced from 20 minutes to 10 minutes. You don't need to wait nearly as long for the round to end if no heads join in.
/:cl:
