### PR TITLE
Removes color-whitelist blocking custom-colored circuit blueprints from being imported

### DIFF
--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -144,6 +144,8 @@
 		return "Bad assembly name."
 	if(assembly_params["desc"] && !reject_bad_text(assembly_params["desc"]))
 		return "Bad assembly description."
+	if(assembly_params["detail_color"] && !reject_bad_text(assembly_params["detail_color"], 7))
+		return "Bad assembly color."
 
 // Loads assembly parameters from a list
 // Doesn't verify any of the parameters it loads, this is the job of verify_save()

--- a/code/modules/integrated_electronics/core/saved_circuits.dm
+++ b/code/modules/integrated_electronics/core/saved_circuits.dm
@@ -124,7 +124,7 @@
 	// Save modified name
 	if(initial(name) != name)
 		assembly_params["name"] = name
-	
+
 	// Save modified description
 	if(initial(desc) != desc)
 		assembly_params["desc"] = desc
@@ -144,8 +144,6 @@
 		return "Bad assembly name."
 	if(assembly_params["desc"] && !reject_bad_text(assembly_params["desc"]))
 		return "Bad assembly description."
-	if(assembly_params["detail_color"] && !(assembly_params["detail_color"] in color_whitelist))
-		return "Bad assembly color."
 
 // Loads assembly parameters from a list
 // Doesn't verify any of the parameters it loads, this is the job of verify_save()
@@ -153,7 +151,7 @@
 	// Load modified name, if any.
 	if(assembly_params["name"])
 		name = assembly_params["name"]
-		
+
 	// Load modified description, if any.
 	if(assembly_params["desc"])
 		desc = assembly_params["desc"]


### PR DESCRIPTION
Integrated circuit printers checked imported colors against a whitelist on import. Was used to prevent cheeky players from circumventing the color limitation in the past. Another cheeky player added a custom color selection a few days ago, making this check against the whitelist obsolete.

Tested it, if a player enters an invalid color, it just shows up as white, which is fine.