### PR TITLE
Adds the ability to quickly use an unequipped item on something by click-dragging it with an empty hand

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -379,6 +379,26 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 /obj/item/proc/on_found(mob/finder)
 	return
 
+/obj/item/MouseDrop(atom/over, src_location, over_location, src_control, over_control, params) //Copypaste of /atom/MouseDrop() since this requires code in a very specific spot
+	if(!usr || !over)
+		return
+	if(SEND_SIGNAL(src, COMSIG_MOUSEDROP_ONTO, over, usr) & COMPONENT_NO_MOUSEDROP)	//Whatever is receiving will verify themselves for adjacency.
+		return
+	if(over == src)
+		return usr.client.Click(src, src_location, src_control, params)
+	var/list/directaccess = usr.DirectAccess()
+	if((usr.CanReach(src) || (src in directaccess)) && (usr.CanReach(over) || (over in directaccess)))
+		if(!usr.get_active_held_item())
+			usr.UnarmedAttack(src, TRUE)
+			if(usr.get_active_held_item() == src)
+				melee_attack_chain(usr, over)
+			return
+	if(!Adjacent(usr) || !over.Adjacent(usr))
+		return // should stop you from dragging through windows
+
+	over.MouseDrop_T(src,usr)
+	return
+
 // called after an item is placed in an equipment slot
 // user is mob that equipped it
 // slot uses the slot_X defines found in setup.dm


### PR DESCRIPTION
Title. This is a huge QoL improvement when it comes to doing things that require repeated inventory management, such as shotgun reloading and complex deconstruction, as instead of having to click the item, wait for click delay, then click the object you want to interact with, you can do it in one smooth motion by simply clicking and dragging the item onto the object you want to interact with, which will place the item in your hand and then instantly use that item on the item you've dragged to. This also makes it far easier to deal with slapcrafting-compatible items by simply clickdragging the ingredients onto the slapcraftable item instead of bumbling around in your inventory

:cl: deathride58
add: You can now quickly use unequipped items on objects by simply click-dragging the item onto the object with an empty active hand. Doing so will place the item in your hand, and then use that item on the object.
/:cl:
