### PR TITLE
Buffs Gloves of the North Star by making them restore 2/3 of the stamina used when punching

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -69,6 +69,7 @@
 
 	if(M.a_intent == INTENT_HARM)
 		M.changeNext_move(CLICK_CD_RAPID)
+		M.adjustStaminaLoss(-2) //Restore 2/3 of the stamina used assuming empty stam buffer. With proper stamina buffer management, this results in a net gain of +.5 stamina per click.
 		if(warcry)
 			M.say("[warcry]", ignore_spam = TRUE, forced = "north star warcry")
 	.= FALSE


### PR DESCRIPTION
Title. This makes the Gloves of the North Star restore 2/3 of the stamina used up by punches every single time you punch in harm intent. With the way the stamina buffer and mob life process ticks works, this means that, with aggressive play and good stamina buffer management, this PR makes it plausible to roughly double your stamina regeneration using the GotNS.

:cl: deathride58
balance: The Gloves of the North Star now restore 2/3 of the stamina used up by punches when harm intent punching. With aggressive play and good stamina buffer management, this makes it entirely plausible to roughly double your stamina regeneration per mob life process tick.
/:cl:
