### PR TITLE
Nerfs dinks - Ballistic projectiles are now the only projectiles that can emit a dink

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -18,6 +18,7 @@
 	var/def_zone = ""	//Aiming at
 	var/atom/movable/firer = null//Who shot it
 	var/suppressed = FALSE	//Attack message
+	var/candink = FALSE //Can this projectile play the dink sound when hitting the head?
 	var/yo = null
 	var/xo = null
 	var/atom/original = null // the original target clicked
@@ -185,7 +186,7 @@
 				playsound(loc, hitsound, volume, 1, -1)
 			L.visible_message("<span class='danger'>[L] is hit by \a [src][organ_hit_text]!</span>", \
 					"<span class='userdanger'>[L] is hit by \a [src][organ_hit_text]!</span>", null, COMBAT_MESSAGE_RANGE)
-		if(def_zone == BODY_ZONE_HEAD)
+		if(candink && def_zone == BODY_ZONE_HEAD)
 			playsound(src, 'sound/weapons/dink.ogg', 30, 1)
 		L.on_hit(src)
 

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -4,6 +4,7 @@
 	damage = 60
 	damage_type = BRUTE
 	nodamage = FALSE
+	candink = TRUE
 	flag = "bullet"
 	hitsound_wall = "ricochet"
 	impact_effect_type = /obj/effect/temp_visual/impact_effect

--- a/code/modules/projectiles/projectile/bullets/special.dm
+++ b/code/modules/projectiles/projectile/bullets/special.dm
@@ -5,6 +5,7 @@
 	knockdown = 60
 	forcedodge = TRUE
 	nodamage = TRUE
+	candink = FALSE
 	hitsound = 'sound/items/bikehorn.ogg'
 	icon = 'icons/obj/hydroponics/harvest.dmi'
 	icon_state = "banana"


### PR DESCRIPTION
Title. It gets a little obnoxious when sec/borgs are spamming lethals into someone and every single laser to the head emits a dink

:cl: deathride58
tweak: Ballistic projectiles are now the only projectiles capable of emitting dinks.
/:cl:
