### PR TITLE
Nerfed Mulebots to hell and back. You know what you did.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -644,7 +644,7 @@
 					"<span class='userdanger'>[src] drives over you!</span>")
 	playsound(loc, 'sound/effects/splat.ogg', 50, 1)
 
-	var/damage = rand(5,15)
+	var/damage = rand(1,2)
 	H.apply_damage(2*damage, BRUTE, BODY_ZONE_HEAD, run_armor_check(BODY_ZONE_HEAD, "melee"))
 	H.apply_damage(2*damage, BRUTE, BODY_ZONE_CHEST, run_armor_check(BODY_ZONE_CHEST, "melee"))
 	H.apply_damage(0.5*damage, BRUTE, BODY_ZONE_L_LEG, run_armor_check(BODY_ZONE_L_LEG, "melee"))


### PR DESCRIPTION

:tweak: Decreased the random modifier of mulebot runover damage from rand(5,15) to rand(1,2) Taking the average damage by mulebot runover from 30 down to 5ish.

[Why]: Because mulebots deal a massive amount of damage extremely quickly, and pAI controlled mulebots are ridiculously powerful when they have a rider.
Yogs and Paradise fixed this issue by removing pAI controlled mulebots, but I think pAI mulebots are pretty fun, when people aren't abusing it.
