### PR TITLE
Makes xeno space ruin have a few non-harmfull orgains

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/derelict1.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict1.dmm
@@ -26,6 +26,7 @@
 "g" = (
 /obj/structure/alien/weeds,
 /obj/structure/table_frame,
+/obj/item/organ/alien/plasmavessel/small/tiny,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
 "h" = (
@@ -77,9 +78,15 @@
 /obj/structure/alien/weeds,
 /obj/structure/bed/nest,
 /obj/effect/decal/remains/xeno,
+/obj/item/organ/brain/alien,
 /turf/open/floor/plating/airless,
 /area/ruin/unpowered)
-
+"s" = (
+/obj/structure/alien/weeds,
+/obj/effect/decal/remains/xeno,
+/obj/item/organ/alien/plasmavessel/small,
+/turf/open/floor/plating/airless,
+/area/ruin/unpowered)
 (1,1,1) = {"
 a
 a
@@ -106,7 +113,7 @@ a
 a
 a
 b
-b
+s
 b
 a
 a


### PR DESCRIPTION
[Changelogs]
Adds 5 alien organs to be found in the xeno ruin. 
3 tiny plasma vessles 
1 alien brain
1 small plasma vessle 

[why]
Brain is useless other then the cargo bounty, and the others are for people to sell as well. Makes the ruin worth looting do to ATM it being nothing...