### PR TITLE
Krav maga leg sweep tweak.

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -86,7 +86,7 @@
 	return 0
 
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	if(D.lying || D.resting)
+	if(D.lying || D.IsKnockdown())
 		return 0
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -92,7 +92,7 @@
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
-	D.Knockdown(40, override_hardstun = 0.01, override_stam = 25)
+	D.Knockdown(40, override_hardstun = 0.01, 25)
 	log_combat(A, D, "leg sweeped")
 	return 1
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -86,13 +86,13 @@
 	return 0
 
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
-	if(D.stat || D.IsKnockdown())
+	if(D.lying || D.resting)
 		return 0
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
-	D.Knockdown(40)
+	D.Knockdown(40, override_duration = 10, 25)
 	log_combat(A, D, "leg sweeped")
 	return 1
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -88,11 +88,12 @@
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(D.lying || D.IsKnockdown())
 		return 0
+	var/hardstun = D.resting ? null : 10
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
-	D.Knockdown(40, override_duration = 10, 25)
+	D.Knockdown(40, override_duration = hardstun, 25)
 	log_combat(A, D, "leg sweeped")
 	return 1
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -88,12 +88,11 @@
 /datum/martial_art/krav_maga/proc/leg_sweep(var/mob/living/carbon/human/A, var/mob/living/carbon/human/D)
 	if(D.lying || D.IsKnockdown())
 		return 0
-	var/hardstun = D.resting ? null : 10
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
-	D.Knockdown(40, override_duration = hardstun, 25)
+	D.Knockdown(40, override_stam = 45)
 	log_combat(A, D, "leg sweeped")
 	return 1
 

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -92,7 +92,7 @@
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
 	D.apply_damage(5, BRUTE)
-	D.Knockdown(40, override_stam = 45)
+	D.Knockdown(40, override_hardstun = 0.01, override_stam = 25)
 	log_combat(A, D, "leg sweeped")
 	return 1
 


### PR DESCRIPTION
:cl:
balance: Buffed krav maga leg sweep stun and stamina damage. On the other hand, it's now unable to be used on already lying targets.
/:cl:

Another feature usefulness dunked by the stam rework, the krav maga leg sweep. Right now, it's hard to keep someone down with it (even with the related ui action button dragged near the center of the screen), whilst still being usable on lying mobs since it preceded the crawling feature (and the little tweaking of the pre-existin stun combat related features of the stam rework).

Values may need tweaking, but since it's not anymore spammable, and being the only stun method inherent this style, the 1 second hardstun sounds fair to me.

On a sidenote, I suppose sleeping carp needs some tweaking, since it doesn't hardstun anymore and is commonly bested by horizontal baton-wielding chumps et similar. But that may be done on another PR.