### PR TITLE
stunbaton status rework.

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -54,7 +54,7 @@
 	//Note this value returned is significant, as it will determine
 	//if a stun is applied or not
 	. = cell.use(chrgdeductamt)
-	if(status && (!. || (chargecheck && cell.charge < hitcost)))
+	if(status && (!. || (chargecheck && cell.charge < hitcost * STUNBATON_CHARGE_LENIENCY)))
 		//we're below minimum, turn off
 		switch_status(FALSE)
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -1,3 +1,5 @@
+#define STUNBATON_CHARGE_LENIENCY 0.3
+
 /obj/item/melee/baton
 	name = "stunbaton"
 	desc = "A stun baton for incapacitating people with."
@@ -112,9 +114,9 @@
 		return ..()
 
 /obj/item/melee/baton/attack_self(mob/user)
-	if(cell && cell.charge > hitcost)
+	if(cell && cell.charge > hitcost * STUNBATON_CHARGE_LENIENCY)
 		if(emped_timer > world.time)
-			to_chat(user, "<span class='warning'>[src] briefly flickers as you try to turn it on, looks like it's momentarily out of service.</span>")
+			to_chat(user, "<span class='warning'>[src] briefly flickers as you fail to turn it on, looks like it's momentarily out of service.</span>")
 		else
 			switch_status(!status)
 			to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
@@ -178,7 +180,7 @@
 		var/stuncharge = cell.charge
 		if(!deductcharge(hitcost, FALSE))
 			stunpwr *= round(stuncharge/hitcost)
-			if(stunpwr < stunforce * 0.2)
+			if(stunpwr < stunforce * STUNBATON_CHARGE_LENIENCY)
 				return FALSE
 
 	L.Knockdown(stunpwr)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -130,10 +130,7 @@
 
 /obj/item/melee/baton/attack(mob/M, mob/living/carbon/human/user)
 	if(status && user.has_trait(TRAIT_CLUMSY) && prob(50))
-		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
-							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		user.Knockdown(stunforce*3)
-		deductcharge(hitcost)
+		clowning_around(user)
 		return
 
 	if(user.getStaminaLoss() >= STAMINA_SOFTCRIT)//CIT CHANGE - makes it impossible to baton in stamina softcrit
@@ -203,6 +200,12 @@
 
 	return TRUE
 
+/obj/item/melee/baton/proc/clowning_around(mob/living/user)
+	user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
+						"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
+	user.Knockdown(stunforce*3)
+	deductcharge(hitcost)
+
 /obj/item/melee/baton/emp_act(severity)
 	. = ..()
 	if (!(. & EMP_PROTECT_SELF))
@@ -238,3 +241,5 @@
 /obj/item/melee/baton/cattleprod/baton_stun()
 	if(sparkler.activate())
 		..()
+
+#undef STUNBATON_CHARGE_LENIENCY

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -69,7 +69,7 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/melee/baton/process()
-	deductcharge(10)
+	deductcharge(18 * hitcost * 0.001)
 
 /obj/item/melee/baton/update_icon()
 	if(status)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -69,7 +69,7 @@
 		STOP_PROCESSING(SSobj, src)
 
 /obj/item/melee/baton/process()
-	deductcharge(18 * hitcost * 0.001)
+	deductcharge(15 * hitcost * 0.001)
 
 /obj/item/melee/baton/update_icon()
 	if(status)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -20,7 +20,6 @@
 	var/hitcost = 1000
 	var/throw_hit_chance = 35
 	var/preload_cell_type //if not empty the baton starts with this type of cell
-	var/emped_timer = 0
 
 /obj/item/melee/baton/get_cell()
 	return cell
@@ -115,11 +114,8 @@
 
 /obj/item/melee/baton/attack_self(mob/user)
 	if(cell && cell.charge > hitcost * STUNBATON_CHARGE_LENIENCY)
