### PR TITLE
Makes ERT suits acid unbreakable 

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -168,6 +168,7 @@ Contains:
 	strip_delay = 130
 	item_flags = NODROP
 	brightness_on = 7
+	resistance_flags = ACID_PROOF
 
 /obj/item/clothing/suit/space/hardsuit/ert
 	name = "emergency response team suit"
@@ -179,6 +180,7 @@ Contains:
 	armor = list("melee" = 65, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 80)
 	slowdown = 0
 	strip_delay = 130
+	resistance_flags = ACID_PROOF
 
 	//ERT Security
 /obj/item/clothing/head/helmet/space/hardsuit/ert/sec


### PR DESCRIPTION
[Changelogs]
Makes all ERT suits acid unbreakable

[why]
No longer will a traitor chemmy throw a beaker of acid and remove ERT suits!
Also xenos cant acid leak over a suit to remove it form ERT.