### PR TITLE
Obfuscates the map vote (only during the voting period)

### DIFF
--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -454,7 +454,7 @@ SUBSYSTEM_DEF(ticker)
 	if(CONFIG_GET(flag/tgstyle_maprotation))
 		INVOKE_ASYNC(SSmapping, /datum/controller/subsystem/mapping/.proc/maprotate)
 	else
-		SSvote.initiate_vote("map","server")
+		SSvote.initiate_vote("map","server",TRUE)
 
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
 	return current_state >= GAME_STATE_PLAYING


### PR DESCRIPTION
Honestly I believe this'll let people make up their own mind instead of helping landslide ones that have more votes when they open it. Who knows.
Not like the result is obfuscated because people will see what map is next afterwards.