### PR TITLE
Makes laser scatter shot cost 4 not 5

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -510,7 +510,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "12g Scatter Laser shot Slugs"
 	desc = "An alternative 8-round Scatter Laser Shot magazine for use in the Bulldog shotgun."
 	item = /obj/item/ammo_box/magazine/m12g/scatter
-	cost = 5 // most armor has less laser protection then bullet
+	cost = 4 // most armor has less laser protection then bullet
 
 /datum/uplink_item/ammo/shotgun/bag
 	name = "12g Ammo Duffel Bag"


### PR DESCRIPTION
[Changelogs]
Laser scatter shot 4 - > 5
:cl: optional name here
tweak:  4 - > 5
/:cl:

[why]
Still good, but not 2tc more then normal bullets. Middle ground is 1tc up then normal