### PR TITLE
Making player requirement for some gamemodes slightly lower so that they actually appear in the game.

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -130,10 +130,10 @@ Credit where due:
 	config_tag = "clockwork_cult"
 	antag_flag = ROLE_SERVANT_OF_RATVAR
 	false_report_weight = 10
-	required_players = 24
+	required_players = 20
 	required_enemies = 4
 	recommended_enemies = 4
-	enemy_minimum_age = 14
+	enemy_minimum_age = 7
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //Silicons can eventually be converted
 	restricted_jobs = list("Chaplain", "Captain")
 	announce_span = "brass"

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -131,7 +131,7 @@ Credit where due:
 	antag_flag = ROLE_SERVANT_OF_RATVAR
 	false_report_weight = 10
 	required_players = 20
-	required_enemies = 4
+	required_enemies = 2
 	recommended_enemies = 4
 	enemy_minimum_age = 7
 	protected_jobs = list("AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain") //Silicons can eventually be converted

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -38,7 +38,7 @@
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
 	required_players = 20
-	required_enemies = 4
+	required_enemies = 2
 	recommended_enemies = 4
 	enemy_minimum_age = 7
 

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -37,10 +37,10 @@
 	false_report_weight = 10
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
-	required_players = 24
-	required_enemies = 4
-	recommended_enemies = 4
-	enemy_minimum_age = 14
+	required_players = 20
+	required_enemies = 3
+	recommended_enemies = 3
+	enemy_minimum_age = 7
 
 	announce_span = "cult"
 	announce_text = "Some crew members are trying to start a cult to Nar'Sie!\n\

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -38,8 +38,8 @@
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
 	required_players = 20
-	required_enemies = 3
-	recommended_enemies = 3
+	required_enemies = 4
+	recommended_enemies = 4
 	enemy_minimum_age = 7
 
 	announce_span = "cult"

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -2,11 +2,11 @@
 	name = "nuclear emergency"
 	config_tag = "nuclear"
 	false_report_weight = 10
-	required_players = 30 // 30 players - 3 players to be the nuke ops = 27 players remaining
+	required_players = 28 // 30 players - 3 players to be the nuke ops = 25 players remaining
 	required_enemies = 2
-	recommended_enemies = 5
+	recommended_enemies = 4
 	antag_flag = ROLE_OPERATIVE
-	enemy_minimum_age = 14
+	enemy_minimum_age = 7
 
 	announce_span = "danger"
 	announce_text = "Syndicate forces are approaching the station in an attempt to destroy it!\n\

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -4,7 +4,7 @@
 	false_report_weight = 10
 	required_players = 28 // 30 players - 3 players to be the nuke ops = 25 players remaining
 	required_enemies = 2
-	recommended_enemies = 4
+	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE
 	enemy_minimum_age = 7
 

--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -10,7 +10,7 @@
 	required_players = 20
 	required_enemies = 1
 	recommended_enemies = 1
-	enemy_minimum_age = 14
+	enemy_minimum_age = 7
 	round_ends_with_antag_death = 1
 	announce_span = "danger"
 	announce_text = "There is a space wizard attacking the station!\n\


### PR DESCRIPTION
[Changelogs]:

:cl: Coolgat3
tweak: Changed player number checks to 20 from 24 for cult and clockcult, also made nukeops 28 required players instead of 30.
tweak: Changed enemy minimum age from 14 to 7
/:cl:

[why]: Those gamemodes never appear. I have no idea why revolution is 30 minimum players but it appears at 10 players by the way. There are many players who think 20 would be the optimal number for things like cult because we never get that 24 player count, unless it's american time. We usually get shit like 22 and 23 during european times, and it'd really be cool if we had those gamemodes appear more often and not just run traitor or ling all this time. Of course this is a blind shot. there will be people saying 4 less crewmembers to fight the cult is super op and cult wins 100% but eh. I disagree with that.
