### PR TITLE
Nerfs Synda NPC block Rng to 25%

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -130,7 +130,7 @@
 /mob/living/simple_animal/hostile/syndicate/melee/bullet_act(obj/item/projectile/Proj)
 	if(!Proj)
 		return
-	if(prob(50))
+	if(prob(25))
 		return ..()
 	else
 		visible_message("<span class='danger'>[src] blocks [Proj] with its shield!</span>")


### PR DESCRIPTION
[Changelogs]
Well if they were a real boy they would have 75% block
But their not a real boy. They are a NPC, that can block legit deathbolts, grandes, mark guns and any other thing that shoots...

:cl: optional name here
balance: 25% < --- 50% For NPC blocking bullshit
ided: Yes 
/:cl:

[why]
They are a NPC, that can block legit deathbolts, grandes, mark guns and any other thing that shoots...
They are hyper lethal and have dogging, space walk, and more!