### PR TITLE
Makes golden toolboxes cost 3 not 5

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1448,7 +1448,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Gold Toolbox"
 	desc = "A gold planted plastitanium toolbox loaded with tools. Comes with a set of AI detection multi-tool and a pare of combat gloves."
 	item = /obj/item/storage/toolbox/gold_real
-	cost = 5 // Has synda tools + gloves + a robust weapon
+	cost = 3 // Has synda tools + gloves + a robust weapon
 	restricted_roles = list("Assistant", "Curator") //Curator do to being made of gold - It fits the theme
 
 /datum/uplink_item/role_restricted/brainwash_disk


### PR DESCRIPTION
[Changelogs]
golden toolboxes cost 3 not 5

:cl: optional name here
tweak:golden toolboxes cost 3 not 5
/:cl:

[why]
Math dosnt really add up to 5, and its not that good of a weapon to cost 2 more tc for a obs weapon