### PR TITLE
Making drake blood punish you less for having terrible luck

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -829,23 +829,15 @@
 		return
 
 	var/mob/living/carbon/human/H = user
-	var/random = rand(1,4)
+	var/random = rand(1,2)
 
 	switch(random)
 		if(1)
-			to_chat(user, "<span class='danger'>Your appearance morphs to that of a very small humanoid ash dragon! You get to look like a freak without the cool abilities.</span>")
-			H.dna.features = list("mcolor" = "A02720", "tail_lizard" = "Dark Tiger", "tail_human" = "None", "snout" = "Sharp", "horns" = "Curled", "ears" = "None", "wings" = "None", "frills" = "None", "spines" = "Long", "body_markings" = "Dark Tiger Body", "legs" = "Digitigrade Legs")
-			H.eye_color = "fee5a3"
-			H.set_species(/datum/species/lizard)
-		if(2)
-			to_chat(user, "<span class='danger'>Your flesh begins to melt! Miraculously, you seem fine otherwise.</span>")
-			H.set_species(/datum/species/skeleton)
-		if(3)
 			to_chat(user, "<span class='danger'>Power courses through you! You can now shift your form at will.</span>")
 			if(user.mind)
 				var/obj/effect/proc_holder/spell/targeted/shapeshift/dragon/D = new
 				user.mind.AddSpell(D)
-		if(4)
+		if(2)
 			to_chat(user, "<span class='danger'>You feel like you could walk straight through lava now.</span>")
 			H.weather_immunities |= "lava"
 


### PR DESCRIPTION
[Changelogs]: 
:cl: Coolgat3
del: Removed the skeleton and lizard transformation from drake blood's effects
/:cl:

[why]: Honestly this PR will probably be rejected. But I did it because I'm tired of the fact that you have 1/4 chance to get this item itself, then some shit chance for there being more than one ash drake, THEN when you actually get lucky enough to get the blood, you get turned into a fucking skeleton. This IS a PR made in rage at RNGesus because in all honesty screw that jerk. The skeleton and lizard transformation is really just useless. The lizard transformation doesn't do anything other than change the way you look, since digitigrades can wear shoes on cit code, and the skeleton transformation is honestly just a punishment for killing an ash drake more than a reward. Don't even get me started on how shitty it feels to kill the third drake in a round and get the most useless sword in the game ever to exist instead of the drake's blood which honestly everyone wants to see.

I doubt it will create much problems with balance since usually traitor miners do not really go hunting, while being transformed into a drake doesn't really make you an antag. It's just the removal of 2 completely useless and even annoying features of the drake blood. The lava walking? We know it is useful, because honestly if you get a lava staff and the blood makes you lava immune? Hell, powergay galore.

Speaking of the fact that being a drake is powergay, let's face it, the whole megafauna hunting idea is one big powergay, and people who get turned into drakes don't even validhunt, they go and vore people instead, and since we are a medium RP server, i think this change would be fun to see for the people who literally waste a whole day farming for drake blood (Yes, I'm referring to myself, although there are a few others who think this.) I hope my rant helps the PR somehow.