### PR TITLE
Adv Syndicate Surgery Duffel Bag tweaks

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -999,7 +999,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	desc = "The Syndicate surgery duffel bag is a toolkit containing all newest surgery tools, surgical drapes, \
 			a Syndicate brand MMI, a straitjacket, a muzzle, and a full Syndicate Combat Medic Kit."
 	item = /obj/item/storage/backpack/duffelbag/syndie/surgery_adv
-	cost = 15 //Mite be to cheap
+	cost = 10
 
 /datum/uplink_item/device_tools/military_belt
 	name = "Chest Rig"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -995,7 +995,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	cost = 1
 
 /datum/uplink_item/device_tools/surgerybag_adv
-	name = "Syndicate Surgery Duffel Bag"
+	name = "Advanced Syndicate Surgery Duffel Bag"
 	desc = "The Syndicate surgery duffel bag is a toolkit containing all newest surgery tools, surgical drapes, \
 			a Syndicate brand MMI, a straitjacket, a muzzle, and a full Syndicate Combat Medic Kit."
 	item = /obj/item/storage/backpack/duffelbag/syndie/surgery_adv


### PR DESCRIPTION
[Changelogs]
Syndicate Surgery Duffel Bag has its own name now
Costs only 10 from 15
:cl: optional name here
tweak: 15 - >10
fix: both bags have the same name
/:cl:

[why]Syndicate Surgery Duffel Bag and adv Syndicate Surgery Duffel Bag were labeled the same
Syndicate Surgery Duffel Bags are never gotten and 15 tc is WAY to much