### PR TITLE
Buffs Temperature Gun

### DIFF
--- a/code/modules/projectiles/projectile/special/temperature.dm
+++ b/code/modules/projectiles/projectile/special/temperature.dm
@@ -5,7 +5,7 @@
 	damage_type = BURN
 	nodamage = FALSE
 	flag = "energy"
-	var/temperature = 100
+	var/temperature = 50
 
 /obj/item/projectile/temp/on_hit(atom/target, blocked = 0)
 	. = ..()
@@ -15,4 +15,4 @@
 
 /obj/item/projectile/temp/hot
 	name = "heat beam"
-	temperature = 400
+	temperature = 450


### PR DESCRIPTION
[Changelogs]
freeze rays now set temp to 50 Kevinz
boil rays now set temp to 450 Kevinz
**_Wow this is worthless_**
[why]
Temp guns are a joke, easly blocked *somehow* and tend not to do much. With so many chems that just "Good joke" or flat out heal you do to temp that it can legit be used as a healing tool rather then a deadly weapon. People heat/cool so fucken fast its a joke