### PR TITLE
[MERGE READY]Reduces the complexity of the two new circuits: pneumatic cannon and stunner.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -215,7 +215,7 @@
 	The 'fire' activator will cause the mechanism to attempt to launch objects at the coordinates, if possible. Note that the \
 	projectile needs to be inside the machine, or on an adjacent tile, and must be medium sized or smaller. The assembly \
 	must also be a gun if you wish to launch something while the assembly is in hand."
-	complexity = 40
+	complexity = 50
 	w_class = WEIGHT_CLASS_SMALL
 	size = 4
 	cooldown_per_use = 30
@@ -306,7 +306,7 @@
 	desc = "Used to stun a target holding the device via electricity."
 	icon_state = "power_relay"
 	extended_desc = "Attempts to stun the holder of this device, with the strength input being the strength of the stun, from 1 to 70."
-	complexity = 15
+	complexity = 30
 	size = 4
 	inputs = list("strength" = IC_PINTYPE_NUMBER)
 	activators = list("stun" = IC_PINTYPE_PULSE_IN, "on success" = IC_PINTYPE_PULSE_OUT, "on fail" = IC_PINTYPE_PULSE_OUT)

--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -215,7 +215,7 @@
 	The 'fire' activator will cause the mechanism to attempt to launch objects at the coordinates, if possible. Note that the \
 	projectile needs to be inside the machine, or on an adjacent tile, and must be medium sized or smaller. The assembly \
 	must also be a gun if you wish to launch something while the assembly is in hand."
-	complexity = 75
+	complexity = 40
 	w_class = WEIGHT_CLASS_SMALL
 	size = 4
 	cooldown_per_use = 30
@@ -306,7 +306,7 @@
 	desc = "Used to stun a target holding the device via electricity."
 	icon_state = "power_relay"
 	extended_desc = "Attempts to stun the holder of this device, with the strength input being the strength of the stun, from 1 to 70."
-	complexity = 60
+	complexity = 15
 	size = 4
 	inputs = list("strength" = IC_PINTYPE_NUMBER)
 	activators = list("stun" = IC_PINTYPE_PULSE_IN, "on success" = IC_PINTYPE_PULSE_OUT, "on fail" = IC_PINTYPE_PULSE_OUT)


### PR DESCRIPTION
Considering both have pretty hefty cooldown (3 sec for the cannon, 5 for the stunner) and external cooldown (1.5 sec for the cannon and 2.5 for the stunner) making them pretty challenging to stack in any effective way, I think it's just fair, because currently it's _pretty_ hard to make anything interesting and have it fit in a single assembly.
Also, I will want stun implants eventually, yes.

Also, regarding some concern expressed about the good old pocket cannons. Those are not a thing anymore. There's only one assembly that can even use weaponized circuits while being held by a human and it's a medium-sized assembly.