### PR TITLE
[Ready] Makes pineapple pizza eatable - Requested by LeglessLizard

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pizza.dm
+++ b/code/modules/food_and_drinks/food/snacks_pizza.dm
@@ -149,16 +149,16 @@
 	icon_state = "pineapplepizza"
 	slice_path = /obj/item/reagent_containers/food/snacks/pizzaslice/pineapple
 	bonus_reagents = list("nutriment" = 6, "vitamin" = 6)
-	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pineapple" = 2, "ham" = 2)
-	foodtype = GRAIN | VEGETABLES | DAIRY | MEAT | FRUIT | PINEAPPLE
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pineapple" = 6, "ham" = 2)
+	foodtype = PINEAPPLE //Over powering tast of gods fruit
 
 /obj/item/reagent_containers/food/snacks/pizzaslice/pineapple
 	name = "\improper Hawaiian pizza slice"
 	desc = "A slice of delicious controversy."
 	icon_state = "pineapplepizzaslice"
 	filling_color = "#FF4500"
-	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pineapple" = 2, "ham" = 2)
-	foodtype = GRAIN | VEGETABLES | DAIRY | MEAT | FRUIT | PINEAPPLE
+	tastes = list("crust" = 1, "tomato" = 1, "cheese" = 1, "pineapple" = 6, "ham" = 2)
+	foodtype = PINEAPPLE //Over powering tast of gods fruit
 
 /obj/item/reagent_containers/food/snacks/pizza/arnold
 	name = "\improper Arnold pizza"


### PR DESCRIPTION
[Changelogs]
**not just removing it**
Makes pineapple pizza just have Pineapple food types so any race can eat it.

[why]
Non-humans can eat it now without being sick *I see why this used to be in the synda bio harm kit*
QoL for a non-powergamy pizza to be eaten without people having a neg moodlit 
