### PR TITLE
Buffs NanoMed Wall units!

### DIFF
--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -13,6 +13,8 @@
 					/obj/item/reagent_containers/medspray/sterilizine = 1)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 2,
 	                  /obj/item/reagent_containers/pill/morphine = 2)
+	premium = list(/obj/item/reagent_containers/hypospray/medipen/tuberculosiscure = 2,
+				   /obj/item/reagent_containers/medspray/synthflesh = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed
@@ -26,3 +28,5 @@
 					/obj/item/reagent_containers/pill/patch/styptic = 1,
 					/obj/item/reagent_containers/pill/patch/silver_sulf = 1,
 					/obj/item/reagent_containers/medspray/sterilizine = 1)
+	premium = list(/obj/item/reagent_containers/hypospray/medipen/tuberculosiscure = 2,
+				   /obj/item/reagent_containers/medspray/synthflesh = 2)

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -13,8 +13,7 @@
 					/obj/item/reagent_containers/medspray/sterilizine = 1)
 	contraband = list(/obj/item/reagent_containers/pill/tox = 2,
 	                  /obj/item/reagent_containers/pill/morphine = 2)
-	premium = list(/obj/item/reagent_containers/hypospray/medipen/tuberculosiscure = 2,
-				   /obj/item/reagent_containers/medspray/synthflesh = 2)
+	premium = list(/obj/item/reagent_containers/medspray/synthflesh = 2)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed
@@ -28,5 +27,4 @@
 					/obj/item/reagent_containers/pill/patch/styptic = 1,
 					/obj/item/reagent_containers/pill/patch/silver_sulf = 1,
 					/obj/item/reagent_containers/medspray/sterilizine = 1)
-	premium = list(/obj/item/reagent_containers/hypospray/medipen/tuberculosiscure = 2,
-				   /obj/item/reagent_containers/medspray/synthflesh = 2)
+	premium = list(/obj/item/reagent_containers/medspray/synthflesh = 2)


### PR DESCRIPTION
[Changelogs]
Adds in synthflesh spray to coin items for wall NanoMed units
Adds in BVAK autoinjector - Aka Anit-Viros or Crit pen
[why]
Synthflesh is a emergency type chem for Paramedics, why not make them use a coin for them!
BVAK autoinjector again will be more suited for Paramedics and should cost a coin for obvs reason 