### PR TITLE
Maybe adds adv health scanner to all borgs that have health scanners

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -504,6 +504,32 @@
 		var/obj/item/surgical_processor/SP = locate() in R.module
 		R.module.remove_module(SP, TRUE)
 
+/obj/item/borg/upgrade/advhealth
+	name = "advanced cyborg health scanner"
+	desc = "An upgrade to the Medical modules, installing a built-in \
+		advanced health scanner, for better readings on patients."
+	icon_state = "cyborg_upgrade3"
+	require_module = 1
+	module_type list=(
+		/obj/item/robot_module/medical,
+		/obj/item/robot_module/standerd, 
+		/obj/item/robot_module/syndicate_medical,
+		/obj/item/robot_module/medihound,
+		/obj/item/robot_module/borgi) 
+
+/obj/item/borg/upgrade/advhealth/action(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if(.)
+		var/obj/item/healthanalyzer/advanced/AH = new(R.module)
+		R.module.basic_modules += AH
+		R.module.add_module(AH, FALSE, TRUE)
+
+/obj/item/borg/upgrade/processor/deactivate(mob/living/silicon/robot/R, user = usr)
+	. = ..()
+	if (.)
+		var/obj/item/healthanalyzer/advanced/AH = locate() in R.module
+		R.module.remove_module(AH, TRUE)
+
 /obj/item/borg/upgrade/ai
 	name = "B.O.R.I.S. module"
 	desc = "Bluespace Optimized Remote Intelligence Synchronization. An uplink device which takes the place of an MMI in cyborg endoskeletons, creating a robotic shell controlled by an AI."

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -510,9 +510,8 @@
 		advanced health scanner, for better readings on patients."
 	icon_state = "cyborg_upgrade3"
 	require_module = 1
-	module_type list=(
+	module_type = list(
 		/obj/item/robot_module/medical,
-		/obj/item/robot_module/standerd, 
 		/obj/item/robot_module/syndicate_medical,
 		/obj/item/robot_module/medihound,
 		/obj/item/robot_module/borgi) 

--- a/code/modules/research/designs/mechfabricator_designs.dm
+++ b/code/modules/research/designs/mechfabricator_designs.dm
@@ -768,6 +768,15 @@
 	construction_time = 120
 	category = list("Cyborg Upgrade Modules")
 
+/datum/design/borg_upgrade_advhealth
+	name = "Cyborg Upgrade (Advance Health Scanner)"
+	id = "borg_upgrade_advhealth"
+	build_type = MECHFAB
+	build_path = /obj/item/borg/upgrade/advhealth
+	materials = list(MAT_METAL=7500, MAT_GLASS=7500, MAT_SILVER=1000, MAT_GOLD=1000, MAT_TITANIUM=2000)
+	construction_time = 100
+	category = list("Cyborg Upgrade Modules")
+
 //Misc
 /datum/design/mecha_tracking
 	name = "Exosuit Tracking Beacon"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -309,7 +309,7 @@
 	display_name = "Cyborg Upgrades: Medical"
 	description = "Medical upgrades for cyborgs."
 	prereq_ids = list("adv_biotech", "robotics")
-	design_ids = list("borg_upgrade_defibrillator", "borg_upgrade_piercinghypospray", "borg_upgrade_highstrengthsynthesiser", "borg_upgrade_expandedsynthesiser", "borg_upgrade_pinpointer", "borg_upgrade_surgicalprocessor")
+	design_ids = list("borg_upgrade_defibrillator", "borg_upgrade_advhealth", "borg_upgrade_piercinghypospray", "borg_upgrade_highstrengthsynthesiser", "borg_upgrade_expandedsynthesiser", "borg_upgrade_pinpointer", "borg_upgrade_surgicalprocessor")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 


### PR DESCRIPTION
[Changelogs]
Made a new borg upgrade that has the Adv health scanner!
Use on any borg that has a health analyzer normal to ADD the adv one. Keeps the old one for obvs reasons

[why]
Borgs have adv chems that heal eye, brain, ear harm as well as rads. Why not let them know if the chem is needed so we dont wast time, and juice on it `To be safe`
