### PR TITLE
Buffs and nerfs night vision trait - makes the night vision trait expand your darksight to 7 tiles but increases the night vision trait's lighting plane alpha from 245 to 250

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -58,7 +58,7 @@
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
-#define LIGHTING_PLANE_ALPHA_NV_TRAIT 245
+#define LIGHTING_PLANE_ALPHA_NV_TRAIT 250
 #define LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -28,6 +28,7 @@
 			eye_color = HMN.eye_color
 		if(HMN.has_trait(TRAIT_NIGHT_VISION) && !lighting_alpha)
 			lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
+			see_in_dark = 8
 	M.update_tint()
 	owner.update_sight()
 


### PR DESCRIPTION
Title. Night vision is basically useless since its effects are more or less equivalent to bumping your monitor's gamma/brightness up. This makes the night vision trait a little less useless by making it grant you the ability to actually see more than a foot in front of you in the dark, but it also nerfs the brightness of the lighting plane with the trait.

:cl: deathride58
balance: The night vision trait now grants you darksight for an entire 1:1 screen, but the alpha of the lighting plane with the trait has been increased from 245 to 250 to balance it out
/:cl:
