### PR TITLE
Local cat forgets to add the same word twice braking a quirk - The fixing

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -166,7 +166,6 @@
 
 /datum/quirk/trandening/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/autosurgeon/gloweyes = new(get_turf(H))
-	H.put_in_hands(gloweyes)
+	var/obj/item/autosurgeon/gloweyes/gloweyes = new(get_turf(H))
 	H.equip_to_slot(gloweyes, SLOT_IN_BACKPACK)
 	H.regenerate_icons()


### PR DESCRIPTION
[Changelogs]
Truns out it steals the last word, so you have to say the last word for the item twice

[why]
***People are getting synda auto implanter that are multy use and thats bad mans***