### PR TITLE
Buffs COC and Capo sword

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -18,8 +18,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BELT
-	force = 10
-	throwforce = 7
+	force = 14
+	throwforce = 10
 	w_class = WEIGHT_CLASS_NORMAL
 	attack_verb = list("flogged", "whipped", "lashed", "disciplined")
 	hitsound = 'sound/weapons/chainhit.ogg'
@@ -57,8 +57,8 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
 	obj_flags = UNIQUE_RENAME
-	force = 15
-	throwforce = 10
+	force = 20
+	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
 	block_chance = 50
 	armour_penetration = 75

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -57,7 +57,7 @@
 	righthand_file = 'icons/mob/inhands/weapons/swords_righthand.dmi'
 	flags_1 = CONDUCT_1
 	obj_flags = UNIQUE_RENAME
-	force = 20
+	force = 18
 	throwforce = 15
 	w_class = WEIGHT_CLASS_BULKY
 	block_chance = 50


### PR DESCRIPTION
[Changelogs]
Buffs Chain of Command and Caps saber 
Sword when thrown dose 5 more harm and per hit is 5 more harm
COC has a buff of 4 melee and when thrown dose 10 harm now

[why]
Heads as well as Capo will loose to a butcher knife or a toolbox. How do they defend themselves? With a stick and some twin? No they use lethal force on those revs!