### PR TITLE
Changed arousal message styling.

### DIFF
--- a/code/modules/goonchat/browserassets/css/browserOutput.css
+++ b/code/modules/goonchat/browserassets/css/browserOutput.css
@@ -316,7 +316,9 @@ h1.alert, h2.alert		{color: #000000;}
 .unconscious			{color: #0000ff;	font-weight: bold;}
 .suicide				{color: #ff5050;	font-style: italic;}
 .green					{color: #03ff39;}
-.nicegreen					{color: #14a833;}
+.nicegreen				{color: #14a833;}
+.userlove				{color: #FF1493;	font-style: italic; font-weight: bold;	text-shadow: 0 0 6px #ff6dbc;}
+.love					{color: #ff006a;	font-style: italic;	text-shadow: 0 0 6px #ff6d6d;}
 .shadowling				{color: #3b2769;}
 .cult					{color: #960000;}
 

--- a/modular_citadel/code/datums/mood_events/generic_positive_events.dm
+++ b/modular_citadel/code/datums/mood_events/generic_positive_events.dm
@@ -21,7 +21,7 @@
 	timeout = 3000
 
 /datum/mood_event/orgasm
-	description = "<font color = #780A53><i><b>I came!</font></i></b>" //funny meme haha
+	description = "<span class='userlove'>I came!</span>\n" //funny meme haha
 	mood_change = 3
 	timeout = 1000
 	

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -222,17 +222,17 @@
 		fluid_source = G.linked_organ.reagents
 	total_fluids = fluid_source.total_volume
 	if(mb_time)
-		src.visible_message("<span class='danger'>[src] starts to [G.masturbation_verb] [p_their()] [G.name].</span>", \
-							"<span class='green'>You start to [G.masturbation_verb] your [G.name].</span>", \
-							"<span class='green'>You start to [G.masturbation_verb] your [G.name].</span>")
+		src.visible_message("<span class='love'>[src] starts to [G.masturbation_verb] [p_their()] [G.name].</span>", \
+							"<span class='userlove'>You start to [G.masturbation_verb] your [G.name].</span>", \
+							"<span class='userlove'>You start to [G.masturbation_verb] your [G.name].</span>")
 
 	if(do_after(src, mb_time, target = src))
 		if(total_fluids > 5)
 			fluid_source.reaction(src.loc, TOUCH, 1, 0)
 			fluid_source.clear_reagents()
-		src.visible_message("<span class='danger'>[src] orgasms, cumming[istype(src.loc, /turf/open/floor) ? " onto [src.loc]" : ""]!</span>", \
-							"<span class='green'>You cum[istype(src.loc, /turf/open/floor) ? " onto [src.loc]" : ""].</span>", \
-							"<span class='green'>You have relieved yourself.</span>")
+		src.visible_message("<span class='love'>[src] orgasms, cumming[istype(src.loc, /turf/open/floor) ? " onto [src.loc]" : ""]!</span>", \
+							"<span class='userlove'>You cum[istype(src.loc, /turf/open/floor) ? " onto [src.loc]" : ""].</span>", \
+							"<span class='userlove'>You have relieved yourself.</span>")
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 		if(G.can_climax)
 			setArousalLoss(min_arousal)
@@ -260,16 +260,16 @@
 	else
 		total_fluids = fluid_source.total_volume
 		if(mb_time) //as long as it's not instant, give a warning
-			src.visible_message("<span class='danger'>[src] looks like they're about to cum.</span>", \
-								"<span class='green'>You feel yourself about to orgasm.</span>", \
-								"<span class='green'>You feel yourself about to orgasm.</span>")
+			src.visible_message("<span class='love'>[src] looks like they're about to cum.</span>", \
+								"<span class='userlove'>You feel yourself about to orgasm.</span>", \
+								"<span class='userlove'>You feel yourself about to orgasm.</span>")
 		if(do_after(src, mb_time, target = src))
 			if(total_fluids > 5)
 				fluid_source.reaction(src.loc, TOUCH, 1, 0)
 			fluid_source.clear_reagents()
-			src.visible_message("<span class='danger'>[src] orgasms[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""], using [p_their()] [G.name]!</span>", \
-								"<span class='green'>You climax[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""] with your [G.name].</span>", \
-								"<span class='green'>You climax using your [G.name].</span>")
+			src.visible_message("<span class='love'>[src] orgasms[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""], using [p_their()] [G.name]!</span>", \
+								"<span class='userlove'>You climax[istype(src.loc, /turf/open/floor) ? ", spilling onto [src.loc]" : ""] with your [G.name].</span>", \
+								"<span class='userlove'>You climax using your [G.name].</span>")
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
 				setArousalLoss(min_arousal)
@@ -288,9 +288,9 @@
 		fluid_source = G.linked_organ.reagents
 	total_fluids = fluid_source.total_volume
 	if(mb_time) //Skip warning if this is an instant climax.
-		src.visible_message("[src] is about to climax with [L]!", \
-							"You're about to climax with [L]!", \
-							"<span class='danger'>You're preparing to climax with someone!</span>")
+		src.visible_message("<span class='love'>[src] is about to climax with [L]!</span>", \
+							"<span class='userlove'>You're about to climax with [L]!</span>", \
+							"<span class='userlove'>You're preparing to climax with someone!</span>")
 	if(spillage)
 		if(do_after(src, mb_time, target = src) && in_range(src, L))
 			fluid_source.trans_to(L, total_fluids*G.fluid_transfer_factor)
@@ -298,9 +298,9 @@
 			if(total_fluids > 5)
 				fluid_source.reaction(L.loc, TOUCH, 1, 0)
 			fluid_source.clear_reagents()
-			src.visible_message("<span class='danger'>[src] climaxes with [L][spillage ? ", overflowing and spilling":""], using [p_their()] [G.name]!</span>", \
-								"<span class='green'>You orgasm with [L][spillage ? ", spilling out of them":""], using your [G.name].</span>", \
-								"<span class='green'>You have climaxed with someone[spillage ? ", spilling out of them":""], using your [G.name].</span>")
+			src.visible_message("<span class='love'>[src] climaxes with [L][spillage ? ", overflowing and spilling":""], using [p_their()] [G.name]!</span>", \
+								"<span class='userlove'>You orgasm with [L][spillage ? ", spilling out of them":""], using your [G.name].</span>", \
+								"<span class='userlove'>You have climaxed with someone[spillage ? ", spilling out of them":""], using your [G.name].</span>")
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
@@ -309,9 +309,9 @@
 		if(do_after(src, mb_time, target = src) && in_range(src, L))
 			fluid_source.trans_to(L, total_fluids)
 			total_fluids = 0
-			src.visible_message("<span class='danger'>[src] climaxes with [L], [p_their()] [G.name] spilling nothing!</span>", \
-								"<span class='green'>You ejaculate with [L], your [G.name] spilling nothing.</span>", \
-								"<span class='green'>You have climaxed inside someone, your [G.name] spilling nothing.</span>")
+			src.visible_message("<span class='love'>[src] climaxes with [L], [p_their()] [G.name] spilling nothing!</span>", \
+								"<span class='userlove'>You ejaculate with [L], your [G.name] spilling nothing.</span>", \
+								"<span class='userlove'>You have climaxed inside someone, your [G.name] spilling nothing.</span>")
 			SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			SEND_SIGNAL(L, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 			if(G.can_climax)
@@ -335,14 +335,14 @@
 	//	to_chat(src, "<span class='warning'>You need a container to do this!</span>")
 	//	return
 
-	src.visible_message("<span class='danger'>[src] starts to [G.masturbation_verb] their [G.name] over [container].</span>", \
-						"<span class='userdanger'>You start to [G.masturbation_verb] your [G.name] over [container].</span>", \
-						"<span class='userdanger'>You start to [G.masturbation_verb] your [G.name] over something.</span>")
+	src.visible_message("<span class='love'>[src] starts to [G.masturbation_verb] their [G.name] over [container].</span>", \
+						"<span class='userlove'>You start to [G.masturbation_verb] your [G.name] over [container].</span>", \
+						"<span class='userlove'>You start to [G.masturbation_verb] your [G.name] over something.</span>")
 	if(do_after(src, mb_time, target = src) && in_range(src, container))
 		fluid_source.trans_to(container, total_fluids)
-		src.visible_message("<span class='danger'>[src] uses [p_their()] [G.name] to fill [container]!</span>", \
-							"<span class='green'>You used your [G.name] to fill [container].</span>", \
-							"<span class='green'>You have relieved some pressure.</span>")
+		src.visible_message("<span class='love'>[src] uses [p_their()] [G.name] to fill [container]!</span>", \
+							"<span class='userlove'>You used your [G.name] to fill [container].</span>", \
+							"<span class='userlove'>You have relieved some pressure.</span>")
 		SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "orgasm", /datum/mood_event/orgasm)
 		if(G.can_climax)
 			setArousalLoss(min_arousal)

--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -104,7 +104,7 @@
 			M.emote(pick("moan","blush"))
 		if(prob(5))
 			var/aroused_message = pick("You feel frisky.", "You're having trouble suppressing your urges.", "You feel in the mood.")
-			to_chat(M, "<span class='love'>[aroused_message]</span>")
+			to_chat(M, "<span class='userlove'>[aroused_message]</span>")
 	..()
 
 /datum/reagent/drug/aphrodisiacplus
@@ -133,7 +133,7 @@
 				aroused_message = pick("You need to fuck someone!", "You're bursting with sexual tension!", "You can't get sex off your mind!")
 			else
 				aroused_message = pick("You feel a bit hot.", "You feel strong sexual urges.", "You feel in the mood.", "You're ready to go down on someone.")
-			to_chat(M, "<span class='love'>[aroused_message]</span>")
+			to_chat(M, "<span class='userlove'>[aroused_message]</span>")
 	..()
 
 /datum/reagent/drug/aphrodisiacplus/addiction_act_stage2(mob/living/M)


### PR DESCRIPTION
Now with less gaudy green.
![firefox_2019-05-20_17-28-59](https://user-images.githubusercontent.com/3196371/58054120-97122300-7b27-11e9-99ff-6e97199a35ba.png)
![dreamseeker_2019-05-20_17-41-22](https://user-images.githubusercontent.com/3196371/58054124-9b3e4080-7b27-11e9-8119-48952b9d57ff.png)
![dreamseeker_2019-05-20_17-41-36](https://user-images.githubusercontent.com/3196371/58054125-9d080400-7b27-11e9-9b7d-ae76f6cdffc7.png)


:cl:
tweak: Changed the styling of arousal messages to use pink-ish colors.
fix: The orgasm moodlet message new-lines properly.
/:cl:

[why]

Gaudy green was a mistake.
