### PR TITLE
[Ready] Buffs RPEDs

### DIFF
--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -5,7 +5,7 @@
 	click_gather = TRUE
 	max_w_class = WEIGHT_CLASS_NORMAL
 	max_combined_w_class = 100
-	max_items = 75
+	max_items = 100
 	display_numerical_stacking = TRUE
 
 /datum/component/storage/concrete/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)
@@ -22,7 +22,7 @@
 	click_gather = TRUE
 	max_w_class = WEIGHT_CLASS_BULKY  // can fit vending refills
 	max_combined_w_class = 800
-	max_items = 325
+	max_items = 350
 	display_numerical_stacking = TRUE
 
 /datum/component/storage/concrete/bluespace/rped/can_be_inserted(obj/item/I, stop_messages, mob/M)
@@ -31,3 +31,6 @@
 		if (!stop_messages)
 			to_chat(M, "<span class='warning'>[parent] only accepts machine parts!</span>")
 		return FALSE
+
+/obj/item/storage/part_replacer/cyborg
+	max_items = 150

--- a/code/datums/components/storage/concrete/rped.dm
+++ b/code/datums/components/storage/concrete/rped.dm
@@ -32,5 +32,5 @@
 			to_chat(M, "<span class='warning'>[parent] only accepts machine parts!</span>")
 		return FALSE
 
-/obj/item/storage/part_replacer/cyborg
+/datum/component/storage/concrete/cyborg/rped
 	max_items = 150


### PR DESCRIPTION
[Changelogs]
Borg RPEDs are now holding 150 parts
BSRPEDS are now holding 325 parts
RPED are now holding 100 parts

[why]
QoL and power creep. Borgs never get there modal or use it rarely so why limit them to only normal RPED limits? 