### PR TITLE
Fixes shield blobs being completely invulnerable to all forms of damage after reaching a weakened state.

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -9,6 +9,7 @@
 	point_return = 4
 	atmosblock = TRUE
 	armor = list("melee" = 25, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+	var/weakened
 
 /obj/structure/blob/shield/scannerreport()
 	if(atmosblock)
@@ -25,10 +26,15 @@
 		name = "weakened strong blob"
 		desc = "A wall of twitching tendrils."
 		atmosblock = FALSE
-		armor = list("melee" = 15, "bullet" = 15, "laser" = 5, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+		if(!weakened)
+			armor = armor.setRating("melee" = 15, "bullet" = 15, "laser" = 5, "energy" = 0, "bomb" = 10, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+			weakened = TRUE
 	else
 		icon_state = initial(icon_state)
 		name = initial(name)
 		desc = initial(desc)
 		atmosblock = TRUE
+		if(weakend)
+			armor = armor.setRating("melee" = 25, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+			weakened = FALSE
 	air_update_turf(1)

--- a/code/modules/antagonists/blob/blob/blobs/shield.dm
+++ b/code/modules/antagonists/blob/blob/blobs/shield.dm
@@ -34,7 +34,7 @@
 		name = initial(name)
 		desc = initial(desc)
 		atmosblock = TRUE
-		if(weakend)
+		if(weakened)
 			armor = armor.setRating("melee" = 25, "bullet" = 25, "laser" = 15, "energy" = 10, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 			weakened = FALSE
 	air_update_turf(1)


### PR DESCRIPTION
Reason number 342452983456928 why trilby PRs scare me. This PR also fixes what appeared to have been an oversight where shield blobs don't recover their armor after becoming unweakened Also, small rebalance/rework for blobs coming after this PR gets merged, blob's in desperate need of some lovin'

:cl: deathride58
fix: Shield blobs no longer become completely invulnerable to all forms of damage after reaching a """weakened""" state
tweak: Taken care of what appeared to have been an oversight where shield blobs don't recover their armor after becoming weakened.
/:cl:
