### PR TITLE
nerfs estim circuits by limiting the amount of staminaloss orgasms can do

### DIFF
--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -177,6 +177,12 @@
 		to_chat(M, "<span class='warning'>Arousal is disabled. Feature is unavailable.</span>")
 
 
+/mob/living/proc/climaxstaminaloss(targetstam)
+	var/curstam = getStaminaLoss()
+	if(curstam < targetstam)
+		adjustStaminaLoss(targetstam - curstam)
+	else
+		to_chat(src, "<span class='warning'>You're too exhausted to keep fucking!</span>")
 
 /mob/living/proc/mob_climax()//This is just so I can test this shit without being forced to add actual content to get rid of arousal. Will be a very basic proc for a while.
 	set name = "Masturbate"
@@ -193,7 +199,7 @@
 								"<span class='userdanger'>You have relieved yourself.</span>")
 					SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 					setArousalLoss(min_arousal)
-					adjustStaminaLoss(40) //Refractory periods 
+					climaxstaminaloss(40) //Refractory periods 
 					/*
 					switch(gender)
 						if(MALE)
@@ -234,7 +240,7 @@
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 		if(G.can_climax)
 			setArousalLoss(min_arousal)
-			adjustStaminaLoss(40) //Refractory periods 
+			climaxstaminaloss(40) //Refractory periods 
 
 
 /mob/living/carbon/human/proc/mob_climax_outside(obj/item/organ/genital/G, mb_time = 30) //This is used for forced orgasms and other hands-free climaxes
@@ -272,7 +278,7 @@
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
 				setArousalLoss(min_arousal)
-				adjustStaminaLoss(40) //Refractory periods 
+				climaxstaminaloss(40) //Refractory periods 
 
 
 /mob/living/carbon/human/proc/mob_climax_partner(obj/item/organ/genital/G, mob/living/L, spillage = TRUE, mb_time = 30) //Used for climaxing with any living thing
@@ -305,7 +311,7 @@
 			SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
 				setArousalLoss(min_arousal)
-				adjustStaminaLoss(40) //Refractory periods 
+				climaxstaminaloss(40) //Refractory periods 
 	else //knots and other non-spilling orgasms
 		if(do_after(src, mb_time, target = src) && in_range(src, L))
 			fluid_source.trans_to(L, total_fluids)
@@ -317,7 +323,7 @@
 			SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
 				setArousalLoss(min_arousal)
-				adjustStaminaLoss(40) //Refractory periods 
+				climaxstaminaloss(40) //Refractory periods 
 
 
 /mob/living/carbon/human/proc/mob_fill_container(obj/item/organ/genital/G, obj/item/reagent_containers/container, mb_time = 30) //For beaker-filling, beware the bartender
@@ -348,7 +354,7 @@
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 		if(G.can_climax)
 			setArousalLoss(min_arousal)
-			adjustStaminaLoss(40) //Refractory periods 
+			climaxstaminaloss(40) //Refractory periods 
 
 /mob/living/carbon/human/proc/pick_masturbate_genitals()
 	var/obj/item/organ/genital/ret_organ


### PR DESCRIPTION
Title. This makes it so that orgasms still make you exhausted, but they can't actually stamcrit you

:cl: deathride58
balance: Staminaloss from orgasms is now capped at 40 total staminaloss. You can no longer be forced into stamcrit by estim circuits.
/:cl:
