### PR TITLE
Enables AI Multicam in Config and Adds an Admin Verb

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -62,6 +62,8 @@
 
 /datum/config_entry/flag/allow_ai	// allow ai job
 
+/datum/config_entry/flag/allow_ai_multicam //whether the AI can use their multicam
+
 /datum/config_entry/flag/disable_human_mood
 
 /datum/config_entry/flag/disable_secborg	// disallow secborg module to be chosen.

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -613,6 +613,10 @@
 	CONFIG_SET(flag/allow_ai_multicam, !almcam)
 	if (almcam)
 		to_chat(world, "<B>The AI no longer has multicam.</B>")
+		for(var/i in GLOB.ai_list)
+			var/mob/living/silicon/ai/aiPlayer = i
+			if(aiPlayer.multicam_on)
+				aiPlayer.end_multicam()
 	else
 		to_chat(world, "<B>The AI now has multicam.</B>")
 	log_admin("[key_name(usr)] toggled AI multicam.")

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -605,6 +605,20 @@
 	world.update_status()
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle AI", "[!alai ? "Disabled" : "Enabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/toggleMulticam()
+	set category = "Server"
+	set desc="Turns mutlicam on and off."
+	set name="Toggle Multicam"
+	var/almcam = CONFIG_GET(flag/allow_ai_multicam)
+	CONFIG_SET(flag/allow_ai_multicam, !almcam)
+	if (almcam)
+		to_chat(world, "<B>The AI no longer has multicam.</B>")
+	else
+		to_chat(world, "<B>The AI now has multicam.</B>")
+	log_admin("[key_name(usr)] toggled AI multicam.")
+	world.update_status()
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Multicam", "[!almcam ? "Disabled" : "Enabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/admins/proc/toggleaban()
 	set category = "Server"
 	set desc="Respawn basically"

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -118,6 +118,7 @@ GLOBAL_LIST_INIT(admin_verbs_server, world.AVerbsServer())
 	/datum/admins/proc/toggleaban,
 	/client/proc/everyone_random,
 	/datum/admins/proc/toggleAI,
+	/datum/admins/proc/toggleMulticam,
 	/client/proc/cmd_admin_delete,		/*delete an instance/object/mob/etc*/
 	/client/proc/cmd_debug_del_all,
 	/client/proc/toggle_random_events,

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -86,7 +86,7 @@
 	var/datum/action/innate/deploy_last_shell/redeploy_action = new
 	var/chnotify = 0
 
-	var/multicam_allowed = FALSE
+	
 	var/multicam_on = FALSE
 	var/obj/screen/movable/pic_in_pic/ai/master_multicam
 	var/list/multicam_screens = list()

--- a/code/modules/mob/living/silicon/ai/multicam.dm
+++ b/code/modules/mob/living/silicon/ai/multicam.dm
@@ -194,7 +194,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 //AI procs
 
 /mob/living/silicon/ai/proc/drop_new_multicam(silent = FALSE)
-	if(!multicam_allowed)
+	if(!CONFIG_GET(flag/allow_ai_multicam))
 		if(!silent)
 			to_chat(src, "<span class='warning'>This action is currently disabled. Contact an administrator to enable this feature.</span>")
 		return
@@ -213,7 +213,7 @@ GLOBAL_DATUM(ai_camera_room_landmark, /obj/effect/landmark/ai_multicam_room)
 	return C
 
 /mob/living/silicon/ai/proc/toggle_multicam()
-	if(!multicam_allowed)
+	if(!CONFIG_GET(flag/allow_ai_multicam))
 		to_chat(src, "<span class='warning'>This action is currently disabled. Contact an administrator to enable this feature.</span>")
 		return
 	if(multicam_on)


### PR DESCRIPTION
AI multicam config now actually works and can be toggled on/off with an admin verb located in the Server tab.

:cl: Multicam Config
config: removed whether or not the stuff for multicam was checking the useless var and instead now checks the CONFIG_GET flag.
admin: Admins now have a verb in the Server tab to turn AI multicam on and off.
/:cl:

[why]: # Ragolution asked me nicely to do this, I had nothing better to do, and it seemed like a nice feature you guys really needed.
