### PR TITLE
readds dirt buildup on turfs, but in a way that doesn't make the server beg for death

### DIFF
--- a/code/game/objects/effects/decals/cleanable/misc.dm
+++ b/code/game/objects/effects/decals/cleanable/misc.dm
@@ -49,6 +49,7 @@
 	canSmoothWith = list(/obj/effect/decal/cleanable/dirt, /turf/closed/wall, /obj/structure/falsewall)
 	smooth = SMOOTH_FALSE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	var/setdirtiness = TRUE
 
 /obj/effect/decal/cleanable/dirt/Initialize()
 	. = ..()
@@ -59,10 +60,20 @@
 		icon_state = ""
 		queue_smooth(src)
 	queue_smooth_neighbors(src)
+	if(setdirtiness && istype(T, /turf/open/floor))
+		var/turf/open/floor/F = T
+		F.dirtlevel = 510
 
 /obj/effect/decal/cleanable/dirt/Destroy()
 	queue_smooth_neighbors(src)
+	var/turf/T = get_turf(src)
+	if(istype(T, /turf/open/floor))
+		var/turf/open/floor/F = T
+		F.dirtlevel = 0
 	return ..()
+
+/obj/effect/decal/cleanable/dirt/natural
+	setdirtiness = FALSE
 
 /obj/effect/decal/cleanable/flour
 	name = "flour"

--- a/modular_citadel/code/game/turfs/cit_turfs.dm
+++ b/modular_citadel/code/game/turfs/cit_turfs.dm
@@ -1,24 +1,18 @@
-//Yes, hi. This is the file that handles Citadel's turf modifications.
+/turf/open/floor
+	var/dirtlevel
+	var/candirtify = TRUE
 
-/*
 /turf/open/floor/Entered(atom/obj, atom/oldloc)
 	. = ..()
-	CitDirtify(obj, oldloc)*/
-
-//Baystation-styled tile dirtification.
-/turf/open/floor/proc/CitDirtify(atom/obj, atom/oldloc)
-	if(prob(50))
-		if(has_gravity(src) && !isobserver(obj))
-			var/dirtamount
-			var/obj/effect/decal/cleanable/dirt/dirt = locate(/obj/effect/decal/cleanable/dirt, src)
-			if(!dirt)
-				dirt = new/obj/effect/decal/cleanable/dirt(src)
-				dirt.alpha = 0
-				dirtamount = 0
-			dirtamount = dirt.alpha + 1
-			if(oldloc && istype(oldloc, /turf/open/floor))
-				var/obj/effect/decal/cleanable/dirt/spreadindirt = locate(/obj/effect/decal/cleanable/dirt, oldloc)
-				if(spreadindirt && spreadindirt.alpha)
-					dirtamount += round(spreadindirt.alpha * 0.05)
-			dirt.alpha = min(dirtamount,255)
-	return TRUE
+	if(candirtify && !isobserver(obj))
+		dirtlevel++
+		if(oldloc && istype(oldloc, /turf/open/floor))
+			var/turf/open/floor/F = oldloc
+			dirtlevel += (F.dirtlevel)*0.025
+		if(dirtlevel >= 255)
+			if(!isobserver(obj))
+				var/obj/effect/decal/cleanable/dirt/dirt = locate(/obj/effect/decal/cleanable/dirt, src)
+				if(!dirt)
+					dirt = new/obj/effect/decal/cleanable/dirt/natural(src)
+				dirtlevel = min(dirtlevel, 510)
+				dirt.alpha = round(min(dirtlevel-255,255))


### PR DESCRIPTION
Title. Dirt buildup was a neat, tiny little feature that gave janitors something to do during overly calm rounds. With this PR, every object, including mobs, will cause dirt to passively build up over time on the turfs they travel over. This results in frequently traveled areas, such as the main hallways, to slowly become visibly dirty over time, resulting in a sort of heatmap effect that shows which areas get traveled through the most.
So, what makes the implementation of footdirt in this PR different from the old implementation? For starters, a turf's dirt level is defined by a new `dirtlevel` var instead of being handled by a dirt decal object. Additionally, dirt decals now only spawn once that dirt level becomes greater than 255. Also, the gravity check was removed to save on performance, and the code has been massively cleaned up. All of this should result in an implementation of footdirt that's much, _much_ friendlier to the server in terms of memory usage and performance.

:cl: deathride58
add: Dirt buildup has been readded, but in a way that's a lot friendlier to the server's memory usage and performance.
/:cl:
