### PR TITLE
Makes conversions mute victims that are deciding their fate, fixes conversions requiring three culties for refusal to cause a sacrifice

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -250,14 +250,18 @@ structure_check() searches for nearby cultist structures required for the invoca
 	currentconversionman = convertee
 	conversiontimeout = world.time + (10 SECONDS)
 	convertee.Stun(100)
+	convertee.add_trait(TRAIT_MUTE, "conversionrune")
 	conversionresult = FALSE
 	while(world.time < conversiontimeout && convertee && !conversionresult)
 		stoplag(1)
 	currentconversionman = null
-	if(convertee && get_turf(convertee) != get_turf(src))
+	if(!convertee)
 		return FALSE
-	if(!conversionresult && convertee)
-		do_sacrifice(convertee, invokers)
+	convertee.remove_trait(TRAIT_MUTE, "conversionrune")
+	if(get_turf(convertee) != get_turf(src))
+		return FALSE
+	if(!conversionresult)
+		do_sacrifice(convertee, invokers, TRUE)
 		return FALSE
 	var/brutedamage = convertee.getBruteLoss()
 	var/burndamage = convertee.getFireLoss()
@@ -279,7 +283,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		H.cultslurring = 0
 	return 1
 
-/obj/effect/rune/convert/proc/do_sacrifice(mob/living/sacrificial, list/invokers)
+/obj/effect/rune/convert/proc/do_sacrifice(mob/living/sacrificial, list/invokers, force_a_sac)
 	var/mob/living/first_invoker = invokers[1]
 	if(!first_invoker)
 		return FALSE

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -293,7 +293,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 
 	var/big_sac = FALSE
-	if((((ishuman(sacrificial) || iscyborg(sacrificial)) && sacrificial.stat != DEAD) || C.cult_team.is_sacrifice_target(sacrificial.mind)) && invokers.len < 3)
+	if(!force_a_sac && (((ishuman(sacrificial) || iscyborg(sacrificial)) && sacrificial.stat != DEAD) || C.cult_team.is_sacrifice_target(sacrificial.mind)) && invokers.len < 3)
 		for(var/M in invokers)
 			to_chat(M, "<span class='cult italic'>[sacrificial] is too greatly linked to the world! You need three acolytes!</span>")
 		log_game("Offer rune failed - not enough acolytes and target is living or sac target")


### PR DESCRIPTION
Title. Apparently it was bugged, fuck. 
fixes #8120 

:cl: deathride58
tweak: Conversion runes will now mute the victim temporarily while they're deciding whether to convert or be sacrificed.
fix: Conversion runes no longer require a third cultist to sacrifice if the victim refuses conversion
/:cl:
