### PR TITLE
Doubles the max say/emote size to match the RP server

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -48,7 +48,7 @@
 #define LINGHIVE_LINK 3
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
-#define MAX_MESSAGE_LEN			1024
+#define MAX_MESSAGE_LEN			2048 //CITADEL CHANGE - was 1024
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80


### PR DESCRIPTION
:cl: izzyinbox
tweak: ups the max say/emote character limit from 1024 to 2048, to match the size of the RP server.
/:cl:

[why]: This should help for people that run into the upper limit with emote length on the occasion.