### PR TITLE
noisy flashlights - makes flashlights play a sound when toggled

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -35,6 +35,7 @@
 /obj/item/flashlight/attack_self(mob/user)
 	on = !on
 	update_brightness(user)
+	playsound(user, on ? 'sound/weapons/magin.ogg' : 'sound/weapons/magout.ogg', 40, 1)
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()


### PR DESCRIPTION
Title. Magin.ogg is completely unused and Magout.ogg is only used for one single item that's insanely rare to see ingame outside of adminbus. These two sounds sound a lot like a thick toggle button being pressed, which made me immediately think of a flashlight being turned on/off. So here's a PR that makes that thought a reality

:cl: deathride58
add: flashlights will now make sounds when toggled on/off
/:cl:
