### PR TITLE
Gives Clown/Mime on skele crews Cooking and growing

### DIFF
--- a/code/modules/jobs/job_types/civilian.dm
+++ b/code/modules/jobs/job_types/civilian.dm
@@ -13,8 +13,7 @@ Clown
 	selection_color = "#dddddd"
 
 	outfit = /datum/outfit/job/clown
-
-	access = list(ACCESS_THEATRE)
+	access = list(ACCESS_THEATRE, ACCESS_HYDROPONICS, ACCESS_KITCHEN,)
 	minimal_access = list(ACCESS_THEATRE)
 
 /datum/job/clown/after_spawn(mob/living/carbon/human/H, mob/M)
@@ -77,7 +76,7 @@ Mime
 
 	outfit = /datum/outfit/job/mime
 
-	access = list(ACCESS_THEATRE)
+	access = list(ACCESS_THEATRE, ACCESS_HYDROPONICS, ACCESS_KITCHEN,)
 	minimal_access = list(ACCESS_THEATRE)
 
 /datum/job/mime/after_spawn(mob/living/carbon/human/H, mob/M)


### PR DESCRIPTION
[Changelogs]
The Clown and The Mime, well on a skele crew, can now have access to Hydro and Cooking area to be usefull when their is no one really around. Or to make pranks and pies to be evil with, Whom knows?

[why]
Glowing for food stuffs, cook gets it to so meh
Cooking for them to be usefull if needed, and help around to get their own pies or make their own gimmicks. 
*TBH I think clown should get access to a ice cream cart to but thats just me*