### PR TITLE
Fixes the stamina hud button - makes it possible to actually click the stamina hud button and fixes the stamina buffer stats displayed by the stamina hud button

### DIFF
--- a/modular_citadel/code/_onclick/hud/stamina.dm
+++ b/modular_citadel/code/_onclick/hud/stamina.dm
@@ -6,12 +6,12 @@
 	name = "stamina"
 	icon_state = "stamina0"
 	screen_loc = ui_stamina
-	mouse_opacity = 0
+	mouse_opacity = 1
 
 /obj/screen/staminas/Click(location,control,params)
 	if(isliving(usr))
 		var/mob/living/L = usr
-		to_chat(L, "<span class='notice'>You have <b>[L.getStaminaLoss()]</b> stamina loss.<br>Your stamina buffer can take <b>[L.stambuffer]</b> stamina loss, and will use <b>50%</b> of that stamina loss when recharging.<br>Your stamina buffer is <b>[(100/L.stambuffer)-(L.bufferedstam*(100/L.stambuffer))]%</b> full.</span>")
+		to_chat(L, "<span class='notice'>You have <b>[L.getStaminaLoss()]</b> stamina loss.<br>Your stamina buffer can take <b>[L.stambuffer]</b> stamina loss, and will use <b>50%</b> of that stamina loss when recharging.<br>Your stamina buffer is <b>[(L.stambuffer*(100/L.stambuffer))-(L.bufferedstam*(100/L.stambuffer))]%</b> full.</span>")
 
 /mob/living/carbon/human/proc/staminahudamount()
 	if(stat == DEAD || recoveringstam)


### PR DESCRIPTION
Title
:cl: deathride58
fix: It's now actually possible to click the stamina hud button
fix: The stamina hud button now displays your stamina buffer correctly
/:cl:
