### PR TITLE
lazyinitlist on IAA targets stealing.

### DIFF
--- a/code/modules/antagonists/traitor/IAA/internal_affairs.dm
+++ b/code/modules/antagonists/traitor/IAA/internal_affairs.dm
@@ -130,6 +130,7 @@
 	if(!owner.current||owner.current.stat==DEAD)
 		return
 	to_chat(owner.current, "<span class='userdanger'> Target eliminated: [victim.name]</span>")
+	LAZYINITLIST(targets_stolen)
 	for(var/objective_ in victim.objectives)
 		if(istype(objective_, /datum/objective/assassinate/internal))
 			var/datum/objective/assassinate/internal/objective = objective_


### PR DESCRIPTION
:cl:
fix: fixes IAA.
/:cl:

This will probably fix IAA not working and only giving out the starting target.
May apply other improvements (?) later, maybe on a different PR.

