### PR TITLE
Attempts to fix the bug where voreprefs sometimes fail to load at all by making mob login force voreprefs to load if vore has been initialized but voreprefs havent

### DIFF
--- a/code/modules/mob/living/login.dm
+++ b/code/modules/mob/living/login.dm
@@ -23,3 +23,5 @@
 
 	if(ranged_ability)
 		ranged_ability.add_ranged_ability(src, "<span class='notice'>You currently have <b>[ranged_ability]</b> active!</span>")
+	if(vore_init && !vorepref_init) //Vore's been initialized, voreprefs haven't. If this triggers then that means that voreprefs failed to load due to the client being missing.
+		apply_vore_prefs()

--- a/modular_citadel/code/modules/vore/eating/living_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/living_vr.dm
@@ -12,6 +12,8 @@
 	var/noisy = TRUE						// tummies are rumbly?
 	var/absorbed = FALSE					//are we absorbed?
 	var/next_preyloop
+	var/vore_init = FALSE					//Has this mob's vore been initialized yet?
+	var/vorepref_init = FALSE				//Has this mob's voreprefs been initialized?
 
 //
 // Hook for generic creation of stuff on new creatures
@@ -34,6 +36,7 @@
 	return 1
 
 /mob/living/proc/init_vore()
+	vore_init = TRUE
 	//Something else made organs, meanwhile.
 	if(LAZYLEN(vore_organs))
 		return TRUE
@@ -407,6 +410,7 @@
 	if(!client || !client.prefs_vr)
 		to_chat(src,"<span class='warning'>You attempted to apply your vore prefs but somehow you're in this character without a client.prefs_vr variable. Tell a dev.</span>")
 		return 0
+	vorepref_init = TRUE
 
 	var/datum/vore_preferences/P = client.prefs_vr
 


### PR DESCRIPTION
Title. I'm unable to confirm if this actually fixes the bug or not since the bug is so inconsistent to reproduce, but this should hopefully help with the unreproducable issues where voreprefs fail to load.
Closes #8205 

:cl: deathride58
fix: If a living mob has vore initialized but doesnt have voreprefs initialized, then client login will force voreprefs to load.
/:cl:
