### PR TITLE
Gives pod lava land ruin a autolathen 

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -272,7 +272,13 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
-
+"Z" = (
+/obj/machinery/autolathe{
+	hacked = TRUE;
+	desc = "This autolathe seems to have its safety light off."
+	},
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/seedvault)
 (1,1,1) = {"
 a
 a
@@ -375,7 +381,7 @@ h
 h
 u
 R
-u
+Z
 Q
 a
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_seed_vault.dmm
@@ -273,6 +273,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/seedvault)
 "Z" = (
+/obj/item/disk/design_disk/plant_disk,
 /obj/machinery/autolathe{
 	hacked = TRUE;
 	desc = "This autolathe seems to have its safety light off."

--- a/code/modules/ruins/lavaland_ruin_code.dm
+++ b/code/modules/ruins/lavaland_ruin_code.dm
@@ -16,6 +16,17 @@
 				/obj/item/seeds/sunflower/moonflower = 8
 				)
 
+/obj/item/disk/design_disk/plant_disk
+	name = "Plant Disk Blueprints"
+	desc = "A disk to be uploaded into the autolathen for more plant disks."
+	icon_state = "datadisk1"
+	max_blueprints = 1
+
+/obj/item/disk/design_disk/golem_shell/Initialize()
+	. = ..()
+	var/datum/design/diskplantgene/P = new
+	blueprints[1] = P
+
 //Free Golems
 
 /obj/item/disk/design_disk/golem_shell


### PR DESCRIPTION
[Changelogs]
replaces a sink with a autolathen
adds in blueprints to get more plant disks
:cl: optional name here
tweak: replaces a sink with a autolathen
/:cl:

[why]
So pod people can print more ammo, tools and other misc items they mite want. - Headsets are in those by the by
