### PR TITLE
Adds Hidden Polychromic Stuff to the Loadout

### DIFF
--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -80,13 +80,6 @@
 	path = /obj/item/clothing/suit/flakjack
 	cost = 2
 
-//Polychromic
-/datum/gear/polychromiccloak
-	name = "Polychromic Cloak"
-	category = SLOT_WEAR_SUIT
-	path = /obj/item/clothing/neck/cloak/polychromic
-	cost = 4
-
 /datum/gear/trekds9_coat
 	name = "DS9 Overcoat (use uniform)"
 	category = SLOT_WEAR_SUIT

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -80,6 +80,13 @@
 	path = /obj/item/clothing/suit/flakjack
 	cost = 2
 
+//Polychromic
+/datum/gear/polychromiccloak
+	name = "Polychromic Cloak"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/neck/cloak/polychromic
+	cost = 4
+
 /datum/gear/trekds9_coat
 	name = "DS9 Overcoat (use uniform)"
 	category = SLOT_WEAR_SUIT

--- a/modular_citadel/code/modules/client/loadout/uniform.dm
+++ b/modular_citadel/code/modules/client/loadout/uniform.dm
@@ -155,22 +155,71 @@
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/bb_sweater/blue
 
+//Polymorphic
+/datum/gear/polybottomless
+	name = "Polychromic Bottomless Shirt"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/bottomless
+	cost = 2
+
+/datum/gear/polyfemtank
+	name = "Polychromic Feminine Tank Top"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/femtank
+	cost = 2
+
+/datum/gear/polyjumpsuit
+	name = "Polychromic Jumpsuit"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/jumpsuit
+	cost = 2
+
 /datum/gear/polykilt
 	name = "Polychromic Kilt"
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/polychromic/kilt
-	cost = 3
+	cost = 2
 
-/datum/gear/polyshorts
-	name = "Polychromic Shorts"
+/datum/gear/polypleat
+	name = "Polychromic Pleated Skirt"
 	category = SLOT_W_UNIFORM
-	path = /obj/item/clothing/under/polychromic/shorts
-	cost = 3
+	path = /obj/item/clothing/under/polychromic/pleat
+	cost = 2
+
+/datum/gear/polyshimatank
+	name = "Polychromic Tank Top"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/shimatank
+	cost = 2
+
+/datum/gear/polyshirt
+	name = "Polychromic Button-Up Shirt"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/shirt
+	cost = 2
 
 /datum/gear/polyshortpants
 	name = "Polychromic Athletic Shorts"
 	category = SLOT_W_UNIFORM
 	path = /obj/item/clothing/under/polychromic/shortpants
+	cost = 2
+
+/datum/gear/polypantsu
+	name = "Polychromic Panties"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/shortpants/pantsu
+	cost = 2
+
+/datum/gear/polyshorts
+	name = "Polychromic Shorts"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/shorts
+	cost = 2
+
+/datum/gear/polyskirt
+	name = "Polychromic Skirt"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/polychromic/skirt
 	cost = 2
 
 // Trekie things


### PR DESCRIPTION
[Changelogs]:
:cl: BurgerBB
add: Added polychromic cloaks, bottomless shirts, male and female tank tops, jumpsuits, pleated skirts, button-up shirts, PANTIES, shorts, capes, and skirts to the loadout.
tweak: Reduced the cost of the polychromic kilt from 3 to 2.
server: Some people may have to reapply their loadout to include already existing items, as the datums were renamed for consistency.
/:cl:

[why]: I noticed a lot of polychromic stuff missing in the loadout. This could be because of donator stuff as I noticed one of the capes was labeled "DONATOR" in a comment, but if not I think they should be added.