### PR TITLE
[Ready] Makes laser scatter shot cost 5 Tc for a drum

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -510,7 +510,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "12g Scatter Laser shot Slugs"
 	desc = "An alternative 8-round Scatter Laser Shot magazine for use in the Bulldog shotgun."
 	item = /obj/item/ammo_box/magazine/m12g/scatter
-	cost = 3
+	cost = 5 // most armor has less laser protection then bullet
 
 /datum/uplink_item/ammo/shotgun/bag
 	name = "12g Ammo Duffel Bag"


### PR DESCRIPTION
[Changelogs]
3tc -> 5tc

[why]
Forgot that 9/10 armor is weaker to lasers then bullets making this ammo 100% better then *all the other types nukies have*
They also if all hit do 90 burn harm*