### PR TITLE
Completely tested and working TEG nerf

### DIFF
--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -65,7 +65,7 @@
 
 
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
-				var/efficiency = 0.65
+				var/efficiency = 0.45
 
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 


### PR DESCRIPTION
[Changelogs]: Reduces TEG efficiency var from .65 to .45

:cl: nicc
balance: teg less gay maybe

/:cl:

[why]: because a TEG with 1 freezer and 1 heater should not be producing 13 MW 5 minutes within the start of the shift
