### PR TITLE
Fixed the jaunt in ninja's katana.

### DIFF
--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -32,7 +32,7 @@
 	if(!IsAvailable())
 		return
 	var/turf/T = get_turf(target)
-	if(target in view(user.client.view, get_turf(user)))
+	if(target in view(user.client.view, user))
 		var/obj/spot1 = new phaseout(get_turf(user), user.dir)
 		user.forceMove(T)
 		playsound(T, dash_sound, 25, 1)

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,4 +8,4 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 
-Useroth = Host
+yourckeygoeshere = Host

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,4 +8,4 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 
-yourckeygoeshere = Host
+Useroth = Host


### PR DESCRIPTION
- As above. It no longer prevents you from teleporting onto completely dark tiles. Now the ninja can prowl in the darkness yet again, where he belongs.
- _As a side effect, you should probably ICly make sure ninja doesn't get x-ray vision, because his katana can jaunt to any tile the he can see._