### PR TITLE
makes teleporter hubs lose their density when ready to teleport (makes it plausible for projectiles to go through teleporters)

### DIFF
--- a/code/game/machinery/teleporter.dm
+++ b/code/game/machinery/teleporter.dm
@@ -81,10 +81,12 @@
 	return
 
 /obj/machinery/teleport/hub/update_icon()
+	density = TRUE
 	if(panel_open)
 		icon_state = "tele-o"
 	else if(is_ready())
 		icon_state = "tele1"
+		density = FALSE
 	else
 		icon_state = "tele0"
 


### PR DESCRIPTION
Title

:cl: deathride58
tweak: Teleporter hubs are no longer dense when on, allowing projectiles to go through teleporters
/:cl:
