### PR TITLE
Rewords Blood Cult 'offer' rune click here prompt.

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -246,7 +246,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		return 0
 	to_chat(convertee, "<span class='cult italic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
 	and something evil takes root.</b></span>")
-	to_chat(convertee, "<span class='cult italic'>Do you wish to embrace the Geometer of Blood? <a href='?src=\ref[src];signmeup=1'>Click here to become a follower of Nar'sie.</a> Or you could choose to continue resisting and suffer a fate worse than death.</span>")
+	to_chat(convertee, "<span class='cult italic'>Do you wish to embrace the Geometer of Blood? <a href='?src=\ref[src];signmeup=1'>Click here to become a follower of Nar'sie.</a> Or you could choose to continue resisting and suffer a fate worse than death...</span>")
 	currentconversionman = convertee
 	conversiontimeout = world.time + (10 SECONDS)
 	convertee.Stun(100)

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -246,7 +246,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 		return 0
 	to_chat(convertee, "<span class='cult italic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
 	and something evil takes root.</b></span>")
-	to_chat(convertee, "<span class='cult italic'>Do you wish to embrace the Geometer of Blood? <a href='?src=\ref[src];signmeup=1'>Click here to stop resisting the truth.</a> Or you could choose to continue resisting...</span>")
+	to_chat(convertee, "<span class='cult italic'>Do you wish to embrace the Geometer of Blood? <a href='?src=\ref[src];signmeup=1'>Click here to become a follower of Nar'sie.</a> Or you could choose to continue resisting and suffer a fate worse than death.</span>")
 	currentconversionman = convertee
 	conversiontimeout = world.time + (10 SECONDS)
 	convertee.Stun(100)


### PR DESCRIPTION
[Changelogs]:
Rewords prompt given on Blood Cult offer runes.

:cl: optional name here
tweak: Rewords the click here prompt given when an attempted conversion is done on an offer rune (for blood cult)
/:cl:

[why]: 
The current click here prompt can be quite confusing, and it has led quite a few people into not clicking it and being sharded, despite wanting to be a cultist.