### PR TITLE
More clown uplink only items

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1359,17 +1359,9 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Clumsy Clown DNA"
 	desc = "A DNA injector that has been loaded with the clown gene that makes people clumsy.. \
 	Making someone clumsy will allow them to use clown firing pins as well as Reverse Revolvers. For a laugh try using this on the HOS to see how many times they shoot themselves in the foot!"
-	cost = 3
+	cost = 1
 	item = /obj/item/dnainjector/clumsymut
 	restricted_roles = list("Clown")
-
-/datum/uplink_item/role_restricted/anitclumsyDNA
-	name = "Clown punishment"
-	desc = "HONK! Looks like one of our agents got got! \
-	We got a barrel of laughs for you, HONK, we got a Mime DNA injector HONK! Use this on a clown HONK to make them not clumsy HONK!"
-	cost = 1 //If Hos or warden gets an uplink they should be able to get it for almost free
-	item = /obj/item/dnainjector/clumsymut
-	restricted_roles = list("Warden", "Head of Security")
 
 /datum/uplink_item/role_restricted/mimery
 	name = "Guide to Advanced Mimery Series"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1357,15 +1357,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/role_restricted/clumsyDNA
 	name = "Clumsy Clown DNA"
-	desc = "A DNA injector that has been loaded with the clown gene that makes people clumsy. \
-	Making someone clumsy will allow them to use clown firing pins as well as Reverse Revolvers. For a laugh try useing this on HOS to see how many times they shoot themselfs in the foot!"
+	desc = "A DNA injector that has been loaded with the clown gene that makes people clumsy.. \
+	Making someone clumsy will allow them to use clown firing pins as well as Reverse Revolvers. For a laugh try using this on the HOS to see how many times they shoot themselves in the foot!"
 	cost = 3
 	item = /obj/item/dnainjector/clumsymut
 	restricted_roles = list("Clown")
 
 /datum/uplink_item/role_restricted/anitclumsyDNA
 	name = "Clown punishment"
-	desc = "HONK Looks like one of are angents got, got! \
+	desc = "HONK! Looks like one of our agents got got! \
 	We got a barrle of laughs for you, HONK, we got a Mime DNA injector HONK! Use this on a clown HONK to make them not clusmy HONK!"
 	cost = 1 //If Hos or warden gets a uplink they should be able to get it for allmost free
 	item = /obj/item/dnainjector/clumsymut

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1366,8 +1366,8 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 /datum/uplink_item/role_restricted/anitclumsyDNA
 	name = "Clown punishment"
 	desc = "HONK! Looks like one of our agents got got! \
-	We got a barrle of laughs for you, HONK, we got a Mime DNA injector HONK! Use this on a clown HONK to make them not clusmy HONK!"
-	cost = 1 //If Hos or warden gets a uplink they should be able to get it for allmost free
+	We got a barrel of laughs for you, HONK, we got a Mime DNA injector HONK! Use this on a clown HONK to make them not clumsy HONK!"
+	cost = 1 //If Hos or warden gets an uplink they should be able to get it for almost free
 	item = /obj/item/dnainjector/clumsymut
 	restricted_roles = list("Warden", "Head of Security")
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1355,13 +1355,28 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/reverse_bear_trap
 	restricted_roles = list("Clown")
 
+/datum/uplink_item/role_restricted/clumsyDNA
+	name = "Clumsy Clown DNA"
+	desc = "A DNA inject that has been loaded with the clown gene that makes people clumsy. \
+	Making someone clumsy will allow them to use clown firing pins as well as Reverse Revolvers. For a laugh try useing this on HOS to see how many times they shoot themselfs in the foot!"
+	cost = 3
+	item = /obj/item/dnainjector/clumsymut
+	restricted_roles = list("Clown")
+
+/datum/uplink_item/role_restricted/anitclumsyDNA
+	name = "Clown punishment"
+	desc = "HONK Looks like one of are angents got, got! \
+	We got a barrle of laughs for you, HONK, we got a Mime DNA injector HONK! Use this on a clown HONK to make them not clusmy HONK!"
+	cost = 1 //If Hos or warden gets a uplink they should be able to get it for allmost free
+	item = /obj/item/dnainjector/clumsymut
+	restricted_roles = list("Warden", "Head of Security")
+
 /datum/uplink_item/role_restricted/mimery
 	name = "Guide to Advanced Mimery Series"
 	desc = "The classical two part series on how to further hone your mime skills. Upon studying the series, the user should be able to make 3x1 invisible walls, and shoot bullets out of their fingers. Obviously only works for Mimes."
 	cost = 12
 	item = /obj/item/storage/box/syndie_kit/mimery
 	restricted_roles = list("Mime")
-	surplus = 0
 
 /datum/uplink_item/role_restricted/ez_clean_bundle
 	name = "EZ Clean Grenade Bundle"
@@ -1383,7 +1398,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Kitchen Gun (TM) .45 Magazine"
 	desc = "An extra eight bullets for an extra eight uses of Kitchen Gun (TM)!"
 	cost = 1
-	surplus = 0
 	restricted_roles = list("Cook", "Janitor")
 	item = /obj/item/ammo_box/magazine/m45/kitchengun
 
@@ -1392,7 +1406,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A potato rigged with explosives. On activation, a special mechanism is activated that prevents it from being dropped. The only way to get rid of it if you are holding it is to attack someone else with it, causing it to latch to that person instead."
 	item = /obj/item/hot_potato/syndicate
 	cost = 4
-	surplus = 0
 	restricted_roles = list("Cook", "Botanist", "Clown", "Mime")
 
 /datum/uplink_item/role_restricted/his_grace
@@ -1412,7 +1425,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 10
 	item = /obj/item/pneumatic_cannon/pie/selfcharge
 	restricted_roles = list("Clown")
-	surplus = 0 //No fun unless you're the clown!
 
 /datum/uplink_item/role_restricted/ancient_jumpsuit
 	name = "Ancient Jumpsuit"
@@ -1420,7 +1432,6 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/clothing/under/color/grey/glorf
 	cost = 20
 	restricted_roles = list("Assistant")
-	surplus = 0
 
 /datum/uplink_item/role_restricted/brainwash_disk
 	name = "Brainwashing Surgery Program"
@@ -1474,7 +1485,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			blast wave \"projectile\". Aspiring scientists may find this highly useful, as forcing the pressure shockwave into a narrow angle seems to be able to bypass whatever quirk of physics \
 			disallows explosive ranges above a certain distance, allowing for the device to use the theoretical yield of a transfer valve bomb, instead of the factual yield."
 	item = /obj/item/gun/blastcannon
-	cost = 14							//High cost because of the potential for extreme damage in the hands of a skilled scientist.
+	cost = 14							//High cost because of the potential for extreme damage in the hands of a skilled gas masked scientist.
 	restricted_roles = list("Research Director", "Scientist")
 
 /datum/uplink_item/device_tools/clown_bomb
@@ -1487,6 +1498,15 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	item = /obj/item/sbeacondrop/clownbomb
 	cost = 15
 	restricted_roles = list("Clown")
+
+/datum/uplink_item/device_tools/honkpins //Idealy so they can place it into their own guns without needing cargo 
+	name = "Hilarious firing pin"
+	desc = "A single firing pin made for Clown agents, this firing pin makes any gun honk when fired if not a true clown! \
+	This firing pin also helps you fire the gun correctly. May the HonkMother HONK you agent."
+	item = /obj/item/firing_pin/clown
+	cost = 1
+	restricted_roles = list("Clown")
+
 /*
 /datum/uplink_item/role_restricted/clowncar
 	name = "Clown Car"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1357,7 +1357,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 
 /datum/uplink_item/role_restricted/clumsyDNA
 	name = "Clumsy Clown DNA"
-	desc = "A DNA inject that has been loaded with the clown gene that makes people clumsy. \
+	desc = "A DNA injector that has been loaded with the clown gene that makes people clumsy. \
 	Making someone clumsy will allow them to use clown firing pins as well as Reverse Revolvers. For a laugh try useing this on HOS to see how many times they shoot themselfs in the foot!"
 	cost = 3
 	item = /obj/item/dnainjector/clumsymut


### PR DESCRIPTION
[Changelogs]
Dear god why
Clown HONK can now get a DNA injector that has the Clumsy gene
Honk, Clown angets can now get HONK PINS
All Surpluse = 0 in role restricted removed - Code improvement  
[why]
Clown pins are for clowns to use other traitor guns or lock out others form their own guns
Clown DNA are for clowns to work with a team if they are one, having their DNA injectors and such
All role items get 0 surpluse do to it being a child of the role restriction so no need to add in 6 more lines of code that dose nothing