### PR TITLE
[s] fixes a major exploit involving concatenators

### DIFF
--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -142,13 +142,14 @@
 
 /obj/item/integrated_circuit/converter/concatenator
 	name = "concatenator"
-	desc = "This can join up to 8 strings together to get one big string."
+	desc = "This can join up to 8 strings together to get a string with a maximum of 512 characters."
 	complexity = 4
 	inputs = list()
 	outputs = list("result" = IC_PINTYPE_STRING)
 	activators = list("concatenate" = IC_PINTYPE_PULSE_IN, "on concatenated" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 	var/number_of_pins = 8
+	var/max_string_length = 512
 
 /obj/item/integrated_circuit/converter/concatenator/Initialize()
 	for(var/i = 1 to number_of_pins)
@@ -157,10 +158,28 @@
 
 /obj/item/integrated_circuit/converter/concatenator/do_work()
 	var/result = null
+	var/spamprotection
 	for(var/k in 1 to inputs.len)
 		var/I = get_pin_data(IC_INPUT, k)
 		if(!isnull(I))
+			if((result ? length(result) : 0) + length(I) > max_string_length)
+				spamprotection = (result ? length(result) : 0) + length(I)
+				break
 			result = result + I
+
+	if(spamprotection >= max_string_length*1.75 && assembly)
+		if(assembly.fingerprintslast)
+			var/mob/M = get_mob_by_key(assembly.fingerprintslast)
+			var/more = ""
+			if(M)
+				more = "[ADMIN_LOOKUPFLW(M)] "
+			message_admins("A concatenator circuit has greatly exceeded its [max_string_length] character limit with a total of [spamprotection] characters, and has been deleted. Assembly last touched by [more ? more : assembly.fingerprintslast].")
+			investigate_log("A concatenator circuit has greatly exceeded its [max_string_length] character limit with a total of [spamprotection] characters, and has been deleted. Assembly last touched by [assembly.fingerprintslast].", INVESTIGATE_CIRCUIT)
+		else
+			message_admins("A concatenator circuit has greatly exceeded its [max_string_length] character limit with a total of [spamprotection] characters, and has been deleted. No associated key.")
+			investigate_log("A concatenator circuit has greatly exceeded its [max_string_length] character limit with a total of [spamprotection] characters, and has been deleted. No associated key.", INVESTIGATE_CIRCUIT)
+		qdel(assembly)
+		return
 
 	set_pin_data(IC_OUTPUT, 1, result)
 	push_data()
@@ -168,15 +187,17 @@
 
 /obj/item/integrated_circuit/converter/concatenator/small
 	name = "small concatenator"
-	desc = "This can join up to 4 strings together to get one big string."
+	desc = "This can join up to 4 strings together to get a string with a maximum of 256 characters."
 	complexity = 2
 	number_of_pins = 4
+	max_string_length = 256
 
 /obj/item/integrated_circuit/converter/concatenator/large
 	name = "large concatenator"
-	desc = "This can join up to 16 strings together to get one very big string."
+	desc = "This can join up to 16 strings together to get a string with a maximum of 1024 characters."
 	complexity = 6
 	number_of_pins = 16
+	max_string_length = 1024
 
 /obj/item/integrated_circuit/converter/separator
 	name = "separator"


### PR DESCRIPTION
You wouldn't believe how hard it was to resist the urge to put a passive-aggressive statement here. Well, fuck, I guess I did anyway.

:cl: deathride58
fix: Nerfed concatenators by limiting the amount of characters they're able to output
/:cl:
