### PR TITLE
[Ready] Makes the SM BS shield last 60 seconds to help people

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -54,7 +54,7 @@
 #define SUPERMATTER_DANGER_PERCENT 50
 #define SUPERMATTER_WARNING_PERCENT 100
 
-#define SUPERMATTER_COUNTDOWN_TIME 30 SECONDS
+#define SUPERMATTER_COUNTDOWN_TIME 60 SECONDS
 
 GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 


### PR DESCRIPTION
[Changelogs]
SUPERMATTER_COUNTDOWN_TIME 30 to 60
This should give 30 more seconds for people to run/fix the SM

[why]
30 seconds isnt a lot of time to let gasses cool the SM lets make it 60! Helps all crew and Engi mains deal with a dieing SM. 