### PR TITLE
Vent Clog Event Rebalance and Improvements

### DIFF
--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -47,7 +47,22 @@
 		"hair_dye",
 		"sugar",
 		"white_glitter",
-		"growthserum"
+		"growthserum",
+
+		"cooking_oil",
+		"frostoil",
+		"sodiumchloride",
+		"cornoil",
+		"uranium",
+		"carpet",
+		"firefighting_foam",
+		"semen",
+		"femcum",
+		"tearjuice",
+		"strange_reagent",
+		"spraytan",
+		"bluespace"
+
 	)
 	//needs to be chemid unit checked at some point
 
@@ -87,8 +102,8 @@
 	else
 		R.add_reagent(pick(saferChems), reagentsAmount)
 
-	var/datum/effect_system/smoke_spread/chem/C = new
-	C.set_up(R,16,T,TRUE)
+	var/datum/effect_system/smoke_spread/chem/smoke_machine/C = new
+	C.set_up(R,16,1,T)
 	C.start()
 	playsound(T, 'sound/effects/smoke.ogg', 50, 1, -3)
 

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -60,8 +60,7 @@
 		"femcum",
 		"tearjuice",
 		"strange_reagent",
-		"spraytan",
-		"bluespace"
+		"spraytan"
 
 	)
 	//needs to be chemid unit checked at some point

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -50,8 +50,6 @@
 		"growthserum",
 
 		"cooking_oil",
-		"frostoil",
-		"sodiumchloride",
 		"cornoil",
 		"uranium",
 		"carpet",
@@ -59,8 +57,7 @@
 		"semen",
 		"femcum",
 		"tearjuice",
-		"strange_reagent",
-		"spraytan"
+		"strange_reagent"
 
 	)
 	//needs to be chemid unit checked at some point

--- a/code/modules/events/vent_clog.dm
+++ b/code/modules/events/vent_clog.dm
@@ -48,8 +48,6 @@
 		"sugar",
 		"white_glitter",
 		"growthserum",
-
-		"cooking_oil",
 		"cornoil",
 		"uranium",
 		"carpet",
@@ -69,8 +67,10 @@
 	endWhen = rand(120, 180)
 	for(var/obj/machinery/atmospherics/components/unary/vent_scrubber/temp_vent in GLOB.machines)
 		var/turf/T = get_turf(temp_vent)
-		if(T && is_station_level(T.z) && !temp_vent.welded)
+		var/area/A = T.loc
+		if(T && is_station_level(T.z) && !temp_vent.welded && !A.safe)
 			vents += temp_vent
+
 	if(!vents.len)
 		return kill()
 

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -234,11 +234,6 @@ GLOBAL_LIST_INIT(frying_bad_chems, list(
 		QDEL_NULL(trash)
 	. = ..()
 
-/obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
-	if(trash)
-		QDEL_NULL(trash)
-	..()
-
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)
 	switch(cook_time)
 		if(0 to 15)

--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -234,6 +234,11 @@ GLOBAL_LIST_INIT(frying_bad_chems, list(
 		QDEL_NULL(trash)
 	. = ..()
 
+/obj/item/reagent_containers/food/snacks/deepfryholder/On_Consume(mob/living/eater)
+	if(trash)
+		QDEL_NULL(trash)
+	..()
+
 /obj/item/reagent_containers/food/snacks/deepfryholder/proc/fry(cook_time = 30)
 	switch(cook_time)
 		if(0 to 15)


### PR DESCRIPTION
[Changelogs]:
:cl: BurgerBB
add: Added the following reagents to the common list of vent clog reagents: ~~Cooking Oil~~, ~~Frost Oil~~, Sodium Chloride, Corn Oil, Uranium, Carpet, Firefighting Foam, semen, femcum, tear juice, strange reagent, ~~spraytan~~.
balance: Vent Clog smoke emits the same transparent smoke as a smoke machine, including how much it transfers. Vent Clogs also do not trigger in areas deemed "Safe" in code, such as in the dorms or trusted areas where dangerous things shouldn't occur.
/:cl:

[why]: I think the smoke fucked with lighting and caused lag. I know for a fact that this isn't the case with the smoke from the smoke machine, so it was changed. Also I felt that new reagents that have neat interactions with turfs and mobs should be added.