### PR TITLE
Adds rule 3 from the Lavaland Role Antag Policy to the ash walker spawn text

### DIFF
--- a/modular_citadel/code/game/objects/structures/ghost_role_spawners.dm
+++ b/modular_citadel/code/game/objects/structures/ghost_role_spawners.dm
@@ -1,0 +1,4 @@
+/obj/effect/mob_spawn/human/ash_walker
+	flavour_text = "<span class='big bold'>You are an ash walker.</span><b> Your tribe worships <span class='danger'>the Necropolis</span>. The wastes are sacred ground, its monsters a blessed bounty. \
+		You have seen lights in the distance... they foreshadow the arrival of outsiders that seek to tear apart the Necropolis and its domain. Fresh sacrifices for your nest.</b> \
+		<br><span class='big bold'>Ash walkers are not to willingly board the station for <u>any reason.</span></font>"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2829,6 +2829,7 @@
 #include "modular_citadel\code\game\objects\items\melee\transforming.dm"
 #include "modular_citadel\code\game\objects\items\robot\robot_upgrades.dm"
 #include "modular_citadel\code\game\objects\items\storage\firstaid.dm"
+#include "modular_citadel\code\game\objects\structures\ghost_role_spawners.dm"
 #include "modular_citadel\code\game\objects\structures\tables_racks.dm"
 #include "modular_citadel\code\game\objects\structures\beds_chairs\chair.dm"
 #include "modular_citadel\code\game\objects\structures\beds_chairs\sofa.dm"


### PR DESCRIPTION
Hotel staff have an equivalent, and it's a problem that happens enough here that this can help change.

:cl: 
tweak: add additional flavor/rules spawn text to ashwalkers
/:cl: