### PR TITLE
Intensifies sanity checks in the client part of /mob/Login() in an attempt to fix the spontaneous lobby forcing bug

### DIFF
--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -43,12 +43,13 @@
 	if(client)
 		client.change_view(CONFIG_GET(string/default_view)) // Resets the client.view in case it was changed.
 
-		if(client.player_details.player_actions.len)
-			for(var/datum/action/A in client.player_details.player_actions)
-				A.Grant(src)
+		if(client.player_details && istype(client.player_details))
+			if(client.player_details.player_actions.len)
+				for(var/datum/action/A in client.player_details.player_actions)
+					A.Grant(src)
 
-		for(var/foo in client.player_details.post_login_callbacks)
-			var/datum/callback/CB = foo
-			CB.Invoke()
+			for(var/foo in client.player_details.post_login_callbacks)
+				var/datum/callback/CB = foo
+				CB.Invoke()
 
 	log_message("Client [key_name(src)] has taken ownership of mob [src]([src.type])", LOG_OWNERSHIP)


### PR DESCRIPTION
So for whatever reason this specific part of /mob/Login() is occasionally runtiming for no reason with a "cannot read null.player_details". I know that byond has a tendency to runtime for no reason at all if there aren't enough sanity checks, so let's see if this fixes it.

:cl: deathride58
code: The client update portion of /mob/Login() now double-checks to make sure client.player_details exists and is of the proper type. This should hopefully fix the "cannot read null.player_details" runtimes that can spontaneously cause clients to get kicked out and forced back to the lobby.
/:cl:
