### PR TITLE
Change Implants to not be located in a mob's contents.

### DIFF
--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -104,7 +104,7 @@
 			H.update_action_buttons_icon()
 		if(implants)
 			for(var/implant_type in implants)
-				var/obj/item/implant/I = new implant_type(H)
+				var/obj/item/implant/I = new implant_type
 				I.implant(H, null, TRUE)
 
 	H.update_body()

--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -103,7 +103,6 @@
 			/obj/structure/cable,
 			/obj/machinery/atmospherics,
 			/obj/item/ammo_casing,
-			/obj/item/implant,
 			/obj/singularity
 			))
 		if(!can_contaminate || blacklisted[thing.type])

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -154,9 +154,9 @@
 		var/obj/item/U = new uplink_type(H, H.key, tc)
 		H.equip_to_slot_or_del(U, SLOT_IN_BACKPACK)
 
-	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)
+	var/obj/item/implant/weapons_auth/W = new
 	W.implant(H)
-	var/obj/item/implant/explosive/E = new/obj/item/implant/explosive(H)
+	var/obj/item/implant/explosive/E = new
 	E.implant(H)
 	H.faction |= ROLE_SYNDICATE
 	H.update_icons()

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -228,7 +228,7 @@
 				dat += "<h4>[src.active_record.fields["name"]]</h4>"
 				dat += "Scan ID [src.active_record.fields["id"]] <a href='byond://?src=[REF(src)];clone=[active_record.fields["id"]]'>Clone</a><br>"
 
-				var/obj/item/implant/health/H = locate(src.active_record.fields["imp"])
+				var/obj/item/implant/health/H = locate(active_record.fields["imp"])
 
 				if ((H) && (istype(H)))
 					dat += "<b>Health Implant Data:</b><br />[H.sensehealth()]<br><br />"

--- a/code/game/machinery/computer/prisoner.dm
+++ b/code/game/machinery/computer/prisoner.dm
@@ -33,11 +33,11 @@
 		dat += "<HR>Chemical Implants<BR>"
 		var/turf/Tr = null
 		for(var/obj/item/implant/chem/C in GLOB.tracked_chem_implants)
-			Tr = get_turf(C)
-			if((Tr) && (Tr.z != src.z))
-				continue//Out of range
 			if(!C.imp_in)
 				continue
+			Tr = get_turf(C.imp_in)
+			if((Tr) && (Tr.z != src.z))
+				continue//Out of range
 			dat += "ID: [C.imp_in.name] | Remaining Units: [C.reagents.total_volume] <BR>"
 			dat += "| Inject: "
 			dat += "<A href='?src=[REF(src)];inject1=[REF(C)]'>(<font class='bad'>(1)</font>)</A>"
@@ -48,7 +48,7 @@
 		for(var/obj/item/implant/tracking/T in GLOB.tracked_implants)
 			if(!isliving(T.imp_in))
 				continue
-			Tr = get_turf(T)
+			Tr = get_turf(T.imp_in)
 			if((Tr) && (Tr.z != src.z))
 				continue//Out of range
 

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -127,11 +127,11 @@
 			if(!I.imp_in || !isliving(I.loc))
 				continue
 			else
-				var/mob/living/M = I.loc
+				var/mob/living/M = I.imp_in
 				if(M.stat == DEAD)
 					if(M.timeofdeath + 6000 < world.time)
 						continue
-				if(is_eligible(I))
+				if(is_eligible(I.imp_in))
 					L[avoid_assoc_duplicate_keys(M.real_name, areaindex)] = I
 
 		var/desc = input("Please select a location to lock in.", "Locking Computer") as null|anything in L

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -124,7 +124,7 @@
 				L[avoid_assoc_duplicate_keys(A.name, areaindex)] = R
 
 		for(var/obj/item/implant/tracking/I in GLOB.tracked_implants)
-			if(!I.imp_in || !isliving(I.loc))
+			if(!I.imp_in || !isliving(I.imp_in))
 				continue
 			else
 				var/mob/living/M = I.imp_in

--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -72,7 +72,7 @@
 				else
 					return FALSE
 
-	forceMove(target)
+	moveToNullspace()
 	imp_in = target
 	target.implants += src
 	if(activated)
@@ -89,7 +89,6 @@
 	return TRUE
 
 /obj/item/implant/proc/removed(mob/living/source, silent = FALSE, special = 0)
-	moveToNullspace()
 	imp_in = null
 	source.implants -= src
 	for(var/X in actions)

--- a/code/game/objects/items/implants/implant_chem.dm
+++ b/code/game/objects/items/implants/implant_chem.dm
@@ -4,6 +4,7 @@
 	icon_state = "reagents"
 	container_type = OPENCONTAINER
 	activated = FALSE
+	var/obj/item/chemholder
 
 /obj/item/implant/chem/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -30,6 +31,21 @@
 	GLOB.tracked_chem_implants -= src
 	return ..()
 
+/obj/item/implant/chem/implant(mob/living/target, mob/user, silent = FALSE)
+	. = ..()
+	if(.)
+		chemholder = new(imp_in)
+		chemholder.resistance_flags |= INDESTRUCTIBLE //bomb-proofing.
+		chemholder.item_flags |= DROPDEL
+		reagents.trans_to(chemholder, reagents.total_volume)
+
+/obj/item/implant/chem/removed(mob/target, silent = FALSE, special = 0)
+	. = ..()
+	if(.)
+		chemholder.reagents.trans_to(src, chemholder.reagents.total_volume)
+		QDEL_NULL(chemholder)
+
+
 /obj/item/implant/chem/trigger(emote, mob/living/source)
 	if(emote == "deathgasp")
 		if(istype(source) && !(source.stat == DEAD))
@@ -46,12 +62,11 @@
 		injectamount = reagents.total_volume
 	else
 		injectamount = cause
-	reagents.trans_to(R, injectamount)
+	chemholder.reagents.trans_to(R, injectamount)
 	to_chat(R, "<span class='italics'>You hear a faint beep.</span>")
-	if(!reagents.total_volume)
+	if(!chemholder.reagents.total_volume)
 		to_chat(R, "<span class='italics'>You hear a faint click from your chest.</span>")
 		qdel(src)
-
 
 /obj/item/implantcase/chem
 	name = "implant case - 'Remote Chemical'"

--- a/code/game/objects/items/implants/implant_explosive.dm
+++ b/code/game/objects/items/implants/implant_explosive.dm
@@ -11,8 +11,9 @@
 	var/popup = FALSE // is the DOUWANNABLOWUP window open?
 	var/active = FALSE
 
-/obj/item/implant/explosive/on_mob_death(mob/living/L, gibbed)
-	activate("death")
+/obj/item/implant/sad_trombone/trigger(emote, mob/source)
+	if(emote == "deathgasp")
+		activate("death")
 
 /obj/item/implant/explosive/get_data()
 	var/dat = {"<b>Implant Specifications:</b><BR>
@@ -29,32 +30,18 @@
 /obj/item/implant/explosive/activate(cause)
 	. = ..()
 	if(!cause || !imp_in || active)
-		return 0
+		return FALSE
 	if(cause == "action_button" && !popup)
 		popup = TRUE
 		var/response = alert(imp_in, "Are you sure you want to activate your [name]? This will cause you to explode!", "[name] Confirmation", "Yes", "No")
 		popup = FALSE
 		if(response == "No")
-			return 0
-	heavy = round(heavy)
-	medium = round(medium)
-	weak = round(weak)
-	to_chat(imp_in, "<span class='notice'>You activate your [name].</span>")
-	active = TRUE
-	var/turf/boomturf = get_turf(imp_in)
-	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [ADMIN_VERBOSEJMP(boomturf)], with cause of [cause].")
-//If the delay is short, just blow up already jeez
-	if(delay <= 7)
-		explosion(src,heavy,medium,weak,weak, flame_range = weak)
-		if(imp_in)
-			imp_in.gib(1)
-		qdel(src)
-		return
-	timed_explosion()
+			return FALSE
+	addtimer(CALLBACK(src, .proc/timed_explosion, cause), 1)
 
 /obj/item/implant/explosive/implant(mob/living/target)
 	for(var/X in target.implants)
-		if(istype(X, type))
+		if(istype(X, /obj/item/implant/explosive))
 			var/obj/item/implant/explosive/imp_e = X
 			imp_e.heavy += heavy
 			imp_e.medium += medium
@@ -65,22 +52,37 @@
 
 	return ..()
 
-/obj/item/implant/explosive/proc/timed_explosion()
-	imp_in.visible_message("<span class='warning'>[imp_in] starts beeping ominously!</span>")
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay*0.25)
-	if(imp_in && !imp_in.stat)
+/obj/item/implant/explosive/proc/timed_explosion(cause)
+	if(cause == "death" && imp_in.stat != DEAD)
+		return FALSE
+	heavy = round(heavy)
+	medium = round(medium)
+	weak = round(weak)
+	to_chat(imp_in, "<span class='notice'>You activate your [name].</span>")
+	active = TRUE
+	var/turf/boomturf = get_turf(imp_in)
+	message_admins("[ADMIN_LOOKUPFLW(imp_in)] has activated their [name] at [ADMIN_VERBOSEJMP(boomturf)], with cause of [cause].")
+	if(delay > 7)
+		imp_in?.visible_message("<span class='warning'>[imp_in] starts beeping ominously!</span>")
+		playsound(get_turf(imp_in ? imp_in : src), 'sound/items/timer.ogg', 30, 0)
+		addtimer(CALLBACK(src, .proc/double_pain, TRUE), delay * 0.25)
+		addtimer(CALLBACK(src, .proc/double_pain), delay * 0.5)
+		addtimer(CALLBACK(src, .proc/double_pain), delay * 0.75)
+		addtimer(CALLBACK(src, .proc/boom_goes_the_weasel), delay)
+	else //If the delay is short, just blow up already jeez
+		boom_goes_the_weasel()
+
+/obj/item/implant/explosive/proc/double_pain(message = FALSE)
+	playsound(get_turf(imp_in ? imp_in : src), 'sound/items/timer.ogg', 30, 0)
+	if(!imp_in)
+		return
+	if(message && imp_in.stat == CONSCIOUS)
 		imp_in.visible_message("<span class='warning'>[imp_in] doubles over in pain!</span>")
-		imp_in.Knockdown(140)
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay*0.25)
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay*0.25)
-	playsound(loc, 'sound/items/timer.ogg', 30, 0)
-	sleep(delay*0.25)
-	explosion(src,heavy,medium,weak,weak, flame_range = weak)
-	if(imp_in)
-		imp_in.gib(1)
+	imp_in.Knockdown(140)
+
+/obj/item/implant/explosive/proc/boom_goes_the_weasel()
+	explosion(get_turf(imp_in ? imp_in : src), heavy, medium, weak, weak, flame_range = weak)
+	imp_in?.gib(TRUE)
 	qdel(src)
 
 /obj/item/implant/explosive/macro
@@ -95,17 +97,7 @@
 /obj/item/implant/explosive/macro/implant(mob/living/target)
 	for(var/X in target.implants)
 		if(istype(X, type))
-			return 0
-
-	for(var/Y in target.implants)
-		if(istype(Y, /obj/item/implant/explosive))
-			var/obj/item/implant/explosive/imp_e = Y
-			heavy += imp_e.heavy
-			medium += imp_e.medium
-			weak += imp_e.weak
-			delay += imp_e.delay
-			qdel(imp_e)
-			break
+			return FALSE
 
 	return ..()
 

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -103,9 +103,21 @@
 	radio.name = "internal radio"
 	radio.subspace_transmission = subspace_transmission
 	radio.canhear_range = 0
+	radio.resistance_flags |= INDESTRUCTIBLE
+	radio.item_flags |= DROPDEL
 	if(radio_key)
 		radio.keyslot = new radio_key
 	radio.recalculateChannels()
+
+/obj/item/implant/radio/implant(mob/living/target, mob/user, silent = FALSE)
+	. = ..()
+	if(.)
+		radio.forceMove(imp_in)
+
+/obj/item/implant/radio/removed(mob/living/source, silent = FALSE, special = 0)
+	. = ..()
+	if(.)
+		radio.forceMove(src)
 
 /obj/item/implant/radio/mining
 	radio_key = /obj/item/encryptionkey/headset_cargo

