### PR TITLE
Buffing sec borg guns.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -192,7 +192,7 @@
 
 /obj/item/stock_parts/cell/secborg
 	name = "security borg rechargeable D battery"
-	maxcharge = 600	//600 max charge / 100 charge per shot = six shots
+	maxcharge = 1750	//35/17/8 disabler/laser/taser shots.
 	materials = list(MAT_GLASS=40)
 
 /obj/item/stock_parts/cell/secborg/empty/Initialize()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -50,7 +50,8 @@
 	can_charge = FALSE
 	desc = "An energy-based laser gun that draws power from the cyborg's internal energy cell directly. So this is what freedom looks like?"
 	selfcharge = EGUN_SELFCHARGE_BORG
-	charge_delay = 6
+	cell_type = /obj/item/stock_parts/cell/secborg
+	charge_delay = 3
 
 /obj/item/gun/energy/laser/cyborg/emp_act()
 	return

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -29,7 +29,8 @@
 	can_flashlight = FALSE
 	can_charge = FALSE
 	selfcharge = EGUN_SELFCHARGE_BORG
-	charge_delay = 10
+	cell_type = /obj/item/stock_parts/cell/secborg
+	charge_delay = 5
 
 /obj/item/gun/energy/e_gun/advtaser/cyborg/mean
 	desc = "An integrated hybrid taser that draws directly from a cyborg's power cell."
@@ -49,7 +50,8 @@
 	desc = "An integrated disabler that draws from a cyborg's power cell. This one contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = FALSE
 	selfcharge = EGUN_SELFCHARGE_BORG
-	charge_delay = 10
+	cell_type = /obj/item/stock_parts/cell/secborg
+	charge_delay = 5
 
 /obj/item/gun/energy/disabler/cyborg/mean
 	desc = "An integrated disabler that draws from a cyborg's power cell."


### PR DESCRIPTION
:cl:
balance: Halved borg energy guns self-recharge delay and increased their cell capacity by 3/4
/:cl:

My previous PR turned out to be a sore. Also putting secborg cells back at use again (excluding the syndieborg LMG's, which you could consider a prop).
