### PR TITLE
More heirlooms! Also changes Mime/Clown's

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -38,9 +38,17 @@
 	var/obj/item/heirloom_type
 	switch(quirk_holder.mind.assigned_role)
 		if("Clown")
-			heirloom_type = /obj/item/bikehorn/golden
+			heirloom_type = /obj/item/paint/anycolor
 		if("Mime")
-			heirloom_type = /obj/item/reagent_containers/food/snacks/baguette
+			heirloom_type = /obj/item/toy/dummy
+		if("Cook")
+			heirloom_type = /obj/item/kitchen/knife
+		if("Medical Doctor")
+			heirloom_type = /obj/item/reagent_containers/hypospray
+		if("Station Engineer")
+			heirloom_type = /obj/item/wirecutters/brass
+		if("Atmospheric Technician")
+			heirloom_type = /obj/item/extinguisher/mini
 		if("Lawyer")
 			heirloom_type = /obj/item/gavelhammer
 		if("Janitor")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -44,7 +44,7 @@
 		if("Cook")
 			heirloom_type = /obj/item/kitchen/knife
 		if("Medical Doctor")
-			heirloom_type = /obj/item/reagent_containers/hypospray
+			heirloom_type = /obj/item/healthanalyzer/advanced
 		if("Station Engineer")
 			heirloom_type = /obj/item/wirecutters/brass
 		if("Atmospheric Technician")
@@ -54,7 +54,7 @@
 		if("Janitor")
 			heirloom_type = /obj/item/mop
 		if("Security Officer")
-			heirloom_type = /obj/item/book/manual/wiki/security_space_law
+			heirloom_type = /obj/item/clothing/accessory/medal/silver/valor
 		if("Scientist")
 			heirloom_type = /obj/item/toy/plush/slimeplushie
 		if("Assistant")

--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -39,16 +39,18 @@
 	switch(quirk_holder.mind.assigned_role)
 		if("Clown")
 			heirloom_type = /obj/item/paint/anycolor
+			heirloom_type = /obj/item/bikehorn/golden
 		if("Mime")
 			heirloom_type = /obj/item/toy/dummy
+			heirloom_type = /obj/item/paint/anycolor
 		if("Cook")
-			heirloom_type = /obj/item/kitchen/knife
+			heirloom_type = /obj/item/kitchen/knife/scimitar
 		if("Medical Doctor")
 			heirloom_type = /obj/item/healthanalyzer/advanced
 		if("Station Engineer")
 			heirloom_type = /obj/item/wirecutters/brass
 		if("Atmospheric Technician")
-			heirloom_type = /obj/item/extinguisher/mini
+			heirloom_type = /obj/item/extinguisher/mini/family
 		if("Lawyer")
 			heirloom_type = /obj/item/gavelhammer
 		if("Janitor")

--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -42,6 +42,18 @@
 	sprite_name = "miniFE"
 	dog_fashion = null
 
+/obj/item/extinguisher/mini/family
+	name = "pocket fire extinguisher"
+	desc = "A old fashen pocket fire extinguisher that has been modified with a larger water tank, and a small high-power sprayer. It feels cool to the touch and has a small humming to it..."
+	icon_state = "miniFE0"
+	item_state = "miniFE"
+	throwforce = 1
+	w_class = WEIGHT_CLASS_SMALL
+	force = 2
+	max_water = 40
+	power = 7
+	cooling_power = 3
+
 /obj/item/extinguisher/Initialize()
 	. = ..()
 	create_reagents(max_water)

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -179,7 +179,7 @@
 
 /obj/item/kitchen/knife/scimitar
 	name = "Scimitar knife"
-	desc = "A knife used to cleanly butcher, its been modifed to be able to cut more meat then a normale knife. Do to the years of use its blade isnt as strong as it once was weaking!"
+	desc = "A knife used to cleanly butcher, its been modifed to be able to cut more meat then a normale knife. Do to the years of use its blade isnt as strong as it once was!"
 	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 
 /obj/item/kitchen/knife/scimiar/Initialize()

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -176,3 +176,12 @@
 	user.visible_message("<span class='suicide'>[user] begins flattening [user.p_their()] head with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return BRUTELOSS
 /* Trays  moved to /obj/item/storage/bag */
+
+/obj/item/kitchen/knife/scimitar
+	name = "Scimitar knife"
+	desc = "A knife used to cleanly butcher, its been modifed to be able to cut more meat then a normale knife. Do to the years of use its blade isnt as strong as it once was weaking!"
+	attack_verb = list("cleaved", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
+
+/obj/item/kitchen/knife/scimiar/Initialize()
+	. = ..()
+	AddComponent(/datum/component/butchering, 90 - force, 100, force - 60) //bonus chance increases depending on force


### PR DESCRIPTION
[Changelogs]
Replaces Mimes heirloom form Beget to Dummy and paint
Gives clown a paint bucket
Adds in heirlooms for the following
Cook witch gets a cooking knife
Medical Doctor a Adv health scanner
Station Engineer gets a brass wire cutter
Atmospheric Technician gets pocket High-power fire b gone
*Rather harmless*
[why]
Mime would get a rather large and useless heirloom when compared to others. 
Honk
Cook already gets knifes, why not give him a good one
MD can make them with easy
SE, I cant think of one thing that has wire cutters have a action bar, so why not give them a fancy one.
Atmospheric Techs never really deal with fire on any massive scale not to give them a good one