### PR TITLE
Buffs blob Shield armor, as well as weaken state

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -8,7 +8,7 @@
 	explosion_block = 3
 	point_return = 4
 	atmosblock = TRUE
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+	armor = list("melee" = 25, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
 /obj/structure/blob/shield/scannerreport()
 	if(atmosblock)
@@ -20,11 +20,12 @@
 
 /obj/structure/blob/shield/update_icon()
 	..()
-	if(obj_integrity <= 75)
+	if(obj_integrity <= 70)
 		icon_state = "blob_shield_damaged"
 		name = "weakened strong blob"
 		desc = "A wall of twitching tendrils."
 		atmosblock = FALSE
+		armor = list("melee" = 15, "bullet" = 15, "laser" = 5, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 	else
 		icon_state = initial(icon_state)
 		name = initial(name)


### PR DESCRIPTION
[Changelogs]
Gives the blob shields basic armor that is a tad better then the rest!
Makes the weaken blob shields happen at 70% rather then 75%
Makes weaken blob shields have less armor then normal. Do to being in a weaken state - This should stop shields from being *vastly* better then normal
:cl: optional name here
add: Armor to blob shields
tweak: block weaken state to 70% from 75%
/:cl:

[why]
Blobs are massively weak as is. This should help blobs hold out, well also help not keep bad blobs alive and winning more often then they should, as a shield is after all meant to tank some damage, we don't want it to take up to 4x its meant to, thus using the weaken blob system we can help speed this system of removal of the blob without the need of mark guns and or toxin bombs to gain ground.