### PR TITLE
Makes transit areas physically throw you out of the transit area instead of simply teleporting you

### DIFF
--- a/code/controllers/subsystem/mapping.dm
+++ b/code/controllers/subsystem/mapping.dm
@@ -435,11 +435,13 @@ GLOBAL_LIST_EMPTY(the_station_areas)
 		GLOB.the_gateway.awaygate = new_gate
 		GLOB.the_gateway.wait = world.time
 
-/datum/controller/subsystem/mapping/proc/RequestBlockReservation(width, height, z, type = /datum/turf_reservation, turf_type_override)
+/datum/controller/subsystem/mapping/proc/RequestBlockReservation(width, height, z, type = /datum/turf_reservation, turf_type_override, border_type_override)
 	UNTIL(initialized && !clearing_reserved_turfs)
 	var/datum/turf_reservation/reserve = new type
 	if(turf_type_override)
 		reserve.turf_type = turf_type_override
+	if(border_type_override)
+		reserve.borderturf = border_type_override
 	if(!z)
 		for(var/i in levels_by_trait(ZTRAIT_RESERVED))
 			if(reserve.Reserve(width, height, i))

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -443,17 +443,22 @@ SUBSYSTEM_DEF(shuttle)
 */
 
 	var/transit_path = /turf/open/space/transit
+	var/border_path = /turf/open/space/transit/border
 	switch(travel_dir)
 		if(NORTH)
 			transit_path = /turf/open/space/transit/north
+			border_path = /turf/open/space/transit/border/north
 		if(SOUTH)
 			transit_path = /turf/open/space/transit/south
+			border_path = /turf/open/space/transit/border/south
 		if(EAST)
 			transit_path = /turf/open/space/transit/east
+			border_path = /turf/open/space/transit/border/east
 		if(WEST)
 			transit_path = /turf/open/space/transit/west
+			border_path = /turf/open/space/transit/border/west
 
-	var/datum/turf_reservation/proposal = SSmapping.RequestBlockReservation(transit_width, transit_height, null, /datum/turf_reservation/transit, transit_path)
+	var/datum/turf_reservation/proposal = SSmapping.RequestBlockReservation(transit_width, transit_height, null, /datum/turf_reservation/transit, transit_path, border_path)
 
 	if(!istype(proposal))
 		return FALSE

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -26,12 +26,37 @@
 /turf/open/space/transit/east
 	dir = EAST
 
+/turf/open/space/transit/border
+	opacity = TRUE
+
+/turf/open/space/transit/border/south
+	dir = SOUTH
+
+/turf/open/space/transit/border/north
+	dir = NORTH
+
+/turf/open/space/transit/border/west
+	dir = WEST
+
+/turf/open/space/transit/border/east
+	dir = EAST
+
 /turf/open/space/transit/Entered(atom/movable/AM, atom/OldLoc)
 	..()
-	if(!locate(/obj/structure/lattice) in src)
+	if(!locate(/obj/structure/lattice) in src && !SSshuttle.is_in_shuttle_bounds(src))
 		throw_atom(AM)
 
 /turf/open/space/transit/proc/throw_atom(atom/movable/AM)
+	if(!AM || istype(AM, /obj/docking_port))
+		return
+	if(AM.loc != src)
+		return
+	if(AM.throwing)
+		return
+	var/turf/T = get_ranged_target_turf(src, turn(dir, 180), 10)
+	AM.safe_throw_at(T, 10, 1, null, FALSE)
+
+/turf/open/space/transit/border/throw_atom(atom/movable/AM)
 	set waitfor = FALSE
 	if(!AM || istype(AM, /obj/docking_port))
 		return

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -41,22 +41,12 @@
 /turf/open/space/transit/border/east
 	dir = EAST
 
-/turf/open/space/transit/Entered(atom/movable/AM, atom/OldLoc)
+/turf/open/space/transit/border/Entered(atom/movable/AM, atom/OldLoc)
 	..()
-	if(!locate(/obj/structure/lattice) in src && !SSshuttle.is_in_shuttle_bounds(src))
+	if(!locate(/obj/structure/lattice) in src)
 		throw_atom(AM)
 
 /turf/open/space/transit/proc/throw_atom(atom/movable/AM)
-	if(!AM || istype(AM, /obj/docking_port))
-		return
-	if(AM.loc != src)
-		return
-	if(AM.throwing)
-		return
-	var/turf/T = get_ranged_target_turf(src, turn(dir, 180), 10)
-	AM.safe_throw_at(T, 10, 1, null, FALSE)
-
-/turf/open/space/transit/border/throw_atom(atom/movable/AM)
 	set waitfor = FALSE
 	if(!AM || istype(AM, /obj/docking_port))
 		return
@@ -91,8 +81,8 @@
 
 	var/turf/T = locate(_x, _y, _z)
 	AM.forceMove(T)
-	var/turf/throwturf = get_ranged_target_turf(T, dir, 10)
-	AM.safe_throw_at(throwturf, 10, 4, null, FALSE)
+	var/turf/throwturf = get_ranged_target_turf(T, dir, 1)
+	AM.safe_throw_at(throwturf, 1, 4, null, FALSE)
 
 
 /turf/open/space/transit/CanBuildHere()

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -91,6 +91,8 @@
 
 	var/turf/T = locate(_x, _y, _z)
 	AM.forceMove(T)
+	var/turf/throwturf = get_ranged_target_turf(T, dir, 10)
+	AM.safe_throw_at(throwturf, 10, 4, null, FALSE)
 
 
 /turf/open/space/transit/CanBuildHere()

--- a/code/modules/mapping/space_management/space_reservation.dm
+++ b/code/modules/mapping/space_management/space_reservation.dm
@@ -9,9 +9,11 @@
 	var/top_right_coords[3]
 	var/wipe_reservation_on_release = TRUE
 	var/turf_type = /turf/open/space
+	var/borderturf
 
 /datum/turf_reservation/transit
 	turf_type = /turf/open/space/transit
+	borderturf = /turf/open/space/transit/border
 
 /datum/turf_reservation/proc/Release()
 	var/v = reserved_turfs.Copy()
@@ -60,7 +62,10 @@
 		T.flags_1 &= ~UNUSED_RESERVATION_TURF_1
 		SSmapping.unused_turfs["[T.z]"] -= T
 		SSmapping.used_turfs[T] = src
-		T.ChangeTurf(turf_type, turf_type)
+		if(borderturf && (T.x == BL.x || T.x == TR.x || T.y == BL.y || T.y == TR.y))
+			T.ChangeTurf(borderturf, borderturf)
+		else
+			T.ChangeTurf(turf_type, turf_type)
 	src.width = width
 	src.height = height
 	return TRUE

--- a/code/modules/mapping/space_management/space_reservation.dm
+++ b/code/modules/mapping/space_management/space_reservation.dm
@@ -22,6 +22,12 @@
 		SSmapping.used_turfs -= i
 	SSmapping.reserve_turfs(v)
 
+/datum/turf_reservation/transit/Release()
+	for(var/turf/open/space/transit/T in reserved_turfs)
+		for(var/atom/movable/AM in T)
+			T.throw_atom(AM)
+	. = ..()
+
 /datum/turf_reservation/proc/Reserve(width, height, zlevel)
 	if(width > world.maxx || height > world.maxy || width < 1 || height < 1)
 		return FALSE


### PR DESCRIPTION
This is similar to how transit areas work on some baycode servers, Goon, and older versions of TG. Except it's modernized and doesn't require the transit area to be prebaked into the map. Due to code limitations, this also means it's plausible to hang on for dear life if you accidentally step one single tile outside of a shuttle. This also means that objects that fall out of moving shuttles will soar through space when exiting transit areas instead of simply staying stationary.

EDIT: as of ed23ce2, shuttles now opt for a more realistic approach. Normal transit turfs now act exactly like normal space tiles when moving around. Exiting the transit area or being present in the transit area when the shuttle exits transit will still teleport you and throw you in the direction the shuttle was moving.

:cl: deathride58
add: Instead of transit turfs simply teleporting things to space, transit is now handled in a somewhat realistic manner. Transit turfs now act like normal space turfs, though exiting the transit area or being present in the transit area after the shuttle moves out of transit will teleport you to space and throw you in the direction the shuttle was moving in.
tweak: Reservation areas are now able to designate a border turf.
/:cl:
