### PR TITLE
fixes a very major bug that makes the game extremely unplayable

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -34,6 +34,7 @@
 #define LIGHT_COLOR_BLUE       "#6496FA" //Cold, diluted blue. rgb(100, 150, 250)
 
 #define LIGHT_COLOR_BLUEGREEN  "#7DE1AF" //Light blueish green. rgb(125, 225, 175)
+#define LIGHT_COLOR_PALEBLUE   "#7DAFE1" //A pale blue-ish color. rgb(125, 175, 225)
 #define LIGHT_COLOR_CYAN       "#7DE1E1" //Diluted cyan. rgb(125, 225, 225)
 #define LIGHT_COLOR_LIGHT_CYAN "#40CEFF" //More-saturated cyan. rgb(64, 206, 255)
 #define LIGHT_COLOR_DARK_BLUE  "#6496FA" //Saturated blue. rgb(51, 117, 248)

--- a/code/modules/atmospherics/machinery/airalarm.dm
+++ b/code/modules/atmospherics/machinery/airalarm.dm
@@ -650,7 +650,7 @@
 		if(0)
 			add_overlay(AALARM_OVERLAY_GREEN)
 			overlay_state = AALARM_OVERLAY_GREEN
-			light_color = LIGHT_COLOR_BLUEGREEN
+			light_color = LIGHT_COLOR_PALEBLUE
 			set_light(brightness_on)
 		if(1)
 			add_overlay(AALARM_OVERLAY_WARN)


### PR DESCRIPTION
Poojawa, you forgot to change the light color that air alarms emit when their status is okay. This literally makes the game extremely unplayable, as a green light being emitted from a neon blue display deeply affects the game. How could you do this?!?!?!

:cl: deathride58
fix: Air alarms now actually emit the proper light color when their status is okay.
/:cl:
