### PR TITLE
Tweaking some cyborg mounted energy guns.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -118,6 +118,10 @@
 #define TRIGGER_GUARD_ALLOW_ALL -1
 #define TRIGGER_GUARD_NONE 0
 #define TRIGGER_GUARD_NORMAL 1
+//E-gun self-recharge values
+#define EGUN_NO_SELFCHARGE 0
+#define EGUN_SELFCHARGE 1
+#define EGUN_SELFCHARGE_BORG 2
 
 //Object/Item sharpness
 #define IS_BLUNT			0

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -153,8 +153,14 @@
 				B.cell.charge = B.cell.maxcharge
 		else if(istype(I, /obj/item/gun/energy))
 			var/obj/item/gun/energy/EG = I
-			if(!EG.chambered)
-				EG.recharge_newshot() //try to reload a new shot.
+			if(EG.cell?.charge < EG.cell.maxcharge)
+				var/obj/item/ammo_casing/energy/S = EG.ammo_type[EG.select]
+				EG.cell.give(S.e_cost * coeff)
+				if(!EG.chambered)
+					EG.recharge_newshot(TRUE)
+				EG.update_icon()
+			else
+				EG.charge_tick = 0
 
 	R.toner = R.tonermax
 
@@ -345,17 +351,6 @@
 	..()
 	to_chat(loc, "<span class='userdanger'>While you have picked the security module, you still have to follow your laws, NOT Space Law. \
 	For Crewsimov, this means you must follow criminals' orders unless there is a law 1 reason not to.</span>")
-
-/obj/item/robot_module/security/respawn_consumable(mob/living/silicon/robot/R, coeff = 1)
-	..()
-	var/obj/item/gun/energy/e_gun/advtaser/cyborg/T = locate(/obj/item/gun/energy/e_gun/advtaser/cyborg) in basic_modules
-	if(T)
-		if(T.cell.charge < T.cell.maxcharge)
-			var/obj/item/ammo_casing/energy/S = T.ammo_type[T.select]
-			T.cell.give(S.e_cost * coeff)
-			T.update_icon()
-		else
-			T.charge_tick = 0
 
 /obj/item/robot_module/peacekeeper
 	name = "Peacekeeper"

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -67,8 +67,7 @@
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		var/borgcharge = selfcharge == EGUN_SELFCHARGE_BORG ? TRUE : FALSE
-		if(borgcharge)
+		if(selfcharge == EGUN_SELFCHARGE_BORG)
 			var/atom/owner = loc
 			if(istype(owner, /obj/item/robot_module))
 				owner = owner.loc

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -76,7 +76,7 @@
 			var/mob/living/silicon/robot/R = owner
 			if(!R.cell?.use(100))
 				return
-			cell.give(100)
+		cell.give(100)
 		if(!chambered) //if empty chamber we try to charge a new shot
 			recharge_newshot(TRUE)
 		update_icon()

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -15,10 +15,10 @@
 	ammo_x_offset = 2
 	var/shaded_charge = FALSE //if this gun uses a stateful charge bar for more detail
 	var/old_ratio = 0 // stores the gun's previous ammo "ratio" to see if it needs an updated icon
-	var/selfcharge = 0
+	var/selfcharge = EGUN_NO_SELFCHARGE // EGUN_SELFCHARGE if true, EGUN_SELFCHARGE_BORG drains the cyborg's cell to recharge its own
 	var/charge_tick = 0
 	var/charge_delay = 4
-	var/use_cyborg_cell = 0 //whether the gun's cell drains the cyborg user's cell to recharge
+	var/use_cyborg_cell = FALSE //whether the gun drains the cyborg user's cell instead, not to be confused with EGUN_SELFCHARGE_BORG
 	var/dead_cell = FALSE //set to true so the gun is given an empty cell
 
 /obj/item/gun/energy/emp_act(severity)
@@ -62,12 +62,22 @@
 	return ..()
 
 /obj/item/gun/energy/process()
-	if(selfcharge && cell && cell.percent() < 100)
+	if(selfcharge && cell?.charge < cell.maxcharge)
 		charge_tick++
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		cell.give(100)
+		var/borgcharge = selfcharge == EGUN_SELFCHARGE_BORG ? TRUE : FALSE
+		if(borgcharge)
+			var/atom/owner = loc
+			if(istype(owner, /obj/item/robot_module))
+				owner = owner.loc
+			if(!iscyborg(owner))
+				return
+			var/mob/living/silicon/robot/R = owner
+			if(!R.cell?.use(100))
+				return
+			cell.give(100)
 		if(!chambered) //if empty chamber we try to charge a new shot
 			recharge_newshot(TRUE)
 		update_icon()

--- a/code/modules/projectiles/guns/energy/energy_gun.dm
+++ b/code/modules/projectiles/guns/energy/energy_gun.dm
@@ -98,7 +98,7 @@
 	can_charge = 0
 	ammo_x_offset = 1
 	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/laser, /obj/item/ammo_casing/energy/disabler)
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 	var/fail_tick = 0
 	var/fail_chance = 0
 

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -4,7 +4,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	w_class = WEIGHT_CLASS_NORMAL
-	materials = list(MAT_METAL=2000)
+	materials = list(MAT_METAL = 2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = 1
@@ -36,7 +36,7 @@
 	desc = "This is an antique laser gun. All craftsmanship is of the highest quality. It is decorated with assistant leather and chrome. The object menaces with spikes of energy. On the item is an image of Space Station 13. The station is exploding."
 	force = 10
 	ammo_x_offset = 3
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
 /obj/item/gun/energy/laser/captain/scattershot
@@ -47,12 +47,17 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/scatter, /obj/item/ammo_casing/energy/laser)
 
 /obj/item/gun/energy/laser/cyborg
-	can_charge = 0
+	can_charge = FALSE
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
-	use_cyborg_cell = 1
+	selfcharge = EGUN_SELFCHARGE_BORG
+	charge_delay = 6
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return
+
+/obj/item/gun/energy/laser/cyborg/mean
+	use_cyborg_cell = TRUE
+	selfcharge = EGUN_NO_SELFCHARGE
 
 /obj/item/gun/energy/laser/scatter
 	name = "scatter laser gun"
@@ -120,7 +125,7 @@
 	clumsy_check = FALSE
 	pin = /obj/item/firing_pin/tag/blue
 	ammo_x_offset = 2
-	selfcharge = TRUE
+	selfcharge = EGUN_SELFCHARGE
 
 /obj/item/gun/energy/laser/bluetag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/bluetag/hitscan)
@@ -134,7 +139,7 @@
 	clumsy_check = FALSE
 	pin = /obj/item/firing_pin/tag/red
 	ammo_x_offset = 2
-	selfcharge = TRUE
+	selfcharge = EGUN_SELFCHARGE
 
 /obj/item/gun/energy/laser/redtag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -4,7 +4,7 @@
 	icon_state = "laser"
 	item_state = "laser"
 	w_class = WEIGHT_CLASS_NORMAL
-	materials = list(MAT_METAL = 2000)
+	materials = list(MAT_METAL=2000)
 	ammo_type = list(/obj/item/ammo_casing/energy/lasergun)
 	ammo_x_offset = 1
 	shaded_charge = 1

--- a/code/modules/projectiles/guns/energy/megabuster.dm
+++ b/code/modules/projectiles/guns/energy/megabuster.dm
@@ -7,7 +7,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/megabuster)
 	clumsy_check = FALSE
 	item_flags = NEEDS_PERMIT
-	selfcharge = TRUE
+	selfcharge = EGUN_SELFCHARGE
 	cell_type = "/obj/item/stock_parts/cell/pulse"
 	icon = 'modular_citadel/icons/obj/guns/VGguns.dmi'
 

