### PR TITLE
Cryosleep no longer holds Borg blueprints

### DIFF
--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -173,6 +173,7 @@
 		/obj/item/gun/energy/e_gun/advtaser/cyborg,
 		/obj/item/gun/energy/printer,
 		/obj/item/gun/energy/kinetic_accelerator/cyborg,
+		/obj/item/areaeditor/blueprints/cyborg,
 		/obj/item/gun/energy/laser/cyborg
 	)
 


### PR DESCRIPTION
[Changelogs]
bug fixing that /obj/item/areaeditor/blueprints/cyborg is held in cryosleep
:cl: optional name here
fix: bug
/:cl:

[why]
Cryo sleep isnt ment to hold robotic things, bug fixing
