### PR TITLE
Makes blobs resource makers use real time.

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/resource.dm
+++ b/code/modules/antagonists/blob/blob/blobs/resource.dm
@@ -21,11 +21,11 @@
 
 /obj/structure/blob/resource/Be_Pulsed()
 	. = ..()
-	if(resource_delay > world.time)
+	if(resource_delay > world.realtime)
 		return
 	flick("blob_resource_glow", src)
 	if(overmind)
 		overmind.add_points(1)
-		resource_delay = world.time + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
+		resource_delay = world.realtime + 40 + overmind.resource_blobs.len * 2.5 //4 seconds plus a quarter second for each resource blob the overmind has
 	else
-		resource_delay = world.time + 40
+		resource_delay = world.realtime + 40


### PR DESCRIPTION
[Changelogs]
Makes blob resource factories use real time and not serb time to gain mats

:cl: optional name here
fix: resources not using real time
/:cl:

[why]
Unfair time lag starving blobs is not a good idea, this should allow for blobs to be able to afford more shields, nodes and other QoL to keep a baby blob alive