### PR TITLE
Knockdowns will now force people to be dismounted from ridden vehicles

### DIFF
--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -1,10 +1,10 @@
 /datum/status_effect/incapacitating/knockdown/on_creation(mob/living/new_owner, set_duration, updating_canmove, override_duration, override_stam)
 	if(iscarbon(new_owner) && (isnum(set_duration) || isnum(override_duration)))
-		new_owner.resting = TRUE
-		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
 		if(istype(new_owner.buckled, /obj/vehicle/ridden))
 			var/obj/buckl = new_owner.buckled
 			buckl.unbuckle_mob(new_owner)
+		new_owner.resting = TRUE
+		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
 		if(isnull(override_duration) && (set_duration > 80))
 			set_duration = set_duration*0.01
 			return ..()

--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -2,6 +2,9 @@
 	if(iscarbon(new_owner) && (isnum(set_duration) || isnum(override_duration)))
 		new_owner.resting = TRUE
 		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
+		if(istype(new_owner.buckled, /obj/vehicle/ridden))
+			var/obj/buckl = new_owner.buckled
+			buckl.unbuckle_mob(new_owner)
 		if(isnull(override_duration) && (set_duration > 80))
 			set_duration = set_duration*0.01
 			return ..()


### PR DESCRIPTION
Title. This affects secways, skateboards, scooters, ATVs, and other vehicles. It's actually pretty annoying that tasers do literally nothing against those on scooters or secways outside of dealing staminaloss, so this PR fixes that.

:cl: deathride58
balance: All knockdown sources will now force people to be dismounted from ridden vehicles.
/:cl:
