### PR TITLE
Makes traitor stimpacks only cost 2 tc

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -886,7 +886,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
 			5 minutes after injection."
 	item = /obj/item/reagent_containers/syringe/stimulants
-	cost = 5
+	cost = 2
 	surplus = 90
 
 /datum/uplink_item/stealthy_tools/mulligan


### PR DESCRIPTION
[Changelogs]
Stimpacks from 5 - > 2

:cl: optional name here
tweak: 5->2
/:cl:

[why]
Post stam rework these are kinda useless to stop stuns. And being one use only should a alternive to just `Lol get adrains` with have 3 chargers and costs around 8 tc to get 