### PR TITLE
I'm tired of my pulls on horizontal spacemen breaking off because of crawling delays.

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -102,22 +102,24 @@
 					return 1
 
 	//CIT CHANGES START HERE - makes it so resting stops you from moving through standing folks without a short delay
-		if(resting && !L.resting && !pulledby)
-			if(attemptingcrawl)
-				return TRUE
-			if(getStaminaLoss() >= STAMINA_SOFTCRIT)
-				to_chat(src, "<span class='warning'>You're too exhausted to crawl under [L].</span>")
-				return TRUE
-			attemptingcrawl = TRUE
+		if(resting && !L.resting)
 			var/origtargetloc = L.loc
-			visible_message("<span class='notice'>[src] is attempting to crawl under [L].</span>", "<span class='notice'>You are now attempting to crawl under [L].</span>")
-			if(do_after(src, CRAWLUNDER_DELAY, target = src))
-				if(resting)
-					var/src_passmob = (pass_flags & PASSMOB)
-					pass_flags |= PASSMOB
-					Move(origtargetloc)
-					if(!src_passmob)
-						pass_flags &= ~PASSMOB
+			if(!pulledby)
+				if(attemptingcrawl)
+					return TRUE
+				if(getStaminaLoss() >= STAMINA_SOFTCRIT)
+					to_chat(src, "<span class='warning'>You're too exhausted to crawl under [L].</span>")
+					return TRUE
+				attemptingcrawl = TRUE
+				visible_message("<span class='notice'>[src] is attempting to crawl under [L].</span>", "<span class='notice'>You are now attempting to crawl under [L].</span>")
+				if(!do_after(src, CRAWLUNDER_DELAY, target = src) || !resting)
+					attemptingcrawl = FALSE
+					return TRUE
+			var/src_passmob = (pass_flags & PASSMOB)
+			pass_flags |= PASSMOB
+			Move(origtargetloc)
+			if(!src_passmob)
+				pass_flags &= ~PASSMOB
 			attemptingcrawl = FALSE
 			return TRUE
 	//END OF CIT CHANGES

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -102,7 +102,7 @@
 					return 1
 
 	//CIT CHANGES START HERE - makes it so resting stops you from moving through standing folks without a short delay
-		if(resting && !L.resting)
+		if(resting && !L.resting && !pulledby)
 			if(attemptingcrawl)
 				return TRUE
 			if(getStaminaLoss() >= STAMINA_SOFTCRIT)


### PR DESCRIPTION


:cl: 
fix: Stops pulls of resting mobs breaking off whenever you swap turfs with someone else because of crawling delays.
/:cl:

This PR is dedicated to the many dragging horizontal spacemen around just to be exasperated by this bug, I emphatize em.
~~Except you medical cheapstakes wasting time dragging dying bodies all the way to medbay's cryo/sleepers despite carrying an array of medicines on yourselves.~~

Meh, makes me wish we had mobility flags & co, but I guess that'd conflict with some niches.