### PR TITLE
Fixes genital-less VR people

### DIFF
--- a/code/modules/VR/vr_sleeper.dm
+++ b/code/modules/VR/vr_sleeper.dm
@@ -167,6 +167,7 @@
 		vr_human.undershirt = H.undershirt
 		vr_human.underwear = H.underwear
 		vr_human.updateappearance(TRUE, TRUE, TRUE)
+		vr_human.give_genitals(TRUE) //CITADEL ADD
 		if(outfit)
 			var/datum/outfit/O = new outfit()
 			O.equip(vr_human)


### PR DESCRIPTION
🆑 Poojawa
fix: VR pods correctly assume people's gender and 12" overcompensation straws
/🆑

(probably) Fixes #7849 