### PR TITLE
Atomizes the med rework's blood effect changes (most things that make a blood effect will now make you actually lose blood) and makes the blood reagent act more like you'd expect

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -125,7 +125,11 @@
 			if(prob(33))
 				I.add_mob_blood(src)
 				var/turf/location = get_turf(src)
-				bleed(totitemdamage)
+				if(iscarbon(src))
+					var/mob/living/carbon/C = src
+					C.bleed(totitemdamage)
+				else
+					add_splatter_floor(location)
 				if(totitemdamage >= 10 && get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(src)
 		return TRUE //successful attack

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -125,8 +125,8 @@
 			if(prob(33))
 				I.add_mob_blood(src)
 				var/turf/location = get_turf(src)
-				add_splatter_floor(location)
-				if(get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
+				bleed(totitemdamage)
+				if(totitemdamage >= 10 && get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(src)
 		return TRUE //successful attack
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -327,7 +327,11 @@
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
 		var/turf/location = get_turf(src)
 		//add_blood doesn't work for borgs/xenos, but add_blood_floor does.
-		L.bleed(DOOR_CRUSH_DAMAGE)
+		if(iscarbon(L))
+			var/mob/living/carbon/C = L
+			C.bleed(DOOR_CRUSH_DAMAGE)
+		else
+			L.add_splatter_floor(location)
 	for(var/obj/mecha/M in get_turf(src))
 		M.take_damage(DOOR_CRUSH_DAMAGE)
 

--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -327,7 +327,7 @@
 			L.adjustBruteLoss(DOOR_CRUSH_DAMAGE)
 		var/turf/location = get_turf(src)
 		//add_blood doesn't work for borgs/xenos, but add_blood_floor does.
-		L.add_splatter_floor(location)
+		L.bleed(DOOR_CRUSH_DAMAGE)
 	for(var/obj/mecha/M in get_turf(src))
 		M.take_damage(DOOR_CRUSH_DAMAGE)
 

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -75,7 +75,7 @@
 			L.visible_message("<span class='danger'>[user] slams [L] onto the meat spike!</span>", "<span class='userdanger'>[user] slams you onto the meat spike!</span>", "<span class='italics'>You hear a squishy wet noise.</span>")
 			L.forceMove(drop_location())
 			L.emote("scream")
-			L.add_splatter_floor()
+			L.bleed(30)
 			L.adjustBruteLoss(30)
 			L.setDir(2)
 			buckle_mob(L, force=1)

--- a/code/game/objects/structures/kitchen_spike.dm
+++ b/code/game/objects/structures/kitchen_spike.dm
@@ -75,7 +75,11 @@
 			L.visible_message("<span class='danger'>[user] slams [L] onto the meat spike!</span>", "<span class='userdanger'>[user] slams you onto the meat spike!</span>", "<span class='italics'>You hear a squishy wet noise.</span>")
 			L.forceMove(drop_location())
 			L.emote("scream")
-			L.bleed(30)
+			if(iscarbon(L))
+				var/mob/living/carbon/C = L
+				C.bleed(30)
+			else
+				L.add_splatter_floor()
 			L.adjustBruteLoss(30)
 			L.setDir(2)
 			buckle_mob(L, force=1)

--- a/code/modules/detectivework/detective_work.dm
+++ b/code/modules/detectivework/detective_work.dm
@@ -93,6 +93,15 @@
 	else if(length(blood_dna))
 		AddComponent(/datum/component/forensics, null, null, blood_dna)
 		bloody_hands = rand(2, 4)
+	if(head)
+		head.add_blood_DNA(blood_dna)
+		update_inv_head()
+	else if(wear_mask)
+		wear_mask.add_blood_DNA(blood_dna)
+		update_inv_wear_mask()
+	if(wear_neck)
+		wear_neck.add_blood_DNA(blood_dna)
+		update_inv_neck()
 	update_inv_gloves()	//handles bloody hands overlays and updating
 	return TRUE
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -87,21 +87,22 @@
 	//CIT CHANGES END HERE
 		apply_damage(totitemdamage, I.damtype, affecting) //CIT CHANGE - replaces I.force with totitemdamage
 		if(I.damtype == BRUTE && affecting.status == BODYPART_ORGANIC)
-			if(prob(33))
+			var/basebloodychance = affecting.brute_dam + totitemdamage
+			if(prob(basebloodychance))
 				I.add_mob_blood(src)
 				var/turf/location = get_turf(src)
-				add_splatter_floor(location)
-				if(get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
+				bleed(totitemdamage)
+				if(totitemdamage >= 10 && get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(src)
 
 				if(affecting.body_zone == BODY_ZONE_HEAD)
-					if(wear_mask)
+					if(wear_mask && prob(basebloodychance))
 						wear_mask.add_mob_blood(src)
 						update_inv_wear_mask()
-					if(wear_neck)
+					if(wear_neck && prob(basebloodychance))
 						wear_neck.add_mob_blood(src)
 						update_inv_neck()
-					if(head)
+					if(head && prob(basebloodychance))
 						head.add_mob_blood(src)
 						update_inv_head()
 

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -90,7 +90,6 @@
 			var/basebloodychance = affecting.brute_dam + totitemdamage
 			if(prob(basebloodychance))
 				I.add_mob_blood(src)
-				var/turf/location = get_turf(src)
 				bleed(totitemdamage)
 				if(totitemdamage >= 10 && get_dist(user, src) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(src)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1552,7 +1552,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				bloody = 1
 				var/turf/location = H.loc
 				if(istype(location))
-					H.add_splatter_floor(location)
+					H.bleed(totitemdamage)
 				if(get_dist(user, H) <= 1)	//people with TK won't get smeared with blood
 					user.add_mob_blood(H)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -164,7 +164,11 @@
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			else
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_loca, splatter_dir)
-			L.bleed(damage)
+			if(iscarbon(L))
+				var/mob/living/carbon/C = L
+				C.bleed(damage)
+			else
+				L.add_splatter_floor(target_loca)
 		else if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -164,8 +164,7 @@
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter/xenosplatter(target_loca, splatter_dir)
 			else
 				new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_loca, splatter_dir)
-			if(prob(33))
-				L.add_splatter_floor(target_loca)
+			L.bleed(damage)
 		else if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -32,6 +32,12 @@
 			else
 				C.blood_volume = min(C.blood_volume + round(reac_volume, 0.1), BLOOD_VOLUME_MAXIMUM)
 
+	if(reac_volume >= 10 && istype(L))
+		L.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
+
+/datum/reagent/blood/reaction_obj(obj/O, volume)
+	if(volume >= 3 && istype(O))
+		O.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
 
 /datum/reagent/blood/on_new(list/data)
 	if(istype(data))

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -26,9 +26,7 @@
 		burn()
 		return 1
 	add_mob_blood(C)
-	var/turf/location = C.loc
-	if(istype(location))
-		C.add_splatter_floor(location)
+	C.bleed(40)
 	var/direction = pick(GLOB.cardinals)
 	var/t_range = rand(2,max(throw_range/2, 2))
 	var/turf/target_turf = get_turf(src)
@@ -54,7 +52,7 @@
 	. = list()
 	var/organ_spilled = 0
 	var/turf/T = get_turf(C)
-	C.add_splatter_floor(T)
+	C.bleed(50)
 	playsound(get_turf(C), 'sound/misc/splort.ogg', 80, 1)
 	for(var/X in C.internal_organs)
 		var/obj/item/organ/O = X


### PR DESCRIPTION
Title. Bloodloss is actually insanely rare in the pre-medrework code. Even if you're turned into pulp and flood a room with your blood, you will *never* actually lose enough blood for bloodloss to be an actual threat. This PR should hopefully somewhat alleviate that by taking the currently cosmetic blood effects and making spacemen actually lose blood when their blood gets spilled.

This PR also makes violence a little more bloody, as the blood reagent will now actually cover items and spacemen in blood, and the blood that covers you when you attack someone will now cover more than just your item, your gloves, and your suit.

:cl: deathride58
tweak: The blood splatter effect that happens when you get attacked will now always make you lose blood depending on the damage you've taken. The effect now also scales with item damage, meaning tiny little papercuts will no longer be able to cause a massive blood splatter.
add: The blood reagent will now cover items and spacemen in blood when applied to objects and mobs.
tweak: Helmets, masks, and neck items are all now valid targets to get splattered when you get covered in blood. Groovy.
/:cl:
