### PR TITLE
This is an entire addition to put stargazers back into clock cult. 

### DIFF
--- a/code/__DEFINES/clockcult.dm
+++ b/code/__DEFINES/clockcult.dm
@@ -28,9 +28,9 @@ GLOBAL_LIST_EMPTY(all_scripture) //a list containing scripture instances; not us
 #define SCRIPTURE_APPLICATION "Application"
 
 //Various costs related to power.
-#define MAX_CLOCKWORK_POWER 50000 //The max power in W that the cult can stockpile
-#define SCRIPT_UNLOCK_THRESHOLD 25000 //Scripts will unlock if the total power reaches this amount
-#define APPLICATION_UNLOCK_THRESHOLD 40000 //Applications will unlock if the total powre reaches this amount
+#define MAX_CLOCKWORK_POWER 80000 //The max power in W that the cult can stockpile
+#define SCRIPT_UNLOCK_THRESHOLD 35000 //Scripts will unlock if the total power reaches this amount
+#define APPLICATION_UNLOCK_THRESHOLD 50000 //Applications will unlock if the total powre reaches this amount
 
 #define ABSCOND_ABDUCTION_COST 95
 

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_slab.dm
@@ -44,12 +44,13 @@
 
 /obj/item/clockwork/slab/cyborg //three scriptures, plus a spear and fabricator
 	clockwork_desc = "A divine link to the Celestial Derelict, allowing for limited recital of scripture."
-	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/ranged_ability/judicial_marker, /datum/clockwork_scripture/ranged_ability/linked_vanguard)
+	quickbound = list(/datum/clockwork_scripture/ranged_ability/judicial_marker, /datum/clockwork_scripture/ranged_ability/linked_vanguard, \
+	/datum/clockwork_scripture/create_object/stargazer)
 	maximum_quickbound = 6 //we usually have one or two unique scriptures, so if ratvar is up let us bind one more
 	actions_types = list()
 
-/obj/item/clockwork/slab/cyborg/engineer //two scriptures, plus a fabricator
-	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/create_object/replicant, /datum/clockwork_scripture/create_object/sigil_of_transmission)
+/obj/item/clockwork/slab/cyborg/engineer //three scriptures, plus a fabricator
+	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/create_object/replicant, /datum/clockwork_scripture/create_object/sigil_of_transmission,  /datum/clockwork_scripture/create_object/stargazer)
 
 /obj/item/clockwork/slab/cyborg/medical //five scriptures, plus a spear
 	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/ranged_ability/linked_vanguard, /datum/clockwork_scripture/ranged_ability/sentinels_compromise, \
@@ -61,12 +62,12 @@
 /obj/item/clockwork/slab/cyborg/peacekeeper //two scriptures, plus a spear
 	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/ranged_ability/hateful_manacles, /datum/clockwork_scripture/ranged_ability/judicial_marker)
 
-/obj/item/clockwork/slab/cyborg/janitor //five scriptures, plus a fabricator
+/obj/item/clockwork/slab/cyborg/janitor //six scriptures, plus a fabricator
 	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/create_object/replicant, /datum/clockwork_scripture/create_object/sigil_of_transgression, \
-	/datum/clockwork_scripture/create_object/ocular_warden, /datum/clockwork_scripture/create_object/mania_motor)
+	 /datum/clockwork_scripture/create_object/stargazer, /datum/clockwork_scripture/create_object/ocular_warden, /datum/clockwork_scripture/create_object/mania_motor)
 
-/obj/item/clockwork/slab/cyborg/service //five scriptures, plus xray vision
-	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/create_object/replicant, \
+/obj/item/clockwork/slab/cyborg/service //six scriptures, plus xray vision
+	quickbound = list(/datum/clockwork_scripture/abscond, /datum/clockwork_scripture/create_object/replicant,/datum/clockwork_scripture/create_object/stargazer, \
 	/datum/clockwork_scripture/spatial_gateway, /datum/clockwork_scripture/create_object/clockwork_obelisk)
 
 /obj/item/clockwork/slab/cyborg/miner //two scriptures, plus a spear and xray vision

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -4,12 +4,12 @@
 
 //Stargazer: Creates a stargazer, a cheap power generator that utilizes starlight.
 /datum/clockwork_scripture/create_object/stargazer
-	descname = "Generates Power From Starlight - Important!"
+	descname = "Generates Power From Starlight"
 	name = "Stargazer"
 	desc = "Forms a weak structure that generates power every second while within three tiles of starlight."
 	invocations = list("Capture their inferior light for us!")
 	channel_time = 50
-	power_cost = 50
+	power_cost = 200
 	object_path = /obj/structure/destructible/clockwork/stargazer
 	creator_message = "<span class='brass'>You form a stargazer, which will generate power near starlight.</span>"
 	observer_message = "<span class='warning'>A large lantern-shaped machine forms!</span>"

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -2,6 +2,32 @@
 // DRIVERS //
 /////////////
 
+//Stargazer: Creates a stargazer, a cheap power generator that utilizes starlight.
+/datum/clockwork_scripture/create_object/stargazer
+	descname = "Generates Power From Starlight - Important!"
+	name = "Stargazer"
+	desc = "Forms a weak structure that generates power every second while within three tiles of starlight."
+	invocations = list("Capture their inferior light for us!")
+	channel_time = 50
+	power_cost = 50
+	object_path = /obj/structure/destructible/clockwork/stargazer
+	creator_message = "<span class='brass'>You form a stargazer, which will generate power near starlight.</span>"
+	observer_message = "<span class='warning'>A large lantern-shaped machine forms!</span>"
+	usage_tip = "For obvious reasons, make sure to place this near a window or somewhere else that can see space!"
+	tier = SCRIPTURE_DRIVER
+	one_per_tile = TRUE
+	primary_component = HIEROPHANT_ANSIBLE
+	sort_priority = 1
+	quickbind = TRUE
+	quickbind_desc = "Creates a stargazer, which generates power when near starlight."
+
+/datum/clockwork_scripture/create_object/stargazer/check_special_requirements()
+	var/area/A = get_area(invoker)
+	if(A.outdoors || A.map_name == "Space" || !A.blob_allowed)
+		to_chat(invoker, "<span class='danger'>Stargazers can't be built off-station.</span>")
+		return
+	return ..()
+	
 
 //Integration Cog: Creates an integration cog that can be inserted into APCs to passively siphon power.
 /datum/clockwork_scripture/create_object/integration_cog
@@ -18,7 +44,7 @@
 	tier = SCRIPTURE_DRIVER
 	space_allowed = TRUE
 	primary_component = HIEROPHANT_ANSIBLE
-	sort_priority = 1
+	sort_priority = 2
 	important = TRUE
 	quickbind = TRUE
 	quickbind_desc = "Creates an integration cog, which can be used to siphon power from an open APC."
@@ -39,7 +65,7 @@
 	tier = SCRIPTURE_DRIVER
 	one_per_tile = TRUE
 	primary_component = HIEROPHANT_ANSIBLE
-	sort_priority = 2
+	sort_priority = 3
 	quickbind = TRUE
 	quickbind_desc = "Creates a Sigil of Transgression, which will briefly stun and slow the next non-Servant to cross it."
 
@@ -59,7 +85,7 @@
 	tier = SCRIPTURE_DRIVER
 	one_per_tile = TRUE
 	primary_component = HIEROPHANT_ANSIBLE
-	sort_priority = 3
+	sort_priority = 4
 	quickbind = TRUE
 	quickbind_desc = "Creates a Sigil of Submission, which will convert non-Servants that remain on it."
 
@@ -76,7 +102,7 @@
 	usage_tip = "The light can be used from up to two tiles away. Damage taken will GREATLY REDUCE the stun's duration."
 	tier = SCRIPTURE_DRIVER
 	primary_component = BELLIGERENT_EYE
-	sort_priority = 4
+	sort_priority = 5
 	slab_overlay = "volt"
 	ranged_type = /obj/effect/proc_holder/slab/kindle
 	ranged_message = "<span class='brass'><i>You charge the clockwork slab with divine energy.</i>\n\
@@ -100,7 +126,7 @@
 	usage_tip = "The manacles are about as strong as zipties, and break when removed."
 	tier = SCRIPTURE_DRIVER
 	primary_component = BELLIGERENT_EYE
-	sort_priority = 5
+	sort_priority = 6
 	ranged_type = /obj/effect/proc_holder/slab/hateful_manacles
 	slab_overlay = "hateful_manacles"
 	ranged_message = "<span class='neovgre_small'><i>You charge the clockwork slab with divine energy.</i>\n\
@@ -124,7 +150,7 @@
 	usage_tip = "You cannot reactivate Vanguard while still shielded by it."
 	tier = SCRIPTURE_DRIVER
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 6
+	sort_priority = 7
 	quickbind = TRUE
 	quickbind_desc = "Allows you to temporarily have quickly regenerating stamina and absorb stuns. All stuns absorbed will affect you when disabled."
 
@@ -156,7 +182,7 @@
 	usage_tip = "The Compromise is very fast to invoke, and will remove holy water from the target Servant."
 	tier = SCRIPTURE_DRIVER
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 7
+	sort_priority = 8
 	quickbind = TRUE
 	quickbind_desc = "Allows you to convert a Servant's brute, burn, and oxygen damage to half toxin damage.<br><b>Click your slab to disable.</b>"
 	slab_overlay = "compromise"
@@ -180,7 +206,7 @@
 	usage_tip = "This can't be used while on Reebe, for obvious reasons."
 	tier = SCRIPTURE_DRIVER
 	primary_component = GEIS_CAPACITOR
-	sort_priority = 8
+	sort_priority = 9
 	important = TRUE
 	quickbind = TRUE
 	quickbind_desc = "Returns you to Reebe."
@@ -238,7 +264,7 @@
 	tier = SCRIPTURE_DRIVER
 	space_allowed = TRUE
 	primary_component = GEIS_CAPACITOR
-	sort_priority = 9
+	sort_priority = 10
 	important = TRUE
 	quickbind = TRUE
 	quickbind_desc = "Creates a new Clockwork Slab."
@@ -259,6 +285,6 @@
 	tier = SCRIPTURE_DRIVER
 	space_allowed = TRUE
 	primary_component = GEIS_CAPACITOR
-	sort_priority = 10
+	sort_priority = 11
 	quickbind = TRUE
 	quickbind_desc = "Creates a pair of Wraith Spectacles, which grant true sight but cause gradual vision loss."

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -1,0 +1,70 @@
+#define STARGAZER_RANGE 3 //How many tiles the stargazer can see out to
+#define STARGAZER_POWER 20 //How many watts will be produced per second when the stargazer sees starlight
+
+//Stargazer: A very fragile but cheap generator that creates power from starlight.
+/obj/structure/destructible/clockwork/stargazer
+	name = "stargazer"
+	desc = "A large lantern-shaped machine made of thin brass. It looks fragile."
+	clockwork_desc = "A lantern-shaped generator that produces power when near starlight."
+	icon_state = "stargazer"
+	unanchored_icon = "stargazer_unwrenched"
+	max_integrity = 40
+	construction_value = 5
+	layer = WALL_OBJ_LAYER
+	break_message = "<span class='warning'>The stargazer's fragile body shatters into pieces!</span>"
+	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
+	light_color = "#DAAA18"
+	var/star_light_star_bright = FALSE //If this stargazer can see starlight
+
+/obj/structure/destructible/clockwork/stargazer/Initialize()
+	. = ..()
+	START_PROCESSING(SSprocessing, src)
+
+/obj/structure/destructible/clockwork/stargazer/Destroy()
+	STOP_PROCESSING(SSprocessing, src)
+	. = ..()
+
+/obj/structure/destructible/clockwork/stargazer/examine(mob/user)
+	..()
+	if(is_servant_of_ratvar(user))
+		to_chat(user, "<span class='nzcrentr_small'>Generates <b>[DisplayPower(STARGAZER_POWER)]</b> per second while viewing starlight within [STARGAZER_RANGE] tiles.</span>")
+	if(star_light_star_bright)
+		to_chat(user, "[is_servant_of_ratvar(user) ? "<span class='nzcrentr_small'>It can see starlight!</span>" : "It's shining brilliantly!"]")
+
+/obj/structure/destructible/clockwork/stargazer/process()
+	star_light_star_bright = check_starlight()
+	if(star_light_star_bright)
+		adjust_clockwork_power(STARGAZER_POWER)
+
+/obj/structure/destructible/clockwork/stargazer/update_anchored(mob/living/user, damage)
+	. = ..()
+	star_light_star_bright = check_starlight()
+
+/obj/structure/destructible/clockwork/stargazer/proc/check_starlight()
+	var/old_status = star_light_star_bright
+	var/has_starlight
+	if(!anchored)
+		has_starlight = FALSE
+	else
+		for(var/turf/T in view(3, src))
+			if(isspaceturf(T))
+				has_starlight = TRUE
+				break
+	if(has_starlight && anchored)
+		var/area/A = get_area(src)
+		if(A.outdoors || A.map_name == "Space" || !A.blob_allowed)
+			has_starlight = FALSE
+	if(old_status != has_starlight)
+		if(has_starlight)
+			visible_message("<span class='nzcrentr_small'>[src] hums and shines brilliantly!</span>")
+			playsound(src, 'sound/machines/clockcult/stargazer_activate.ogg', 50, TRUE)
+			add_overlay("stargazer_light")
+			set_light(1.5, 5)
+		else
+			if(anchored) //We lost visibility somehow
+				visible_message("<span class='danger'>[src] flickers, and falls dark.</span>")
+			else
+				visible_message("<span class='danger'>[src] whooshes quietly as it slides into a less bulky form.</span>")
+			cut_overlays()
+			set_light(0)
+	return has_starlight

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -1,5 +1,5 @@
 #define STARGAZER_RANGE 3 //How many tiles the stargazer can see out to
-#define STARGAZER_POWER 15 //How many watts will be produced per second when the stargazer sees starlight
+#define STARGAZER_POWER 7 //How many watts will be produced per second when the stargazer sees starlight
 
 //Stargazer: A very fragile but cheap generator that creates power from starlight.
 /obj/structure/destructible/clockwork/stargazer

--- a/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/stargazer.dm
@@ -1,5 +1,5 @@
 #define STARGAZER_RANGE 3 //How many tiles the stargazer can see out to
-#define STARGAZER_POWER 20 //How many watts will be produced per second when the stargazer sees starlight
+#define STARGAZER_POWER 15 //How many watts will be produced per second when the stargazer sees starlight
 
 //Stargazer: A very fragile but cheap generator that creates power from starlight.
 /obj/structure/destructible/clockwork/stargazer

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1226,6 +1226,7 @@
 #include "code\modules\antagonists\clockcult\clock_scriptures\scripture_scripts.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\_trap_object.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\ark_of_the_clockwork_justicar.dm"
+#include "code\modules\antagonists\clockcult\clock_structures\stargazer.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\clockwork_obelisk.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\eminence_spire.dm"
 #include "code\modules\antagonists\clockcult\clock_structures\heralds_beacon.dm"


### PR DESCRIPTION
[Changelogs]:

:cl: Bringing light to Ratvar
add: Added stargazers back into the clockcult. 
tweak: gave stargazers to engineer,service and janitor borgs. 
balance: kept the cap on power for Ratvar but buffed some of the costs to compensate for such a sharp power increase. 
config: changed values of cap to 80000(50000), value to script unlock to 35000(25000) and application unlock to 50000(40000)

[why]:I feel clock cult power can be a bit too low and having more options to work with in terms of acquiring power was a much better feel prior to it's removal. Let alone giving cults with low player counts a much better chance with defense on Reebe. Of course this is only an initial change and is easily subject to change in terms of balancing it verses crew. 