### PR TITLE
Makes jogging let you avoid water slips, but only if you have less than 20% staminaloss

### DIFF
--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -245,6 +245,10 @@
 				return 0
 			if(C.m_intent == MOVE_INTENT_WALK && (lube&NO_SLIP_WHEN_WALKING))
 				return 0
+			if(ishuman(C) && (lube&NO_SLIP_WHEN_WALKING))
+				var/mob/living/carbon/human/H = C
+				if(!H.sprinting && H.getStaminaLoss() >= 20)
+					return 0
 		if(!(lube&SLIDE_ICE))
 			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")
 			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)


### PR DESCRIPTION
Title. With this PR, sprinting over water is still a guaranteed slip, and walking will still let you pass. This PR makes a further distinction between jogging and sprinting beyond a simple +1 movement speed by adding a state between sprinting and walking that water slips take into account. The value of 20% staminaloss is used since it's a spot where exhaustion starts kicking in but isn't really felt, which makes it harder to retain your balance if you're moving too fast. The value is low enough to the point where water is still something to be legitimately wary of during combat, but also high enough to the point where you won't have to lynch the janitor if he even thinks about using a mop.

:cl: deathride58
add: Jogging is no longer treated exactly the same as sprinting for water slips. When you're jogging, you will only slip on water if you have more than 20% staminaloss.
/:cl:
