### PR TITLE
Experimental fix to a currently unreproducable bug where you can become immune to stamloss

### DIFF
--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -455,6 +455,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		adjustStaminaLoss(resting ? (recoveringstam ? -7.5 : -3) : -1.5)//CIT CHANGE - decreases adjuststaminaloss to stop stamina damage from being such a joke
 
 	if(!recoveringstam && incomingstammult != 1)
+		incomingstammult = max(0.01, incomingstammult)
 		incomingstammult = min(1, incomingstammult*2)
 
 	//CIT CHANGES START HERE. STAMINA BUFFER STUFF


### PR DESCRIPTION
Title. The *only* way it could possibly happen is if incomingstammult somehow becomes exactly 0. So this PR makes sure that incomingstammult will *always* be *at least* 0.01, which is the minimum that the thing that sets incomingstammult can set.

:cl: deathride58
fix: Divine shenanigans can no longer result in someone becoming immune to staminaloss
/:cl:
