### PR TITLE
Fixes staminaloss targeted at the head not redirecting to the chest

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1653,13 +1653,19 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 	var/obj/item/bodypart/BP = null
 	if(isbodypart(def_zone))
-		BP = def_zone
+		if(damagetype == STAMINA && istype(def_zone, /obj/item/bodypart/head))
+			BP = H.get_bodypart(check_zone(BODY_ZONE_CHEST))
+		else
+			BP = def_zone
 	else
 		if(!def_zone)
 			def_zone = ran_zone(def_zone)
+		if(damagetype == STAMINA && def_zone == BODY_ZONE_HEAD)
+			def_zone = BODY_ZONE_CHEST
 		BP = H.get_bodypart(check_zone(def_zone))
-		if(!BP)
-			BP = H.bodyparts[1]
+
+	if(!BP)
+		BP = H.bodyparts[1]
 
 	switch(damagetype)
 		if(BRUTE)


### PR DESCRIPTION
Title. The head is stamina immune, as it's supposed to redirect to the chest.

:cl: deathride58
fix: Staminaloss targeted at the head now properly redirects to the chest.
/:cl:
