### PR TITLE
Adrenal rebalancing/nerfing. Again. And a very slight meth buff.

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -33,24 +33,8 @@
 /obj/item/implant/adrenalin/activate()
 	. = ..()
 	uses--
+	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10, "stimulants" = 10), "<span class='boldnotice'>You feel a sudden surge of energy!</span>")
 	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
-	imp_in.SetSleeping(0)
-	imp_in.SetStun(0)
-	imp_in.SetKnockdown(0)
-	imp_in.SetUnconscious(0)
-	imp_in.adjustStaminaLoss(-150)
-	imp_in.stuttering = 0
-	imp_in.updatehealth()
-	imp_in.update_stamina()
-	imp_in.resting = 0
-	imp_in.lying = 0
-	imp_in.update_canmove()
-
-	imp_in.reagents.add_reagent("inaprovaline", 3) //let's give another chance to dumb fucks who forget to breathe
-	imp_in.reagents.add_reagent("synaptizine", 10)
-	imp_in.reagents.add_reagent("omnizine", 10)
-	imp_in.reagents.add_reagent("stimulants", 10)
-
 	if(!uses)
 		qdel(src)
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -108,20 +108,7 @@
 			to_chat(loc, "<span class='warning'>Combat injection is still recharging.</span>")
 			return
 		var/mob/living/carbon/human/M = loc
-		M.SetSleeping(0)
-		M.SetUnconscious(0)
-		M.SetStun(0)
-		M.SetKnockdown(0)
-		M.reagents.add_reagent("inaprovaline", 3)
-		M.reagents.add_reagent("synaptizine", 10)
-		M.reagents.add_reagent("stimulants", 10)
-		M.adjustStaminaLoss(-150)
-		M.stuttering = 0
-		M.updatehealth()
-		M.update_stamina()
-		M.resting = 0
-		M.lying = 0
-		M.update_canmove()
+		M.do_adrenaline(150, FALSE, 0, 0, TRUE, list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10), "<span class='boldnotice'>You feel a sudden surge of energy!</span>")
 		combat_cooldown = 0
 		START_PROCESSING(SSobj, src)
 

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -12,21 +12,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	to_chat(user, "<span class='notice'>Energy rushes through us.[user.lying ? " We arise." : ""]</span>")
-	user.SetSleeping(0)
-	user.SetUnconscious(0)
-	user.SetStun(0)
-	user.SetKnockdown(0)
-	user.reagents.add_reagent("changelingadrenaline", 10)
-	user.reagents.add_reagent("changelinghaste", 2) //For a really quick burst of speed
-	user.reagents.add_reagent("inaprovaline", 3) //let's give another chance to dumb fucks who forget to breathe
-	user.adjustStaminaLoss(-150)
-	user.stuttering = 0
-	user.updatehealth()
-	user.update_stamina()
-	user.resting = 0
-	user.lying = 0
-	user.update_canmove()
-
+	user.do_adrenaline(100, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadreanline" = 5), "<span class='notice'>Energy rushes through us.</span>")
 	return TRUE
-

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -12,5 +12,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	user.do_adrenaline(100, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadreanline" = 5), "<span class='notice'>Energy rushes through us.</span>")
+	user.do_adrenaline(100, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>")
 	return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1180,3 +1180,32 @@
 			update_transform()
 		if("lighting_alpha")
 			sync_lighting_plane_alpha()
+
+/mob/living/proc/do_adrenaline(
+			stamina_boost = 150,
+			put_on_feet = TRUE,
+			clamp_unconscious_to = 0,
+			clamp_immobility_to = 0,
+			reset_misc = TRUE,
+			healing_chems = list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10, "stimulants" = 10),
+			message = "<span class='boldnotice'>You feel a surge of energy!</span>"
+		)
+	if(AmountSleeping() > clamp_unconscious_to)
+		SetSleeping(clamp_unconscious_to)
+	if(AmountUnconscious() > clamp_unconscious_to)
+		SetUnconscious(clamp_unconscious_to)
+	if(AmountStun() > clamp_immobility_to)
+		SetStun(clamp_immobility_to)
+	if(AmountKnockdown() > clamp_immobility_to)
+		SetKnockdown(clamp_immobility_to)
+	adjustStaminaLoss(max(0, -stamina_boost))
+	if(put_on_feet)
+		resting = FALSE
+		lying = FALSE
+	if(reset_misc)
+		stuttering = 0
+	updatehealth()
+	update_stamina()
+	update_canmove()
+	for(var/chem in healing_chems)
+		reagents.add_reagent(chem, healing_chems[chem])

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_adrenaline.dm
@@ -4,22 +4,7 @@
 
 	if(!ninjacost(0,N_ADRENALINE))
 		var/mob/living/carbon/human/H = affecting
-		H.SetSleeping(0)
-		H.SetStun(0)
-		H.SetKnockdown(0)
-		H.SetUnconscious(0)
-		H.adjustStaminaLoss(-150)
-		H.stuttering = 0
-		H.updatehealth()
-		H.update_stamina()
-		H.resting = 0
-		H.lying = 0
-		H.update_canmove()
-
-		H.reagents.add_reagent("inaprovaline", 3) //let's give another chance to dumb fucks who forget to breathe
-		H.reagents.add_reagent("synaptizine", 10)
-		H.reagents.add_reagent("omnizine", 10)
-		H.reagents.add_reagent("stimulants", 10)
+		H.do_adrenaline(150, TRUE, 0, 0, TRUE, list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10), "<span class='boldnotice'>You feel a sudden surge of energy!</span>")
 
 		H.say(pick("A CORNERED FOX IS MORE DANGEROUS THAN A JACKAL!","HURT ME MOOORRREEE!","IMPRESSIVE!"), forced = "ninjaboost")
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -555,7 +555,7 @@
 	if(!D)
 		WARNING("[my_atom] attempted to add a reagent called '[reagent]' which doesn't exist. ([usr])")
 		return FALSE
-	
+
 	update_total()
 	var/cached_total = total_volume
 	if(cached_total + amount > maximum_volume)
@@ -599,9 +599,9 @@
 	if(data)
 		R.data = data
 		R.on_new(data)
-	
+
 	if(isliving(my_atom))
-		R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete 
+		R.on_mob_add(my_atom) //Must occur befor it could posibly run on_mob_delete
 	update_total()
 	if(my_atom)
 		my_atom.on_reagent_change(ADD_REAGENT)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -164,6 +164,9 @@
 	overdose_threshold = 20
 	addiction_threshold = 10
 	metabolization_rate = 0.75 * REAGENTS_METABOLISM
+	var/brain_damage = TRUE
+	var/jitter = TRUE
+	var/confusion = TRUE
 
 /datum/reagent/drug/methamphetamine/on_mob_add(mob/living/L)
 	..()
@@ -181,10 +184,10 @@
 	M.AdjustKnockdown(-40, 0)
 	M.AdjustUnconscious(-40, 0)
 	M.adjustStaminaLoss(-7.5 * REM, 0)
-	M.Jitter(2)
-	M.adjustBrainLoss(rand(1,4))
-	if(prob(30))
-		M.confused = max(1, M.confused)
+	if(jitter)
+		M.Jitter(2)
+	if(brain_damage)
+		M.adjustBrainLoss(rand(1,4))
 	M.heal_overall_damage(2, 2)
 	if(prob(5))
 		M.emote(pick("twitch", "shiver"))
@@ -239,6 +242,14 @@
 		M.emote(pick("twitch","drool","moan"))
 	..()
 	. = 1
+
+/datum/reagent/drug/methamphetamine/changeling
+	id = "changelingmeth"
+	name = "Changeling Adrenaline"
+	addiction_threshold = 35
+	overdose_threshold = 35
+	jitter = FALSE
+	brain_damage = FALSE
 
 /datum/reagent/drug/bath_salts
 	name = "Bath Salts"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1171,6 +1171,7 @@
 	M.AdjustUnconscious(-20, 0)
 	M.AdjustStun(-20, 0)
 	M.AdjustKnockdown(-20, 0)
+	M.AdjustSleeping(-20, 0)
 	M.adjustStaminaLoss(-30, 0)
 	..()
 	return TRUE


### PR DESCRIPTION
Meth no longer confuses you.

Adrenaline refactored to use a do_adreanline proc.
From least complicated to most:

Adrenal implants, being limited in use and not usually used with other high powered items (cough ninja) are not nerfed.

Abductors lost their auto-stand

Ninjas lost their stimulants, as they already run faster than anyone else due to their shoes. They don't need to be mach 2.

Changeling adreanline are pretty spammable - 
So, they lost autostand, and their instant boost has been reduced to 100 from 150
Their inaprovaline has been changed to epinephrine (a bit more powerful for crit stabilization/such)
Their 2 units of changeling super-speed chem has been removed, rpelaced with 10 units of a special changeling meth with higher overdose and no brain damage/jittering. Meth regenerates stamina at a fast-ish rate (for station chems) and makes them immune to slowdown, including low health and stamina slowdowns, as well as healing 2 brute and 2 burn per second. I don't like mach 2 combat.
Changeling adrenaline chemical reduced from 10 to 5. It cuts 2 seocnds of unconsciousness + sleeping (added the sleeping part) per second and heals 30 stamina per second.
Changelings now no longer instantly get up from sleeping when adreanlining. They get it clamped to 70, so they will, with the adreanline chemicals, get up from sleeping/unconsciousness in 2-3 seconds rather than instantly, assuming they had more than 7 seconds of sleeping/unconsciousness.