### PR TITLE
Makes M-90gl Carbine cost 16 tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -207,7 +207,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A fully-loaded, specialized three-round burst carbine that fires 5.56mm ammunition from a 30 round magazine \
 			with a togglable 40mm under-barrel grenade launcher."
 	item = /obj/item/gun/ballistic/automatic/m90
-	cost = 18
+	cost = 16
 	surplus = 50
 	include_modes = list(/datum/game_mode/nuclear)
 


### PR DESCRIPTION
[Changelogs]
M-90gl Carbine costs 18tc - > 16 tc
:cl: optional name here
tweak: 18tc - > 16tc
/:cl:

[why]
Rare to see in use, ammo is less effective at killing and its main gimmick is hard to use in combat.
