### PR TITLE
Fancier throws, bullet casings, and more

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -536,12 +536,16 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	callback = CALLBACK(src, .proc/after_throw, callback) //replace their callback with our own
 	. = ..(target, range, speed, thrower, spin, diagonals_first, callback)
 
-
 /obj/item/proc/after_throw(datum/callback/callback)
 	if (callback) //call the original callback
 		. = callback.Invoke()
 	throw_speed = initial(throw_speed) //explosions change this.
 	item_flags &= ~IN_INVENTORY
+	var/matrix/M = matrix(transform)
+	M.Turn(rand(-170, 170))
+	transform = M
+	pixel_x = rand(-12, 12)
+	pixel_y = rand(-12, 12)
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)

--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -266,6 +266,9 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 		if("large")
 			pixel_x = rand(-5, 5)
 			pixel_y = rand(-5, 5)
+	var/matrix/M = matrix(transform)
+	M.Turn(rand(-170, 170))
+	transform = M
 
 /obj/item/shard/afterattack(atom/A as mob|obj, mob/user, proximity)
 	. = ..()

--- a/code/modules/food_and_drinks/drinks/drinks.dm
+++ b/code/modules/food_and_drinks/drinks/drinks.dm
@@ -120,6 +120,12 @@
 	I.SwapColor(rgb(255, 0, 220, 255), rgb(0, 0, 0, 0))
 	B.icon = I
 	B.name = "broken [name]"
+	if(ranged)
+		var/matrix/M = matrix(B.transform)
+		M.Turn(rand(-170, 170))
+		B.transform = M
+		B.pixel_x = rand(-12, 12)
+		B.pixel_y = rand(-12, 12)
 	if(prob(33))
 		new/obj/item/shard(drop_location())
 	playsound(src, "shatter", 70, 1)
@@ -296,6 +302,12 @@
 	B.force = 0
 	B.throwforce = 0
 	B.desc = "A carton with the bottom half burst open. Might give you a papercut."
+	if(ranged)
+		var/matrix/M = matrix(B.transform)
+		M.Turn(rand(-170, 170))
+		B.transform = M
+		B.pixel_x = rand(-12, 12)
+		B.pixel_y = rand(-12, 12)
 	transfer_fingerprints_to(B)
 	qdel(src)
 

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -23,6 +23,12 @@
 	var/obj/item/broken_bottle/B = new (loc)
 	if(!ranged)
 		thrower.put_in_hands(B)
+	else
+		var/matrix/M = matrix(B.transform)
+		M.Turn(rand(-170, 170))
+		B.transform = M
+		B.pixel_x = rand(-12, 12)
+		B.pixel_y = rand(-12, 12)
 	B.icon_state = icon_state
 
 	var/icon/I = new('icons/obj/drinks.dmi', src.icon_state)

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -188,6 +188,7 @@
 		update_inv_hands()
 		I.pixel_x = initial(I.pixel_x)
 		I.pixel_y = initial(I.pixel_y)
+		I.transform = initial(I.transform)
 		return hand_index || TRUE
 	return FALSE
 

--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -73,6 +73,11 @@
 /obj/item/ammo_casing/proc/bounce_away(still_warm = FALSE, bounce_delay = 3)
 	update_icon()
 	SpinAnimation(10, 1)
+	var/matrix/M = matrix(transform)
+	M.Turn(rand(-170,170))
+	transform = M
+	pixel_x = rand(-12, 12)
+	pixel_y = rand(-12, 12)
 	var/turf/T = get_turf(src)
 	if(still_warm && T && T.bullet_sizzle)
 		addtimer(CALLBACK(GLOBAL_PROC, .proc/playsound, src, 'sound/items/welder.ogg', 20, 1), bounce_delay) //If the turf is made of water and the shell casing is still hot, make a sizzling sound when it's ejected.

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -103,6 +103,7 @@
 
 	else if(bartender_check(target) && thrown)
 		visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
+		transform = initial(transform)
 		return
 
 	else


### PR DESCRIPTION
This PR can be described in these two images alone
![image](https://user-images.githubusercontent.com/6356337/52616844-e7625080-2e67-11e9-9096-17dbb3479088.png)

![image](https://user-images.githubusercontent.com/6356337/52616831-df0a1580-2e67-11e9-802f-2a96c4bf131f.png)

Need I say more?

:cl: deathride58
add: When an item is thrown, it will now be rotated and displaced.
add: Shards of glass will now be rotated when spawned.
add: Bullet casings will now be rotated when they're ejected from a gun.
add: Bottles now have random rotations and pixel offsets when smashed via throwing.
add: Picking up an item will now reset its rotation.
add: Glasses thrown onto tables by bartenders will now have their rotation reset.
/:cl:
