### PR TITLE
TGs Chem_dispenser, upgradable chemicals and a new Syndicate First Aid Kit.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -69,7 +69,7 @@
 		"sulfonal",
 		"frostoil",
 		"carpotoxin",
-		"plasma"
+		"histamine"
 	)
 
 	var/list/saved_recipes = list()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -49,12 +49,27 @@
 		"bromine",
 		"stable_plasma"
 	)
+//these become available once upgraded.
+	var/list/upgrade_reagents = list(
+		"oil",
+		"ammonia"
+	)
+
+	var/list/upgrade_reagents2 = list(
+		"acetone",
+		"phenol",
+		"diethylamine"
+	)
+
+	var/list/upgrade_reagents3 = list(
+		"omnizine"
+	)
+
 	var/list/emagged_reagents = list(
-		"space_drugs",
-		"morphine",
+		"sulfonal",
+		"frostoil",
 		"carpotoxin",
-		"mine_salve",
-		"toxin"
+		"plasma"
 	)
 
 	var/list/saved_recipes = list()
@@ -74,7 +89,17 @@
 	..()
 	if(panel_open)
 		to_chat(user, "<span class='notice'>[src]'s maintenance hatch is open!</span>")
-
+	if(in_range(user, src) || isobserver(user))
+		to_chat(user, "<span class='notice'>The status display reads: <br>Recharging <b>[recharge_amount]</b> power units per interval.<br>Power efficiency increased by <b>[(powerefficiency*1000)-100]%</b>.<span>")
+		switch(macrotier)
+			if(1)
+				to_chat(user, "<span class='notice'>Macro granularity at <b>5u</b>.<span>")
+			if(2)
+				to_chat(user, "<span class='notice'>Macro granularity at <b>3u</b>.<span>")
+			if(3)
+				to_chat(user, "<span class='notice'>Macro granularity at <b>2u</b>.<span>")
+			if(4)
+				to_chat(user, "<span class='notice'>Macro granularity at <b>1u</b>.<span>")
 /obj/machinery/chem_dispenser/process()
 	if (recharge_counter >= 4)
 		if(!is_operational())
@@ -346,6 +371,12 @@
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		if (M.rating > macrotier)
 			macrotier = M.rating
+		if (M.rating > 1)
+			dispensable_reagents |= upgrade_reagents
+		if (M.rating > 2)
+			dispensable_reagents |= upgrade_reagents2
+		if (M.rating > 3)
+			dispensable_reagents |= upgrade_reagents3
 	powerefficiency = round(newpowereff, 0.01)
 
 
@@ -447,13 +478,16 @@
 		"tomatojuice",
 		"lemonjuice",
 		"menthol"
-	)
+	) //prevents the soda machine from obtaining chemical upgrades. .
+	upgrade_reagents = null
+	upgrade_reagents2 = null
+	upgrade_reagents3 = null
 	emagged_reagents = list(
 		"thirteenloko",
-		"whiskeycola",
-		"mindbreaker",
-		"tirizene"
+		"morphine",
+		"uranium"
 	)
+
 
 /obj/machinery/chem_dispenser/drinks/fullupgrade //fully ugpraded stock parts, emagged
 	desc = "Contains a large reservoir of soft drinks. This model has had its safeties shorted out."
@@ -497,13 +531,15 @@
 		"creme_de_cacao",
 		"triple_sec",
 		"sake"
-	)
+	)//prevents the booze machine from obtaining chemical upgrades.
+	upgrade_reagents = null
+	upgrade_reagents2 = null
+	upgrade_reagents3 = null
 	emagged_reagents = list(
-		"ethanol",
 		"iron",
+		"clownstears",
 		"minttoxin",
-		"atomicbomb",
-		"fernet"
+		"slimejelly"
 	)
 
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade //fully ugpraded stock parts, emagged
@@ -528,6 +564,7 @@
 	name = "mutagen dispenser"
 	desc = "Creates and dispenses mutagen."
 	dispensable_reagents = list("mutagen")
+	upgrade_reagents = null
 	emagged_reagents = list("plasma")
 
 
@@ -550,7 +587,11 @@
 		"ammonia",
 		"ash",
 		"diethylamine")
-	
+	//same as above.
+	upgrade_reagents = null
+	upgrade_reagents2 = null
+	upgrade_reagents3 = null
+
 /obj/machinery/chem_dispenser/mutagensaltpeter/Initialize()
 	. = ..()
 	component_parts = list()

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -413,7 +413,7 @@
 	description = "Slowly heals all damage types. Overdose will cause damage in all types instead."
 	reagent_state = LIQUID
 	color = "#DCDCDC"
-	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	metabolization_rate = 1 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -413,7 +413,7 @@
 	description = "Slowly heals all damage types. Overdose will cause damage in all types instead."
 	reagent_state = LIQUID
 	color = "#DCDCDC"
-	metabolization_rate = 1 * REAGENTS_METABOLISM
+	metabolization_rate = 0.5 * REAGENTS_METABOLISM
 	overdose_threshold = 30
 
 /datum/reagent/medicine/omnizine/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -224,7 +224,7 @@
 /datum/chemical_reaction/tricordrazine
 	name = "Tricordrazine"
 	id = "tricordrazine"
-	results = list("tricordrazine" = 3)
+	results = list("tricordrazine" = 2)
 	required_reagents = list("bicaridine" = 1, "kelotane" = 1, "antitoxin" = 1)
 
 /datum/chemical_reaction/regen_jelly

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -61,7 +61,7 @@
 	icon_state = "hypo"
 	volume = 35
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("oculine" = 5, "stimulants" = 15, "atropine" = 15)
+	list_reagents = list("inacusiate" = 5, "stimulants" = 15, "atropine" = 15)
 
 /obj/item/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -54,6 +54,15 @@
 	list_reagents = list("omnizine" = 30)
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 
+/obj/item/reagent_containers/hypospray/emergency_combat
+	name = "emergency combat stabilizer" //Used for the new combat medical kit.
+	desc = "A small modified air-needle auto injector, used by support operatives to quickly stabilize their allies in critical condition."
+	amount_per_transfer_from_this = 5
+	icon_state = "hypo"
+	volume = 35
+	ignore_flags = 1 // So they can heal their comrades.
+	list_reagents = list("oculine" = 5, "stimulants" = 15, "atropine" = 15)
+
 /obj/item/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
@@ -61,7 +70,7 @@
 	icon_state = "combat_hypo"
 	volume = 90
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("epinephrine" = 30, "omnizine" = 30, "leporazine" = 15, "atropine" = 15)
+	list_reagents = list("tricordrazine" = 30, "omnizine" = 30)
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with experimental medical compounds for rapid healing."

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1003,12 +1003,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	exclude_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/device_tools/medkit
-	name = "Syndicate Combat Medic Kit"
-	desc = "This first aid kit is a suspicious brown and red. Included is a combat stimulant injector \
-			for rapid healing, a medical HUD for quick identification of injured personnel, \
-			and other supplies helpful for a field medic."
+	name = "New Syndicate Combat Medic Kit"
+	desc = "A superior version of the older combat first aid kit. \
+			Included are two injectors for rapid healing or stabilization, \
+			two medical spray bottles, a diamond piercing syringe \
+			and a medical HUD for quick identification of injured personnel."
 	item = /obj/item/storage/firstaid/tactical
-	cost = 4
+	cost = 6
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/device_tools/syndietome
@@ -1504,7 +1505,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 15
 	restricted_roles = list("Clown")
 
-/datum/uplink_item/device_tools/honkpins //Idealy so they can place it into their own guns without needing cargo 
+/datum/uplink_item/device_tools/honkpins //Idealy so they can place it into their own guns without needing cargo
 	name = "Hilarious firing pin"
 	desc = "A single firing pin made for Clown agents, this firing pin makes any gun honk when fired if not a true clown! \
 	This firing pin also helps you fire the gun correctly. May the HonkMother HONK you agent."


### PR DESCRIPTION
[Changelogs]: 
-Examining every dispenser now gives you more details about its current status. 
-When upgraded, the chemical dispenser unlocks new chems, that allow for easier producing of high-grade stuff.
-When hacked with a Cryptographic Sequencer, The Booze, Soda and Chemist dispenser now have more viable reagents to choose from.
-The Syndicate Combat Medic Kit cost has changed from 4 to 6 Telecrystals
However, this kit now contains: two injectors for rapid healing and stabilization, two medical spray bottles, a diamond piercing syringe and a medical HUD.
-Omnizine’s Metabolism Rate has changed from 0.1 to 0.4 per tick.
-Tricordrazine now makes 2, instead of 3 unit.

[why]: 
- Quality of life improvement. It’s often hard to guess, what your local scientist upgrades in your dispenser. Also, more information never hurts. 
- Allows for more variety of medicine been used/made, because non-professionals or lazy people will have an easier access to these chemicals now. 
- The current Syndicate Combat Medic Kit is fairly trash. I made it more variable, so that Syndicate operators are no longer screwed, when they are alone. However, it's still worse than the Medical gun or a Syndicate Medical Cyborg.
- Because Omnizine now is found inside the chemical dispenser, at the highest tech level, it will be nerfed, so that it won't be abused too much.
- With the change, Dogborgs/dumb Medical Doctors will no longer be able to accidentally overdose crew members inside their sleepers with Tricordrazin. Though, you can still do it, but it requires more clicks than before.  

Yeah, uh, that's my first time making a PR
Please no bully, if I did something wrong. 