### PR TITLE
Replaces all missing texture turf on Omega Station with sandy plating as was intended.

### DIFF
--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -1026,7 +1026,8 @@
 /turf/closed/wall,
 /area/hallway/primary/starboard/fore)
 "abu" = (
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "abv" = (
 /turf/closed/wall,
@@ -1271,7 +1272,8 @@
 /area/asteroid/nearstation)
 "abS" = (
 /obj/item/stack/ore/glass,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "abT" = (
 /turf/closed/wall,
@@ -2090,7 +2092,8 @@
 	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "adw" = (
 /turf/open/floor/plating{
@@ -3353,11 +3356,13 @@
 "afM" = (
 /obj/item/stack/ore/iron,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "afN" = (
 /obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "afP" = (
 /obj/structure/table/wood,
@@ -3831,7 +3836,8 @@
 "agE" = (
 /obj/item/stack/ore/silver,
 /obj/item/stack/ore/iron,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "agF" = (
 /turf/closed/wall/r_wall,
@@ -4771,7 +4777,8 @@
 /area/quartermaster/storage)
 "aik" = (
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "aim" = (
 /obj/structure/rack,
@@ -5733,7 +5740,8 @@
 /area/quartermaster/storage)
 "ajQ" = (
 /obj/item/stack/ore/iron,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/asteroid/nearstation)
 "ajR" = (
 /obj/structure/rack,
@@ -9822,7 +9830,8 @@
 /area/engine/atmos)
 "aqG" = (
 /obj/structure/door_assembly/door_assembly_mhatch,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "aqI" = (
 /obj/structure/closet/secure_closet/security/sec,
@@ -10343,7 +10352,8 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "arB" = (
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/maintenance/port/fore)
 "arC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36271,7 +36281,8 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "bvg" = (
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
 "bvh" = (
 /obj/structure/closet/emcloset{
@@ -40507,7 +40518,8 @@
 "sIA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/barricade/wooden,
-/turf/open/floor/plating/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "sIB" = (
 /turf/closed/wall/rust,
@@ -41786,7 +41798,8 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/ai_monitored/turret_protected/aisat_interior)
 "sNj" = (
 /obj/effect/turf_decal/bot,
@@ -42384,7 +42397,8 @@
 /obj/structure/cable/white{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating/airless/astplate,
+/obj/effect/turf_decal/sand/plating,
+/turf/open/floor/plating/airless,
 /area/asteroid/nearstation)
 "sOK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{


### PR DESCRIPTION

:cl: Tupinambis
fix: Omegastation should no longer have any turf with missing textures, as those spots have been replaced with playing covered in a sandy turf decal.
/:cl:
