### PR TITLE
Optimizes get_hearers_in_view by caching the results of view() in the proc

### DIFF
--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -221,9 +221,10 @@
 	else  // A variation of get_hear inlined here to take advantage of the compiler's fastpath for obj/mob in view
 		var/lum = T.luminosity
 		T.luminosity = 6 // This is the maximum luminosity
-		for(var/mob/M in view(R, T))
+		var/list/cachedview = view(R, T)
+		for(var/mob/M in cachedview)
 			processing_list += M
-		for(var/obj/O in view(R, T))
+		for(var/obj/O in cachedview)
 			processing_list += O
 		T.luminosity = lum
 


### PR DESCRIPTION
This is called often enough for the redundant view() calls to build up. View() is kind of an expensive operation.

:cl: deathride58
code: get_hearers_in_view() now actually caches the results of view() instead of calling view() twice
/:cl:
