### PR TITLE
babyproofs limb icon caches from admin varedits

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -231,8 +231,9 @@
 		var/obj/item/bodypart/BP = X
 		BP.update_limb()
 	
-	LAZYINITLIST(limb_icon_cache)
-	
+	if(!islist(limb_icon_cache))
+		limb_icon_cache = list()
+
 	//LOAD ICONS
 	if(limb_icon_cache[icon_render_key])
 		load_limb_from_cache()

--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -230,7 +230,9 @@
 	for(var/X in bodyparts)
 		var/obj/item/bodypart/BP = X
 		BP.update_limb()
-
+	
+	LAZYINITLIST(limb_icon_cache)
+	
 	//LOAD ICONS
 	if(limb_icon_cache[icon_render_key])
 		load_limb_from_cache()


### PR DESCRIPTION
come on guys don't null out static variables