### PR TITLE
Minor circuit balance tweaks - limits locomotion circuits to jogging speed and doubles the complexity of mmi/pai connector circuits

### DIFF
--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -144,7 +144,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	complexity = 10
 	cooldown_per_use = 1
-	ext_cooldown = 1
+	ext_cooldown = 2
 	inputs = list("direction" = IC_PINTYPE_DIR)
 	outputs = list("obstacle" = IC_PINTYPE_REF)
 	activators = list("step towards dir" = IC_PINTYPE_PULSE_IN,"on step"=IC_PINTYPE_PULSE_OUT,"blocked"=IC_PINTYPE_PULSE_OUT)

--- a/code/modules/integrated_electronics/subtypes/smart.dm
+++ b/code/modules/integrated_electronics/subtypes/smart.dm
@@ -125,7 +125,7 @@
 	name = "man-machine interface tank"
 	desc = "This circuit is just a jar filled with an artificial liquid mimicking the cerebrospinal fluid."
 	extended_desc = "This jar can hold 1 man-machine interface and let it take control of some basic functions of the assembly."
-	complexity = 29
+	complexity = 60
 	inputs = list("laws" = IC_PINTYPE_LIST)
 	outputs = list(
 		"man-machine interface" = IC_PINTYPE_REF,
@@ -254,7 +254,7 @@
 	name = "pAI connector circuit"
 	desc = "This circuit lets you fit in a personal artificial intelligence to give it some form of control over the bot."
 	extended_desc = "You can wire various functions to it."
-	complexity = 29
+	complexity = 60
 	inputs = list("laws" = IC_PINTYPE_LIST)
 	outputs = list(
 		"personal artificial intelligence" = IC_PINTYPE_REF,


### PR DESCRIPTION
Title. PAI/MMI drones are *insanely* strong and annoying at the moment, partly due to their innate ludicrous speed. This PR alleviates what the majority of their annoyance factor comes from, while also somewhat restricting the room for automation within a pAI drone.

:cl: deathride58
balance: Locomotion circuits are now restricted to jogging speed
balance: MMI circuits and pAI circuits both now have 60 complexity, up from their original 29.
/:cl:
