### PR TITLE
Makes the roundend notification in IRC a little more verbose

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -192,7 +192,7 @@
 	//Set news report and mode result
 	mode.set_round_result()
 
-	send2irc("Server", "Round just ended.")
+	send2irc("Server", "Round of [mode.name] just ended[mode_result == "undefined" ? "." : "with a [mode_result]."] Survival rate: [PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%")
 
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -192,7 +192,9 @@
 	//Set news report and mode result
 	mode.set_round_result()
 
-	send2irc("Server", "A round of [mode.name] just ended[mode_result == "undefined" ? "." : "with a [mode_result]."] Survival rate: [PERCENT(popcount[POPCOUNT_SURVIVORS]/GLOB.joined_player_list.len)]%")
+	var/survival_rate = GLOB.joined_player_list.len ? "PERCENT(popcount[POPCOUNT_SURVIVORS]/GLOB.joined_player_list.len)%" : "there's literally no players"
+
+	send2irc("Server", "A round of [mode.name] just ended[mode_result == "undefined" ? "." : " with a [mode_result]."] Survival rate: [survival_rate]")
 
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -192,7 +192,7 @@
 	//Set news report and mode result
 	mode.set_round_result()
 
-	var/survival_rate = GLOB.joined_player_list.len ? "PERCENT(popcount[POPCOUNT_SURVIVORS]/GLOB.joined_player_list.len)%" : "there's literally no players"
+	var/survival_rate = GLOB.joined_player_list.len ? "PERCENT(popcount[POPCOUNT_SURVIVORS]/GLOB.joined_player_list.len)%" : "there's literally no player"
 
 	send2irc("Server", "A round of [mode.name] just ended[mode_result == "undefined" ? "." : " with a [mode_result]."] Survival rate: [survival_rate]")
 

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -192,7 +192,7 @@
 	//Set news report and mode result
 	mode.set_round_result()
 
-	send2irc("Server", "Round of [mode.name] just ended[mode_result == "undefined" ? "." : "with a [mode_result]."] Survival rate: [PERCENT(popcount[POPCOUNT_SURVIVORS]/total_players)]%")
+	send2irc("Server", "A round of [mode.name] just ended[mode_result == "undefined" ? "." : "with a [mode_result]."] Survival rate: [PERCENT(popcount[POPCOUNT_SURVIVORS]/GLOB.joined_player_list.len)]%")
 
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()


### PR DESCRIPTION
Title. "round has ended" doesn't say jack shit, and makes it pretty hard to keep track of what kind of round just happened on the server. I'm also a lazy man who's too lazy to open up statbus, so this gives me easier access to the info necessary to make armchair observations about the state of certain roundtypes. This PR adds the round type, the end result of the round, and the survival rate to the message that's sent to IRC when a round ends.

:cl: deathride58
admin: The out-of-game round end notification is now a little more verbose. It'll now display the round type, end result of the round, and the survival rate.
/:cl:
