### PR TITLE
Makes .357 cost only 2tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -466,7 +466,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "A speed loader that contains seven additional .357 Magnum rounds; usable with the Syndicate revolver. \
 			For when you really need a lot of things dead."
 	item = /obj/item/ammo_box/a357
-	cost = 4
+	cost = 2
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/ammo/shotgun


### PR DESCRIPTION
[Changelogs]
.357 costs 2tc from 4

:cl: optional name here
tweak: 4 - > 2
/:cl:

[why]
Cheap ammo that you can easy to print off at a prolathen. `But Lilly the high costs thats for nukie`
Yes. The costs is to nerf nukies froma 60 harm gun that can be speed loaded, having high costs ammo thats less good then ASP or normal guns just makes the gun unused by most antag groups