### PR TITLE
Makes brainwash disks cost 3 tc not 5

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1457,7 +1457,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	Insert into an Operating Console to enable the procedure."
 	item = /obj/item/disk/surgery/brainwashing
 	restricted_roles = list("Medical Doctor")
-	cost = 5
+	cost = 3
 
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"


### PR DESCRIPTION
[Changelogs]
brainwash disks cost 3 tc not 5

:cl: optional name here
tweak:brainwash disks cost 3 tc not 5
/:cl:

[why]
Hard as hell to pull off, backfires and leaves evidence of what your doing, sus as hell and offten not used do to being such a pain to even pull off