### PR TITLE
Nerfs the effects of slime speed potions on vehicles by limiting the speed gain to sprinting speed

### DIFF
--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -849,10 +849,10 @@
 		var/obj/vehicle/V = C
 		var/datum/component/riding/R = V.GetComponent(/datum/component/riding)
 		if(R)
-			if(R.vehicle_move_delay <= 0 )
+			if(R.vehicle_move_delay <= 1 )
 				to_chat(user, "<span class='warning'>The [C] can't be made any faster!</span>")
 				return ..()
-			R.vehicle_move_delay = 0
+			R.vehicle_move_delay = 1
 
 	to_chat(user, "<span class='notice'>You slather the red gunk over the [C], making it faster.</span>")
 	C.remove_atom_colour(WASHABLE_COLOUR_PRIORITY)


### PR DESCRIPTION
Title. #7996 was my first attempt to make the fun shit balanced by adding actual bloody counterplay to people using vehicles. But then I actually played a round as a scientist and realized just how completely broken speed potion'd scooters actually are ingame even after that nerf. This nerfs slime speed potions by bringing speed potion'd vehicles on par with the sprinting speed, meaning they still have very obvious utility in that they make it possible to traverse the station at sprinting speeds without using stamina, but are no longer capable of making you outrun borg pounces, ballistics, and other fast things.

:cl: deathride58
balance: Slime speed potions can now only increase the speed of vehicles to be on par with sprinting speed. They can no longer make a scooter roll around ten times faster than a speeding blue hedgehog.
/:cl:
