### PR TITLE
Makes xenos tackle hardstun 1.5 seconds if not resting and if resting .25 seconds.

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -273,9 +273,9 @@
 			else
 				playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
 				if(!lying)				//CITADEL EDIT
-					Knockdown(100, TRUE, FALSE, 30, 25)
+					Knockdown(25, TRUE, FALSE, 30, 25)
 				else
-					Knockdown(100)
+					Knockdown(50)
 				log_combat(M, src, "tackled")
 				visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
 					"<span class='userdanger'>[M] has tackled down [src]!</span>")


### PR DESCRIPTION
[Changelogs]
Makes xenos hardstun less auto win

[why]
It legit is a auto win, you cant do anything about and is unskilled combat