### PR TITLE
[Ready] Makes upgraded drop pods not explode

### DIFF
--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -41,7 +41,7 @@
 /obj/structure/closet/supplypod/bluespacepod
 	style = STYLE_BLUESPACE
 	bluespace = TRUE
-	explosionSize = list(0,0,0,0)
+	explosionSize = list(0,0,0,0) //So we dont kill mobs or brake bombs
 	landingDelay = 15 //Slightly quicker than the supplypod
 
 /obj/structure/closet/supplypod/centcompod

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -41,7 +41,7 @@
 /obj/structure/closet/supplypod/bluespacepod
 	style = STYLE_BLUESPACE
 	bluespace = TRUE
-	explosionSize = list(0,0,1,2)
+	explosionSize = list(0,0,0,0)
 	landingDelay = 15 //Slightly quicker than the supplypod
 
 /obj/structure/closet/supplypod/centcompod

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -41,7 +41,7 @@
 /obj/structure/closet/supplypod/bluespacepod
 	style = STYLE_BLUESPACE
 	bluespace = TRUE
-	explosionSize = list(0,0,0,0) //So we dont kill mobs or brake bombs
+	explosionSize = list(0,0,0,0) //So we dont kill mobs or brake bombs 
 	landingDelay = 15 //Slightly quicker than the supplypod
 
 /obj/structure/closet/supplypod/centcompod


### PR DESCRIPTION
[Changelogs]
Blue space drop pods will not destroy there mobs/flashes/bombs

[why]
It kills all mobs when they land, they also destroy flashes as well as any grande 