### PR TITLE
Update ion_storm.dm

### DIFF
--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -8,11 +8,11 @@
 
 /datum/round_event/ion_storm
 	var/replaceLawsetChance = 25 //chance the AI's lawset is completely replaced with something else per config weights
-	var/removeRandomLawChance = 10 //chance the AI has one random supplied or inherent law removed
-	var/removeDontImproveChance = 10 //chance the randomly created law replaces a random law instead of simply being added
-	var/shuffleLawsChance = 10 //chance the AI's laws are shuffled afterwards
-	var/botEmagChance = 10
-	var/announceEvent = ION_RANDOM // -1 means don't announce, 0 means have it randomly announce, 1 means
+	var/removeRandomLawChance = 15 //chance the AI has one random supplied or inherent law removed
+	var/removeDontImproveChance = 15 //chance the randomly created law replaces a random law instead of simply being added
+	var/shuffleLawsChance = 15 //chance the AI's laws are shuffled afterwards
+	var/botEmagChance = 20
+	var/announceEvent = ION_RANDOM // -1 means don't announce, 0 means have it randomly announce, 1 means it is announced
 	var/ionMessage = null
 	var/ionAnnounceChance = 33
 	announceWhen	= 1
@@ -30,7 +30,7 @@
 
 
 /datum/round_event/ion_storm/start()
-	//AI laws
+	//Generate AI law change
 	for(var/mob/living/silicon/ai/M in GLOB.alive_mob_list)
 		M.laws_sanity_check()
 		if(M.stat != DEAD && M.see_in_dark != 0)
@@ -53,10 +53,41 @@
 			log_game("Ion storm changed laws of [key_name(M)] to [english_list(M.laws.get_law_list(TRUE, TRUE))]")
 			M.post_lawchange()
 
+	//Generate Cyborg law change
+	for(var/mob/living/silicon/robot/M in GLOB.alive_mob_list)
+		M.laws_sanity_check()
+		if(M.stat != DEAD && M.see_in_dark != 0)
+			if(prob(replaceLawsetChance))
+				M.laws.pick_weighted_lawset()
+
+			if(prob(removeRandomLawChance))
+				M.remove_law(rand(1, M.laws.get_law_amount(list(LAW_INHERENT, LAW_SUPPLIED))))
+
+			var/message = ionMessage || generate_ion_law()
+			if(message)
+				if(prob(removeDontImproveChance))
+					M.replace_random_law(message, list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))
+				else
+					M.add_ion_law(message)
+
+			if(prob(shuffleLawsChance))
+				M.shuffle_laws(list(LAW_INHERENT, LAW_SUPPLIED, LAW_ION))
+
+			log_game("Ion storm changed laws of [key_name(M)] to [english_list(M.laws.get_law_list(TRUE, TRUE))]")
+			M.post_lawchange()
+
+
+	//Chance to emag a Bot
 	if(botEmagChance)
 		for(var/mob/living/simple_animal/bot/bot in GLOB.alive_mob_list)
 			if(prob(botEmagChance))
 				bot.emag_act()
+
+	//Chance to emag a Cyborg
+	if(botEmagChance)
+		for(var/mob/living/silicon/robot/robot in GLOB.alive_mob_list)
+			if(prob(botEmagChance))
+				robot.SetEmagged(1)
 
 /proc/generate_ion_law()
 	//Threats are generally bad things, silly or otherwise. Plural.

--- a/code/modules/events/ion_storm.dm
+++ b/code/modules/events/ion_storm.dm
@@ -8,10 +8,10 @@
 
 /datum/round_event/ion_storm
 	var/replaceLawsetChance = 25 //chance the AI's lawset is completely replaced with something else per config weights
-	var/removeRandomLawChance = 15 //chance the AI has one random supplied or inherent law removed
-	var/removeDontImproveChance = 15 //chance the randomly created law replaces a random law instead of simply being added
-	var/shuffleLawsChance = 15 //chance the AI's laws are shuffled afterwards
-	var/botEmagChance = 20
+	var/removeRandomLawChance = 10 //chance the AI has one random supplied or inherent law removed
+	var/removeDontImproveChance = 10 //chance the randomly created law replaces a random law instead of simply being added
+	var/shuffleLawsChance = 10 //chance the AI's laws are shuffled afterwards
+	var/botEmagChance = 10
 	var/announceEvent = ION_RANDOM // -1 means don't announce, 0 means have it randomly announce, 1 means it is announced
 	var/ionMessage = null
 	var/ionAnnounceChance = 33
@@ -82,12 +82,6 @@
 		for(var/mob/living/simple_animal/bot/bot in GLOB.alive_mob_list)
 			if(prob(botEmagChance))
 				bot.emag_act()
-
-	//Chance to emag a Cyborg
-	if(botEmagChance)
-		for(var/mob/living/silicon/robot/robot in GLOB.alive_mob_list)
-			if(prob(botEmagChance))
-				robot.SetEmagged(1)
 
 /proc/generate_ion_law()
 	//Threats are generally bad things, silly or otherwise. Plural.


### PR DESCRIPTION
:cl:
[Changelogs]: # Changes done to the Ion Storm event
add: Made Cyborgs be affected by Ion Storm Law Changes like AIs
/:cl:

[why]: # This makes Cyborgs be affected by Ion Storms and gives them Ion Laws.
Why this change? First of all, it was weird that AIs and small Bots get affected by Ion Storms, but Cyborgs didn't. Secondly, people were Metagaming that unsynced Borgs were safe. The emagging chance might be a bit high, compared to before, but a 20% chance for such a rare event isn't too much in my opinion.
