### PR TITLE
[Ready] Adds magboots to UV Engi units

### DIFF
--- a/code/game/machinery/suit_storage_unit.dm
+++ b/code/game/machinery/suit_storage_unit.dm
@@ -41,6 +41,7 @@
 /obj/machinery/suit_storage_unit/engine
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine
 	mask_type = /obj/item/clothing/mask/breath
+	storage_type= /obj/item/clothing/shoes/magboots
 
 /obj/machinery/suit_storage_unit/ce
 	suit_type = /obj/item/clothing/suit/space/hardsuit/engine/elite


### PR DESCRIPTION
[Changelogs]
Makes the two engi UVs have magboots
[why]
I ded
Do to fucken space wind being a thing that pushes you into space, into fire, into the SM, into like everware you dont want to be well fixing something making you reset the task bar
QoL for Engi-s