### PR TITLE
fixes body_markings being assigned as a list when in reality its a string and everything uses it as a string

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -45,7 +45,7 @@
 	var/species_color = ""
 	var/mutation_color = ""
 	var/no_update = 0
-	var/list/body_markings = list() 	//for bodypart markings
+	var/body_markings 	//for bodypart markings
 	var/list/markings_color = list()
 	var/auxmarking
 	var/list/auxmarking_color = list()


### PR DESCRIPTION
Title

:cl: deathride58
fix: Fixed body_markings in bodyparts being assigned as a list when in reality, it's a string and literally everything expects it to be a string and uses it as a string. This should mean that markings no longer have completely fucked up caches for character preview and other things.
/:cl:
