### PR TITLE
Makes stamcrit completely unaffected by health

### DIFF
--- a/modular_citadel/code/modules/mob/living/living.dm
+++ b/modular_citadel/code/modules/mob/living/living.dm
@@ -104,7 +104,7 @@
 /mob/living/carbon/update_stamina()
 	var/total_health = getStaminaLoss()
 	if(total_health)
-		if(!recoveringstam && total_health <= STAMINA_CRIT_TRADITIONAL && !stat)
+		if(!recoveringstam && total_health >= STAMINA_CRIT && !stat)
 			to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
 			resting = TRUE
 			if(combatmode)
@@ -112,7 +112,7 @@
 			recoveringstam = TRUE
 			filters += CIT_FILTER_STAMINACRIT
 			update_canmove()
-	if(recoveringstam && total_health >= STAMINA_SOFTCRIT_TRADITIONAL)
+	if(recoveringstam && total_health <= STAMINA_SOFTCRIT)
 		to_chat(src, "<span class='notice'>You don't feel nearly as exhausted anymore.</span>")
 		recoveringstam = FALSE
 		filters -= CIT_FILTER_STAMINACRIT

--- a/modular_citadel/code/modules/mob/living/living.dm
+++ b/modular_citadel/code/modules/mob/living/living.dm
@@ -102,8 +102,8 @@
 			return FALSE
 
 /mob/living/carbon/update_stamina()
-	var/total_health = (min(health*2,100) - getStaminaLoss())
-	if(getStaminaLoss())
+	var/total_health = getStaminaLoss()
+	if(total_health)
 		if(!recoveringstam && total_health <= STAMINA_CRIT_TRADITIONAL && !stat)
 			to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
 			resting = TRUE


### PR DESCRIPTION
Being able to keep someone in stamcrit by stabbing them below 50 health is horrid for gameplay. Being able to fall into stamcrit much easier if you have a broken arm and a large stab wound in the chest is horrid for gameplay. Originally made for the med rework since it ditches the concept of having an arbitrary whole-body health value, but stamcrit being unaffected by health is a something that definitely deserves to be a part of the experience independent of the med rework.

:cl: deathride58
balance: Stamina is no longer affected by health at all.
/:cl:
