### PR TITLE
Makes plasma men be able to wear SEVA suits without a their hat on

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -147,6 +147,7 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 10, "bomb" = 25, "bio" = 50, "rad" = 25, "fire" = 100, "acid" = 25)
 	resistance_flags = FIRE_PROOF | GOLIATH_WEAKNESS
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
 
 /obj/item/clothing/mask/gas/seva
 	name = "SEVA Mask"


### PR DESCRIPTION
[Changelogs]
Makes SEVA suit not make plasma men die well waring it.


[why]
Hat cant be worn without the suit, so no one can power game a free space hat. Plasma men are the 'Hardcore race' tho the ease to play and have many upsides rather then downsides. Lets make the SEVA suit not fuck over plasma men for buying it!
