### PR TITLE
Fixes Kitchen Gun (TM) sprite

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -35,7 +35,7 @@
 /obj/item/gun/ballistic/automatic/pistol/m1911/kitchengun
 	name = "\improper Kitchen Gun (TM)"
 	desc = "Say goodbye to dirt with Kitchen Gun (TM)! Laser sight and night vision accessories sold separately."
-	icon_state = "kitchengun"
+	icon_state = "m1911"
 	mag_type = /obj/item/ammo_box/magazine/m45/kitchengun
 
 /obj/item/gun/ballistic/automatic/pistol/deagle


### PR DESCRIPTION
[Changelogs]
Fixes Kitchen Gun (TM) sprite

[why]
It was broken and made to look 100% like M1911