### PR TITLE
Gives space queen's men void jet packs + tweeks

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -33,7 +33,6 @@
 	else
 		toggle_internals(user)
 
-
 /obj/item/tank/jetpack/proc/cycle(mob/user)
 	if(user.incapacitated())
 		return
@@ -47,7 +46,6 @@
 	for(var/X in actions)
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
-
 
 /obj/item/tank/jetpack/proc/turn_on()
 	on = TRUE
@@ -91,7 +89,7 @@
 	desc = "A jetpack made from two air tanks, a fire extinguisher and some atmospherics equipment. It doesn't look like it can hold much."
 	icon_state = "jetpack-improvised"
 	item_state = "jetpack-sec"
-	volume = 20 //normal jetpacks have 70 volume
+	volume = 30 //normal jetpacks have 70 volume
 	gas_type = null //it starts empty
 	full_speed = FALSE //moves at hardsuit jetpack speeds
 
@@ -119,6 +117,7 @@
 /obj/item/tank/jetpack/void
 	name = "void jetpack (oxygen)"
 	desc = "It works well in a void."
+	volume = 60
 	icon_state = "jetpack-void"
 	item_state =  "jetpack-void"
 
@@ -133,7 +132,7 @@
 	desc = "A lightweight tactical harness, used by those who don't want to be weighed down by traditional jetpacks."
 	icon_state = "jetpack-mini"
 	item_state = "jetpack-mini"
-	volume = 40
+	volume = 50
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
 
@@ -152,8 +151,6 @@
 	icon_state = "jetpack-sec"
 	item_state = "jetpack-sec"
 
-
-
 /obj/item/tank/jetpack/carbondioxide
 	name = "jetpack (carbon dioxide)"
 	desc = "A tank of compressed carbon dioxide for use as propulsion in zero-gravity areas. Painted black to indicate that it should not be used as a source for internals."
@@ -161,7 +158,6 @@
 	item_state =  "jetpack-black"
 	distribute_pressure = 0
 	gas_type = /datum/gas/carbon_dioxide
-
 
 /obj/item/tank/jetpack/suit
 	name = "hardsuit jetpack upgrade"
@@ -220,7 +216,6 @@
 		turn_off()
 		return
 	..()
-
 
 //Return a jetpack that the mob can use
 //Back worn jetpacks, hardsuit internal packs, and so on.

--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -120,6 +120,7 @@
 	volume = 60
 	icon_state = "jetpack-void"
 	item_state =  "jetpack-void"
+	full_speed = FALSE //Old pre-hardsuit tech
 
 /obj/item/tank/jetpack/oxygen
 	name = "jetpack (oxygen)"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -219,7 +219,7 @@
 	suit_type = /obj/item/clothing/suit/space
 	helmet_type = /obj/item/clothing/head/helmet/space
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/machinery/suit_storage_unit/pirate
+	storage_type = /obj/item/tank/jetpack/void
 
 /obj/machinery/loot_locator
 	name = "Booty Locator"

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -48,8 +48,6 @@
 	if(!shuttle_spawned)
 		spawn_shuttle()
 
-
-
 /datum/round_event/pirates/start()
 	if(!paid_off && !shuttle_spawned)
 		spawn_shuttle()
@@ -150,7 +148,6 @@
 	to_chat(user,"<span class='notice'>You retrieve the siphoned credits!</span>")
 	credits_stored = 0
 
-
 /obj/machinery/shuttle_scrambler/proc/send_notification()
 	priority_announce("Data theft signal detected, source registered on local gps units.")
 
@@ -222,8 +219,7 @@
 	suit_type = /obj/item/clothing/suit/space
 	helmet_type = /obj/item/clothing/head/helmet/space
 	mask_type = /obj/item/clothing/mask/breath
-	storage_type = /obj/item/tank/internals/oxygen
-
+	storage_type = /obj/machinery/suit_storage_unit/pirate
 
 /obj/machinery/loot_locator
 	name = "Booty Locator"


### PR DESCRIPTION
[Changelogs]
Makes nukie jet packs have 50v
Makes void harnesses have 60v
Gives space Queen's men some basic void packs
Makes Void jet pack slower

:cl: optional name here
add: Added a few jet packs to the space queens men
tweak: volume of jet packs
/:cl:

[why]
Void packs are ment to be old and used. Why they are smaller yet get the same air is byond me
Nukies like to zoom around space, lets let them do it a bit more. After all its a hard life as a red suit.
Space Queen's men are basicly fucked over if they ever get into a space battle and not have a jet pack. So they HAVE to steal some or make their own. Really shitty thing to do if they want to green text.