--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -103,21 +103,9 @@
 	radio.name = "internal radio"
 	radio.subspace_transmission = subspace_transmission
 	radio.canhear_range = 0
-	radio.resistance_flags |= INDESTRUCTIBLE
-	radio.item_flags |= DROPDEL
 	if(radio_key)
 		radio.keyslot = new radio_key
 	radio.recalculateChannels()
-
-/obj/item/implant/radio/implant(mob/living/target, mob/user, silent = FALSE)
-	. = ..()
-	if(.)
-		radio.forceMove(imp_in)
-
-/obj/item/implant/radio/removed(mob/living/source, silent = FALSE, special = 0)
-	. = ..()
-	if(.)
-		radio.forceMove(src)
 
 /obj/item/implant/radio/mining
 	radio_key = /obj/item/encryptionkey/headset_cargo

--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -4,30 +4,44 @@
 	icon_state = "storage"
 	item_color = "r"
 	var/max_slot_stacking = 4
+	var/obj/item/storage/bluespace_pocket/pocket
 
 /obj/item/implant/storage/activate()
 	. = ..()
-	SEND_SIGNAL(src, COMSIG_TRY_STORAGE_SHOW, imp_in, TRUE)
+	SEND_SIGNAL(pocket, COMSIG_TRY_STORAGE_SHOW, imp_in, TRUE)
 
 /obj/item/implant/storage/removed(source, silent = FALSE, special = 0)
-	. = ..()
-	if(.)
-		if(!special)
-			qdel(GetComponent(/datum/component/storage/concrete/implant))
+	if(!special)
+		qdel(pocket)
+	else
+		pocket?.moveToNullspace()
+	return ..()
 
 /obj/item/implant/storage/implant(mob/living/target, mob/user, silent = FALSE)
 	for(var/X in target.implants)
 		if(istype(X, type))
 			var/obj/item/implant/storage/imp_e = X
-			GET_COMPONENT_FROM(STR, /datum/component/storage, imp_e)
+			GET_COMPONENT_FROM(STR, /datum/component/storage, imp_e.pocket)
 			if(!STR || (STR && STR.max_items < max_slot_stacking))
-				imp_e.AddComponent(/datum/component/storage/concrete/implant)
+				imp_e.pocket.AddComponent(/datum/component/storage/concrete/implant)
 				qdel(src)
 				return TRUE
 			return FALSE
-	AddComponent(/datum/component/storage/concrete/implant)
+	. = ..()
+	if(.)
+		if(pocket)
+			pocket.forceMove(target)
+		else
+			pocket = new(target)
 
-	return ..()
+/obj/item/storage/bluespace_pocket
+	name = "internal bluespace pocket"
+	icon_state = "pillbox"
+	w_class = WEIGHT_CLASS_TINY
+	desc = "A tiny yet spacious pocket, usually found implanted inside sneaky syndicate agents and nowhere else."
+	component_type = /datum/component/storage/concrete/implant
+	resistance_flags = INDESTRUCTIBLE //A bomb!
+	item_flags = DROPDEL
 
 /obj/item/implanter/storage
 	name = "implanter (storage)"

--- a/code/game/objects/items/stacks/telecrystal.dm
+++ b/code/game/objects/items/stacks/telecrystal.dm
@@ -9,9 +9,10 @@
 	item_flags = NOBLUDGEON
 
 /obj/item/stack/telecrystal/attack(mob/target, mob/user)
-	if(target == user) //You can't go around smacking people with crystals to find out if they have an uplink or not.
-		for(var/obj/item/implant/uplink/I in target)
-			if(I && I.imp_in)
+	if(target == user && isliving(user)) //You can't go around smacking people with crystals to find out if they have an uplink or not.
+		var/mob/living/L = user
+		for(var/obj/item/implant/uplink/I in L.implants)
+			if(I?.imp_in)
 				GET_COMPONENT_FROM(hidden_uplink, /datum/component/uplink, I)
 				if(hidden_uplink)
 					hidden_uplink.telecrystals += amount

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -75,15 +75,14 @@
 
 				temp += "<B>Implant Signals:</B><BR>"
 				for (var/obj/item/implant/tracking/W in GLOB.tracked_implants)
-					if (!W.imp_in || !isliving(W.loc))
+					if (!isliving(W.imp_in))
 						continue
-					else
-						var/mob/living/M = W.loc
-						if (M.stat == DEAD)
-							if (M.timeofdeath + 6000 < world.time)
-								continue
+					var/mob/living/M = W.imp_in
+					if (M.stat == DEAD)
+						if (M.timeofdeath + 6000 < world.time)
+							continue
 
-					var/turf/tr = get_turf(W)
+					var/turf/tr = get_turf(W.imp_in)
 					if (tr.z == sr.z && tr)
 						var/direct = max(abs(tr.x - sr.x), abs(tr.y - sr.y))
 						if (direct < 20)

--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -52,5 +52,5 @@
 /datum/outfit/abductor/scientist/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	..()
 	if(!visualsOnly)
-		var/obj/item/implant/abductor/beamplant = new /obj/item/implant/abductor(H)
+		var/obj/item/implant/abductor/beamplant = new
 		beamplant.implant(H)

--- a/code/modules/antagonists/overthrow/overthrow.dm
+++ b/code/modules/antagonists/overthrow/overthrow.dm
@@ -107,9 +107,9 @@
 /datum/antagonist/overthrow/proc/equip_overthrow()
 	if(!owner || !owner.current || !ishuman(owner.current)) // only equip existing human overthrow members. This excludes the AI, in particular.
 		return
-	var/obj/item/implant/storage/S = locate(/obj/item/implant/storage) in owner.current
+	var/obj/item/implant/storage/S = locate(/obj/item/implant/storage) in owner.current.implants
 	if(!S)
-		S = new(owner.current)
+		S = new
 		S.implant(owner.current)
 	var/I = pick(possible_useful_items)
 	if(ispath(I)) // in case some admin decides to fuck the list up for fun

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -245,7 +245,7 @@
 	if(!istype(M))
 		return
 
-	var/obj/item/implant/exile/Implant = new/obj/item/implant/exile(M)
+	var/obj/item/implant/exile/Implant = new
 	Implant.implant(M)
 
 /datum/antagonist/wizard/academy/create_objectives()

--- a/code/modules/awaymissions/mission_code/Academy.dm
+++ b/code/modules/awaymissions/mission_code/Academy.dm
@@ -210,8 +210,6 @@
 		if(4)
 			//Destroy Equipment
 			for (var/obj/item/I in user)
-				if (istype(I, /obj/item/implant))
-					continue
 				qdel(I)
 		if(5)
 			//Monkeying

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -10,7 +10,7 @@
 	if(visualsOnly)
 		return
 
-	var/obj/item/implant/mindshield/L = new/obj/item/implant/mindshield(H)
+	var/obj/item/implant/mindshield/L = new
 	L.implant(H, null, 1)
 
 	var/obj/item/radio/R = H.ears

--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -399,7 +399,7 @@
 	R.set_frequency(FREQ_CENTCOM)
 	R.freqlock = TRUE
 
-	var/obj/item/implant/mindshield/L = new/obj/item/implant/mindshield(H)//Here you go Deuryn
+	var/obj/item/implant/mindshield/L = new //Here you go Deuryn
 	L.implant(H, null, 1)
 
 
@@ -426,7 +426,7 @@
 
 /datum/outfit/debug //Debug objs plus hardsuit
 	name = "Debug outfit"
-	uniform = /obj/item/clothing/under/patriotsuit 
+	uniform = /obj/item/clothing/under/patriotsuit
 	suit = /obj/item/clothing/suit/space/hardsuit/syndi/elite
 	shoes = /obj/item/clothing/shoes/magboots/advance
 	suit_store = /obj/item/tank/internals/oxygen

--- a/code/modules/clothing/outfits/vr.dm
+++ b/code/modules/clothing/outfits/vr.dm
@@ -29,9 +29,9 @@
 	. = ..()
 	var/obj/item/uplink/U = new /obj/item/uplink/nuclear_restricted(H, H.key, 80)
 	H.equip_to_slot_or_del(U, SLOT_IN_BACKPACK)
-	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(H)
+	var/obj/item/implant/weapons_auth/W = new
 	W.implant(H)
-	var/obj/item/implant/explosive/E = new/obj/item/implant/explosive(H)
+	var/obj/item/implant/explosive/E = new
 	E.implant(H)
 	H.faction |= ROLE_SYNDICATE
 	H.update_icons()

--- a/code/modules/mining/minebot.dm
+++ b/code/modules/mining/minebot.dm
@@ -49,7 +49,7 @@
 	toggle_mode_action.Grant(src)
 	var/datum/action/innate/minedrone/dump_ore/dump_ore_action = new()
 	dump_ore_action.Grant(src)
-	var/obj/item/implant/radio/mining/imp = new(src)
+	var/obj/item/implant/radio/mining/imp = new
 	imp.implant(src)
 
 	access_card = new /obj/item/card/id(src)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -11,6 +11,10 @@
 	if(!no_bodyparts)
 		spread_bodyparts(no_brain, no_organs)
 
+	for(var/X in implants)
+		var/obj/item/implant/I = X
+		qdel(I)
+
 	spawn_gibs(no_bodyparts)
 	qdel(src)
 

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -344,8 +344,8 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return message
 
 /mob/living/proc/radio(message, message_mode, list/spans, language)
-	var/obj/item/implant/radio/imp = locate() in src
-	if(imp && imp.radio.on)
+	var/obj/item/implant/radio/imp = locate() in implants
+	if(imp?.radio.on)
 		if(message_mode == MODE_HEADSET)
 			imp.radio.talk_into(src, message, , spans, language)
 			return ITALICS | REDUCE_RANGE

--- a/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/extra_drone_types.dm
@@ -49,7 +49,7 @@
 	. = ..()
 	GET_COMPONENT_FROM(hidden_uplink, /datum/component/uplink, internal_storage)
 	hidden_uplink.telecrystals = 30
-	var/obj/item/implant/weapons_auth/W = new/obj/item/implant/weapons_auth(src)
+	var/obj/item/implant/weapons_auth/W = new
 	W.implant(src)
 
 /mob/living/simple_animal/drone/snowflake

--- a/code/modules/mob/living/simple_animal/hostile/wizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/wizard.dm
@@ -46,7 +46,8 @@
 	fireball.human_req = 0
 	fireball.player_lock = 0
 	AddSpell(fireball)
-	implants += new /obj/item/implant/exile(src)
+	var/obj/item/implant/exile/I = new
+	I.implant(src, null, TRUE)
 
 	mm = new /obj/effect/proc_holder/spell/targeted/projectile/magic_missile
 	mm.clothes_req = 0

--- a/code/modules/research/xenobiology/xenobiology.dm
+++ b/code/modules/research/xenobiology/xenobiology.dm
@@ -699,7 +699,7 @@
 	desc = "A miraculous chemical mix that grants human like intelligence to living beings. It has been modified with Syndicate technology to also grant an internal radio implant to the target and authenticate with identification systems."
 
 /obj/item/slimepotion/slime/sentience/nuclear/after_success(mob/living/user, mob/living/simple_animal/SM)
-	var/obj/item/implant/radio/syndicate/imp = new(src)
+	var/obj/item/implant/radio/syndicate/imp = new
 	imp.implant(SM, user)
 
 	SM.access_card = new /obj/item/card/id/syndicate(SM)
@@ -963,7 +963,7 @@
 
 	to_chat(user, "<span class='notice'>You feed the potion to [M].</span>")
 	to_chat(M, "<span class='notice'>Your mind tingles as you are fed the potion. You can hear radio waves now!</span>")
-	var/obj/item/implant/radio/slime/imp = new(src)
+	var/obj/item/implant/radio/slime/imp = new
 	imp.implant(M, user)
 	qdel(src)
 


### PR DESCRIPTION
:cl:
refactor: Refactors implants to not be located into the implanted's contents.
fix: This translates to them being unaffected by explosions and maybe other stuff going byond coders foresigth. The storage implant's pocket and chem implant's container are still contained within the mob though.
fix: Fixes storage implants actually dropping the stored items into nullspace on removal.
/:cl:

Completing the switch from contents checks to implants list checks and fixing a couple issues with implants. Alternative to #8139.

