### PR TITLE
Makes plasma men not rad nor hunger proof

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
+++ b/code/modules/mob/living/carbon/human/species_types/plasmamen.dm
@@ -5,7 +5,7 @@
 	sexes = 0
 	meat = /obj/item/stack/sheet/mineral/plasma
 	species_traits = list(NOBLOOD,NOTRANSSTING)
-	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_NOHUNGER)
+	inherent_traits = list(TRAIT_RESISTCOLD)
 	inherent_biotypes = list(MOB_INORGANIC, MOB_HUMANOID)
 	mutantlungs = /obj/item/organ/lungs/plasmaman
 	mutanttongue = /obj/item/organ/tongue/bone/plasmaman


### PR DESCRIPTION
[Changelogs]
Plasmamen suits are 95% rad proof anyways, why would they not eat?
Anithugboxing


[why]
Hugboxing at its finest here...
Lilly-Trilby-Cat-Fail-CoderToday at 12:00 AM
If I remove the no hunger and the rad proofing form plasma men. Your not going to yell at me correct?
Just to make this clear
PoojawaToday at 12:02 AM
that's fine.
@Bhijn (deathride58) Can I remove plasma men rad proofing and no hunger loss without being yelled at?
Bhijn (deathride58)Today at 12:05 AM
yeah