### PR TITLE
Low plasma concentration does not damage anymore

### DIFF
--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -15,7 +15,7 @@
 	var/safe_co2_min = 0
 	var/safe_co2_max = 10 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_min = 0
-	var/safe_toxins_max = 1
+	var/safe_toxins_max = 0.5
 	var/SA_para_min = 1 //Sleeping agent
 	var/SA_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -15,7 +15,7 @@
 	var/safe_co2_min = 0
 	var/safe_co2_max = 10 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_min = 0
-	var/safe_toxins_max = 0.5
+	var/safe_toxins_max = MOLES_GAS_VISIBLE
 	var/SA_para_min = 1 //Sleeping agent
 	var/SA_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -15,7 +15,7 @@
 	var/safe_co2_min = 0
 	var/safe_co2_max = 10 // Yes it's an arbitrary value who cares?
 	var/safe_toxins_min = 0
-	var/safe_toxins_max = 0.05
+	var/safe_toxins_max = 1
 	var/SA_para_min = 1 //Sleeping agent
 	var/SA_sleep_min = 5 //Sleeping agent
 	var/BZ_trip_balls_min = 1 //BZ gas
@@ -324,7 +324,7 @@
 		// Clear out moods when no miasma at all
 		else
 			SEND_SIGNAL(owner, COMSIG_CLEAR_MOOD_EVENT, "smell")
-		
+
 		handle_breath_temperature(breath, H)
 		breath.garbage_collect()
 	return TRUE


### PR DESCRIPTION
[Changelogs]: 
As the title says, it changes a few values inside the lungs so trace amounts of plasma do not cause toxic damage. Minimum plasma safety is now 0.5% of the atmosphere instead of 0.05% (which is extremely hard to each even with scrubbers on contaminated-mode). This should clean up the issue with everyone accumulating toxins after a toxic spill in a public area.

:cl: optional name here
balance: Lungs maximum toxin threshold is 0.5% of the atmosphere.
fix: Permanently contaminated atmosphere does not murder crew anymore.
/:cl:

[why]: A simple fix and solution for a problem that annoys me as medical staff and that can't (or  won't) be fixed by engineering due to lacking access and/or turfs that can't be reached by scrubbers.
