### PR TITLE
Makes sprinting not take stamloss in zero gravity or when pulled

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -4,7 +4,7 @@
 /mob/living/carbon/human/Move(NewLoc, direct)
 	var/oldpseudoheight = pseudo_z_axis
 	. = ..()
-	if(. && sprinting && !(movement_type & FLYING) && canmove && !resting && m_intent == MOVE_INTENT_RUN)
+	if(. && sprinting && !(movement_type & FLYING) && canmove && !resting && m_intent == MOVE_INTENT_RUN && has_gravity(loc) && !pulledby)
 		adjustStaminaLossBuffered(0.3)
 		if((oldpseudoheight - pseudo_z_axis) >= 8)
 			to_chat(src, "<span class='warning'>You trip off of the elevated surface!</span>")


### PR DESCRIPTION
Movement code is absolute shit but this is the best I can do with a one line change

:cl: deathride58
tweak: Sprinting no longer takes stam when you're being pulled or when you're in zero gravity. Other sources of involuntary movement are not affected.
/:cl:
