### PR TITLE
Changes Jukebox Availability

### DIFF
--- a/code/game/machinery/dance_machine.dm
+++ b/code/game/machinery/dance_machine.dm
@@ -5,7 +5,7 @@
 	icon_state = "jukebox"
 	verb_say = "states"
 	density = TRUE
-	req_access = list(ACCESS_BAR)
+	req_one_access = list(ACCESS_BAR, ACCESS_KITCHEN, ACCESS_HYDROPONICS, ACCESS_ENGINE, ACCESS_CARGO, ACCESS_THEATRE)
 	var/active = FALSE
 	var/list/rangers = list()
 	var/stop = 0

--- a/modular_citadel/code/modules/cargo/packs.dm
+++ b/modular_citadel/code/modules/cargo/packs.dm
@@ -23,6 +23,6 @@
 
 /datum/supply_pack/misc/jukebox
 	name = "Jukebox"
-	cost = 1000000
+	cost = 35000
 	contains = list(/obj/machinery/jukebox)
 	crate_name = "Jukebox"


### PR DESCRIPTION
Changes the massive price of the jukebox to something much more affordable, as well as broadens access needed to use it.

With upcoming songs being added to give the jukebox more variety in tracks, it should make sense that the jukeboxes become more available. Grants access to changing the songs to Chefs, botanists, theatre access, cargo, and now engineers. Also not sure why at all the price was 1,000,000 credits.