### PR TITLE
ISINRANGE_EX fix

### DIFF
--- a/code/__DEFINES/maths.dm
+++ b/code/__DEFINES/maths.dm
@@ -74,7 +74,7 @@
 #define ISINRANGE(val, min, max) (min <= val && val <= max)
 
 // Same as above, exclusive.
-#define ISINRANGE_EX(val, min, max) (min < val && val > max)
+#define ISINRANGE_EX(val, min, max) (min < val && val < max)
 
 #define ISINTEGER(x) (round(x) == x)
 


### PR DESCRIPTION
:cl:
code: Fixes ISINRANGE_EX using the wrong relational operator.
/:cl:
