### PR TITLE
Gives combat mode examine text along with a visible message on activation

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -88,6 +88,9 @@
 
 		if(digitalcamo)
 			msg += "[t_He] [t_is] moving [t_his] body in an unnatural and blatantly unsimian manner.\n"
+	
+	if(combatmode)
+		msg += "[t_He] [t_is] visibly tense[resting ? "." : ", and [t_is] standing in combative stance."]\n"
 
 	GET_COMPONENT_FROM(mood, /datum/component/mood, src)
 	if(mood)

--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -3,6 +3,7 @@
 	var/lastmousedir
 	var/wrongdirmovedelay
 	var/lastdirchange
+	var/combatmessagecooldown
 
 /mob/living/carbon/CanPass(atom/movable/mover, turf/target)
 	. = ..()
@@ -27,6 +28,9 @@
 	if(hud_used && hud_used.static_inventory)
 		for(var/obj/screen/combattoggle/selector in hud_used.static_inventory)
 			selector.rebasetointerbay(src)
+	if(world.time >= combatmessagecooldown && combatmode)
+		visible_message("<span class='warning'>[src] [resting ? "tenses up" : "drops into a combative stance"].</span>")
+	combatmessagecooldown = 10 SECONDS + world.time //This is set 100% of the time to make sure squeezing regen out of process cycles doesn't result in the combat mode message getting spammed
 	SEND_SIGNAL(src, COMSIG_COMBAT_TOGGLED, src, combatmode)
 	return TRUE
 


### PR DESCRIPTION
Title. If you haven't touched your combat mode button at all within ten seconds, this PR will make it so that enabling combat mode will make a visible message to everyone around you. This PR also makes it possible to see if someone's in combat mode by simply examining them.

:cl: deathride58
add: Combat mode is now displayed in examine text
add: Combat mode now makes a visible message when enabled if you haven't touched your combat mode button in the last ten seconds. It's done this way to avoid chat spam from those who know how to pull off stam regen squeezing.
/:cl:
