### PR TITLE
Halfs the CNS Rebooter Implant costs

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1336,7 +1336,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "CNS Rebooter Implant"
 	desc = "This implant will help you get back up on your feet faster after being stunned. Comes with an autosurgeon."
 	item = /obj/item/autosurgeon/anti_stun
-	cost = 12
+	cost = 6
 
 /datum/uplink_item/cyber_implants/reviver
 	name = "Reviver Implant"


### PR DESCRIPTION
[Changelogs]
CNS Rebooter Implant now costs 6 form 12
:cl: optional name here
balance: halfs the costs of CNS rebooter
/:cl:

[why]
A implant that dosnt help against stam, can back fire, and costs the most. 