### PR TITLE
Makes action buttons fill the entire screen on widescreen and other weird view sizes

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -162,6 +162,8 @@
 		return
 
 	var/button_number = 0
+	var/list/cview = getviewsize(client.view)
+	var/supportedcolumns = cview[1]-2
 
 	if(hud_used.action_buttons_hidden)
 		for(var/datum/action/A in actions)
@@ -177,7 +179,7 @@
 			if(B.moved)
 				B.screen_loc = B.moved
 			else
-				B.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number)
+				B.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number, supportedcolumns)
 			if(reload_screen)
 				client.screen += B
 
@@ -186,30 +188,26 @@
 			return
 
 	if(!hud_used.hide_actions_toggle.moved)
-		hud_used.hide_actions_toggle.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number+1)
+		hud_used.hide_actions_toggle.screen_loc = hud_used.ButtonNumberToScreenCoords(button_number+1, supportedcolumns)
 	else
 		hud_used.hide_actions_toggle.screen_loc = hud_used.hide_actions_toggle.moved
 	if(reload_screen)
 		client.screen += hud_used.hide_actions_toggle
 
-
-
-#define AB_MAX_COLUMNS 10
-
-/datum/hud/proc/ButtonNumberToScreenCoords(number) // TODO : Make this zero-indexed for readabilty
-	var/row = round((number - 1)/AB_MAX_COLUMNS)
-	var/col = ((number - 1)%(AB_MAX_COLUMNS)) + 1
+/datum/hud/proc/ButtonNumberToScreenCoords(number, supportedcolumns) // TODO : Make this zero-indexed for readabilty
+	var/row = round((number - 1)/supportedcolumns)
+	var/col = ((number - 1)%(supportedcolumns)) + 1
 
 	var/coord_col = "+[col-1]"
-	var/coord_col_offset = 4 + 2 * col
+	var/coord_col_offset = 2 + 2 * col
 
 	var/coord_row = "[row ? -row : "+0"]"
 
 	return "WEST[coord_col]:[coord_col_offset],NORTH[coord_row]:-6"
 
-/datum/hud/proc/SetButtonCoords(obj/screen/button,number)
-	var/row = round((number-1)/AB_MAX_COLUMNS)
-	var/col = ((number - 1)%(AB_MAX_COLUMNS)) + 1
+/datum/hud/proc/SetButtonCoords(obj/screen/button,number, supportedcolumns)
+	var/row = round((number-1)/supportedcolumns)
+	var/col = ((number - 1)%(supportedcolumns)) + 1
 	var/x_offset = 32*(col-1) + 4 + 2*col
 	var/y_offset = -32*(row+1) + 26
 


### PR DESCRIPTION
It's free screen real estate 2: electric boogaloo
![image](https://user-images.githubusercontent.com/6356337/55295256-efa32a80-53d8-11e9-988e-8860e275caca.png)


:cl: deathride58
add: Action buttons are now able to fill the entire screen in widescreen and other weird view sizes.
/:cl:
