### PR TITLE
[s] Fixes xenos being able to pick up and use literally any item in the game so long as they strip it off someone else first

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -264,7 +264,7 @@
 				if(pocket_item)
 					if(pocket_item == (pocket_id == SLOT_R_STORE ? r_store : l_store)) //item still in the pocket we search
 						dropItemToGround(pocket_item)
-						if(!put_in_hands(pocket_item))
+						if(!usr.can_hold_items() || !usr.put_in_hands(pocket_item))
 							pocket_item.forceMove(drop_location())
 				else
 					if(place_item)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -705,7 +705,7 @@
 						log_combat(src, who, "stripped [what] off")
 			if(what == who.get_item_by_slot(where))
 				if(who.dropItemToGround(what))
-					if(!put_in_hands(what))
+					if(!can_hold_items() || !put_in_hands(what))
 						what.forceMove(drop_location())
 					log_combat(src, who, "stripped [what] off")
 


### PR DESCRIPTION
WEW LADS

:cl: deathride58
fix: Xenos can no longer strip items off of people to be capable of using any item in the game.
fix: also, items from pockets get placed into your hands properly now
/:cl:
