### PR TITLE
Fixes a mob's last word never actually being properly tracked

### DIFF
--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -170,7 +170,6 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 			var/message_len = length(message)
 			message = copytext(message, 1, health_diff) + "[message_len > health_diff ? "-.." : "..."]"
 			message = Ellipsis(message, 10, 1)
-			last_words = message
 			message_mode = MODE_WHISPER_CRIT
 			succumbed = TRUE
 	else
@@ -179,6 +178,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	message = treat_message(message)
 	if(!message)
 		return
+
+	last_words = message
 
 	spans |= get_spans()
 


### PR DESCRIPTION
Title. This means the first death of a round will actually have their last words be properly tracked. This also means viewing deaths in statbus will be a smidge more entertaining. For whatever reason, last words were literally only recorded if you whispersuccumb'd while in crit

:cl: deathride58
fix: A mob's last words are now properly tracked and recorded on death. The first death of the round will now actually display the victim's last words on the round end screen.
/:cl:
