### PR TITLE
Labcoats carry mk II hypos, hypokits hold more

### DIFF
--- a/code/modules/clothing/suits/labcoat.dm
+++ b/code/modules/clothing/suits/labcoat.dm
@@ -5,7 +5,28 @@
 	item_state = "labcoat"
 	blood_overlay_type = "coat"
 	body_parts_covered = CHEST|ARMS
-	allowed = list(/obj/item/analyzer, /obj/item/stack/medical, /obj/item/dnainjector, /obj/item/reagent_containers/dropper, /obj/item/reagent_containers/syringe, /obj/item/reagent_containers/hypospray, /obj/item/healthanalyzer, /obj/item/flashlight/pen, /obj/item/reagent_containers/glass/bottle, /obj/item/reagent_containers/glass/beaker, /obj/item/reagent_containers/pill, /obj/item/storage/pill_bottle, /obj/item/paper, /obj/item/melee/classic_baton/telescopic, /obj/item/soap, /obj/item/sensor_device, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
+	allowed = list(
+		/obj/item/analyzer,
+		/obj/item/stack/medical,
+		/obj/item/dnainjector,
+		/obj/item/reagent_containers/dropper,
+		/obj/item/reagent_containers/syringe,
+		/obj/item/reagent_containers/hypospray,
+		/obj/item/hypospray/mkii,
+		/obj/item/healthanalyzer,
+		/obj/item/flashlight/pen,
+		/obj/item/reagent_containers/glass/bottle,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/pill,
+		/obj/item/storage/pill_bottle,
+		/obj/item/paper,
+		/obj/item/melee/classic_baton/telescopic,
+		/obj/item/soap,
+		/obj/item/sensor_device,
+		/obj/item/tank/internals/emergency_oxygen,
+		/obj/item/tank/internals/plasmaman
+		)
+
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 50, "rad" = 0, "fire" = 50, "acid" = 50)
 	togglename = "buttons"
 	species_exception = list(/datum/species/golem)

--- a/modular_citadel/code/game/objects/items/storage/firstaid.dm
+++ b/modular_citadel/code/game/objects/items/storage/firstaid.dm
@@ -23,14 +23,14 @@
 
 /obj/item/storage/firstaid/o2
 	icon_state = "oxy"
-	
+
 /obj/item/storage/firstaid/radbgone
 	icon_state = "rad"
-	
+
 /obj/item/storage/firstaid/radbgone/Initialize(mapload)
     . = ..()
     icon_state = pick("[initial(icon_state)]","[initial(icon_state)]2","[initial(icon_state)]3","[initial(icon_state)]4")
-	
+
 /obj/item/storage/firstaid/tactical
 	icon_state = "tactical"
 
@@ -50,10 +50,10 @@
 /obj/item/storage/hypospraykit/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_SMALL
-	STR.max_combined_w_class = 5
-	STR.max_items = 5
-	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	STR.max_items = 12
+	STR.can_hold = typecacheof(list(
+	/obj/item/hypospray/mkii,
+	/obj/item/reagent_containers/glass/bottle/vial))
 
 /obj/item/storage/hypospraykit/regular
 	icon_state = "firstaid-mini"
@@ -136,10 +136,10 @@
 /obj/item/storage/hypospraykit/cmo/ComponentInitialize()
 	. = ..()
 	GET_COMPONENT(STR, /datum/component/storage)
-	STR.max_w_class = WEIGHT_CLASS_SMALL
-	STR.max_combined_w_class = 6
 	STR.max_items = 6
-	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	STR.can_hold = typecacheof(list(
+	/obj/item/hypospray/mkii,
+	/obj/item/reagent_containers/glass/bottle/vial))
 
 /obj/item/storage/hypospraykit/cmo/PopulateContents()
 	if(empty)


### PR DESCRIPTION
:cl: Poojawa
tweak: hypospray kits hold 12 now, but only vials and sprays themselves
fix: labcoats can carry MK II hyposprays on them now.
/:cl:

inventory juggling is annoying. 

this gives those kits a reason to be kept for hypospray users. They now can only store hypospray vials and the units themselves. Makes sense with how tiny vials are after all.