--- a/code/modules/projectiles/guns/energy/mounted.dm
+++ b/code/modules/projectiles/guns/energy/mounted.dm
@@ -5,12 +5,9 @@
 	icon_state = "taser"
 	item_state = "armcannonstun4"
 	force = 5
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 	can_flashlight = 0
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL // Has no trigger at all, uses neural signals instead
-
-/obj/item/gun/energy/e_gun/advtaser/mounted/dropped()//if somebody manages to drop this somehow...
-	..()
 
 /obj/item/gun/energy/laser/mounted
 	name = "mounted laser"
@@ -19,8 +16,5 @@
 	icon_state = "laser"
 	item_state = "armcannonlase"
 	force = 5
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 	trigger_guard = TRIGGER_GUARD_ALLOW_ALL
-
-/obj/item/gun/energy/laser/mounted/dropped()
-	..()

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -48,7 +48,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/flora/yield, /obj/item/ammo_casing/energy/flora/mut)
 	modifystate = 1
 	ammo_x_offset = 1
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 
 /obj/item/gun/energy/meteorgun
 	name = "meteor gun"
@@ -59,7 +59,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/meteor)
 	cell_type = "/obj/item/stock_parts/cell/potato"
 	clumsy_check = 0 //Admin spawn only, might as well let clowns use it.
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 
 /obj/item/gun/energy/meteorgun/pen
 	name = "meteor pen"

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -25,10 +25,16 @@
 
 /obj/item/gun/energy/e_gun/advtaser/cyborg
 	name = "cyborg taser"
-	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell. The weapon contains a limiter to prevent the cyborg's power cell from overheating."
-	can_flashlight = 0
-	can_charge = 0
-	use_cyborg_cell = 1
+	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell. The one contains a limiter to prevent the cyborg's power cell from overheating."
+	can_flashlight = FALSE
+	can_charge = FALSE
+	selfcharge = EGUN_SELFCHARGE_BORG
+	charge_delay = 10
+
+/obj/item/gun/energy/e_gun/advtaser/cyborg/mean
+	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell."
+	use_cyborg_cell = TRUE
+	selfcharge = EGUN_NO_SELFCHARGE
 
 /obj/item/gun/energy/disabler
 	name = "disabler"
@@ -40,6 +46,12 @@
 
 /obj/item/gun/energy/disabler/cyborg
 	name = "cyborg disabler"
-	desc = "An integrated disabler that draws from a cyborg's power cell. This weapon contains a limiter to prevent the cyborg's power cell from overheating."
-	can_charge = 0
-	use_cyborg_cell = 1
+	desc = "An integrated disabler that draws from a cyborg's power cell. This one contains a limiter to prevent the cyborg's power cell from overheating."
+	can_charge = FALSE
+	selfcharge = EGUN_SELFCHARGE_BORG
+	charge_delay = 10
+
+/obj/item/gun/energy/disabler/cyborg/mean
+	desc = "An integrated disabler that draws from a cyborg's power cell."
+	use_cyborg_cell = TRUE
+	selfcharge = EGUN_NO_SELFCHARGE

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -166,7 +166,12 @@
 	// These items will NOT be preserved
 	var/list/do_not_preserve_items = list (
 		/obj/item/mmi/posibrain,
+		/obj/item/gun/energy/laser/mounted,
+		/obj/item/gun/energy/e_gun/advtaser/mounted,
+		/obj/item/gun/ballistic/revolver/grenadelauncher/cyborg,
 		/obj/item/gun/energy/disabler/cyborg,
+		/obj/item/gun/energy/e_gun/advtaser/cyborg,
+		/obj/item/gun/energy/printer,
 		/obj/item/gun/energy/kinetic_accelerator/cyborg,
 		/obj/item/gun/energy/laser/cyborg
 	)

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/handguns.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/handguns.dm
@@ -144,4 +144,4 @@ obj/item/projectile/bullet/c10mm/soporific
 	icon_state = "raygun"
 	desc = "A toy laser with a classic, retro feel and look. Compatible with existing laser tag systems."
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/raytag)
-	selfcharge = TRUE
+	selfcharge = EGUN_SELFCHARGE

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
@@ -456,7 +456,7 @@
 	obj_flags = 0
 	fire_delay = 40
 	weapon_weight = WEAPON_HEAVY
-	selfcharge = TRUE
+	selfcharge = EGUN_SELFCHARGE
 	charge_delay = 2
 	recoil = 2
 	cell_type = /obj/item/stock_parts/cell/toymagburst

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -16,13 +16,21 @@
 	update_icon()
 
 /obj/item/gun/energy/pumpaction/process()	//makes it not rack itself when self-charging
-	if(selfcharge)
+	if(selfcharge && cell?.charge < cell.maxcharge)
 		charge_tick++
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		if(!cell)
-			return
+		var/borgcharge = selfcharge == EGUN_SELFCHARGE_BORG ? TRUE : FALSE
+		if(borgcharge)
+			var/atom/owner = loc
+			if(istype(owner, /obj/item/robot_module))
+				owner = owner.loc
+			if(!iscyborg(owner))
+				return
+			var/mob/living/silicon/robot/R = owner
+			if(!R.cell?.use(100))
+				return
 		cell.give(100)
 	update_icon()
 

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -21,8 +21,7 @@
 		if(charge_tick < charge_delay)
 			return
 		charge_tick = 0
-		var/borgcharge = selfcharge == EGUN_SELFCHARGE_BORG ? TRUE : FALSE
-		if(borgcharge)
+		if(selfcharge == EGUN_SELFCHARGE_BORG)
 			var/atom/owner = loc
 			if(istype(owner, /obj/item/robot_module))
 				owner = owner.loc

--- a/modular_citadel/code/modules/projectiles/guns/toys.dm
+++ b/modular_citadel/code/modules/projectiles/guns/toys.dm
@@ -15,7 +15,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/dispersal, /obj/item/ammo_casing/energy/laser/wavemotion)
 	ammo_x_offset = 2
 	modifystate = 1
-	selfcharge = TRUE
+	selfcharge = EGUN_SELFCHARGE
 	item_flags = NONE
 	clumsy_check = FALSE
 

--- a/modular_citadel/code/modules/vore/resizing/sizegun_vr.dm
+++ b/modular_citadel/code/modules/vore/resizing/sizegun_vr.dm
@@ -12,7 +12,7 @@
 	charge_cost = 100
 	projectile_type = /obj/item/projectile/beam/shrinklaser
 	modifystate = "sizegun-shrink"
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 	firemodes = list(
 		list(mode_name		= "grow",
 			projectile_type	= /obj/item/projectile/beam/growlaser,
@@ -153,7 +153,7 @@ datum/design/sizeray
 	desc = "Size manipulator using bluespace breakthroughs."
 	item_state = null	//so the human update icon uses the icon_state instead.
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/shrinkray, /obj/item/ammo_casing/energy/laser/growthray)
-	selfcharge = 1
+	selfcharge = EGUN_SELFCHARGE
 	charge_delay = 5
 	ammo_x_offset = 2
 	clumsy_check = 1


### PR DESCRIPTION
:cl:
tweak: Cyborg mounted disablers/tasers/lasers now slowly self-recharge off the cyborg user's power cell instead of draining from it directly.
tweak: Borg rechargers now properly recharge the borg module's energy guns.
fix: Prevents a couple more special/mounted guns from being preserved on cryo
/:cl:

This means a secborg's disabler will eventually run low on ammo after a reasonable twenty shots or something instead of being able to keep going till the user's cell goes low. The syndieborg's 3d-printer-lmg is unaffected.

I'm pretty much open to reviews and suggestions. Retained the old versions into subtypes, but probably won't be used, so free to tell me if you want them deleted.