### PR TITLE
Allows Abductors to revive their dead agent, granted they recover the body.

### DIFF
--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -27,7 +27,7 @@
 
 /datum/surgery_step/revive
 	name = "repair body"
-	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/abductor/gizmo = 100, /obj/item/melee/baton = 75, /obj/item/gun/energy = 60)
+	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/abductor/gizmo = 100, /obj/item/melee/baton = 75, /obj/item/organ/cyberimp/arm/baton = 75, /obj/item/organ/cyberimp/arm/gun/taser = 60, /obj/item/gun/energy/e_gun/advtaser = 60, /obj/item/gun/energy/taser = 60)
 	time = 120
 
 /datum/surgery_step/revive/tool_check(mob/user, obj/item/tool)

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -27,7 +27,7 @@
 
 /datum/surgery_step/revive
 	name = "repair body"
-	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/melee/baton = 75, /obj/item/gun/energy = 60)
+	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/abductor/gizmo = 100, /obj/item/melee/baton = 75, /obj/item/gun/energy = 60)
 	time = 120
 
 /datum/surgery_step/revive/tool_check(mob/user, obj/item/tool)


### PR DESCRIPTION
Adds Abductor Science Tool to acceptable implements to revive a dead body via Advanced Surgery.

As abductors have access to adv. surgery, why not give them this? Usually a dead agent is a death sentence for an abductor team who must either rely on the Scientist to either hijack cloning, steal a defib faster than he can teleport twice, or just solo it.

Also makes their ability to spawn a new agent vest actually relevant and not some meaningless tripe.
