### PR TITLE
Disables TG's biased preference-based map voting system in favor of an actual end-of-round map voting system

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -250,6 +250,8 @@
 
 /datum/config_entry/flag/maprotation
 
+/datum/config_entry/flag/tgstyle_maprotation
+
 /datum/config_entry/number/maprotatechancedelta
 	config_entry_value = 0.75
 	min_val = 0

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -449,9 +449,12 @@ SUBSYSTEM_DEF(ticker)
 	maprotatechecked = 1
 
 	//map rotate chance defaults to 75% of the length of the round (in minutes)
-	if (!prob((world.time/600)*CONFIG_GET(number/maprotatechancedelta)))
+	if (!prob((world.time/600)*CONFIG_GET(number/maprotatechancedelta)) && CONFIG_GET(flag/tgstyle_maprotation))
 		return
-	INVOKE_ASYNC(SSmapping, /datum/controller/subsystem/mapping/.proc/maprotate)
+	if(CONFIG_GET(flag/tgstyle_maprotation))
+		INVOKE_ASYNC(SSmapping, /datum/controller/subsystem/mapping/.proc/maprotate)
+	else
+		SSvote.initiate_vote("map","server")
 
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
 	return current_state >= GAME_STATE_PLAYING

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -139,6 +139,12 @@ SUBSYSTEM_DEF(vote)
 						restart = 1
 					else
 						GLOB.master_mode = .
+			if("map")
+				var/datum/map_config/VM = config.maplist[.]
+				message_admins("The map has been voted for and will change to: [VM.map_name]")
+				log_admin("The map has been voted for and will change to: [VM.map_name]")
+				if(SSmapping.changemap(config.maplist[.]))
+					to_chat(world, "<span class='boldannounce'>The map vote has chosen [VM.map_name] for next round!</span>")
 	if(restart)
 		var/active_admins = 0
 		for(var/client/C in GLOB.admins)
@@ -188,6 +194,10 @@ SUBSYSTEM_DEF(vote)
 				choices.Add("Restart Round","Continue Playing")
 			if("gamemode")
 				choices.Add(config.votable_modes)
+			if("map")
+				choices.Add(config.maplist)
+				for(var/i in choices)//this is necessary because otherwise we'll end up with a bunch of /datum/map_config's as the default vote value instead of 0 as intended
+					choices[i] = 0
 			if("roundtype") //CIT CHANGE - adds the roundstart secret/extended vote
 				choices.Add("secret", "extended")
 			if("custom")

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -685,7 +685,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			dat += "<b>Ambient Occlusion:</b> <a href='?_src_=prefs;preference=ambientocclusion'>[ambientocclusion ? "Enabled" : "Disabled"]</a><br>"
 			dat += "<b>Fit Viewport:</b> <a href='?_src_=prefs;preference=auto_fit_viewport'>[auto_fit_viewport ? "Auto" : "Manual"]</a><br>"
 
-			if (CONFIG_GET(flag/maprotation))
+			if (CONFIG_GET(flag/maprotation) && CONFIG_GET(flag/tgstyle_maprotation))
 				var/p_map = preferred_map
 				if (!p_map)
 					p_map = "Default"

--- a/config/config.txt
+++ b/config/config.txt
@@ -363,6 +363,11 @@ ANNOUNCE_ADMIN_LOGOUT
 ## You should edit maps.txt to match your configuration when you enable this.
 MAPROTATION
 
+## TG-style map rotation
+## By default, Citadel uses a more traditional method of map voting, where at the end of a round, players are given a full upfront vote.
+## This PR will disable that, and will make the server use TG's map rotation instead.
+#TGSTYLE_MAPROTATION
+
 ## Map voting
 ## Allows players to vote for their preffered map
 ## When it's set to zero, the map will be randomly picked each round


### PR DESCRIPTION
Title. This PR makes it so that, when the shuttle's leaving for centcom, the map system will no longer use heavily biased voting methods that effectively leave the next map up to RNG. Instead, the server will start up a vote that will actually let players have a say in what map will be played on the server next.
This will allow contributors, current and future, to have the freedom of being able to experiment with new map design ideas without having to worry about if their map will receive heavy backlash. This will allow comfybunker and other experimental maps like it to coexist with the existing maps while letting the players themselves decide "hey, we want to play this map" instead of having the game force everyone into it regardless of overall reception.
The issue with TG's preference-based voting system is that there's really not much player choice at all. Since players rarely ever tinker with their game preferences, TG's built-in map rotation is heavily, *heavily* skewed towards favoring whatever map is set as the default. And on top of that, maps that have 0 players who have the map set as their map preference still have an RNG chance to be picked, as a result of TG heavily trying to push a "hey, let's make sure every single map gets played at least once a day" thing.
I can rant on and on about the topic, but this PR description is getting long enough

:cl: deathride58
add: When the shuttle leaves for centcom, a vote will be started to select the next map instead of the map being randomly chosen via biased voting methods
server: If a server operator wishes to re-enable the biased TG preference voting system, you can do so by toggling the TGSTYLE_MAPROTATION config flag on in the config.txt. Keep in mind that doing so will bring you great misfortune.
/:cl:
