### PR TITLE
Armory Standardization and more!

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -50066,8 +50066,8 @@
 	},
 /obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
-	pixel_x = 0;
-	pixel_y = 0
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/effect/turf_decal/bot{
 	dir = 2

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -499,6 +499,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abo" = (
@@ -767,7 +768,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abR" = (

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -643,10 +643,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/riot,
-/obj/item/clothing/suit/armor/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/light{
 	dir = 1
 	},
@@ -655,19 +651,11 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/head/helmet/riot,
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/item/shield/riot{
 	pixel_x = -3;
 	pixel_y = 3
 	},
 /obj/item/shield/riot,
-/obj/item/shield/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -687,15 +675,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
 	},
@@ -788,6 +767,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "abR" = (
@@ -1018,6 +998,11 @@
 /area/crew_quarters/heads/hos)
 "acv" = (
 /obj/structure/closet/secure_closet/contraband/armory,
+/obj/effect/spawner/lootdrop/armory_contraband,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "acw" = (
@@ -1183,10 +1168,6 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/bot{
 	dir = 2
@@ -1408,10 +1389,6 @@
 	pixel_y = 3
 	},
 /obj/item/gun/ballistic/shotgun/riot,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
@@ -50089,8 +50066,8 @@
 	},
 /obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/bot{
 	dir = 2
@@ -50707,14 +50684,6 @@
 	},
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -54796,6 +54796,11 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bPB" = (
@@ -55937,10 +55942,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/vest,
-/obj/item/clothing/suit/armor/vest{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/item/clothing/head/helmet{
 	layer = 3.00001;
 	pixel_x = -3;
@@ -55950,11 +55951,6 @@
 	layer = 3.00001;
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -56968,10 +56964,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/firealarm{
 	dir = 8;
 	pixel_x = -24
@@ -56995,13 +56987,17 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -58551,10 +58547,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
 	dir = 4
-	},
-/obj/item/gun/energy/e_gun/advtaser{
-	pixel_x = 3;
-	pixel_y = -3
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
@@ -60471,8 +60463,8 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -60511,6 +60503,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bXS" = (

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -56986,10 +56986,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/laser{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/energy/laser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
 /obj/structure/window/reinforced{
@@ -60462,10 +60459,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/energy/e_gun,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -60497,7 +60497,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "bXS" = (
@@ -62894,6 +62893,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel,
 /area/ai_monitored/security/armory)
 "cbI" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -3086,8 +3086,8 @@
 	},
 /obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
-	pixel_x = 0;
-	pixel_y = 0
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3595,10 +3595,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/energy/e_gun,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1965,6 +1965,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aes" = (
@@ -3062,7 +3063,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/gun/energy/e_gun/advtaser,
-/obj/item/gun/energy/e_gun/advtaser,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3086,8 +3086,8 @@
 	},
 /obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -3518,8 +3518,6 @@
 /obj/item/clothing/head/helmet/alt,
 /obj/item/clothing/suit/armor/bulletproof,
 /obj/item/clothing/head/helmet/alt,
-/obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/head/helmet/alt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -3598,8 +3596,8 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -1965,7 +1965,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "aes" = (
@@ -3549,6 +3548,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "agS" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -5185,6 +5185,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/obj/effect/spawner/lootdrop/armory,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aiU" = (
@@ -5741,7 +5742,6 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/e_gun,
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_x = -26
@@ -5749,6 +5749,11 @@
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
+	},
+/obj/item/gun/energy/laser,
+/obj/item/gun/energy/laser{
+	pixel_x = 3;
+	pixel_y = -3
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2610,9 +2610,12 @@
 /area/security/armory)
 "aij" = (
 /obj/structure/closet/secure_closet/contraband/armory,
-/obj/item/poster/random_contraband,
 /obj/item/clothing/suit/security/officer/russian,
-/obj/item/grenade/plastic/c4,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aik" = (
@@ -3012,6 +3015,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajh" = (
@@ -3054,10 +3058,6 @@
 	},
 /obj/item/storage/box/rubbershot,
 /obj/item/storage/box/rubbershot,
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -3395,6 +3395,10 @@
 /obj/item/gun/energy/laser{
 	pixel_x = -3;
 	pixel_y = 3
+	},
+/obj/item/gun/energy/laser{
+	pixel_x = 0;
+	pixel_y = 0
 	},
 /obj/item/gun/energy/laser{
 	pixel_x = 3;
@@ -3860,7 +3864,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akM" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3396,10 +3396,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/laser{
-	pixel_x = 0;
-	pixel_y = 0
-	},
+/obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2846,6 +2846,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "aiP" = (
@@ -3015,7 +3016,6 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/spawner/lootdrop/armory_contraband,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "ajh" = (

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -33,28 +33,25 @@
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
 	lootdoubles = FALSE
-	lootcount = 2
 	loot = list(
 				/obj/item/gun/ballistic/automatic/pistol = 2,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 1,
 				/obj/item/gun/ballistic/automatic/pistol/APS = 1,
-				/obj/item/gun/ballistic/revolver/mateba = 2,
-				/obj/item/gun/ballistic/automatic/pistol/deagle = 4,
-				/obj/item/gun/ballistic/shotgun/boltaction = 4,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 5,
+				/obj/item/gun/ballistic/shotgun/boltaction = 2,
+				/obj/item/storage/box/syndie_kit/throwing_weapons = 4,
 				/obj/item/gun/ballistic/automatic/toy/pistol/riot = 6,
 				/obj/item/soap/syndie = 8,
 				/obj/item/storage/box/syndie_kit/space = 2,
-				/obj/item/grenade/plastic/c4 = 8,
+				/obj/item/grenade/plastic/c4 = 6,
 				/obj/item/toy/cards/deck/syndicate = 8,
 				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 8,
-				/obj/item/toy/syndicateballoon = 6
+				/obj/item/toy/syndicateballoon = 2
 				)
 
 /obj/effect/spawner/lootdrop/armory
 	name = "armory equipment spawner"
 	loot = list(
-				/obj/item/gun/energy/e_gun/mini = 2,
+				/obj/item/gun/energy/e_gun/mini = 3,
 				/obj/item/gun/energy/taser = 2,
 				/obj/item/gun/energy/disabler = 2,
 				/obj/item/gun/ballistic/automatic/pistol/m1911 = 1

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -33,20 +33,32 @@
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
 	lootdoubles = FALSE
-
+	lootcount = 2
 	loot = list(
-				/obj/item/gun/ballistic/automatic/pistol = 8,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
-				/obj/item/gun/ballistic/revolver/mateba,
-				/obj/item/gun/ballistic/automatic/pistol/deagle
+				/obj/item/gun/ballistic/automatic/pistol = 2,
+				/obj/item/gun/ballistic/shotgun/automatic/combat = 1,
+				/obj/item/gun/ballistic/automatic/pistol/APS = 1,
+				/obj/item/gun/ballistic/revolver/mateba = 2,
+				/obj/item/gun/ballistic/automatic/pistol/deagle = 4,
+				/obj/item/gun/ballistic/shotgun/boltaction = 4,
+				/obj/item/storage/box/syndie_kit/throwing_weapons = 5,
+				/obj/item/gun/ballistic/automatic/toy/pistol/riot = 6,
+				/obj/item/soap/syndie = 8,
+				/obj/item/storage/box/syndie_kit/space = 2,
+				/obj/item/grenade/plastic/c4 = 8,
+				/obj/item/toy/cards/deck/syndicate = 8,
+				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 8,
+				/obj/item/toy/syndicateballoon = 6
 				)
 
-/obj/effect/spawner/lootdrop/armory_contraband/metastation
-	loot = list(/obj/item/gun/ballistic/automatic/pistol = 5,
-				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
-				/obj/item/gun/ballistic/revolver/mateba,
-				/obj/item/gun/ballistic/automatic/pistol/deagle,
-				/obj/item/storage/box/syndie_kit/throwing_weapons = 3)
+/obj/effect/spawner/lootdrop/armory
+	name = "armory equipment spawner"
+	loot = list(
+				/obj/item/gun/energy/e_gun/mini = 2,
+				/obj/item/gun/energy/taser = 2,
+				/obj/item/gun/energy/disabler = 2,
+				/obj/item/gun/ballistic/automatic/pistol/m1911 = 1
+				)
 
 /obj/effect/spawner/lootdrop/gambling
 	name = "gambling valuables spawner"


### PR DESCRIPTION

:cl: Tupinambis
add: New "armory" loot spawner has been added to every maps armory. Has a chance of spawning a taser, disabler, mini e-gun, or (most rare) a m1911.
tweak: The armory contraband spawner has been added to every map except omega, and features an expanded list of potential spawns, of which it will spawn two items from. Combat shotguns and stetchkins are now much rarer than they were before.
balance: All station armories with the exception of omega station have now been standardized to contain 3 hybrid tasers, 3 blaster rifles, 2 blaster carbines, and 2 riot shotguns with 4 rubber shot boxes, as well as two sets of riot armor and bulletproof armor (Delta features 2 sets of standard armor as well). Omega is a scaled down version of this.
/:cl:

[why]: This should hopefully bring more variety to the armory, and as a result more variety to rounds, while not giving too much power to sec. A benefit of standardization is that security on one map shouldn't be weaker on another map and vice versa. A large benefit of reducing round start security equipment on some maps, is that it should encourage security to order equipment from cargo (interdepartmental interaction and the risk of antagonists possibly intervening.)
