### PR TITLE
Significantly Reworks the Wizard Transformation Event

### DIFF
--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -5,6 +5,18 @@
 	max_occurrences = 5
 	earliest_start = 0 MINUTES
 
+/datum/round_event/wizard/race
+	var/list/stored_name
+	var/list/stored_species
+	var/list/stored_dna
+
+/datum/round_event/wizard/race/setup()
+	stored_name = list()
+	stored_species = list()
+	stored_dna = list()
+	endWhen = rand(600,1200) //10 to 20 minutes
+	..()
+
 /datum/round_event/wizard/race/start()
 
 	var/all_the_same = 0
@@ -12,18 +24,35 @@
 
 	for(var/speciestype in subtypesof(/datum/species))
 		var/datum/species/S = new speciestype()
-		if(!S.dangerous_existence && !S.blacklisted)
+		if(!S.dangerous_existence && !S.blacklisted && !S.nojumpsuit) //Dangerous Species, Blacklisted Species, and Species who can't wear jumpsuits are blacklisted.
 			all_species += speciestype
 
 	var/datum/species/new_species = pick(all_species)
 
-	if(prob(50))
+	if(prob(75))
 		all_the_same = 1
 
-	for(var/mob/living/carbon/human/H in GLOB.carbon_list) //yes, even the dead
+	for(var/mob/living/carbon/human/H in GLOB.carbon_list)
+		var/turf/T = get_turf(H)
+		if(!T)
+			continue
+		if(!is_station_level(T.z))
+			continue
+		stored_name[H] = H.real_name
+		stored_species[H] = H.dna.species
+		stored_dna[H] = H.dna.unique_enzymes
 		H.set_species(new_species)
 		H.real_name = H.dna.species.random_name(H.gender,1)
 		H.dna.unique_enzymes = H.dna.generate_unique_enzymes()
 		to_chat(H, "<span class='notice'>You feel somehow... different?</span>")
 		if(!all_the_same)
 			new_species = pick(all_species)
+
+/datum/round_event/wizard/race/end()
+	for(var/mob/living/carbon/human/H in GLOB.carbon_list)
+		if(!(stored_name[H] && stored_species[H] && stored_dna[H]))
+			continue
+		H.set_species(stored_species[H])
+		H.real_name = stored_name[H]
+		H.dna.unique_enzymes = stored_dna[H]
+		to_chat(H, "<span class='notice'>You feel back to your normal self again.</span>")

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1596,6 +1596,7 @@
 #include "code\modules\events\wizard\lava.dm"
 #include "code\modules\events\wizard\magicarp.dm"
 #include "code\modules\events\wizard\petsplosion.dm"
+#include "code\modules\events\wizard\race.dm"
 #include "code\modules\events\wizard\rpgloot.dm"
 #include "code\modules\events\wizard\shuffle.dm"
 #include "code\modules\events\wizard\summons.dm"

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1596,7 +1596,6 @@
 #include "code\modules\events\wizard\lava.dm"
 #include "code\modules\events\wizard\magicarp.dm"
 #include "code\modules\events\wizard\petsplosion.dm"
-#include "code\modules\events\wizard\race.dm"
 #include "code\modules\events\wizard\rpgloot.dm"
 #include "code\modules\events\wizard\shuffle.dm"
 #include "code\modules\events\wizard\summons.dm"


### PR DESCRIPTION
[Changelogs]:
:cl: BurgerBB
balance: Significantly tweaks the Wizard race transformation event to be less unreasonably troublesome.
/:cl:

[why]: This will probably be controversial, but currently there is a random event that causes everyone's race to switch to something else. This is unreasonably problematic for several reasons.

1. People are snowflakes. They do not like it when their character is swapped with something else without much effort.
2. People don't like snowflakes. They don't like be transformed into a randomly generated neon-pink floor length braid slimegirl.
3. It can seriously and unreasonably fuck over people. Inventory slots can easily be removed because of it. If you're in space, and you transform into a mushroom man, you're dead or crippled.

To solve this, the following was implemented:
- You will revert to your normal self after 10-20 minutes. Most wizard rounds last this long, but in cases where it's a really bad peacewiz or stealthwiz, this can ease the burden of having to become a snowflake.
- Only those on station z-levels are affected. Miners cannot be affected by this, as it may cause a quick death.
- You can no longer transform into a species that cannot wear a jumpsuit, such as golems or mushroom men.
- Upped the universal transformation chance from 50% to 75%. This means that there is a higher chance that everyone transforms into the same race.