### PR TITLE
Chemical Patches fix.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -495,11 +495,11 @@
 /mob/living/carbon/human/proc/canUseHUD()
 	return !(src.stat || IsKnockdown() || IsStun() || src.restrained())
 
-/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, var/penetrate_thick = 0)
+/mob/living/carbon/human/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE, bypass_immunity = FALSE)
 	. = 1 // Default to returning true.
 	if(user && !target_zone)
 		target_zone = user.zone_selected
-	if(has_trait(TRAIT_PIERCEIMMUNE))
+	if(has_trait(TRAIT_PIERCEIMMUNE) && !bypass_immunity)
 		. = 0
 	// If targeting the head, see if the head item is thin enough.
 	// If targeting anything else, see if the wear suit is thin enough.

--- a/code/modules/reagents/reagent_containers/patch.dm
+++ b/code/modules/reagents/reagent_containers/patch.dm
@@ -14,10 +14,10 @@
 /obj/item/reagent_containers/pill/patch/attack(mob/living/L, mob/user)
 	if(ishuman(L))
 		var/obj/item/bodypart/affecting = L.get_bodypart(check_zone(user.zone_selected))
-		if(!L.can_inject(user, 1, affecting)) //like monkey code, thickmaterial stops patches
-			return
 		if(!affecting)
 			to_chat(user, "<span class='warning'>The limb is missing!</span>")
+			return
+		if(!L.can_inject(user, TRUE, user.zone_selected, FALSE, TRUE)) //stopped by clothing, not by species immunity.
 			return
 		if(affecting.status != BODYPART_ORGANIC)
 			to_chat(user, "<span class='notice'>Medicine won't work on a robotic limb!</span>")


### PR DESCRIPTION
:cl:
fix: Fixes chemical patches always checking the suit slot even if the targetted limb was the head.
fix: Skeleton, nightmare and golem races are once again available to get chemical patches applied onto.
/:cl:

Closes #7661. Although I find the idea of trauma medications being ineffective on certain species/bodies charming, it lacks countermeasures and wasn't the original scope of #7651.
