### PR TITLE
Makes the new player panel display the currently selected character name

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -33,7 +33,8 @@
 	return
 
 /mob/dead/new_player/proc/new_player_panel()
-	var/output = "<center><p><a href='byond://?src=[REF(src)];show_preferences=1'>Setup Character</a></p>"
+	var/output = "<center><p>Welcome, <b>[client ? client.prefs.real_name : "Unknown User"]</b></p>"
+	output += "<p><a href='byond://?src=[REF(src)];show_preferences=1'>Setup Character</a></p>"
 
 	if(SSticker.current_state <= GAME_STATE_PREGAME)
 		switch(ready)


### PR DESCRIPTION
Title. People joining in as the wrong character is a surprisingly common occurrence. This PR should fix that by making it obvious what character you have currently selected when you connect to the server.

:cl: deathride58
add: The new player panel now displays your currently selected character's name
/:cl:
