### PR TITLE
actually fixes ghost role spawners leaving null entries in mob_spawners

### DIFF
--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -65,9 +65,9 @@
 
 /obj/effect/mob_spawn/Destroy()
 	GLOB.poi_list -= src
-	LAZYREMOVE(GLOB.mob_spawners[name], src)
-	if(!LAZYLEN(GLOB.mob_spawners[name]))
-		GLOB.mob_spawners -= name
+	LAZYREMOVE(GLOB.mob_spawners[job_description ? job_description : name], src)
+	if(!LAZYLEN(GLOB.mob_spawners[job_description ? job_description : name]))
+		GLOB.mob_spawners -= job_description ? job_description : name
 	return ..()
 
 /obj/effect/mob_spawn/proc/special(mob/M)


### PR DESCRIPTION
im a robust coder mom i swear
:cl: deathride58
fix: The bug where ghost role spawners leave null entries in glob.mob_spawners has actually been fixed
/:cl:
