### PR TITLE
Makes Neo_Jelly Od at 22u - Requested by  Coldstorm

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1060,7 +1060,7 @@
     reagent_state = LIQUID
     metabolization_rate = 1 * REAGENTS_METABOLISM
     color = "#91D865"
-    overdose_threshold = 30
+    overdose_threshold = 22
     taste_description = "jelly"
 
 /datum/reagent/medicine/neo_jelly/on_mob_life(mob/living/carbon/M)


### PR DESCRIPTION
[Changelogs]

Coldstorm wanted it to od at 22u for a miner nerf

[why]
Making it so that you cant just have 2 medipends rapidly heal you! stops the miner chem stack rolling on megafuna 
