### PR TITLE
Buffs foam force riot darts to be 31 not 25!

### DIFF
--- a/code/modules/projectiles/projectile/reusable/foam_dart.dm
+++ b/code/modules/projectiles/projectile/reusable/foam_dart.dm
@@ -38,4 +38,4 @@
 	name = "riot foam dart"
 	icon_state = "foamdart_riot_proj"
 	ammo_type = /obj/item/ammo_casing/caseless/foam_dart/riot
-	stamina = 25
+	stamina = 31


### PR DESCRIPTION
[Changelogs]
Traitors have to shoot at the same speed as 10mm and hit all 8 shots to down someone, thats legit worthless!

[why]
***Wow this is worthless like temp gun***
It can easily be out chem memed like dislabers and costs a few tc to get those guns to make riots work, hopefully this will make non-lethal traitors viable more so!