### PR TITLE
experimental timer fix - increasing timer buckets to 2 minutes. might cut down on tritium bombs freezing the server, might break literally everything

### DIFF
--- a/code/controllers/subsystem/timer.dm
+++ b/code/controllers/subsystem/timer.dm
@@ -1,4 +1,4 @@
-#define BUCKET_LEN (world.fps*1*60) //how many ticks should we keep in the bucket. (1 minutes worth)
+#define BUCKET_LEN (world.fps*2*60) //how many ticks should we keep in the bucket. (1 minutes worth)
 #define BUCKET_POS(timer) ((round((timer.timeToRun - SStimer.head_offset) / world.tick_lag) % BUCKET_LEN)||BUCKET_LEN)
 #define TIMER_MAX (world.time + TICKS2DS(min(BUCKET_LEN-(SStimer.practical_offset-DS2TICKS(world.time - SStimer.head_offset))-1, BUCKET_LEN-1)))
 #define TIMER_ID_MAX (2**24) //max float with integer precision


### PR DESCRIPTION
uh oh! let's see if this reduces the amount of time that's needed to join buckets.