### PR TITLE
Buffs defib users by making them stop pulling automatically

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -411,6 +411,8 @@
 			to_chat(user, "<span class='warning'>[src] are recharging!</span>")
 		return
 
+	user.stop_pulling() //User has hands full, and we don't care about anyone else pulling on it, their problem. CLEAR!!
+
 	if(user.a_intent == INTENT_DISARM)
 		do_disarm(M, user)
 		return


### PR DESCRIPTION
:cl: Poojawa
balance: Defib users automatically stop pulling when they attempt to perform a defib shock
/:cl:

really just QoL for lag and busy doctors. Anyone else holding onto the patient will still get shocked, but the user won't. Doesn't make sense they'd still be pulling a person with handfuls of shock paddles anyway.