### PR TITLE
[Ready] Fixes power tool drill fitting in boots/wallet

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -34,6 +34,7 @@
 
 /datum/component/storage/concrete/pockets/shoes/Initialize()
 	. = ..()
+	cant_hold = typecacheof(list(/obj/item/screwdriver/power))
 	can_hold = typecacheof(list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
@@ -44,6 +45,7 @@
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
 	. = ..()
+	cant_hold = typecacheof(list(/obj/item/screwdriver/power))
 	can_hold = typecacheof(list(
 		/obj/item/kitchen/knife, /obj/item/switchblade, /obj/item/pen,
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,

--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -13,6 +13,7 @@
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
 	STR.max_items = 4
+	STR.cant_hold = typecacheof(list(/obj/item/screwdriver/power))
 	STR.can_hold = typecacheof(list(
 		/obj/item/stack/spacecash,
 		/obj/item/card,


### PR DESCRIPTION
[Changelogs]
Fun fact, drill bit power tool fits in wallets and boots. But not the wrench bit. Clearly a bug

[why]
Power tools shouldn't fit in a boot or a wallet. And the wrench bit dosn't fit in the wallet or boot so it must be a bug.