-		if(emped_timer > world.time)
-			to_chat(user, "<span class='warning'>[src] briefly flickers as you fail to turn it on, looks like it's momentarily out of service.</span>")
-		else
-			switch_status(!status)
-			to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
+		switch_status(!status)
+		to_chat(user, "<span class='notice'>[src] is now [status ? "on" : "off"].</span>")
 	else
 		switch_status(FALSE, TRUE)
 		if(!cell)
@@ -211,11 +207,6 @@
 	if (!(. & EMP_PROTECT_SELF))
 		switch_status(FALSE)
 		deductcharge(1000 / severity)
-		var/downtime = 5 SECONDS / severity
-		if(emped_timer > world.time)
-			emped_timer += downtime * 0.5
-		else
-			emped_timer = world.time + downtime
 
 //Makeshift stun baton. Replacement for stun gloves.
 /obj/item/melee/baton/cattleprod

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -6,27 +6,23 @@
 	item_state = "teleprod"
 	slot_flags = null
 
-/obj/item/melee/baton/cattleprod/teleprod/attack(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit
-	..()
-	if(status && user.has_trait(TRAIT_CLUMSY) && prob(50))
-		user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
-							"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
-		if(do_teleport(user, get_turf(user), 50))//honk honk
-			SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
-			user.Knockdown(stunforce*3)
-			deductcharge(hitcost)
-		else
-			SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
-			user.Knockdown(stunforce*3)
-			deductcharge(hitcost/4)
+/obj/item/melee/baton/cattleprod/teleprod/baton_stun(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit
+	. = ..()
+	if(!. || !istype(M) || M.anchored)
 		return
 	else
-		if(status)
-			if(!istype(M) && M.anchored)
-				return .
-			else
-				SEND_SIGNAL(M, COMSIG_LIVING_MINOR_SHOCK)
-				do_teleport(M, get_turf(M), 15)
+		SEND_SIGNAL(M, COMSIG_LIVING_MINOR_SHOCK)
+		do_teleport(M, get_turf(M), 15)
+
+/obj/item/melee/baton/cattleprod/teleprod/clowning_around(mob/living/user)
+	user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
+						"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
+	SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
+	user.Knockdown(stunforce*3)
+	if(do_teleport(user, get_turf(user), 50))
+		deductcharge(hitcost)
+	else
+		deductcharge(hitcost * 0.25)
 
 /obj/item/melee/baton/cattleprod/attackby(obj/item/I, mob/user, params)//handles sticking a crystal onto a stunprod to make a teleprod
 	if(istype(I, /obj/item/stack/ore/bluespace_crystal))


### PR DESCRIPTION
:cl:
balance: EMPs now flick off stunbatons, they can be turned back on immediately by the user anyway.
balance: Stunbatons now very slowly consume charge whilst kept on, at a rate of 4/1000th of a standard batoning charge cost per tick.
balance: Softened up the charge cost checks to stop the above update from practically reducing the maximum uses of a stun baton by one. Now, should the remaining charge be lower than the hit cost, the resulting stun will be be proportional to the remaining charge divided by the hitcost, within a limit under which the stun batoning just won't happen.
/:cl:

~~EMP is currently hilariously bad against stunbaton (and powercells with more than a couple thousand units of charge in general) compared to the wide majority of other objects & electronics, taking roughly half a dozen EMPs to be totally drained, or more if the stunbatoner is savyy enough to load in a higher quality power cell, reason I discarded the idea of merely buffing the emp_act() charge deduction, as it would still be cheesed.~~

Deprecated. Now only flick batons off, a minor nausiance.

Added a mild charge deduction of a 4/1000th of hitcost per tick while the stunbaton is left on. From experience, keeping a stunbaton off was only useful during violent harmbatoning to the head.

Added some leniency to the remaining charge checks to avoid the above processing update from nerfing batonings by one, so the resulting stun power will now be proportional to the amount of charge left compared to the hitcost should said charge be inferior than the cost.

Current values may be subject to changes.

Also cleaned up old and rarely used teleprods.