### PR TITLE
Properly fixes igniters by increasing the max hotspot expose temperature for sparks to 700 from 300

### DIFF
--- a/code/game/objects/effects/effect_system/effects_sparks.dm
+++ b/code/game/objects/effects/effect_system/effects_sparks.dm
@@ -30,20 +30,20 @@
 	playsound(src, "sparks", 100, TRUE)
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(300,5)
+		T.hotspot_expose(700,5)
 	QDEL_IN(src, 20)
 
 /obj/effect/particle_effect/sparks/Destroy()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(300,1)
+		T.hotspot_expose(700,1)
 	return ..()
 
 /obj/effect/particle_effect/sparks/Move()
 	..()
 	var/turf/T = loc
 	if(isturf(T))
-		T.hotspot_expose(300,1)
+		T.hotspot_expose(700,1)
 
 /datum/effect_system/spark_spread
 	effect_type = /obj/effect/particle_effect/sparks

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -187,6 +187,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	var/datum/effect_system/spark_spread/spark_system
+	var/effectcooldown
 	var/working = 0
 	var/p_dir = NORTH
 	var/p_flipped = FALSE
@@ -207,7 +208,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 /obj/item/pipe_dispenser/New()
 	. = ..()
 	spark_system = new /datum/effect_system/spark_spread
-	spark_system.set_up(5, 0, src)
+	spark_system.set_up(1, 0, src)
 	spark_system.attach(src)
 	if(!first_atmos)
 		first_atmos = GLOB.atmos_pipe_recipes[GLOB.atmos_pipe_recipes[1]][1]
@@ -313,8 +314,9 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			else
 				mode |= n
 
-	if(playeffect)
+	if(playeffect && world.time >= effectcooldown)
 		spark_system.start()
+		effectcooldown = world.time + 100
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 0)
 
 /obj/item/pipe_dispenser/pre_attack(atom/A, mob/user)

--- a/code/modules/power/singularity/emitter.dm
+++ b/code/modules/power/singularity/emitter.dm
@@ -66,7 +66,7 @@
 
 	sparks = new
 	sparks.attach(src)
-	sparks.set_up(5, TRUE, src)
+	sparks.set_up(1, TRUE, src)
 
 /obj/machinery/power/emitter/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
Title. #8117 was improperly merged before the 24 hour grace period, however, it was pushed to the wrong branch, so it cant be reverted by this PR. This PR actually and properly fixes the bug by increasing the hotspot expose temperature to 700, as it was supposed to be before TG decided it to be a good idea to make sparks literally useless. The reason it went unnoticed by me is because it was included in the hard sync, and I stopped paying attention to TG's PRs after a couple months after we broke up with TG. With the other PR in place, the PR that makes hotspot exposure a lot more effective when the conditions for actual hotspot exposure are met, this should mean that science's burn chamber should properly work now. This is effectively a revert of TG's changes

:cl: deathride58
fix: Sparks and igniters will now actually heat areas rather than cooling them, as was intended.
tweak: To alleviate some potential complaints, RPDs now have a cooldown before they can create sparks, and both RPDs and emitters produce less sparks.
/:cl: