### PR TITLE
Makes nukie flamer cost 2 tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -261,7 +261,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A flamethrower, fueled by a portion of highly flammable biotoxins stolen previously from Nanotrasen \
 			stations. Make a statement by roasting the filth in their own greed. Use with caution."
 	item = /obj/item/flamethrower/full/tank
-	cost = 4
+	cost = 2
 	surplus = 40
 	include_modes = list(/datum/game_mode/nuclear)
 


### PR DESCRIPTION
[Changelogs]
Makes the flamer cost 2 tc from 4tc
:cl: optional name here
tweak: tweaked a few things
/:cl:

[why]
```//Operator backpack spray```
```/obj/item/watertank/op```
```	name = "backpack water tank"```
```	desc = "A New Russian backpack spray for systematic cleansing of carbon lifeforms."```
```	volume = 2000```
```	slowdown = 0```

```/obj/item/watertank/op/Initialize()```
```	. = ..()```
```	reagents.add_reagent("mutagen",350)```
```	reagents.add_reagent("napalm",125)```
```	reagents.add_reagent("welding_fuel",125)```
```	reagents.add_reagent("clf3",300)```
```	reagents.add_reagent("cryptobiolin",350)```
```	reagents.add_reagent("plasma",250)```
```	reagents.add_reagent("condensedcapsaicin",500)```
Horribly out class by pryo bundle that is ironicly a steal of saving for a one man armory