### PR TITLE
Makes mulligan cost only 3

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -894,7 +894,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "Screwed up and have security on your tail? This handy syringe will give you a completely new identity \
 			and appearance."
 	item = /obj/item/reagent_containers/syringe/mulligan
-	cost = 4
+	cost = 3
 	surplus = 30
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
[Changelogs]
mulligan costs 4 - > 3
:cl: optional name here
tweak: mulligan costs 4 - > 3
/:cl:

[why]
Mulligan is useful, but not worth 4 tc to mix up you genes and such making you no longer having a good id, as well as removed your AI protection