### PR TITLE
Makes the captain's coat protect as much as the carapace.

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -498,9 +498,10 @@
 
 /obj/item/clothing/suit/hooded/wintercoat/captain
 	name = "captain's winter coat"
+	desc = "A heavy jacket made from 'synthetic' animal furs. This one is reinforced with protective materials to offer enough protection for the station's Captain."
 	icon_state = "coatcaptain"
 	item_state = "coatcaptain"
-	armor = list("melee" = 25, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 50)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 50, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 90)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
 /obj/item/clothing/suit/hooded/wintercoat/captain/Initialize()

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -501,7 +501,7 @@
 	desc = "A heavy jacket made from 'synthetic' animal furs. This one is reinforced with protective materials to offer enough protection for the station's Captain."
 	icon_state = "coatcaptain"
 	item_state = "coatcaptain"
-	armor = list("melee" = 50, "bullet" = 40, "laser" = 50, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 90)
+	armor = list("melee" = 50, "bullet" = 40, "laser" = 50, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 90)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/captain
 
 /obj/item/clothing/suit/hooded/wintercoat/captain/Initialize()


### PR DESCRIPTION
[Changelogs]:

:cl: Coolgat3
tweak: Made the captain's coat have same armor values as the carapace, except for the fire protection since fur that doesn't burn makes little sense. Also changed the description of the coat so it's more fitting and clear that the coat is in fact protecting the user. EDIT: Made it also have the same fire protection after asking kevin, quote: "Sure, how do you think furries survive plasma fires?"
/:cl:

[why]: Kevin said the winter coat should protect as much as the carapace, I also think that, and in general, I feel like it should be a preference of looks whether someone prefers a coat or a vest.
