### PR TITLE
fancy throws - makes throws perform the attack animation and play a sound

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -188,6 +188,8 @@
 	if(thrown_thing)
 		visible_message("<span class='danger'>[src] has thrown [thrown_thing].</span>")
 		src.log_message("has thrown [thrown_thing]", LOG_ATTACK)
+		do_attack_animation(target, no_effect = 1)
+		playsound(loc, 'sound/weapons/punchmiss.ogg', 50, 1, -1)
 		newtonian_move(get_dir(target, src))
 		thrown_thing.throw_at(target, thrown_thing.throw_range, thrown_thing.throw_speed, src)
 


### PR DESCRIPTION
Title. This makes throws feel more impactful, in a way that'll hopefully convey their stamina cost

:cl: deathride58
add: Throwing items will now perform the attack animation and play a sound
/:cl:
