### PR TITLE
Golden toolboxes. 

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -208,3 +208,38 @@
 	new/obj/item/stack/cable_coil/orange(src)
 	new/obj/item/stack/cable_coil/cyan(src)
 	new/obj/item/stack/cable_coil/white(src)
+
+/obj/item/storage/toolbox/gold_real
+	name = "golden toolbox"
+	desc = "A larger then normal toolbox made of gold plated plastitanium."
+	item_state = "gold"
+	icon_state = "gold"
+	has_latches = FALSE
+	force = 16 // Less then a spear
+	throwforce = 14
+	throw_speed = 5
+	throw_range = 10
+
+/obj/item/storage/toolbox/gold_real/PopulateContents()
+	new /obj/item/screwdriver/nuke(src)
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool/largetank(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/wirecutters(src, "red")
+	new /obj/item/multitool/ai_detect(src)
+	new /obj/item/clothing/gloves/combat(src)
+
+/obj/item/storage/toolbox/gold_real/ComponentInitialize()
+	. = ..()
+	GET_COMPONENT(STR, /datum/component/storage)
+	STR.max_combined_w_class = 40
+	STR.max_items = 12
+
+/obj/item/storage/toolbox/gold_fake // used in crafting
+	name = "golden toolbox"
+	desc = "A gold plated toolbox, fancy and harmless do to the gold plating being on cardboard!"
+	icon_state = "gold"
+	item_state = "gold"
+	has_latches = FALSE
+	force = 0
+	throwforce = 0

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -709,3 +709,14 @@
 	reqs = list(/obj/item/tank/internals/oxygen/red = 2, /obj/item/extinguisher = 1, /obj/item/pipe = 3, /obj/item/stack/cable_coil = 30)//red oxygen tank so it looks right
 	category = CAT_MISC
 	tools = list(TOOL_WRENCH, TOOL_WELDER, TOOL_WIRECUTTER)
+
+/datum/crafting_recipe/goldenbox
+	name = "Gold Plated Toolbox"
+	result = /obj/item/storage/toolbox/gold_fake 
+	reqs = list(/obj/item/stack/sheet/cardboard = 1, //so we dont null items in crafting
+				/obj/item/stack/cable_coil = 10,
+				/obj/item/stack/sheet/mineral/gold = 1,
+				/obj/item/stock_parts/cell = 1,
+				/datum/reagent/water  = 15)
+	time = 40
+	category = CAT_MISC

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1438,6 +1438,13 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 20
 	restricted_roles = list("Assistant")
 
+/datum/uplink_item/role_restricted/goldenbox
+	name = "Gold Toolbox"
+	desc = "A gold planted plastitanium toolbox loaded with tools. Comes with a set of AI detection multi-tool and a pare of combat gloves."
+	item = /obj/item/storage/toolbox/gold_real
+	cost = 5 // Has synda tools + gloves + a robust weapon
+	restricted_roles = list("Assistant", "Curator") //Curator do to being made of gold - It fits the theme
+
 /datum/uplink_item/role_restricted/brainwash_disk
 	name = "Brainwashing Surgery Program"
 	desc = "A disk containing the procedure to perform a brainwashing surgery, allowing you to implant an objective onto a target. \


### PR DESCRIPTION
[Changelogs]
Adds two new toolboxes
A real golden toolbox for traitor grays and adventurer to buy with a full set of synda tools - Its also robust as a toolbox
Well a fake cardboard one can be made to look swag=y 
:cl: optional name here
add: golden swag boxes
/:cl:

[why]
Hecken unused sprites. Looks hecken grate and adds in more fun items for a traitor to get
