### PR TITLE
Fixes centcom zlevel hyperspace acting like normal space (and also fixes the title screen while im at it)

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -4696,7 +4696,7 @@
 	},
 /area/abductor_ship)
 "lI" = (
-/turf/open/space/transit,
+/turf/open/space/transit/centcom,
 /area/space)
 "lJ" = (
 /obj/machinery/door/airlock/centcom{
@@ -20511,7 +20511,7 @@ fX
 fX
 fX
 fX
-fY
+fX
 fX
 fX
 fX
@@ -21282,7 +21282,7 @@ fX
 fX
 fX
 fX
-fX
+fY
 fX
 fX
 fX

--- a/code/game/turfs/space/transit.dm
+++ b/code/game/turfs/space/transit.dm
@@ -41,6 +41,14 @@
 /turf/open/space/transit/border/east
 	dir = EAST
 
+/turf/open/space/transit/centcom
+	dir = SOUTH
+
+/turf/open/space/transit/centcom/Entered(atom/movable/AM, atom/OldLoc)
+	..()
+	if(!locate(/obj/structure/lattice) in src)
+		throw_atom(AM)
+
 /turf/open/space/transit/border/Entered(atom/movable/AM, atom/OldLoc)
 	..()
 	if(!locate(/obj/structure/lattice) in src)


### PR DESCRIPTION
Title. Currently, BoH bombs let scientists and other shitters with hardsuits freely explore the centcom z-level since they currently act like normal space turfs. This PR fixes that. This PR also fixes the title screen's offset while I'm at it.

:cl: deathride58
fix: Transit turfs on the centcom z-level now function properly again at keeping mobs within the areas defined by their boundaries.
fix: The title screen is also positioned correctly again.
/:cl:
