### PR TITLE
Security Stunbaton Rebalancing v2

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -162,16 +162,19 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	L.Knockdown(stunforce)
+	if(L.getStaminaLoss() >= 36)
+		L.Knockdown(stunforce)
+		return 1
+
 	L.adjustStaminaLoss(stunforce*0.1, affected_zone = (istype(user) ? user.zone_selected : BODY_ZONE_CHEST))//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)
 		L.lastattacker = user.real_name
 		L.lastattackerckey = user.ckey
-		L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
-								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
-		log_combat(user, L, "stunned")
+		L.visible_message("<span class='danger'>[user] has whacked [L] with [src]!</span>", \
+								"<span class='userdanger'>[user] has whacked you with [src]!</span>")
+		log_combat(user, L, "whacked")
 
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -162,12 +162,9 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	if(L.getStaminaLoss() >= 36)
-		L.Knockdown(stunforce)
-		return 1
-
+	L.Knockdown(L.getStaminaLoss()*stunforce*0.015)
 	L.adjustStaminaLoss(stunforce*0.1, affected_zone = (istype(user) ? user.zone_selected : BODY_ZONE_CHEST))//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
-	L.apply_effect(EFFECT_STUTTER, stunforce)
+	L.apply_effect(EFFECT_STUTTER)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)
 		L.lastattacker = user.real_name

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -162,7 +162,7 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	L.Knockdown(L.getStaminaLoss()*stunforce*0.015)
+	L.Knockdown(L.getStaminaLoss()*stunforce*0.015+1)
 	L.adjustStaminaLoss(stunforce*0.1, affected_zone = (istype(user) ? user.zone_selected : BODY_ZONE_CHEST))//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
 	L.apply_effect(EFFECT_STUTTER)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -162,7 +162,7 @@
 		if(!deductcharge(hitcost))
 			return 0
 
-	L.Knockdown(L.getStaminaLoss()*stunforce*0.015+1)
+	L.Knockdown(L.getStaminaLoss()*stunforce*0.0115+1)
 	L.adjustStaminaLoss(stunforce*0.1, affected_zone = (istype(user) ? user.zone_selected : BODY_ZONE_CHEST))//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
 	L.apply_effect(EFFECT_STUTTER)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -172,8 +172,8 @@
 	if(user)
 		L.lastattacker = user.real_name
 		L.lastattackerckey = user.ckey
-		L.visible_message("<span class='danger'>[user] has whacked [L] with [src]!</span>", \
-								"<span class='userdanger'>[user] has whacked you with [src]!</span>")
+		L.visible_message("<span class='danger'>[user] has bapped [L] with [src]!</span>", \
+								"<span class='userdanger'>[user] has bapped you with [src]!</span>")
 		log_combat(user, L, "whacked")
 
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -2,7 +2,7 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 250
+	e_cost = 200
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/electrode/spec

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -2,7 +2,7 @@
 	projectile_type = /obj/item/projectile/energy/electrode
 	select_name = "stun"
 	fire_sound = 'sound/weapons/taser.ogg'
-	e_cost = 200
+	e_cost = 250
 	harmful = FALSE
 
 /obj/item/ammo_casing/energy/electrode/spec


### PR DESCRIPTION
:cl: Tupinambis
balance: Stunbatons no longer knock targets down unless they have taken more than 0 stamloss. They will also not disarm unless the target has taken at least 50 stamloss.
/:cl:

[why]: Currently stunbatons serve as an instant win button, as getting hit once will spell your doom in most situations. This change should allow antagonists to retaliate assuming they have not already taken severe stamloss, as they will no longer drop their weapons immediately. Hopefully fights will be more interesting, and weapons like the esword will be more viable.

NOTICE: TASER CHANGES HAVE BEEN REVERTED AFTER TESTING