### PR TITLE
lets try to fix heat not spreading - makes hotspot_expose() force air updates like space heaters do

### DIFF
--- a/code/modules/atmospherics/environmental/LINDA_fire.dm
+++ b/code/modules/atmospherics/environmental/LINDA_fire.dm
@@ -47,6 +47,7 @@
 		heating.temperature = exposed_temperature
 		heating.react()
 		assume_air(heating)
+		air_update_turf()
 	return igniting
 
 //This is the icon for fire on turfs, also helps for nurturing small fires until they are full tile


### PR DESCRIPTION
Title. This is a pretty weird bug, as it wasn't present on TG despite the code being mostly the same

:cl: deathride58
fix: [EXPERIMENTAL] attempted to fix heat failing to spread from heat sources like plasma fires and welding tools
/:cl:
