### PR TITLE
QOL for pickpocketing - Stripping items off of someone will now place them in your hands if possible

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -264,6 +264,8 @@
 				if(pocket_item)
 					if(pocket_item == (pocket_id == SLOT_R_STORE ? r_store : l_store)) //item still in the pocket we search
 						dropItemToGround(pocket_item)
+						if(!put_in_hands(pocket_item))
+							pocket_item.forceMove(drop_location())
 				else
 					if(place_item)
 						if(place_item.mob_can_equip(src, usr, pocket_id, FALSE, TRUE))

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -700,9 +700,13 @@
 				var/list/L = where
 				if(what == who.get_item_for_held_index(L[2]))
 					if(who.dropItemToGround(what))
+						if(!put_in_hands(what))
+							what.forceMove(drop_location())
 						log_combat(src, who, "stripped [what] off")
 			if(what == who.get_item_by_slot(where))
 				if(who.dropItemToGround(what))
+					if(!put_in_hands(what))
+						what.forceMove(drop_location())
 					log_combat(src, who, "stripped [what] off")
 
 // The src mob is trying to place an item on someone


### PR DESCRIPTION
Title. It doesn't really make much sense for pickpocketing to place the item on the ground instead of in your hands since people IRL don't immediately drop things on the ground when they take them off of someone.

:cl: deathride58
tweak: Pickpocketing items will now place them in your hands if possible
/:cl:
