### PR TITLE
Rebuffs reactive armor because giving the repulse (!!!) armor 20 seconds and the nerfed tesla armor (!!!) 15 seconds is pretty stupid.

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -126,7 +126,7 @@
 
 /obj/item/clothing/suit/armor/reactive/stealth
 	name = "reactive stealth armor"
-	reactivearmor_cooldown_duration = 300
+	reactivearmor_cooldown_duration = 75
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
@@ -153,7 +153,7 @@
 	name = "reactive tesla armor"
 	desc = "An experimental suit of armor with sensitive detectors hooked up to a huge capacitor grid, with emitters strutting out of it. Zap."
 	siemens_coefficient = -1
-	reactivearmor_cooldown_duration = 150
+	reactivearmor_cooldown_duration = 25
 	var/tesla_power = 25000
 	var/tesla_range = 20
 	var/tesla_flags = TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE
@@ -187,7 +187,7 @@
 
 /obj/item/clothing/suit/armor/reactive/repulse
 	name = "reactive repulse armor"
-	reactivearmor_cooldown_duration = 200
+	reactivearmor_cooldown_duration = 50
 	desc = "An experimental suit of armor that violently throws back attackers."
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
@@ -213,7 +213,7 @@
 
 /obj/item/clothing/suit/armor/reactive/table
 	name = "reactive table armor"
-	reactivearmor_cooldown_duration = 500
+	reactivearmor_cooldown_duration = 0
 	desc = "If you can't beat the memes, embrace them."
 	var/tele_range = 10
 

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -187,7 +187,7 @@
 
 /obj/item/clothing/suit/armor/reactive/repulse
 	name = "reactive repulse armor"
-	reactivearmor_cooldown_duration = 35
+	reactivearmor_cooldown_duration = 20
 	desc = "An experimental suit of armor that violently throws back attackers."
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)

--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -126,7 +126,7 @@
 
 /obj/item/clothing/suit/armor/reactive/stealth
 	name = "reactive stealth armor"
-	reactivearmor_cooldown_duration = 75
+	reactivearmor_cooldown_duration = 65
 	desc = "An experimental suit of armor that renders the wearer invisible on detection of imminent harm, and creates a decoy that runs away from the owner. You can't fight what you can't see."
 
 /obj/item/clothing/suit/armor/reactive/stealth/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
@@ -153,7 +153,7 @@
 	name = "reactive tesla armor"
 	desc = "An experimental suit of armor with sensitive detectors hooked up to a huge capacitor grid, with emitters strutting out of it. Zap."
 	siemens_coefficient = -1
-	reactivearmor_cooldown_duration = 25
+	reactivearmor_cooldown_duration = 20
 	var/tesla_power = 25000
 	var/tesla_range = 20
 	var/tesla_flags = TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE
@@ -187,7 +187,7 @@
 
 /obj/item/clothing/suit/armor/reactive/repulse
 	name = "reactive repulse armor"
-	reactivearmor_cooldown_duration = 50
+	reactivearmor_cooldown_duration = 35
 	desc = "An experimental suit of armor that violently throws back attackers."
 
 /obj/item/clothing/suit/armor/reactive/repulse/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)


### PR DESCRIPTION
Really.
Repulse rebuffed to 2 seconds instead of 20 - Why the hell is it 20 when throwing into walls only does 10 damage and it isn't even a reliable stun? Even when it does stun/knockdown it doesn't disarm. There's rarely enough items for it to be powerful.
Tesla rebuffed to 2 seconds instead of 15 - If it's going to be 15 I might as well give it the old values back so it's as powerful as it was unnerfed. No reason at all to nerf it this hard when it's already nerfed. The only thing op was no cooldown, not having a cooldown that isn't 15 seconds.
Stealth rebuffed to 6.5 instead of 30 - IT IS ALREADY NERFED TO NOT BE INVISIBLE. If it's 30 it might as well be a proper 100% chance deadringer instead of this crap.
And all the while, the teleport armor, which actually blocks multihits because it teleports you away from things like shotgun blasts, wasn't even touched? What kind of balance is this? They would be fine with just a slight cooldown, except for maybe stealth, especially with staminacombat.