### PR TITLE
Makes angel, android, and synth now magic mirror races again

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -99,7 +99,7 @@
 	name = "magic mirror"
 	desc = "Turn and face the strange... face."
 	icon_state = "magic_mirror"
-	var/list/races_blacklist = list("skeleton", "agent", "angel", "military_synth", "memezombies", "clockwork golem servant", "android", "synth", "mush", "zombie", "memezombie")
+	var/list/races_blacklist = list("skeleton", "agent", "military_synth", "memezombies", "clockwork golem servant", "mush", "zombie", "memezombie")
 	var/list/choosable_races = list()
 
 /obj/structure/mirror/magic/New()


### PR DESCRIPTION
[Changelogs]
Pride and magic mirrors can now become angel, synth, and android, races  again
:cl: optional name here
tweak: unbacklists things
/:cl:

[why]:
Android is legit just a Full body robot that can be done at shift start
Angel is a lava land spawn, and the idea of pride is that you look down on others. - Angels do this for a living on the sin-full
Synths do to robot agenda - God damn it addition 