### PR TITLE
Engineering Showers! (Fixed 4 REALZIES this time)

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -46031,6 +46031,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cek" = (
@@ -46039,6 +46042,9 @@
 	name = "engineering security door"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/shower{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cel" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -44325,7 +44325,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/structure/closet/radiation,
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bWF" = (
@@ -44352,7 +44354,10 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/radiation,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bWH" = (
@@ -44932,6 +44937,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYn" = (
@@ -44956,6 +44962,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYp" = (
@@ -53780,7 +53787,7 @@
 "eSB" = (
 /obj/machinery/computer/cryopod{
 	dir = 1;
-	pixel_y = -26;
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)


### PR DESCRIPTION
Engineering showers for the maps that do not have them. Useful for decontamination or departmental bonding.

Now with the up-to-date map files so no merge issues with poojs new cryopod additions.

I disliked radbombing medbay on the two most popular maps, while the two less commonly played maps have decontamination showers in engi. For the pubby showers, I moved the two radclosets two tiles south.

![](http://puu.sh/DuOhv/e63e299c2a.png)
![](http://puu.sh/DuOfB/ad47fc32c0.png)

