### PR TITLE
Remove kebab's omegastation's job changes

### DIFF
--- a/code/modules/jobs/map_changes/map_changes.dm
+++ b/code/modules/jobs/map_changes/map_changes.dm
@@ -1,6 +1,4 @@
 //this needs to come after the job_types subfolder to keep the correct ordering
 
-#include "..\..\..\..\_maps\map_files\OmegaStation\job_changes.dm"
-#undef JOB_MODIFICATION_MAP_NAME
 #include "..\..\..\..\_maps\map_files\PubbyStation\job_changes.dm"
 #undef JOB_MODIFICATION_MAP_NAME


### PR DESCRIPTION
Title. Omegastation's job changes being present causes all sorts of weird as fuck issues that I'm unable to reproduce in local testing or even reproduce consistently. It'd be much better to handle this kind of shit with helper objects on the map itself anyhow.

:cl: deathride58
del: Omegastation's job changes will no longer be included at compile time.
/:cl:
