### PR TITLE
Fixes it being plausible to zoom guns that are in your pockets, on your back, in your suit slot, or anywhere else that isn't your hands

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -477,8 +477,12 @@
 
 /datum/action/toggle_scope_zoom/IsAvailable()
 	. = ..()
-	if(!. && gun)
+	if(!gun)
+		return FALSE
+	if(!.)
 		gun.zoom(owner, FALSE)
+	if(!owner.get_held_index_of_item(gun))
+		return FALSE
 
 /datum/action/toggle_scope_zoom/Remove(mob/living/L)
 	gun.zoom(L, FALSE)


### PR DESCRIPTION
Title

:cl: deathride58
fix: It's now only possible to zoom a gun if it's in one of your hands
/:cl:
