### PR TITLE
Flavor text with special characters don't get partially unescaped

### DIFF
--- a/code/__HELPERS/text.dm
+++ b/code/__HELPERS/text.dm
@@ -94,6 +94,8 @@
 // Used to get a properly sanitized multiline input, of max_length
 /proc/stripped_multiline_input(mob/user, message = "", title = "", default = "", max_length=MAX_MESSAGE_LEN, no_trim=FALSE)
 	var/name = input(user, message, title, default) as message|null
+	if(isnull(name)) // Return null if canceled.
+		return null
 	if(no_trim)
 		return copytext(html_encode(name), 1, max_length)
 	else

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1458,7 +1458,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = stripped_multiline_input(usr,"Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!","Flavor Text",html_decode(features["flavor_text"]), MAX_MESSAGE_LEN*2, TRUE) as null|message
+					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", html_decode(features["flavor_text"]), MAX_MESSAGE_LEN*2, TRUE)
 					if(!isnull(msg))
 						msg = copytext(msg, 1, MAX_MESSAGE_LEN*2)
 						features["flavor_text"] = msg

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -23,6 +23,7 @@
 
 /mob/proc/print_flavor_text()
 	if(flavor_text && flavor_text != "")
+		// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
 		var/msg = html_decode(replacetext(flavor_text, "\n", " "))
 		if(lentext(msg) <= 40)
 			return "<span class='notice'>[html_encode(msg)]</span>"

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -23,11 +23,11 @@
 
 /mob/proc/print_flavor_text()
 	if(flavor_text && flavor_text != "")
-		var/msg = replacetext(flavor_text, "\n", " ")
+		var/msg = html_decode(replacetext(flavor_text, "\n", " "))
 		if(lentext(msg) <= 40)
-			return "<span class='notice'>[msg]</span>"
+			return "<span class='notice'>[html_encode(msg)]</span>"
 		else
-			return "<span class='notice'>[copytext(msg, 1, 37)]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
+			return "<span class='notice'>[html_encode(copytext(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
 
 /mob/proc/get_top_level_mob()
 	if(istype(src.loc,/mob)&&src.loc!=src)

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -8,9 +8,9 @@
 	set src in usr
 	if(usr != src)
 		usr << "No."
-	var/msg = input(usr,"Set the flavor text in your 'examine' verb. Can also be used for OOC notes about your character.","Flavor Text",html_decode(flavor_text)) as message|null
-
-	if(msg != null)
+	var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", html_decode(flavor_text), MAX_MESSAGE_LEN*2, TRUE)
+	
+	if(!isnull(msg))
 		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
 		msg = html_encode(msg)
 


### PR DESCRIPTION
Copying the text that was escaped would occasionally trim an escaping character. Now it's decoded, copied, then encoded to prevent it.

Fixes #8312
:cl:
fix: Flavor text with special characters will not get partially unescaped.
fix: Canceling when setting flavor text does not clear it anymore.
/:cl:
