### PR TITLE
Boxstation Crew Monitor

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -27901,8 +27901,8 @@
 	pixel_x = 30
 	},
 /obj/machinery/light,
-/mob/living/simple_animal/bot/cleanbot{
-	name = "C.L.E.A.N."
+/obj/machinery/computer/crew{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -31596,7 +31596,7 @@
 /area/medical/sleeper)
 "bwC" = (
 /obj/machinery/computer/med_data{
-	dir = 4
+	dir = 3
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
@@ -56882,6 +56882,12 @@
 /obj/item/pen,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"ium" = (
+/mob/living/simple_animal/bot/cleanbot{
+	name = "C.L.E.A.N."
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "izv" = (
 /obj/machinery/vending/clothing,
 /obj/machinery/light/small{
@@ -94182,7 +94188,7 @@ blm
 bmL
 boi
 bpw
-bhh
+ium
 bsx
 btX
 bvj


### PR DESCRIPTION
Adds a crew monitor console to the Boxstation med desk area since literally every other map has it.
Moved the C.L.E.A.N. to the middle of Medbay.

![](http://puu.sh/DyeZd/6e1da5c7d0.png)