### PR TITLE
buff sleepy pens to quickly drain stamina after 10 seconds

### DIFF
--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -311,7 +311,7 @@
 		if(10 to 20)
 			M.confused += 1
 			M.drowsyness += 1
-			M.adjustStaminaLossBuffered(5)
+			M.adjustStaminaLoss(5)
 		if(20 to INFINITY)
 			M.Sleeping(40, 0)
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -304,13 +304,14 @@
 	reagent_state = SOLID
 	color = "#000067" // rgb: 0, 0, 103
 	toxpwr = 0
-	metabolization_rate = 1.5 * REAGENTS_METABOLISM
+	metabolization_rate = 1 * REAGENTS_METABOLISM
 
 /datum/reagent/toxin/chloralhydratedelayed/on_mob_life(mob/living/carbon/M)
 	switch(current_cycle)
 		if(10 to 20)
 			M.confused += 1
 			M.drowsyness += 1
+			M.adjustStaminaLossBuffered(5)
 		if(20 to INFINITY)
 			M.Sleeping(40, 0)
 	..()

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -311,7 +311,7 @@
 		if(10 to 20)
 			M.confused += 1
 			M.drowsyness += 1
-			M.adjustStaminaLoss(5)
+			M.adjustStaminaLoss(7.5)
 		if(20 to INFINITY)
 			M.Sleeping(40, 0)
 	..()


### PR DESCRIPTION
they're too unused and crappy under stamina combat, easily combatable with coffee and more or less useless unless they manage to down you first or lock you into a room.