### PR TITLE
Makes PDA bomb cart cost 5 not 6

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -768,7 +768,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			The concussive effect from the explosion will knock the recipient out for a short period, and deafen \
 			them for longer. Beware, it has a chance to detonate your PDA."
 	item = /obj/item/cartridge/virus/syndicate
-	cost = 6
+	cost = 5
 	restricted = TRUE
 
 /datum/uplink_item/stealthy_weapons/suppressor


### PR DESCRIPTION
[Changelogs]
PDA bomb cart costs 5 not 6

:cl: optional name here
tweak: 5->6
/:cl:

[why] Bomb carts not as good as one mite think for its a auto flag of traitors and meta
