### PR TITLE
Makes soviet clothing no longer need to be hacked AND emaged

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -433,7 +433,6 @@
 /datum/supply_pack/security/russianclothing
 	name = "Russian Surplus Clothing"
 	desc = "An old russian crate full of surplus armor that they used to use! Has two sets of bulletproff armor, a few union suits and some warm hats!"
-	hidden = TRUE
 	contraband = TRUE
 	cost = 5000 // Its basicly sec suits, good boots/gloves
 	contains = list(/obj/item/clothing/suit/security/officer/russian,


### PR DESCRIPTION
[Changelogs]
Fixes soviet clothing needing to be emaged
:cl: optional name here
fix: clothing needing a emag
/:cl:

[why]
The idea back when i made the crates was that you could get a weapon crate as well. That never merged. So having both crates isnt as stupidly op as you think