### PR TITLE
Increases the atmospherics turf subsystem's wait from 1 to 2 in an attempt to reduce lag

### DIFF
--- a/code/controllers/subsystem/air_turfs.dm
+++ b/code/controllers/subsystem/air_turfs.dm
@@ -4,7 +4,7 @@ SUBSYSTEM_DEF(air_turfs)
 	name = "Atmospherics - Turfs"
 	init_order = INIT_ORDER_AIR_TURFS
 	priority = FIRE_PRIORITY_AIR_TURFS
-	wait = 1
+	wait = 2
 	flags = SS_BACKGROUND
 	runlevels = RUNLEVEL_GAME | RUNLEVEL_POSTGAME
 	var/list/currentrun = list()


### PR DESCRIPTION
Title. After going through with testmerging and untestmerging #7895 multiple times, I've been able to determine that turfs forcing air updates on heat changes is not a direct cause of the lag and high MC processing usage later on in rounds. This PR attempts to fix the lag caused by atmos late into the round by doubling the wait time of the atmospherics turf subsystem, which has the negative effect of slowing down air spreading and such, but should have the positive effect of freeing up the server's processing power for other tasks

:cl: deathride58
tweak: The atmospherics turf subsystem now has double the wait time, which should free up server processing power for other tasks.
/:cl:
