### PR TITLE
lets try fixing the fucking stamcrit bug - removes redundant update_stamina() calls and moves update_stamina() calls outside of if clauses

### DIFF
--- a/code/modules/mob/living/carbon/damage_procs.dm
+++ b/code/modules/mob/living/carbon/damage_procs.dm
@@ -178,7 +178,6 @@
 		parts -= picked
 	if(updating_health)
 		updatehealth()
-		update_stamina()
 	if(update)
 		update_damage_overlays()
 	update_stamina() //CIT CHANGE - makes sure update_stamina() always gets called after a health update

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -23,7 +23,7 @@
 		var/bprv = handle_bodyparts()
 		if(bprv & BODYPART_LIFE_UPDATE_HEALTH)
 			updatehealth()
-			update_stamina()
+	update_stamina()
 
 	if(stat != DEAD)
 		handle_brain_damage()

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -243,7 +243,7 @@
 	adjustStaminaLoss(-stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina()
+	update_stamina()
 
 // damage ONE external organ, organ gets randomly selected from damaged ones.
 /mob/living/proc/take_bodypart_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE)
@@ -252,7 +252,7 @@
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina()
+	update_stamina()
 
 // heal MANY bodyparts, in random order
 /mob/living/proc/heal_overall_damage(brute = 0, burn = 0, stamina = 0, only_robotic = FALSE, only_organic = TRUE, updating_health = TRUE)
@@ -261,7 +261,7 @@
 	adjustStaminaLoss(-stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina()
+	update_stamina()
 
 // damage MANY bodyparts, in random order
 /mob/living/proc/take_overall_damage(brute = 0, burn = 0, stamina = 0, updating_health = TRUE)
@@ -270,7 +270,7 @@
 	adjustStaminaLoss(stamina, FALSE)
 	if(updating_health)
 		updatehealth()
-		update_stamina()
+	update_stamina()
 
 //heal up to amount damage, in a given order
 /mob/living/proc/heal_ordered_damage(amount, list/damage_types)


### PR DESCRIPTION
This should, ***IN THEORY,*** fix the weird inconsistent bug where you can sometimes get stuck in stamcrit permanently. Since I'm completely unable to reproduce the bug myself, I'm unable to say for certain whether this actually fixes it or not, but let's hope.

:cl: deathride58
fix: The bug where you can sometimes get permanently stuck in stamcrit should HOPEFULLY be fixed. I'm unable to reproduce the bug myself, but let's hope.
/:cl:
