### PR TITLE
Making overthrow actually fun like it was meant to be

### DIFF
--- a/code/modules/antagonists/overthrow/overthrow.dm
+++ b/code/modules/antagonists/overthrow/overthrow.dm
@@ -1,4 +1,4 @@
-#define INITIAL_CRYSTALS 5 // initial telecrystals in the boss' uplink
+#define INITIAL_CRYSTALS 24 // initial telecrystals in the boss' uplink
 
 // Syndicate mutineer agents. They're agents selected by the Syndicate to take control of stations when assault teams like nuclear operatives cannot be sent.
 // They sent teams made of 3 agents, of which only one is woke up at round start. The others are, lore-wise, sleeping agents and must be implanted with the converter to wake up.


### PR DESCRIPTION
[Changelogs]: 

:cl: Coolgat3
tweak: Changed the overthrow boss TC from 5 to 24
/:cl:

[why]: Overthrow is meant to be a FUN and rather chaotic gamemode. The description literally says "The agents are supposed to take over the station when a normal assault team can not be sent" So in my opninion giving the boss acces to 24 TC which will allow them to arm up their team well will actually make the gamemode a lot more fun and chaotic. 24 tc is more than that one lone traitor but not enough for the romerol kit. I doubt overthrow teams will ever cooperate so any "48 TC team" situations shouldn't really happen. I mean hell. Overthrow happens rarely, it's already better than revs, but it's rather stale beacuse of the fact that to actually dmanage anything you need to raid armory to get proper weapons, that leaves the other team/s pretty much weaponless if you manage to grab all the stuff from the armory as one team.
