### PR TITLE
Makes the efficiency of the TEG be dependant on how much gas is actively combusting in the hot pipe

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/circulator.dm
@@ -61,6 +61,8 @@
 		//Actually transfer the gas
 		var/datum/gas_mixture/removed = air2.remove(transfer_moles)
 
+		removed.react(src)
+
 		update_parents()
 
 		return removed

--- a/code/modules/power/generator.dm
+++ b/code/modules/power/generator.dm
@@ -65,7 +65,7 @@
 
 
 			if(delta_temperature > 0 && cold_air_heat_capacity > 0 && hot_air_heat_capacity > 0)
-				var/efficiency = 0.45
+				var/efficiency = 0.00025 + (hot_air.reaction_results["fire"]*0.01)
 
 				var/energy_transfer = delta_temperature*hot_air_heat_capacity*cold_air_heat_capacity/(hot_air_heat_capacity+cold_air_heat_capacity)
 


### PR DESCRIPTION
Title. This means that the meme strat of simply shoving hypernoblium into both sides of the TEG and then making use of heaters/coolers to keep the gas circling simply no longer works. You now have to actually be using actively combusting gas to produce any meaningful amount of power with the TEG. This directly paves the way to make the TEG a potential way to produce research points.

:cl: deathride58
balance: The TEG will now only produce a meaningful amount of power if the hot pipe contains gas that's actively combusting
/:cl:
