### PR TITLE
Nerfs lings by making hivemind require one DNA point to obtain

### DIFF
--- a/code/modules/antagonists/changeling/powers/hivemind.dm
+++ b/code/modules/antagonists/changeling/powers/hivemind.dm
@@ -3,7 +3,7 @@
 	name = "Hivemind Communication"
 	desc = "We tune our senses to the airwaves to allow us to discreetly communicate and exchange DNA with other changelings."
 	helptext = "We will be able to talk with other changelings with :g. Exchanged DNA do not count towards absorb objectives."
-	dna_cost = 0
+	dna_cost = 1
 	chemical_cost = -1
 
 /obj/effect/proc_holder/changeling/hivemind_comms/on_purchase(mob/user, is_respec)
@@ -17,6 +17,9 @@
 	var/obj/effect/proc_holder/changeling/hivemind_download/S2 = new
 	if(!changeling.has_sting(S2))
 		changeling.purchasedpowers+=S2
+	var/obj/effect/proc_holder/changeling/linglink/S3 = new
+	if(!changeling.has_sting(S3))
+		changeling.purchasedpowers+=S3
 
 // HIVE MIND UPLOAD/DOWNLOAD DNA
 GLOBAL_LIST_EMPTY(hivemind_bank)

--- a/code/modules/antagonists/changeling/powers/linglink.dm
+++ b/code/modules/antagonists/changeling/powers/linglink.dm
@@ -2,7 +2,7 @@
 	name = "Hivemind Link"
 	desc = "Link your victim's mind into the hivemind for personal interrogation."
 	chemical_cost = 0
-	dna_cost = 0
+	dna_cost = -1
 	req_human = 1
 
 /obj/effect/proc_holder/changeling/linglink/can_sting(mob/living/carbon/user)


### PR DESCRIPTION
Title. Changelings are balanced as a solo antag, and with team objectives being removed, this makes ling's innate hivemind pretty pointless

:cl: 
balance: Changelings no longer start off with hivemind communication as an innate ability. Hivemind communication now requires 1 dna point, on par with syndicate encryption keys, which are 2 TC.
code: Hivemind link now relies on hivemind communication just like the hivemind download/upload abilities.
/:cl:
