### PR TITLE
Making the Ripley mech not useless (More info inside)

### DIFF
--- a/code/game/mecha/working/ripley.dm
+++ b/code/game/mecha/working/ripley.dm
@@ -2,14 +2,14 @@
 	desc = "Autonomous Power Loader Unit. This newer model is refitted with powerful armour against the dangers of planetary mining."
 	name = "\improper APLU \"Ripley\""
 	icon_state = "ripley"
-	step_in = 4 //Move speed, lower is faster.
-	var/fast_pressure_step_in = 2 //step_in while in normal pressure conditions
-	var/slow_pressure_step_in = 4 //step_in while in better pressure conditions
+	step_in = 3 //Move speed, lower is faster.
+	var/fast_pressure_step_in = 2
+	var/slow_pressure_step_in = 3
 	max_temperature = 20000
 	max_integrity = 200
-	lights_power = 7
+	lights_power = 8
 	deflect_chance = 15
-	armor = list("melee" = 40, "bullet" = 20, "laser" = 10, "energy" = 20, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 30, "bullet" = 15, "laser" = 10, "energy" = 20, "bomb" = 40, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	max_equip = 6
 	wreckage = /obj/structure/mecha_wreckage/ripley
 	var/list/cargo = new
@@ -64,6 +64,9 @@
 	desc = "Autonomous Power Loader Unit. This model is refitted with additional thermal protection."
 	name = "\improper APLU \"Firefighter\""
 	icon_state = "firefighter"
+	step_in = 4
+	fast_pressure_step_in = 2
+	slow_pressure_step_in = 4
 	max_temperature = 65000
 	max_integrity = 250
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF


### PR DESCRIPTION
[Changelogs]:

:cl: Coolgat3
tweak: Raised the ripley's movement speed and lights range by 1, also lowered its armor to compensate.
/:cl:

[why]: The ripley mech is really just USELESS as of now. It has great potential to be an amazing roundstart mech for cargo to push crates around. I want to make it so that it has a non-charged gygax movement speed (one speed faster than the ripley now) and less armor, so that it is purely a working mech. There is no downsides whatsoever to making a firefighter over a ripley right now, which is rather dumb in my opinion. Now you will sacrifice that little bit of speed for lava protection and more armor if you choose to make a firefighter instead.
