### PR TITLE
Fixes spawners with defined job descriptions causing the mob spawners list to fill up with null entries (makes spawner menu work again and properly removes ghost roles from latejoin menu when filled)

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -65,8 +65,8 @@
 
 /obj/effect/mob_spawn/Destroy()
 	GLOB.poi_list -= src
-	LAZYREMOVE(GLOB.mob_spawners, src)
-	if(!LAZYLEN(GLOB.mob_spawners))
+	LAZYREMOVE(GLOB.mob_spawners[name], src)
+	if(!LAZYLEN(GLOB.mob_spawners[name]))
 		GLOB.mob_spawners -= name
 	return ..()
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -65,9 +65,8 @@
 
 /obj/effect/mob_spawn/Destroy()
 	GLOB.poi_list -= src
-	var/list/spawners = GLOB.mob_spawners[name]
-	LAZYREMOVE(spawners, src)
-	if(!LAZYLEN(spawners))
+	LAZYREMOVE(GLOB.mob_spawners, src)
+	if(!LAZYLEN(GLOB.mob_spawners))
 		GLOB.mob_spawners -= name
 	return ..()
 


### PR DESCRIPTION
Title.

:cl: deathride58
fix: The mob spawners list no longer leaves null entries behind when a spawner has a job description defined. The latejoin menu will no longer show ghost roles that are filled, and the spawners menu actually works again.
/:cl:
