### PR TITLE
fixes the bug where you can sometimes get permanently stuck sprinting while using the sprint hotkey

### DIFF
--- a/modular_citadel/code/modules/keybindings/bindings_human.dm
+++ b/modular_citadel/code/modules/keybindings/bindings_human.dm
@@ -1,13 +1,13 @@
 /mob/living/carbon/human/key_down(_key, client/user)
 	switch(_key)
 		if("Shift")
-			togglesprint()
+			sprint_hotkey(TRUE)
 			return
 	return ..()
 
 /mob/living/carbon/human/key_up(_key, client/user)
 	switch(_key)
 		if("Shift")
-			togglesprint()
+			sprint_hotkey(FALSE)
 			return
 	return ..()

--- a/modular_citadel/code/modules/keybindings/bindings_robot.dm
+++ b/modular_citadel/code/modules/keybindings/bindings_robot.dm
@@ -1,13 +1,13 @@
 /mob/living/silicon/robot/key_down(_key, client/user)
 	switch(_key)
 		if("Shift")
-			togglesprint()
+			sprint_hotkey(TRUE)
 			return
 	return ..()
 
 /mob/living/silicon/robot/key_up(_key, client/user)
 	switch(_key)
 		if("Shift")
-			togglesprint()
+			sprint_hotkey(FALSE)
 			return
 	return ..()

--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -31,3 +31,7 @@
 		for(var/obj/screen/sprintbutton/selector in hud_used.static_inventory)
 			selector.insert_witty_toggle_joke_here(src)
 	return TRUE
+
+/mob/living/carbon/human/proc/sprint_hotkey(targetstatus)
+	if(targetstatus ? !sprinting : sprinting)
+		togglesprint()

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -23,3 +23,7 @@
 		for(var/obj/screen/sprintbutton/selector in hud_used.static_inventory)
 			selector.insert_witty_toggle_joke_here(src)
 	return TRUE
+
+/mob/living/silicon/robot/proc/sprint_hotkey(targetstatus)
+	if(targetstatus ? !sprinting : sprinting)
+		togglesprint()


### PR DESCRIPTION
Title

:cl: deathride58
fix: The sprint hotkey will no longer cause you to get permanently stuck sprinting if the server lags. Just tap shift again if you get stuck
/:cl:
