### PR TITLE
Syndicate bombs (The drink) can now spawn in snack vests

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -370,7 +370,7 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
 		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
 		/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola,
-		/obj/item/reagent_containers/food/drinks/drinkingglass/syndicatebomb
+		/obj/item/reagent_containers/food/drinks/drinkingglass/filled/syndicatebomb
 		))
 		new rig_snacks(src)
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -369,7 +369,8 @@
 		/obj/item/reagent_containers/food/drinks/soda_cans/space_up,
 		/obj/item/reagent_containers/food/drinks/soda_cans/pwr_game,
 		/obj/item/reagent_containers/food/drinks/soda_cans/lemon_lime,
-		/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola
+		/obj/item/reagent_containers/food/drinks/drinkingglass/filled/nuka_cola,
+		/obj/item/reagent_containers/food/drinks/drinkingglass/syndicatebomb
 		))
 		new rig_snacks(src)
 

--- a/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/drinkingglass.dm
@@ -90,6 +90,10 @@
 	name = "Nuka Cola"
 	list_reagents = list("nuka_cola" = 50)
 
+/obj/item/reagent_containers/food/drinks/drinkingglass/filled/syndicatebomb
+	name = "Syndicat Bomb"
+	list_reagents = list("syndicatebomb" = 50)
+
 /obj/item/reagent_containers/food/drinks/drinkingglass/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/reagent_containers/food/snacks/egg)) //breaking eggs
 		var/obj/item/reagent_containers/food/snacks/egg/E = I


### PR DESCRIPTION
[Changelogs]
Snack vest can now be vended with Syndicate bomb drinks

[why]
Mostly memes, and its Rng and little to no power gaming can be done with it that I know of. After we have it spawn nuke_cola anyways *and that is a massive speed buff*