### PR TITLE
Fixes nameless captains being announced with "Captain Captain on deck!"

### DIFF
--- a/code/modules/jobs/job_types/captain.dm
+++ b/code/modules/jobs/job_types/captain.dm
@@ -26,7 +26,7 @@ Captain
 
 /datum/job/captain/announce(mob/living/carbon/human/H)
 	..()
-	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "Captain [H.real_name] on deck!"))
+	SSticker.OnRoundstart(CALLBACK(GLOBAL_PROC, .proc/minor_announce, "Captain [H.nameless ? "" : "[H.real_name] "]on deck!"))
 
 /datum/outfit/job/captain
 	name = "Captain"


### PR DESCRIPTION
Title. I'll admit, it was actually pretty hilarious at first, but it is an oversight.

:cl: deathride58
fix: Nameless captains will no longer proc a "Captain Captain on deck!" message. Instead, it'll be a much more boring but much more sensical  "Captain on deck!" message.
/:cl:
