### PR TITLE
Makes wall igniters for science actually ignite burnmix

### DIFF
--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -57,7 +57,7 @@
 
 /obj/machinery/sparker
 	name = "mounted igniter"
-	desc = "A wall-mounted ignition device."
+	desc = "A wall-mounted ignition device. This mounted igniter has been modified heavily to be able to light plasma in the controlled environment of the Toxin Burner."
 	icon = 'icons/obj/stationobjs.dmi'
 	icon_state = "migniter"
 	resistance_flags = FIRE_PROOF
@@ -73,7 +73,7 @@
 /obj/machinery/sparker/Initialize()
 	. = ..()
 	spark_system = new /datum/effect_system/spark_spread
-	spark_system.set_up(25, 2, src)
+	spark_system.set_up(12, 2, src)
 	spark_system.attach(src)
 
 /obj/machinery/sparker/Destroy()

--- a/code/game/machinery/igniter.dm
+++ b/code/game/machinery/igniter.dm
@@ -73,7 +73,7 @@
 /obj/machinery/sparker/Initialize()
 	. = ..()
 	spark_system = new /datum/effect_system/spark_spread
-	spark_system.set_up(2, 1, src)
+	spark_system.set_up(25, 2, src)
 	spark_system.attach(src)
 
 /obj/machinery/sparker/Destroy()


### PR DESCRIPTION
[Changelogs]
Makes sparks maybe work for wall igniters for sci
[why]
`Wow this is useless`
Lets not force people to throw in a light welder or lighter into a burner chamber so it works?
I ded.
Salt PR 