### PR TITLE
reduces stamloss for shotgun pumping from 5 to 2

### DIFF
--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -43,7 +43,7 @@
 	pump(user)
 	recentpump = world.time + 10
 	if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
-		user.adjustStaminaLossBuffered(5) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
+		user.adjustStaminaLossBuffered(2) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
 	return
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)


### PR DESCRIPTION
So, IRL, pumping a shotgun is about as tiring as swinging a light one-handed shortsword. Ingame however, pumping a shotgun is just as tiring as swinging around a toolbox. This also applies to each step of racking a bolt-action rifle. Guns in general have pretty light stamina usage across the board, but pump shotguns aren't quite powerful enough in comparison to justify the higher stamina cost, especially since barrel-based shotguns are much more easily accessible than pump shotguns and take much less stam

:cl: deathride58
balance: Pump-action shotguns now take 2 stamina per pump instead of 5 stamina per pump. This also applies to bolt-action rifles, as bolt racking counts as pumping.
/:cl:
