### PR TITLE
Makes Dinner for two have loot

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/derelict2.dmm
+++ b/_maps/RandomRuins/SpaceRuins/derelict2.dmm
@@ -64,12 +64,17 @@
 /obj/structure/chair{
 	dir = 4
 	},
+/obj/item/clothing/under/polychromic/shirt,
+/obj/item/clothing/neck/tie/black,
+/obj/item/clothing/shoes/laceup,
+/obj/item/storage/wallet/random,
+/obj/item/clothing/gloves/color/white,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/dinner_for_two)
 "n" = (
 /obj/structure/table,
-/obj/item/candle{
+/obj/item/candle/infinite{
 	pixel_y = 5
 	},
 /obj/item/trash/plate{
@@ -84,6 +89,11 @@
 /obj/structure/chair{
 	dir = 8
 	},
+/obj/item/clothing/under/polychromic/skirt,
+/obj/item/clothing/shoes/laceup,
+/obj/item/clothing/gloves/color/white,
+/obj/item/clothing/glasses/regular,
+/obj/item/lipstick/random,
 /obj/effect/decal/remains/human,
 /turf/open/floor/plasteel,
 /area/ruin/space/has_grav/powered/dinner_for_two)


### PR DESCRIPTION
[Changelogs]: 
Gives Dinner for two
Never ending candle - Fancy!
Ploy Shirt/Skirt -IF @Toriate ALLOWS IT 
Two fancy shoes - Their dating!
Wallet(With items) - Man should pay for the bill after all!
Glasses, Black tie, Lipstick - Adds story to them 

[why]
Adds story and makes the ruin worth looting. Harmless loot after all!
If Toriate wants I can and will replace each suit with a different type
Male will get Red Suit (Library's red suit)
Female will get a Red Evening Gown