### PR TITLE
makes the DNR status affect ghost role (event and spawner roles) eligibility, makes cryopods always apply DNR status, and readds suicide + ghost admin logging

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -413,7 +413,8 @@
 	var/list/candidates = list()
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		candidates += G
+		if(G.can_reenter_round)
+			candidates += G
 
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates)
 

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -41,6 +41,11 @@
 		return
 	if(QDELETED(src) || QDELETED(user))
 		return
+	if(isobserver(user))
+		var/mob/dead/observer/O = user
+		if(!O.can_reenter_round)
+			to_chat(user, "<span class='warning'>You are unable to reenter the round.</span>")
+			return
 	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and as such, it's very likely to be off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)
 		return

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -198,11 +198,13 @@
 
 		death(0)
 
-/mob/living/proc/suicide_log()
-	log_game("[key_name(src)] committed suicide at [AREACOORD(src)] as [src.type].")
+/mob/living/proc/suicide_log(ghosting)
+	log_game("[key_name(src)] [ghosting ? "ghosted" : "committed suicide"] at [AREACOORD(src)] as [src.type].")
+	message_admins("[key_name(src)] [ghosting ? "ghosted" : "committed suicide"] at [AREACOORD(src)].")
 
-/mob/living/carbon/human/suicide_log()
-	log_game("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) committed suicide at [AREACOORD(src)].")
+/mob/living/carbon/human/suicide_log(ghosting)
+	log_game("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) [is_special_character(src) ? "(ANTAG!) " : ""][ghosting ? "ghosted" : "committed suicide"] at [AREACOORD(src)].")
+	message_admins("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) [is_special_character(src) ? "(ANTAG!) " : ""][ghosting ? "ghosted" : "committed suicide"] at [AREACOORD(src)].")
 
 /mob/living/proc/canSuicide()
 	switch(stat)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -310,7 +310,6 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(response != "Ghost")
 		return
 	ghostize(0)
-	suicide_log(TRUE)
 
 /mob/dead/observer/Move(NewLoc, direct)
 	if(updatedir)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -18,6 +18,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	invisibility = INVISIBILITY_OBSERVER
 	hud_type = /datum/hud/ghost
 	var/can_reenter_corpse
+	var/can_reenter_round = TRUE
 	var/datum/hud/living/carbon/hud = null // hud
 	var/bootime = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
@@ -266,6 +267,7 @@ Works together with spawning an observer, noted above.
 			var/mob/dead/observer/ghost = new(src)	// Transfer safety to observer spawning proc.
 			SStgui.on_transfer(src, ghost) // Transfer NanoUIs.
 			ghost.can_reenter_corpse = can_reenter_corpse
+			ghost.can_reenter_round = (can_reenter_corpse && !suiciding)
 			ghost.key = key
 			return ghost
 
@@ -280,7 +282,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 
 // CITADEL EDIT
 	if(istype(loc, /obj/machinery/cryopod))
-		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")//darn copypaste
 			return
 		var/obj/machinery/cryopod/C = loc
@@ -293,20 +295,22 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(stat == DEAD)
 		ghostize(1)
 	else
-		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+		var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 		if(response != "Ghost")
 			return	//didn't want to ghost after-all
 		ghostize(0)						//0 parameter is so we can never re-enter our body, "Charlie, you can never come baaaack~" :3
+		suicide_log(TRUE)
 
 /mob/camera/verb/ghost()
 	set category = "OOC"
 	set name = "Ghost"
 	set desc = "Relinquish your life and enter the land of the dead."
 
-	var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you may not play again this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
+	var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst still alive you won't be able to re-enter this round! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 	if(response != "Ghost")
 		return
 	ghostize(0)
+	suicide_log(TRUE)
 
 /mob/dead/observer/Move(NewLoc, direct)
 	if(updatedir)
@@ -616,6 +620,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	if(istype (target, /mob/living/simple_animal/hostile/spawner))
 		to_chat(src, "<span class='warning'>This isn't really a creature, now is it!</span>")
 		return 0
+
+	if(!can_reenter_round)
+		to_chat(src, "<span class='warning'>You are unable to re-enter the round.</span>")
+		return FALSE
 
 	if(can_reenter_corpse && mind && mind.current)
 		if(alert(src, "Your soul is still tied to your former life as [mind.current.name], if you go forward there is no going back to that life. Are you sure you wish to continue?", "Move On", "Yes", "No") == "No")

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -365,10 +365,8 @@
 
 	// Ghost and delete the mob.
 	if(!mob_occupant.get_ghost(1))
-		if(world.time < 30 * 600)//before the 30 minute mark
-			mob_occupant.ghostize(0) // Players despawned too early may not re-enter the game
-		else
-			mob_occupant.ghostize(1)
+		mob_occupant.ghostize(0) // Players who cryo out may not re-enter the round
+
 	QDEL_NULL(occupant)
 	open_machine()
 	name = initial(name)


### PR DESCRIPTION
Title. Cryo exists solely so that people can actually leave the round if they have to. However, lately, there have been people abusing cryo solely to be eligible for midround antagonist rolls after a boring roundstart. This PR directly fixes that by making cryopods always apply the DNR status even after 30 minutes, while also making it so that ghost roles (both event and spawner ghost roles) are fully affected by the DNR status. If you are voluntarily and intentionally leaving a round, then you should not be able to reenter it. People who enter the game via observing are still more than eligible for ghost roles.

:cl: deathride58
tweak: Ghost role eligibility for both event and spawner ghost roles is now affected by DNR status. If you suicide, ghost, or cryo out, you will be unable to qualify for any ghost roles
tweak: Cryo now applies DNR status no matter how long the round has been going on
tweak: Suicide is now properly admin logged as it is supposed to be. Ghosting while alive is now also logged.
/:cl:
