### PR TITLE
Reduces FRAME cart by 2tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -844,7 +844,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 			You will receive the unlock code upon activating the virus, and the new uplink may be charged with \
 			telecrystals normally."
 	item = /obj/item/cartridge/virus/frame
-	cost = 4
+	cost = 2
 	restricted = TRUE
 
 /datum/uplink_item/stealthy_tools/agent_card


### PR DESCRIPTION
[Changelogs]
FRAME cart now only costs 2tc
:cl: optional name here
tweak: 4tc - > 2tc
/:cl:

[why]
Rarely works as you intend and do to spawing a hollow uplink onto people, it becomes clear as day your being framed 