### PR TITLE
Comments out hunger noises until an intermediate coder adds a preference for it

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1144,6 +1144,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 			H.update_inv_w_uniform()
 			H.update_inv_wear_suit()
 	
+	/*
 	if(H.noisy && H.nutrition <= NUTRITION_LEVEL_STARVING)
 		if(prob(10))
 			playsound(get_turf(H),"hunger_sounds",35,0,-5,1,ignore_walls = FALSE,channel=CHANNEL_PRED)
@@ -1151,7 +1152,8 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 	else if(H.noisy && H.nutrition <= NUTRITION_LEVEL_HUNGRY)
 		if(prob(10))
 			playsound(get_turf(H),"hunger_sounds",15,0,-5,1,ignore_walls = FALSE,channel=CHANNEL_PRED)
- 
+ 	*/
+
 	// nutrition decrease and satiety
 	if (H.nutrition > 0 && H.stat != DEAD && !H.has_trait(TRAIT_NOHUNGER))
 		// THEY HUNGER


### PR DESCRIPTION
No one who knows how to add the preference is interested in doing it, so this is unfortunately the next-best thing. 

To be clear, the existing preference only governs whether or not you **produce** the noises, **not** whether or not you **hear** the noises. People don't like hearing them. 