### PR TITLE
Buffs RPE and nerfs BSRPEs

### DIFF
--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -5,7 +5,7 @@
 	click_gather = TRUE
 	max_w_class = WEIGHT_CLASS_NORMAL
 	max_combined_w_class = 100
-	max_items = 50
+	max_items = 75
 	display_numerical_stacking = TRUE
 
 /datum/component/storage/concrete/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)
@@ -22,7 +22,7 @@
 	click_gather = TRUE
 	max_w_class = WEIGHT_CLASS_BULKY  // can fit vending refills
 	max_combined_w_class = 800
-	max_items = 400
+	max_items = 250
 	display_numerical_stacking = TRUE
 
 /datum/component/storage/concrete/bluespace/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)

--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -22,7 +22,7 @@
 	click_gather = TRUE
 	max_w_class = WEIGHT_CLASS_BULKY  // can fit vending refills
 	max_combined_w_class = 800
-	max_items = 250
+	max_items = 325
 	display_numerical_stacking = TRUE
 
 /datum/component/storage/concrete/bluespace/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)


### PR DESCRIPTION
[Changelogs]
RPE now holds 75 parts (25 more items)
BSRPEs now hold 250 parts (150 less)

[why]
QoL of RPEs making them hold more for t3/t2 upgrades before silver is gotten
BSRPEs holding 400 is insane and is more then double the parts it takes to max even delta 