### PR TITLE
Readds Self-Surgery + Tweaks

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -87,8 +87,11 @@
 
 /mob/living/carbon/attackby(obj/item/I, mob/user, params)
 	if(lying && surgeries.len)
-		if(user != src && (user.a_intent == INTENT_HELP || user.a_intent == INTENT_DISARM))
+		if(user.a_intent != INTENT_HARM)
 			for(var/datum/surgery/S in surgeries)
+				if(!S.can_self_surgery() && user != src)
+					continue
+
 				if(S.next_step(user,user.a_intent))
 					return 1
 	return ..()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -89,7 +89,7 @@
 	if(lying && surgeries.len)
 		if(user.a_intent != INTENT_HARM)
 			for(var/datum/surgery/S in surgeries)
-				if(!S.can_self_surgery() && user != src)
+				if(user == src && !S.can_self_surgery())
 					continue
 
 				if(S.next_step(user,user.a_intent))

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -6,6 +6,8 @@
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
 
+/datum/surgery/amputation/can_self_surgery()
+	return TRUE
 
 /datum/surgery_step/sever_limb
 	name = "sever limb"

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -4,6 +4,8 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
 
+/datum/surgery/cavity_implant/can_self_surgery()
+	return TRUE
 
 //handle cavity
 /datum/surgery_step/handle_cavity

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -4,6 +4,9 @@
 	species = list(/mob/living/simple_animal/slime)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 
+/datum/surgery/core_removal/can_self_surgery()
+	return target != BODY_ZONE_HEAD
+
 /datum/surgery/core_removal/can_start(mob/user, mob/living/target)
 	if(target.stat == DEAD)
 		return 1

--- a/code/modules/surgery/dental_implant.dm
+++ b/code/modules/surgery/dental_implant.dm
@@ -3,6 +3,9 @@
 	steps = list(/datum/surgery_step/drill, /datum/surgery_step/insert_pill)
 	possible_locs = list(BODY_ZONE_PRECISE_MOUTH)
 
+/datum/surgery/dental_implant/can_self_surgery()
+	return TRUE
+
 /datum/surgery_step/insert_pill
 	name = "insert pill"
 	implements = list(/obj/item/reagent_containers/pill = 100)

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -4,7 +4,6 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
 
-
 //extract implant
 /datum/surgery_step/extract_implant
 	name = "extract implant"

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -47,6 +47,9 @@
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 	requires_real_bodypart = TRUE
 
+/datum/surgery/augmentation/can_self_surgery()
+	return !(target in list(BODY_ZONE_HEAD,BODY_ZONE_CHEST))
+
 //SURGERY STEP SUCCESSES
 
 /datum/surgery_step/replace_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/bodypart/tool, datum/surgery/surgery)

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -13,7 +13,8 @@
 	if(!C.get_bodypart(user.zone_selected)) //can only start if limb is missing
 		return 1
 
-
+/datum/surgery/prosthetic_replacement/can_self_surgery()
+	return target != BODY_ZONE_HEAD //I MEAN I DON'T THINK THIS IS POSSIBLE BUT...
 
 /datum/surgery_step/add_prosthetic
 	name = "add prosthetic"

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -3,6 +3,8 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/remove_object)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 
+/datum/surgery/embedded_removal/can_self_surgery()
+	return target != BODY_ZONE_HEAD
 
 /datum/surgery_step/remove_object
 	name = "remove embedded objects"

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -16,6 +16,9 @@
 	var/success_multiplier = 0								//Step success propability multiplier
 	var/requires_real_bodypart = 0							//Some surgeries don't work on limbs that don't really exist
 
+/datum/surgery/proc/can_self_surgery()
+	return FALSE
+
 /datum/surgery/New(surgery_target, surgery_location, surgery_bodypart)
 	..()
 	if(surgery_target)
@@ -68,7 +71,7 @@
 	SSblackbox.record_feedback("tally", "surgeries_completed", 1, type)
 	qdel(src)
 
-/datum/surgery/proc/get_propability_multiplier()
+/datum/surgery/proc/get_propability_multiplier(var/mob/user)
 	var/propability = 0.5
 	var/turf/T = get_turf(target)
 
@@ -78,6 +81,9 @@
 		propability = 0.8
 	else if(locate(/obj/structure/bed, T))
 		propability = 0.7
+
+	if(target == user)
+		propability *= 0.5
 
 	return propability + success_multiplier
 
@@ -93,7 +99,7 @@
 		var/datum/species/abductor/S = H.dna.species
 		if(S.scientist)
 			return TRUE
-	
+
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		var/obj/item/surgical_processor/SP = locate() in R.module.modules
@@ -101,7 +107,7 @@
 			return FALSE
 		if(type in SP.advanced_surgeries)
 			return TRUE
-	
+
 	var/turf/T = get_turf(target)
 	var/obj/structure/table/optable/table = locate(/obj/structure/table/optable, T)
 	if(!table || !table.computer)


### PR DESCRIPTION
[Changelogs]:
:cl: BurgerBB
add: Readds self surgery for the following procedures: Amputation, Cavity Implant, Core Removal, Dental Implant, Implant Removal, Limb Augmentation (Chest and Head excluded), Prosthetic Replacement (Head excluded), and Embedded Object Removal (Head excluded).
balance: Self-surgery success rate is halved compared to someone else doing it.
/:cl:

[why]: It is possible in reality to perform some of these surgeries yourself. It's also very useful for when the medical doctors are too busy erping in the dorms, or if you're a roboticist and you want to tell the other one to "fuck off and do it yourself" when for the tenth round in a row they want augmentations.
