### PR TITLE
Reduces the pixel variance of thrown objects by four pixels and attempts to fix bartender glasses tilting uncontrollably

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -544,8 +544,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/matrix/M = matrix(transform)
 	M.Turn(rand(-170, 170))
 	transform = M
-	pixel_x = rand(-12, 12)
-	pixel_y = rand(-12, 12)
+	pixel_x = rand(-8, 8)
+	pixel_y = rand(-8, 8)
 
 /obj/item/proc/remove_item_from_storage(atom/newLoc) //please use this if you're going to snowflake an item out of a obj/item/storage
 	if(!newLoc)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -82,6 +82,9 @@
 			if(D.active)
 				return TRUE
 
+/obj/item/reagent_containers/proc/ForceResetRotation()
+	transform = initial(transform)
+
 /obj/item/reagent_containers/proc/SplashReagents(atom/target, thrown = FALSE)
 	if(!reagents || !reagents.total_volume || !spillable)
 		return
@@ -104,6 +107,7 @@
 	else if(bartender_check(target) && thrown)
 		visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
 		transform = initial(transform)
+		addtimer(CALLBACK(src, .proc/ForceResetRotation), 1)
 		return
 
 	else


### PR DESCRIPTION
Title.

:cl: deathride58
tweak: Since apparently the game is literally unplayable if items are not in the exact center of a turf, the maximum pixel variance of thrown objects has been reduced by four pixels to make things a smidge more clearer for those that dont know what a turf is.
fix: Bartender glasses should HOPEFULLY no longer be tilted when landing on a table. Why the fuck is after_throw called via a timer.
/:cl:
