### PR TITLE
Abductor baton buff. Because it currently sucks balls.

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -503,7 +503,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	L.lastattacker = user.real_name
 	L.lastattackerckey = user.ckey
 
-	L.adjustStaminaLoss(60) //because previously it took 5-6 hits to actually "incapacitate" someone for the purposes of the sleep inducement
+	L.adjustStaminaLoss(35) //because previously it took 5-6 hits to actually "incapacitate" someone for the purposes of the sleep inducement
 	L.Knockdown(140)
 	L.apply_effect(EFFECT_STUTTER, 7)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -503,6 +503,7 @@ Congratulations! You are now trained for invasive xenobiology research!"}
 	L.lastattacker = user.real_name
 	L.lastattackerckey = user.ckey
 
+	L.adjustStaminaLoss(60) //because previously it took 5-6 hits to actually "incapacitate" someone for the purposes of the sleep inducement
 	L.Knockdown(140)
 	L.apply_effect(EFFECT_STUTTER, 7)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)


### PR DESCRIPTION
With this, the abduction "procedure" speed will be similar to how it used to be, instead of having to hit 5-6 times in quick succession, with the risk of the victim freely calling for help over the radio.
Considering only abductors can wield it, I don't think it's really overpowered, though I'm open to comments regarding balance.