### PR TITLE
Makes it possible to instantly get up from resting at a stamina cost equal to your entire stamina buffer

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/species.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species.dm
@@ -13,10 +13,29 @@
 		H.visible_message("<span class='warning'>[M] attempted to touch [H]!</span>")
 		return TRUE
 	switch(M.a_intent)
-		if("disarm")
+		if(INTENT_HELP)
+			if(M == H)
+				althelp(M, H, attacker_style)
+				return TRUE
+			return FALSE
+		if(INTENT_DISARM)
 			altdisarm(M, H, attacker_style)
 			return TRUE
 	return FALSE
+
+/datum/species/proc/althelp(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
+	if(user == target && istype(user))
+		if(user.getStaminaLoss() >= STAMINA_SOFTCRIT)
+			to_chat(user, "<span class='warning'>You're too exhausted for that.</span>")
+			return
+		if(!user.resting)
+			to_chat(user, "<span class='notice'>You can only force yourself up if you're on the ground.</span>")
+			return
+		user.visible_message("<span class='notice'>[user] forces [p_them()]self up to [p_their()] feet!</span>", "<span class='notice'>You force yourself up to your feet!</span>")
+		user.resting = 0
+		user.update_canmove()
+		user.adjustStaminaLossBuffered(user.stambuffer) //Rewards good stamina management by making it easier to instantly get up from resting
+		playsound(user, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 /datum/species/proc/altdisarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(user.getStaminaLoss() >= STAMINA_SOFTCRIT)


### PR DESCRIPTION
Title. This PR rewards proper stamina management by adding a readily-available defensive option that isn't running. To get up instantly from resting, right click yourself in help intent with an empty hand while in combat mode. This will cost stamina equal to your entire stamina buffer. This means if you manage your stamina well, the total cost when applied to your actual stamina will only be 10 stam total. But on the flipside of the coin, if your stamina buffer is empty when you try to force yourself up, you'll be spending the full 20 stamina with your actual stamina.

:cl: deathride58
add: You can now right-click yourself in help intent in combat mode to instantly get up from resting. This will cost stamina equal to your entire stamina buffer. Manage your stamina well, and you'll be able to shrug off a single stray golden bolt
/:cl:
