### PR TITLE
Fancy lighting wave 2 - nonbinary colored lighting now applies to gun/helmet flashlights, borgs, bots, welders, and more

### DIFF
--- a/code/game/machinery/camera/camera.dm
+++ b/code/game/machinery/camera/camera.dm
@@ -7,6 +7,7 @@
 	desc = "It's used to monitor rooms."
 	icon = 'icons/obj/machines/camera.dmi'
 	icon_state = "camera"
+	light_color = "#CDDDFF"
 	use_power = ACTIVE_POWER_USE
 	idle_power_usage = 5
 	active_power_usage = 10
@@ -396,7 +397,7 @@
 			if(cam == src)
 				return
 	if(on)
-		set_light(AI_CAMERA_LUMINOSITY)
+		set_light(AI_CAMERA_LUMINOSITY, 0.8)
 	else
 		set_light(0)
 

--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -77,7 +77,7 @@
 
 /obj/effect/decal/cleanable/greenglow/Initialize(mapload)
 	. = ..()
-	set_light(1)
+	set_light(2, 0.8, "#22FFAA")
 
 /obj/effect/decal/cleanable/greenglow/ex_act()
 	return

--- a/code/game/objects/items/candle.dm
+++ b/code/game/objects/items/candle.dm
@@ -47,7 +47,7 @@
 		//src.damtype = "fire"
 		if(show_message)
 			usr.visible_message(show_message)
-		set_light(CANDLE_LUMINOSITY)
+		set_light(CANDLE_LUMINOSITY, 0.8)
 		START_PROCESSING(SSobj, src)
 		update_icon()
 

--- a/code/game/objects/items/cigs_lighters.dm
+++ b/code/game/objects/items/cigs_lighters.dm
@@ -542,7 +542,7 @@ CIGARETTE PACKETS ARE IN FANCY.DM
 		damtype = "fire"
 		hitsound = 'sound/items/welder.ogg'
 		attack_verb = list("burnt", "singed")
-		set_light(1)
+		set_light(2, 0.6, LIGHT_COLOR_FIRE)
 		START_PROCESSING(SSobj, src)
 	else
 		hitsound = "swing_hit"

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -104,7 +104,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 /obj/item/pda/Initialize()
 	. = ..()
 	if(fon)
-		set_light(f_lum, f_pow, flash_color)
+		set_light(f_lum, f_pow, f_col)
 
 	GLOB.PDAs += src
 	if(default_cartridge)
@@ -741,7 +741,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		set_light(0)
 	else if(f_lum)
 		fon = TRUE
-		set_light(f_lum, f_pow, f_color)
+		set_light(f_lum, f_pow, f_col)
 	update_icon()
 
 /obj/item/pda/proc/remove_pen()

--- a/code/game/objects/items/devices/PDA/PDA.dm
+++ b/code/game/objects/items/devices/PDA/PDA.dm
@@ -49,6 +49,8 @@ GLOBAL_LIST_EMPTY(PDAs)
 	var/scanmode = PDA_SCANNER_NONE
 	var/fon = FALSE //Is the flashlight function on?
 	var/f_lum = 2.3 //Luminosity for the flashlight function
+	var/f_pow = 0.6 //Power for the flashlight function
+	var/f_col = "#FFCC66" //Color for the flashlight function
 	var/silent = FALSE //To beep or not to beep, that is the question
 	var/toff = FALSE //If TRUE, messenger disabled
 	var/tnote = null //Current Texts
@@ -102,7 +104,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 /obj/item/pda/Initialize()
 	. = ..()
 	if(fon)
-		set_light(f_lum)
+		set_light(f_lum, f_pow, flash_color)
 
 	GLOB.PDAs += src
 	if(default_cartridge)
@@ -739,7 +741,7 @@ GLOBAL_LIST_EMPTY(PDAs)
 		set_light(0)
 	else if(f_lum)
 		fon = TRUE
-		set_light(f_lum)
+		set_light(f_lum, f_pow, f_color)
 	update_icon()
 
 /obj/item/pda/proc/remove_pen()

--- a/code/game/objects/items/tools/weldingtool.dm
+++ b/code/game/objects/items/tools/weldingtool.dm
@@ -147,7 +147,7 @@
 		explode()
 	switched_on(user)
 	if(welding)
-		set_light(light_intensity)
+		set_light(light_intensity, 0.75, LIGHT_COLOR_FIRE)
 
 	update_icon()
 

