### PR TITLE
Makes bloodcult conversions consensual, similar to Bay.

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -464,9 +464,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 //Ritual of Dimensional Rending: Calls forth the avatar of Nar'Sie upon the station.
 /obj/effect/rune/narsie
 	cultist_name = "Nar'Sie"
-	cultist_desc = "tears apart dimensional barriers, calling forth the Geometer. Requires 9 invokers."
+	cultist_desc = "tears apart dimensional barriers, calling forth the Geometer. Requires 9 invokers, minus one for every 3 sacrifices."
 	invocation = "TOK-LYR RQA-NAP G'OLT-ULOFT!!"
-	req_cultists = 9
+	req_cultists = 1
 	icon = 'icons/effects/96x96.dmi'
 	color = RUNE_COLOR_DARKRED
 	icon_state = "rune_large"
@@ -493,6 +493,10 @@ structure_check() searches for nearby cultist structures required for the invoca
 	if(!is_station_level(z))
 		return
 	var/mob/living/user = invokers[1]
+	if(invokers.len < 9 - (GLOB.sacrificed.len * 0.35))
+		to_chat(user, "<span class='danger'>You need at least [(9 - (GLOB.sacrificed.len * 0.35)) - invokers.len] more adjacent cultists to use this rune in such a manner.</span>")
+		fail_invoke()
+		return
 	var/datum/antagonist/cult/user_antag = user.mind.has_antag_datum(/datum/antagonist/cult,TRUE)
 	var/datum/objective/eldergod/summon_objective = locate() in user_antag.cult_team.objectives
 	var/area/place = get_area(src)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -185,6 +185,9 @@ structure_check() searches for nearby cultist structures required for the invoca
 	color = RUNE_COLOR_OFFER
 	req_cultists = 1
 	rune_in_use = FALSE
+	var/mob/living/currentconversionman
+	var/conversiontimeout
+	var/conversionresult
 
 /obj/effect/rune/convert/do_invoke_glow()
 	return
@@ -241,6 +244,21 @@ structure_check() searches for nearby cultist structures required for the invoca
 			to_chat(M, "<span class='warning'>Something is shielding [convertee]'s mind!</span>")
 		log_game("Offer rune failed - convertee had anti-magic")
 		return 0
+	to_chat(convertee, "<span class='cult italic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
+	and something evil takes root.</b></span>")
+	to_chat(convertee, "<span class='cult italic'>Do you wish to embrace the Geometer of Blood? <a href='?src=\ref[src];signmeup=1'>Click here to stop resisting the truth.</a> Or you could choose to continue resisting...</span>")
+	currentconversionman = convertee
+	conversiontimeout = world.time + (10 SECONDS)
+	convertee.Stun(100)
+	conversionresult = FALSE
+	while(world.time < conversiontimeout && convertee && !conversionresult)
+		stoplag(1)
+	currentconversionman = null
+	if(convertee && get_turf(convertee) != get_turf(src))
+		return FALSE
+	if(!conversionresult && convertee)
+		do_sacrifice(convertee, invokers)
+		return FALSE
 	var/brutedamage = convertee.getBruteLoss()
 	var/burndamage = convertee.getFireLoss()
 	if(brutedamage || burndamage)
@@ -252,8 +270,6 @@ structure_check() searches for nearby cultist structures required for the invoca
 	SSticker.mode.add_cultist(convertee.mind, 1)
 	new /obj/item/melee/cultblade/dagger(get_turf(src))
 	convertee.mind.special_role = ROLE_CULTIST
-	to_chat(convertee, "<span class='cult italic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
-	and something evil takes root.</b></span>")
 	to_chat(convertee, "<span class='cult italic'><b>Assist your new compatriots in their dark dealings. Your goal is theirs, and theirs is yours. You serve the Geometer above all else. Bring it back.\
 	</b></span>")
 	if(ishuman(convertee))
@@ -313,6 +329,12 @@ structure_check() searches for nearby cultist structures required for the invoca
 			sacrificial.gib()
 	return TRUE
 
+/obj/effect/rune/convert/Topic(href, href_list)
+	if(href_list["signmeup"])
+		if(currentconversionman == usr)
+			conversionresult = TRUE
+		else
+			to_chat(usr, "<span class='cult italic'><b>Your fate has already been set in stone.</b></span>")
 
 
 /obj/effect/rune/empower


### PR DESCRIPTION
Title. Bloodcult conversions are no longer instant, and instead have a maximum timer of 10 seconds. As soon as the conversion begins, the convertee is given a message asking if they wish to join the cult. If the convertee accepts, the conversion instantly completes so long as the convertee is still on the same turf. If the timer runs out, the convertee is instead sacrificed so long as the convertee is still on the same turf. This PR also makes it so that sacrifices will reduce the amount of cultists needed to summon narsie by one third, meaning it'll be plausible to summon narsie with only one single cultist if the cult has successfully sacrificed 24 players.

This should drastically improve the quality of those that get converted to blood cultists by allowing those who do not like conversion antags to opt out of conversion.

:cl: deathride58
add: Bloodcult conversions are now consensual. Convertees are given a ten second timer to accept or wait out. This should drastically improve the quality of those that get converted into bloodcult.
add: All sacrifices now count as a third of a cultist for the end-game narsie summon.
/:cl:
