### PR TITLE
Rework of Vent Clog Event

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -13,16 +13,49 @@
 	var/list/vents  = list()
 	var/randomProbability = 1
 	var/reagentsAmount = 100
-	var/list/saferChems = list("water","carbon","flour","cleaner","nutriment","condensedcapsaicin","mushroomhallucinogen","lube","pink_glitter","cryptobiolin",
-						 "plantbgone","blood","charcoal","space_drugs","morphine","holywater","ethanol","hot_coco","sacid","mindbreaker","rotatium","bluespace",
-						 "pax","laughter","concentrated_barbers_aid","colorful_reagent","dizzysolution","tiresolution","sodiumchloride","beer","hair_dye","sugar","white_glitter","growthserum")
+	var/list/saferChems = list(
+		"water",
+		"carbon",
+		"flour",
+		"cleaner",
+		"nutriment",
+		"condensedcapsaicin",
+		"mushroomhallucinogen",
+		"lube",
+		"pink_glitter",
+		"cryptobiolin",
+		"plantbgone",
+		"blood",
+		"charcoal",
+		"space_drugs",
+		"morphine",
+		"holywater",
+		"ethanol",
+		"hot_coco",
+		"sacid",
+		"mindbreaker",
+		"rotatium",
+		"bluespace",
+		"pax",
+		"laughter",
+		"concentrated_barbers_aid",
+		"colorful_reagent",
+		"dizzysolution",
+		"tiresolution",
+		"sodiumchloride",
+		"beer",
+		"hair_dye",
+		"sugar",
+		"white_glitter",
+		"growthserum"
+	)
 	//needs to be chemid unit checked at some point
 
 /datum/round_event/vent_clog/announce()
 	priority_announce("The scrubbers network is experiencing a backpressure surge. Some ejection of contents may occur.", "Atmospherics alert")
 
 /datum/round_event/vent_clog/setup()
-	endWhen = rand(25, 100)
+	endWhen = rand(120, 180)
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
 		var/turf/T = get_turf(temp_vent)
 		if(T && is_station_level(T.z) && !temp_vent.welded)
@@ -30,25 +63,34 @@
 	if(!vents.len)
 		return kill()
 
-/datum/round_event/vent_clog/start()
-	for(var/obj/machinery/atmospherics/components/unary/vent in vents)
-		if(vent && vent.loc)
-			var/datum/reagents/R = new/datum/reagents(1000)
-			R.my_atom = vent
-			if (prob(randomProbability))
-				R.add_reagent(get_random_reagent_id(), reagentsAmount)
-			else
-				R.add_reagent(pick(saferChems), reagentsAmount)
+/datum/round_event/vent_clog/tick()
 
-			var/datum/effect_system/foam_spread/foam = new
-			foam.set_up(200, get_turf(vent), R)
-			foam.start()
+	if(!vents.len)
+		return kill()
 
-			var/cockroaches = prob(33) ? 3 : 0
-			while(cockroaches)
-				new /mob/living/simple_animal/cockroach(get_turf(vent))
-				cockroaches--
-		CHECK_TICK
+	CHECK_TICK
+
+	var/obj/machinery/atmospherics/components/unary/vent = pick(vents)
+	vents -= vent
+
+	if(!vent)
+		return
+
+	var/turf/T = get_turf(vent)
+	if(!T)
+		return
+
+	var/datum/reagents/R = new/datum/reagents(1000)
+	R.my_atom = vent
+	if (prob(randomProbability))
+		R.add_reagent(get_random_reagent_id(), reagentsAmount)
+	else
+		R.add_reagent(pick(saferChems), reagentsAmount)
+
+	var/datum/effect_system/smoke_spread/chem/C = new
+	C.set_up(R,16,T,TRUE)
+	C.start()
+	playsound(T, 'sound/effects/smoke.ogg', 50, 1, -3)
 
 /datum/round_event_control/vent_clog/threatening
 	name = "Clogged Vents: Threatening"


### PR DESCRIPTION
[Changelogs]: 
:cl: BurgerBB
refactor: Reworked the Vent Clog event to spray smoke instead of foam, also made it shoot smoke over time instead through each vent instead of all at once.
/:cl:

[why]: The vent clog event is annoying and laggy. It is effectively a pause button for the server in terms of gameplay and time dilation. This PR fixes that.