### PR TITLE
Makes plasma heal rads, just like in "head-cannon" lore

### DIFF
--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -534,7 +534,6 @@
 	race = /datum/species/android
 	mutationtext = "<span class='danger'>The pain subsides. You feel... artificial.</span>"
 
-
 //BLACKLISTED RACES
 /datum/reagent/mutationtoxin/skeleton
 	name = "Skeleton Mutation Toxin"
@@ -559,7 +558,6 @@
 	color = "#5EFF3B" //RGB: 94, 255, 59
 	race = /datum/species/lizard/ashwalker
 	mutationtext = "<span class='danger'>The pain subsides. You feel... savage.</span>"
-
 
 //DANGEROUS RACES
 /datum/reagent/mutationtoxin/shadow
@@ -1355,9 +1353,6 @@
 	color = "#FFFFFF" // white
 	random_color_list = list("#FFFFFF") //doesn't actually change appearance at all
 
-
-
-
 //////////////////////////////////Hydroponics stuff///////////////////////////////
 
 /datum/reagent/plantnutriment
@@ -1395,15 +1390,7 @@
 	color = "#9D9D00" // RBG: 157, 157, 0
 	tox_prob = 15
 
-
-
-
-
-
-
 // GOON OTHERS
-
-
 
 /datum/reagent/oil
 	name = "Oil"
@@ -1424,6 +1411,11 @@
 
 /datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/C)
 	C.adjustPlasma(10)
+	..()
+
+/datum/reagent/stable_plasma/on_mob_life(mob/living/carbon/M)
+	if(M.radiation > 0)
+		M.radiation -= min(M.radiation, 10)
 	..()
 
 /datum/reagent/iodine

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -86,6 +86,11 @@
 		return
 	..()
 
+/datum/reagent/toxin/plasma/on_mob_life(mob/living/carbon/M)
+	if(M.radiation > 0)
+		M.radiation -= min(M.radiation, 15)
+	..()
+
 /datum/reagent/toxin/lexorin
 	name = "Lexorin"
 	id = "lexorin"


### PR DESCRIPTION
[Changelogs]
Plasma normal being raw in from will absorb 15 rads per action
Stable plasma being mixed and contamiated will only heal 10 rads a action...
[why]
Plasma in my headcannon lore legit removes and absorbs rads, Rads in a annoying and deadly thing no one can handle in the first place
This will help deal with "Nukie" level of rads on a person being able to chem stack and quickly treat lethal levels of rads much faster speeding up the game progression of rad removal. Helps many races out that dont care about toxins, or such
We need better ways to clear mob rads faster to stop "Medical is more radioactive then the SM"