### PR TITLE
Upgrades Synda sleepers with T3 Parts!

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -212,6 +212,17 @@
 	icon_state = "sleeper_s"
 	controls_inside = TRUE
 
+/obj/machinery/sleeper/syndie/Initialize()
+	. = ..()
+	component_parts = list()
+	component_parts += new /obj/item/circuitboard/machine/sleeper(null)
+	component_parts += new /obj/item/stock_parts/matter_bin/super(null)
+	component_parts += new /obj/item/stock_parts/manipulator/pico(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stack/sheet/glass(null)
+	component_parts += new /obj/item/stack/cable_coil(null)
+	RefreshParts()
+
 /obj/machinery/sleeper/syndie/fullupgrade/Initialize()
 	. = ..()
 	component_parts = list()


### PR DESCRIPTION
[Changelogs]
Makes nukes/space ruins as well as space queens men sleeper better and like useful!


[why]
_**Wow this is worthless**_ 
If anyone wants to heal any amount of harm at any of these sleepers they have to heal with patches/chems before healing at the sleeper, and cant heal toxin harm. This fixes that so that they can heal themselves of most types of harm.