### PR TITLE
Tweaks how Slurring works and makes slurring directly proportional to drunkeness.

### DIFF
--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,9 +1,14 @@
 /mob/living/carbon/human/say_mod(input, message_mode)
 	verb_say = dna.species.say_mod
-	if(slurring)
-		return "slurs"
-	else
-		. = ..()
+	switch(slurring)
+		if(25 to 50)
+			return "jumbles"
+		if(50 to 75)
+			return "slurs"
+		if(75 to INFINITY)
+			return "garbles"
+		else
+			. = ..()
 
 /mob/living/carbon/human/treat_message(message)
 	message = dna.species.handle_speech(message,src)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -532,7 +532,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		stuttering = max(stuttering-1, 0)
 
 	if(slurring)
-		slurring = max(slurring-1,0)
+		slurring = max(slurring-0.15,0)
 
 	if(cultslurring)
 		cultslurring = max(cultslurring-1, 0)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -532,7 +532,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		stuttering = max(stuttering-1, 0)
 
 	if(slurring)
-		slurring = max(slurring-0.15,0,drunkenness)
+		slurring = max(slurring-1,0,drunkenness)
 
 	if(cultslurring)
 		cultslurring = max(cultslurring-1, 0)

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -532,7 +532,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		stuttering = max(stuttering-1, 0)
 
 	if(slurring)
-		slurring = max(slurring-0.15,0)
+		slurring = max(slurring-0.15,0,drunkenness)
 
 	if(cultslurring)
 		cultslurring = max(cultslurring-1, 0)
@@ -550,15 +550,10 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 		drunkenness = max(drunkenness - (drunkenness * 0.04), 0)
 		if(drunkenness >= 6)
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "drunk", /datum/mood_event/drunk)
-			if(prob(25))
-				slurring += 2
 			jitteriness = max(jitteriness - 3, 0)
 			if(has_trait(TRAIT_DRUNK_HEALING))
 				adjustBruteLoss(-0.12, FALSE)
 				adjustFireLoss(-0.06, FALSE)
-
-		if(drunkenness >= 11 && slurring < 5)
-			slurring += 1.2
 
 		if(mind && (mind.assigned_role == "Scientist" || mind.assigned_role == "Research Director"))
 			if(SSresearch.science_tech)

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -334,7 +334,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 		message = stutter(message)
 
 	if(slurring)
-		message = slur(message)
+		message = slur(message,slurring)
 
 	if(cultslurring)
 		message = cultslur(message)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -64,7 +64,7 @@
 		p++
 	return sanitize(t)
 
-/proc/slur(n)
+/proc/slur(n,var/strength=50)
 	var/phrase = html_decode(n)
 	var/leng = lentext(phrase)
 	var/counter=lentext(phrase)
@@ -72,7 +72,7 @@
 	var/newletter=""
 	while(counter>=1)
 		newletter=copytext(phrase,(leng-counter)+1,(leng-counter)+2)
-		if(rand(1,3)==3)
+		if(rand(1,100)<=strength)
 			if(lowertext(newletter)=="o")
 				newletter="u"
 			if(lowertext(newletter)=="s")
@@ -83,17 +83,17 @@
 				newletter="oo"
 			if(lowertext(newletter)=="c")
 				newletter="k"
-		if(rand(1,20)==20)
+		if(rand(1,100) <= strength*0.5)
 			if(newletter==" ")
 				newletter="...huuuhhh..."
 			if(newletter==".")
 				newletter=" *BURP*."
-		switch(rand(1,20))
-			if(1)
+		if(rand(1,100) <= strength)
+			if(rand(1,5) == 1)
 				newletter+="'"
-			if(10)
+			if(rand(1,5) == 1)
 				newletter+="[newletter]"
-			if(20)
+			if(rand(1,5) == 1)
 				newletter+="[newletter][newletter]"
 		newphrase+="[newletter]";counter-=1
 	return newphrase

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1277,8 +1277,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	if(!M.has_trait(TRAIT_ALCOHOL_TOLERANCE))
 		M.confused = max(M.confused+2,0)
 		M.Dizzy(10)
-	if (!M.slurring)
-		M.slurring = 1
+	M.slurring = max(M.slurring,50)
 	M.slurring += 3
 	switch(current_cycle)
 		if(51 to 200)
@@ -1306,8 +1305,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	M.dizziness +=1.5
 	switch(current_cycle)
 		if(15 to 45)
-			if(!M.slurring)
-				M.slurring = 1
+			M.slurring = max(M.slurring,50)
 			M.slurring += 3
 		if(45 to 55)
 			if(prob(50))
@@ -1336,8 +1334,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	M.dizziness +=2
 	switch(current_cycle)
 		if(15 to 45)
-			if(!M.slurring)
-				M.slurring = 1
+			M.slurring = max(M.slurring,50)
 			M.slurring += 3
 		if(45 to 55)
 			if(prob(50))
@@ -1364,8 +1361,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_desc = "A drink enjoyed by people during the 1960's."
 
 /datum/reagent/consumable/ethanol/hippies_delight/on_mob_life(mob/living/carbon/M)
-	if (!M.slurring)
-		M.slurring = 1
+	M.slurring = max(M.slurring,50)
 	switch(current_cycle)
 		if(1 to 5)
 			M.Dizzy(10)

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -402,8 +402,7 @@
 	taste_description = "mushroom"
 
 /datum/reagent/mushroomhallucinogen/on_mob_life(mob/living/carbon/M)
-	if(!M.slurring)
-		M.slurring = 1
+	M.slurring = max(M.slurring,50)
 	switch(current_cycle)
 		if(1 to 5)
 			M.Dizzy(5)


### PR DESCRIPTION
[Changelogs]: 
:cl: BurgerBB
tweak: Tweaks how slurring works so it's more of a gradual change into slurring instead of immediate.
balance: Slurring is now directly proportional to your drunkenness, with other sources of slur being added on top of it.
/:cl:

[why]: It was pretty jarring that there was a fine line between not being slurred and being slurred when drunk. Like you could type a sentence, and it would be 100% incoherent, but 1 second later after your slurring level is gone naturally, you'd start typing normal sentences. This is fixed by making it so that slurring is directly affected by your drunkenness level, and making it so the slur proc can accept a strength value.