### PR TITLE
Brings NTPR to the nice discord bot

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -199,6 +199,10 @@
 	if(length(CONFIG_GET(keyed_list/cross_server)))
 		send_news_report()
 
+	//tell the nice people on discord what went on before the salt cannon happens.
+	world.TgsTargetedChatBroadcast("The current round has ended. Please standby for your shift interlude Nanotrasen News Network's report!", FALSE)
+	world.TgsTargetedChatBroadcast(send_news_report(),FALSE)
+
 	CHECK_TICK
 
 	//These need update to actually reflect the real antagonists

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -566,7 +566,7 @@ SUBSYSTEM_DEF(ticker)
 		send2otherserver(news_source, news_message,"News_Report")
 		return news_message
 	else
-		return "We reget to inform you that shit be whack, yo. And none of our reporters have any idea of what may or may not have gone on."
+		return "We regret to inform you that shit be whack, yo. None of our reporters have any idea of what may or may not have gone on."
 
 /datum/controller/subsystem/ticker/proc/GetTimeLeft()
 	if(isnull(SSticker.timeLeft))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -564,6 +564,9 @@ SUBSYSTEM_DEF(ticker)
 
 	if(news_message)
 		send2otherserver(news_source, news_message,"News_Report")
+		return news_message
+	else
+		return "We reget to inform you that shit be whack, yo. And none of our reporters have any idea of what may or may not have gone on."
 
 /datum/controller/subsystem/ticker/proc/GetTimeLeft()
 	if(isnull(SSticker.timeLeft))


### PR DESCRIPTION
:cl: Poojawa
server: Discord bot will now report when a round ends and give the vague news ticker that a sister-station would have received for the game mode and result of the round.
/:cl:

Why is it only new game starting and meme commands that work?

:v