### PR TITLE
Singallers are now input instead of button mashing

### DIFF
--- a/code/__HELPERS/radio.dm
+++ b/code/__HELPERS/radio.dm
@@ -12,3 +12,8 @@
 /proc/format_frequency(frequency)
 	frequency = text2num(frequency)
 	return "[round(frequency / 10)].[frequency % 10]"
+
+//Opposite of format, returns as a number
+/proc/unformat_frequency(frequency)
+	frequency = text2num(frequency)
+	return frequency * 10

--- a/code/modules/assembly/signaler.dm
+++ b/code/modules/assembly/signaler.dm
@@ -58,18 +58,12 @@
 <A href='byond://?src=[REF(src)];send=1'>Send Signal</A><BR>
 <B>Frequency/Code</B> for signaler:<BR>
 Frequency:
-<A href='byond://?src=[REF(src)];freq=-10'>-</A>
-<A href='byond://?src=[REF(src)];freq=-2'>-</A>
 [format_frequency(src.frequency)]
-<A href='byond://?src=[REF(src)];freq=2'>+</A>
-<A href='byond://?src=[REF(src)];freq=10'>+</A><BR>
+<A href='byond://?src=[REF(src)];set=freq'>Set</A><BR>
 
 Code:
-<A href='byond://?src=[REF(src)];code=-5'>-</A>
-<A href='byond://?src=[REF(src)];code=-1'>-</A>
 [src.code]
-<A href='byond://?src=[REF(src)];code=1'>+</A>
-<A href='byond://?src=[REF(src)];code=5'>+</A><BR>
+<A href='byond://?src=[REF(src)];set=code'>Set</A><BR>
 [t1]
 </TT>"}
 		user << browse(dat, "window=radio")
@@ -85,17 +79,23 @@ Code:
 		onclose(usr, "radio")
 		return
 
-	if (href_list["freq"])
-		var/new_frequency = (frequency + text2num(href_list["freq"]))
-		if(new_frequency < MIN_FREE_FREQ || new_frequency > MAX_FREE_FREQ)
-			new_frequency = sanitize_frequency(new_frequency)
-		set_frequency(new_frequency)
+	if (href_list["set"])
 
-	if(href_list["code"])
-		src.code += text2num(href_list["code"])
-		src.code = round(src.code)
-		src.code = min(100, src.code)
-		src.code = max(1, src.code)
+		if(href_list["set"] == "freq")
+			var/new_freq = input(usr, "Input a new signalling frequency", "Remote Signaller Frequency", format_frequency(frequency)) as num|null
+			if(!usr.canUseTopic(src, BE_CLOSE))
+				return
+			new_freq = unformat_frequency(new_freq)
+			new_freq = sanitize_frequency(new_freq, TRUE)
+			set_frequency(new_freq)
+
+		if(href_list["set"] == "code")
+			var/new_code = input(usr, "Input a new signalling code", "Remote Signaller Code", code) as num|null
+			if(!usr.canUseTopic(src, BE_CLOSE))
+				return
+			new_code = round(new_code)
+			new_code = CLAMP(new_code, 1, 100)
+			code = new_code
 
 	if(href_list["send"])
 		spawn( 0 )


### PR DESCRIPTION
Porting TG#43799

🆑 Tetr4
tweak: Remote signallers now use input boxes instead of inc/dec buttons.
fix: Remote signaller freq range no longer clamps to the wrong range.
/🆑
