### PR TITLE
Loadout items are forced to backpacks, fixes Security Officer Navy uniform

### DIFF
--- a/modular_citadel/code/controllers/subsystem/job.dm
+++ b/modular_citadel/code/controllers/subsystem/job.dm
@@ -23,7 +23,12 @@
 				continue
 			var/obj/item/I = new G.path
 			if(!M.equip_to_slot_if_possible(I, G.category, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) // If the job's dresscode compliant, try to put it in its slot, first
-				if(!M.equip_to_slot_if_possible(I, SLOT_IN_BACKPACK, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) // Otherwise, try to put it in the backpack
+				if(iscarbon(M))
+					var/mob/living/carbon/C = M
+					var/obj/item/storage/backpack/B = C.back
+					if(!B || !SEND_SIGNAL(B, COMSIG_TRY_STORAGE_INSERT, I, null, TRUE, TRUE)) // Otherwise, try to put it in the backpack, for carbons.
+						I.forceMove(get_turf(C))
+				else if(!M.equip_to_slot_if_possible(I, SLOT_IN_BACKPACK, disable_warning = TRUE, bypass_equip_delay_self = TRUE)) // Otherwise, try to put it in the backpack
 					I.forceMove(get_turf(M)) // If everything fails, just put it on the floor under the mob.
 
 /datum/controller/subsystem/job/proc/FreeRole(rank)

--- a/modular_citadel/code/modules/client/loadout/_security.dm
+++ b/modular_citadel/code/modules/client/loadout/_security.dm
@@ -29,10 +29,10 @@
 	restricted_roles = list("Security Officer")
 
 /datum/gear/navyblueuniformofficer
- 	name = "security officer navyblue uniform"
+ 	name = "Security officer navyblue uniform"
  	category = SLOT_W_UNIFORM
  	path = /obj/item/clothing/under/rank/security/navyblue
- 	restricted_roles = list("Security officer")
+ 	restricted_roles = list("Security Officer")
 
 /datum/gear/navybluejacketwarden
 	name = "warden navyblue jacket"


### PR DESCRIPTION
:cl: Poojawa
fix: fixed Navy officer uniforms that failed to spawn
code: Loadout items will be forcefully added to backpacks or at your feet instead of left behind at title screen
/:cl:

revives #7515 but with proper indentation and now proper `SEND_SIGNAL` stuff.