### PR TITLE
Makes the PB more robust by allowing admins to let specific ckeys bypass the panic bunker

### DIFF
--- a/code/_globalvars/lists/mobs.dm
+++ b/code/_globalvars/lists/mobs.dm
@@ -6,6 +6,8 @@ GLOBAL_LIST_EMPTY(deadmins)							//all ckeys who have used the de-admin verb.
 GLOBAL_LIST_EMPTY(directory)							//all ckeys with associated client
 GLOBAL_LIST_EMPTY(stealthminID)						//reference list with IDs that store ckeys, for stealthmins
 
+GLOBAL_LIST_EMPTY(bunker_passthrough)
+
 //Since it didn't really belong in any other category, I'm putting this here
 //This is for procs to replace all the goddamn 'in world's that are chilling around the code
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -70,6 +70,8 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/cmd_admin_pm_context,	/*right-click adminPM interface*/
 	/client/proc/cmd_admin_pm_panel,		/*admin-pm list*/
 	/client/proc/panicbunker,
+	/client/proc/addbunkerbypass,
+	/client/proc/revokebunkerbypass,
 	/client/proc/stop_sounds,
 	/client/proc/hide_verbs,			/*hides all our adminverbs*/
 	/client/proc/hide_most_verbs,		/*hides all our hideable adminverbs*/
@@ -233,6 +235,8 @@ GLOBAL_LIST_INIT(admin_verbs_hideable, list(
 	/proc/release,
 	/client/proc/reload_admins,
 	/client/proc/panicbunker,
+	/client/proc/addbunkerbypass,
+	/client/proc/revokebunkerbypass,
 	/client/proc/admin_change_sec_level,
 	/client/proc/toggle_nuke,
 	/client/proc/cmd_display_del_log,

--- a/code/modules/admin/verbs/panicbunker.dm
+++ b/code/modules/admin/verbs/panicbunker.dm
@@ -13,3 +13,28 @@
 	if (new_pb && !SSdbcore.Connect())
 		message_admins("The Database is not connected! Panic bunker will not work until the connection is reestablished.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Panic Bunker", "[new_pb ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
+/client/proc/addbunkerbypass(ckeytobypass as text)
+	set category = "Special Verbs"
+	set name = "Add PB Bypass"
+	set desc = "Allows a given ckey to connect despite the panic bunker for a given round."
+	if(!CONFIG_GET(flag/sql_enabled))
+		to_chat(usr, "<span class='adminnotice'>The Database is not enabled!</span>")
+		return
+
+	GLOB.bunker_passthrough |= ckeytobypass
+	log_admin("[key_name(usr)] has added [ckeytobypass] to the current round's bunker bypass list.")
+	message_admins("[key_name(usr)] has added [ckeytobypass] to the current round's bunker bypass list.")
+
+/client/proc/revokebunkerbypass(ckeytobypass as text)
+	set category = "Special Verbs"
+	set name = "Revoke PB Bypass"
+	set desc = "Revoke's a ckey's permission to bypass the panic bunker for a given round."
+	if(!CONFIG_GET(flag/sql_enabled))
+		to_chat(usr, "<span class='adminnotice'>The Database is not enabled!</span>")
+		return
+
+	GLOB.bunker_passthrough -= ckeytobypass
+	log_admin("[key_name(usr)] has removed [ckeytobypass] from the current round's bunker bypass list.")
+	message_admins("[key_name(usr)] has removed [ckeytobypass] from the current round's bunker bypass list.")
+

--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -499,7 +499,7 @@ GLOBAL_LIST_EMPTY(external_rsc_urls)
 		qdel(query_client_in_db)
 		return
 	if(!query_client_in_db.NextRow())
-		if (CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey])
+		if (CONFIG_GET(flag/panic_bunker) && !holder && !GLOB.deadmins[ckey] && !ckey in GLOB.bunker_passthrough)
 			log_access("Failed Login: [key] - New account attempting to connect during panic bunker")
 			message_admins("<span class='adminnotice'>Failed Login: [key] - New account attempting to connect during panic bunker</span>")
 			to_chat(src, "<span class='notice'>You must first join the Discord to verify your account before joining this server.<br>To do so, read the rules and post a request in the #station-access-requests channel under the \"Main server\" category in the Discord server linked here: <a href='https://discord.gg/E6SQuhz'>https://discord.gg/E6SQuhz</a></span>") //CIT CHANGE - makes the panic bunker disconnect message point to the discord


### PR DESCRIPTION
Title. This adds a pair of admin verbs, "Add PB Bypass", and "Revoke PB Bypass", both available within the special verbs tab. These two do exactly as they say on the tin, simply click the verb then type in a ckey to let that ckey bypass the panic bunker for the rest of the round. This directly stops the meme of raiders opting to have one guy make an access request then everyone piling in as soon as the PB's lifted. QOL for new players and admins alike.

:cl: deathride58
admin: Added the "add PB bypass" and "revoke PB bypass" verbs, which allow admins to let a specific ckey to bypass the panic bunker for the rest of the round
/:cl:
