### PR TITLE
buffs lavaland's cacti just a smidge by increasing the amount of vitfro they have by 1.5x (4 > 6)

### DIFF
--- a/code/modules/mining/lavaland/ash_flora.dm
+++ b/code/modules/mining/lavaland/ash_flora.dm
@@ -189,7 +189,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/ash_flora/cactus_fruit
 	name = "cactus fruit"
-	list_reagents = list("vitamin" = 2, "nutriment" = 2, "vitfro" = 4)
+	list_reagents = list("vitamin" = 2, "nutriment" = 2, "vitfro" = 6)
 	desc = "A cactus fruit covered in a thick, reddish skin. And some ash."
 	icon_state = "cactus_fruit"
 	seed = /obj/item/seeds/lavaland/cactus


### PR DESCRIPTION
Title. Ashwalkers have four readily accessible methods for healing on lavaland (assuming no other ruins). In order from rarest to most common, they are legion cores, first aid kits, cacti, and leafy mushrooms. However, the gap between their second rarest and third rarest healing item is pretty massive, first aid kits are overkill for the vast majority of injuries, while cacti only heal about a fifth of an ashwalker's health. This PR tightens the gap a little by making cacti heal around a third of an ashwalker's health instead of just a fifth of it, which should help make ashwalkers a little less prone to dying.

:cl: deathride58
balance: Cacti in lavaland now have 6u of vitfro instead of just 4u. This lessens the gap between cacti and first aid kits, the third rarest and second rarest readily available healing methods for ashwalkers, respectively.
/:cl:
