### PR TITLE
Makes mind shields bomb proof

### DIFF
--- a/code/game/objects/items/implants/implant_mindshield.dm
+++ b/code/game/objects/items/implants/implant_mindshield.dm
@@ -1,6 +1,7 @@
 /obj/item/implant/mindshield
 	name = "mindshield implant"
 	desc = "Protects against brainwashing."
+	resistance_flags = INDESTRUCTIBLE
 	activated = 0
 
 /obj/item/implant/mindshield/get_data()


### PR DESCRIPTION
[Changelogs]
Makes mindshields bomb proof

Why?
Fire ball 3x kills implants meaning 3 frag ammo and a flash will legit convert someone or other memes of that sort. If they get gibbed then they will drop a 0 icon mindshield that has to be recovers via injector and a ALT CLICK meaning that it can be a memey strat to get a mindshield via this way.