### PR TITLE
makes the succumb verb available in the IC tab

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -312,7 +312,8 @@
 	return TRUE
 
 /mob/living/verb/succumb(whispered as null)
-	set hidden = TRUE
+	set name = "Succumb"
+	set category = "IC"
 	if (InCritical())
 		log_message("Has [whispered ? "whispered his final words" : "succumbed to death"] while in [InFullCritical() ? "hard":"soft"] critical with [round(health, 0.1)] points of health!", LOG_ATTACK)
 		adjustOxyLoss(health - HEALTH_THRESHOLD_DEAD)


### PR DESCRIPTION
why was this a hidden verb

:cl: deathride58
tweak: The succumb verb is now available in the IC tab
/:cl:
