### PR TITLE
A weight tweak to d-esword and baseball bat, to make them catch up with the stamina rework. 

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -290,6 +290,8 @@
 	var/hacked = FALSE
 	var/brightness_on = 6 //TWICE AS BRIGHT AS A REGULAR ESWORD
 	var/list/possible_colors = list("red", "blue", "green", "purple")
+	total_mass = 0.375 //Survival flashlights typically weigh around 5 ounces.
+	var/total_mass_on = 3.4 //The typical medieval sword, on the other hand, weighs roughly 3 pounds. //Values copied from the regular e-sword
 
 /obj/item/twohanded/dualsaber/suicide_act(mob/living/carbon/user)
 	if(wielded)
@@ -387,6 +389,7 @@
 	if(wielded)
 		sharpness = IS_SHARP
 		w_class = w_class_on
+		total_mass = total_mass_on
 		hitsound = 'sound/weapons/blade1.ogg'
 		START_PROCESSING(SSobj, src)
 		set_light(brightness_on)
@@ -394,6 +397,7 @@
 /obj/item/twohanded/dualsaber/unwield() //Specific unwield () to switch hitsounds.
 	sharpness = initial(sharpness)
 	w_class = initial(w_class)
+	total_mass = initial(total_mass)
 	..()
 	hitsound = "swing_hit"
 	STOP_PROCESSING(SSobj, src)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -500,6 +500,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	w_class = WEIGHT_CLASS_HUGE
 	var/homerun_ready = 0
 	var/homerun_able = 0
+	total_mass = 2.7 //a regular wooden major league baseball bat weighs somewhere between 2 to 3.4 pounds, according to google
 
 /obj/item/melee/baseball_bat/homerun
 	name = "home run bat"


### PR DESCRIPTION
- Makes the dual-esword use the same weight values as regular e-sword, instead of the WEIGHT_CLASS_BULKY tier weight, making it drain less stamina
- Makes baseball bats more realistic regarding their weight, instead of swinging like WEIGHT_CLASS_HUGE items.

If you ask me, tbh, I'm still not feeling the 3.4 pound e-swords, but that's material for another discussion and another PR.