--- a/code/modules/clothing/head/hardhat.dm
+++ b/code/modules/clothing/head/hardhat.dm
@@ -4,6 +4,8 @@
 	icon_state = "hardhat0_yellow"
 	item_state = "hardhat0_yellow"
 	var/brightness_on = 4 //luminosity when on
+	light_color = "#FFCC66"
+	var/power_on = 0.8
 	var/on = FALSE
 	item_color = "yellow" //Determines used sprites: hardhat[on]_[item_color] and hardhat[on]_[item_color]2 (lying down sprite)
 	armor = list("melee" = 15, "bullet" = 5, "laser" = 20,"energy" = 10, "bomb" = 20, "bio" = 10, "rad" = 20, "fire" = 100, "acid" = 50)
@@ -29,7 +31,7 @@
 		A.UpdateButtonIcon()
 
 /obj/item/clothing/head/hardhat/proc/turn_on(mob/user)
-	set_light(brightness_on)
+	set_light(brightness_on, power_on)
 
 /obj/item/clothing/head/hardhat/proc/turn_off(mob/user)
 	set_light(0)

--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -321,7 +321,7 @@
 /obj/item/clothing/head/helmet/proc/update_helmlight(mob/user = null)
 	if(F)
 		if(F.on)
-			set_light(F.brightness_on)
+			set_light(F.brightness_on, F.flashlight_power, F.light_color)
 		else
 			set_light(0)
 		update_icon()

--- a/code/modules/clothing/spacesuits/plasmamen.dm
+++ b/code/modules/clothing/spacesuits/plasmamen.dm
@@ -54,7 +54,7 @@
 	user.update_inv_head() //So the mob overlay updates
 
 	if(on)
-		set_light(brightness_on)
+		set_light(brightness_on, 0.8, "#FFCC66")
 	else
 		set_light(0)
 

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -11,7 +11,7 @@
 	circuit = /obj/item/circuitboard/machine/microwave
 	pass_flags = PASSTABLE
 	light_color = LIGHT_COLOR_YELLOW
-	light_power = 3
+	light_power = 0.9
 	var/operating = FALSE // Is it on?
 	var/dirty = 0 // = {0..100} Does it need cleaning?
 	var/broken = 0 // ={0,1,2} How broken is it???

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -71,6 +71,8 @@
 
 	var/lamp_max = 10 //Maximum brightness of a borg lamp. Set as a var for easy adjusting.
 	var/lamp_intensity = 0 //Luminosity of the headlamp. 0 is off. Higher settings than the minimum require power.
+	light_color = "#FFCC66"
+	light_power = 0.8
 	var/lamp_cooldown = 0 //Flag for if the lamp is on cooldown after being forcibly disabled.
 
 	var/sight_mode = 0

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -5,6 +5,8 @@
 	gender = NEUTER
 	mob_biotypes = list(MOB_ROBOTIC)
 	light_range = 3
+	light_power = 0.9
+	light_color = "#CDDDFF"
 	stop_automated_movement = 1
 	wander = 0
 	healable = 0

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -386,7 +386,7 @@
 /obj/item/gun/proc/update_gunlight(mob/user = null)
 	if(gun_light)
 		if(gun_light.on)
-			set_light(gun_light.brightness_on)
+			set_light(gun_light.brightness_on, gun_light.flashlight_power, gun_light.light_color)
 		else
 			set_light(0)
 		cut_overlays(flashlight_overlay, TRUE)


### PR DESCRIPTION
Title. See changed files for a full list of what's changed

:cl: deathride58
tweak: A lot more light sources now use the same nonbinary colored lighting philosophies as flashlights and light fixtures!
tweak: Flashlights mounted to guns and helmets now retain the same color and power as their original light. Lavaland's caves will reflect a fluorescent blue as you shine your KA around, and sec's helmets are now capable of illuminating maint in that fancy fluorescent blue.
tweak: Cameras now shine a fluorescent blue when lit up by an AI
tweak: Glowing goo now actually glows green.
tweak: Candles had their power reduced from 1 to 0.8.
tweak: Lighters now shine a little further, and are now properly colored.
tweak: PDAs now shine an incandescent yellow to match their sprite.
tweak: Welding tools now shine an appropriate color
tweak: Hardhats now shine an incandescent yellow.
tweak: Plasmaman helmets now shine an incandescent yellow.
tweak: Microwaves no longer overpower literally every single light in the game, instead having a power of 0.9.
tweak: Borgs now have incandescent yellow lights to match their sprites
tweak: Bots now shine a fluorescent blue light
/:cl:
