### PR TITLE
Makes auto fit viewport enabled by default for new players

### DIFF
--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -120,7 +120,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/parallax
 
 	var/ambientocclusion = TRUE
-	var/auto_fit_viewport = FALSE
+	var/auto_fit_viewport = TRUE
 
 	var/uplink_spawn_loc = UPLINK_PDA
 


### PR DESCRIPTION
"Hey why is my screen so small" is such a common question from new players, and it's got a simple answer of "Use the fit viewport button in the ooc tab"
But the pref that automatically presses that button is disabled by default thanks to TG. So let's make that pref press that button by default.

:cl: deathride58
tweak: Auto fit viewport is now enabled by default for new players. One less question off the FAQ
/:cl:
