### PR TITLE
Disabler buff, taser nerf

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -69,7 +69,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 36 
+	damage = 24 // Citadel change for balance from 36
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -69,7 +69,7 @@
 /obj/item/projectile/beam/disabler
 	name = "disabler beam"
 	icon_state = "omnilaser"
-	damage = 24 // Citadel change for balance from 36
+	damage = 36 
 	damage_type = STAMINA
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'

--- a/modular_citadel/code/modules/projectiles/projectile/energy.dm
+++ b/modular_citadel/code/modules/projectiles/projectile/energy.dm
@@ -1,2 +1,2 @@
 /obj/item/projectile/energy/electrode
-	stamina = 36
+	stamina = 24


### PR DESCRIPTION
:cl: optional name here
balance: changed disabler stamina drain from 24 to 36 and direct electrode stamina drain from 36 to 24.
/:cl:

[why]: # (Please add a short description [two lines down] of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding.)

Instant knockdown + 3hit stamcrit on electrodes is pretty powerful. Most fights tend to play out as "click on mans with gun, once he is horizontal click twice and win", or "miss 5 yellow balls, cry as you get robusted". Meanwhile, disablers can't even stamcrit people from a full magazine, making them on par with laser tag guns (which at least cause eyeblur, which actually makes it hard to see). Changes should encourage actually switching to disabler function on the hybrid taser (as you won't be able to consistently stamcrit with electrodes anymore; at least without depleting all 5 taser charges.