### PR TITLE
lets try fixing lag during highpop - makes mouse movements only call onmousemove in combat mode

### DIFF
--- a/code/_onclick/drag_drop.dm
+++ b/code/_onclick/drag_drop.dm
@@ -111,7 +111,7 @@
 	if(mob && LAZYLEN(mob.mousemove_intercept_objects))
 		for(var/datum/D in mob.mousemove_intercept_objects)
 			D.onMouseMove(object, location, control, params)
-	if(mob)	//CIT CHANGE - passes onmousemove() to mobs
+	if(!show_popup_menus && mob)	//CIT CHANGE - passes onmousemove() to mobs
 		mob.onMouseMove(object, location, control, params)	//CIT CHANGE - ditto
 	..()
 


### PR DESCRIPTION
title

:cl: deathride58
code: In an attempt to improve performance during highpop, mouse movements will now only call onmousemove() while a user is in combat mode
/:cl:
