### PR TITLE
Nerfs wavedashing

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -19,7 +19,7 @@
 		var/mob/living/L = user
 		if(L.resting && do_after(L, max(10, L.getStaminaLoss()*0.5), 0, src))
 			if(Adjacent(L, src))
-				L.forceMove(src)
+				step(L, get_dir(L, src))
 				playsound(L, "rustle", 25, 1)
 
 /turf/open/indestructible


### PR DESCRIPTION
Requesting speedmerge since this is a pretty major bug @kevinz000 @nik707 

:cl: deathride58
fix: You can no longer phase through solid objects via scrambling
/:cl:
