### PR TITLE
Revert "Doubles the max say/emote size to match the RP server"

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -48,7 +48,7 @@
 #define LINGHIVE_LINK 3
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
-#define MAX_MESSAGE_LEN			2048 //CITADEL CHANGE - was 1024
+#define MAX_MESSAGE_LEN			1024
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#7807
Turns out doubling the say size is a bad thing.