### PR TITLE
Makes OOC and LOOC actually use different toggles

### DIFF
--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -90,10 +90,6 @@ GLOBAL_LIST_INIT(dildo_colors, list(//mostly neon colors
 		"Purple"	= "#e300ff"//purple
 		))
 
-//Looc stuff
-GLOBAL_VAR_INIT(looc_allowed, 1)
-GLOBAL_VAR_INIT(dlooc_allowed, 1)
-
 //Crew objective and miscreants stuff
 GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 
@@ -123,36 +119,6 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 	prefs.save_preferences()
 	src << "You will [(prefs.chat_toggles & CHAT_LOOC) ? "now" : "no longer"] see messages on the LOOC channel."
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/datum/admins/proc/togglelooc()
-	set category = "Server"
-	set desc="Fukken metagamers"
-	set name="Toggle LOOC"
-	toggle_looc()
-	log_admin("[key_name(usr)] toggled LOOC.")
-	message_admins("[key_name_admin(usr)] toggled LOOC.")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "TLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
-/proc/toggle_looc(toggle = null)
-	if(toggle != null) //if we're specifically en/disabling ooc
-		if(toggle != GLOB.looc_allowed)
-			GLOB.looc_allowed = toggle
-		else
-			return
-	else //otherwise just toggle it
-		GLOB.looc_allowed = !GLOB.looc_allowed
-	world << "<B>The LOOC channel has been globally [GLOB.looc_allowed ? "enabled" : "disabled"].</B>"
-
-/datum/admins/proc/toggleloocdead()
-	set category = "Server"
-	set desc="Toggle dis bitch"
-	set name="Toggle Dead LOOC"
-	GLOB.dlooc_allowed = !( GLOB.dlooc_allowed )
-
-	log_admin("[key_name(usr)] toggled Dead LOOC.")
-	message_admins("[key_name_admin(usr)] toggled Dead LOOC.")
-	SSblackbox.record_feedback("tally", "admin_verb", 1, "TDLOOC") //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
-
 
 /mob/living/carbon/proc/has_penis()
 	if(getorganslot("penis"))//slot shared with ovipositor

--- a/code/_globalvars/configuration.dm
+++ b/code/_globalvars/configuration.dm
@@ -9,6 +9,7 @@ GLOBAL_VAR_INIT(changelog_hash, "")
 GLOBAL_VAR_INIT(hub_visibility, FALSE)
 
 GLOBAL_VAR_INIT(ooc_allowed, TRUE)	// used with admin verbs to disable ooc - not a config option apparently
+GLOBAL_VAR_INIT(looc_allowed, TRUE)
 GLOBAL_VAR_INIT(dooc_allowed, TRUE)
 GLOBAL_VAR_INIT(aooc_allowed, FALSE)
 GLOBAL_VAR_INIT(enter_allowed, TRUE)

--- a/code/modules/admin/admin.dm
+++ b/code/modules/admin/admin.dm
@@ -538,13 +538,22 @@
 	message_admins("[key_name_admin(usr)] toggled OOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle OOC", "[GLOB.ooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 
+/datum/admins/proc/toggleooclocal()
+	set category = "Server"
+	set desc="Toggle dat bitch"
+	set name="Toggle Local OOC"
+	toggle_looc()
+	log_admin("[key_name(usr)] toggled LOOC.")
+	message_admins("[key_name_admin(usr)] toggled LOOC.")
+	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Local OOC", "[GLOB.ooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
+
 /datum/admins/proc/toggleoocdead()
 	set category = "Server"
 	set desc="Toggle dis bitch"
 	set name="Toggle Dead OOC"
 	toggle_dooc()
 
-	log_admin("[key_name(usr)] toggled OOC.")
+	log_admin("[key_name(usr)] toggled Dead OOC.")
 	message_admins("[key_name_admin(usr)] toggled Dead OOC.")
 	SSblackbox.record_feedback("nested tally", "admin_toggle", 1, list("Toggle Dead OOC", "[GLOB.dooc_allowed ? "Enabled" : "Disabled"]")) //If you are copy-pasting this, ensure the 2nd parameter is unique to the new proc!
 

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -24,6 +24,7 @@ GLOBAL_LIST_INIT(admin_verbs_admin, world.AVerbsAdmin())
 	/client/proc/game_panel,			/*game panel, allows to change game-mode etc*/
 	/client/proc/check_ai_laws,			/*shows AI and borg laws*/
 	/datum/admins/proc/toggleooc,		/*toggles ooc on/off for everyone*/
+	/datum/admins/proc/toggleooclocal,	/*toggles looc on/off for everyone*/
 	/datum/admins/proc/toggleoocdead,	/*toggles ooc on/off for everyone who is dead*/
 	/datum/admins/proc/toggleaooc,		/*toggles antag ooc on/off*/
 	/datum/admins/proc/toggleenter,		/*toggles whether people can join the current game*/

--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -24,11 +24,8 @@
 		return
 
 	if(!holder)
-		if(!GLOB.ooc_allowed)
-			to_chat(src, "<span class='danger'> OOC is globally muted</span>")
-			return
-		if(!GLOB.dooc_allowed && (mob.stat == DEAD))
-			to_chat(usr, "<span class='danger'> OOC for dead mobs has been turned off.</span>")
+		if(!GLOB.looc_allowed)
+			to_chat(src, "<span class='danger'> LOOC is globally muted</span>")
 			return
 		if(prefs.muted & MUTE_OOC)
 			to_chat(src, "<span class='danger'> You cannot use OOC (muted).</span>")

--- a/code/modules/client/verbs/ooc.dm
+++ b/code/modules/client/verbs/ooc.dm
@@ -80,6 +80,16 @@
 		GLOB.ooc_allowed = !GLOB.ooc_allowed
 	to_chat(world, "<B>The OOC channel has been globally [GLOB.ooc_allowed ? "enabled" : "disabled"].</B>")
 
+/proc/toggle_looc(toggle = null)
+	if(toggle != null)
+		if(toggle != GLOB.looc_allowed)
+			GLOB.looc_allowed = toggle
+		else
+			return
+	else
+		GLOB.looc_allowed = !GLOB.looc_allowed
+
+
 /proc/toggle_dooc(toggle = null)
 	if(toggle != null)
 		if(toggle != GLOB.dooc_allowed)


### PR DESCRIPTION
Title. Because sometimes, we have to mute OOC, but LOOC is a very important thing to have sometimes.

:cl: deathride58
tweak: OOC and LOOC now use separate toggles. You can now use LOOC while OOC is globally toggled off, and admins now have the option to toggle LOOC off separately from OOC
code: also revamped and reorganized relevant looc adminverb code
/:cl:
