### PR TITLE
Update revenant_names.json

### DIFF
--- a/strings/revenant_names.json
+++ b/strings/revenant_names.json
@@ -1,10 +1,9 @@
 {
     "spirit_type": [
         "Spirit",
-        "Ghost",
-        "Spectre",
+		"Spectre",
         "Phantom",
-        "Revenant",
+		"Phantom",
         "Essence",
         "Soul"
     ],


### PR DESCRIPTION
Removes the chance of revenant to roll in the name so as to slowly shift their names from Rev, to mainly phantom. Added another 1 phantoms in the list to give it a higher roll chance. No more "Rev in medbay!" causing unneeded revolutionary preparations as well as trying to give them a more generalized name of phantom.

Ideally shifting the common word of Rev to mean actual revolutionaries over time.