### PR TITLE
fixes pacifism eyestabbing, better this time.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -449,7 +449,11 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	return 0
 
 /obj/item/proc/eyestab(mob/living/carbon/M, mob/living/carbon/user)
-
+	if(user.has_trait(TRAIT_PACIFISM))
+		to_chat(user, "<span class='warning'>You don't want to harm [M]!</span>")
+		return
+	if(user.has_trait(TRAIT_CLUMSY) && prob(50))
+		M = user
 	var/is_human_victim = 0
 	var/obj/item/bodypart/affecting = M.get_bodypart(BODY_ZONE_HEAD)
 	if(ishuman(M))

--- a/code/game/objects/items/kitchen.dm
+++ b/code/game/objects/items/kitchen.dm
@@ -49,8 +49,6 @@
 		forkload = null
 
 	else if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
-		if(user.has_trait(TRAIT_CLUMSY) && prob(50))
-			M = user
 		return eyestab(M,user)
 	else
 		return ..()
@@ -79,8 +77,6 @@
 
 /obj/item/kitchen/knife/attack(mob/living/carbon/M, mob/living/carbon/user)
 	if(user.zone_selected == BODY_ZONE_PRECISE_EYES)
-		if(user.has_trait(TRAIT_CLUMSY) && prob(50))
-			M = user
 		return eyestab(M,user)
 	else
 		return ..()

--- a/code/game/objects/items/tools/screwdriver.dm
+++ b/code/game/objects/items/tools/screwdriver.dm
@@ -75,11 +75,6 @@
 		return ..()
 	if(user.zone_selected != BODY_ZONE_PRECISE_EYES && user.zone_selected != BODY_ZONE_HEAD)
 		return ..()
-	if(user.has_trait(TRAIT_PACIFISM))
-		to_chat(user, "<span class='warning'>You don't want to harm [M]!</span>")
-		return
-	if(user.has_trait(TRAIT_CLUMSY) && prob(50))
-		M = user
 	return eyestab(M,user)
 
 /obj/item/screwdriver/brass
@@ -103,7 +98,7 @@
 
 /obj/item/screwdriver/abductor/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "screwdriver_nuke")
-	
+
 /obj/item/screwdriver/power
 	name = "hand drill"
 	desc = "A simple powered hand drill. It's fitted with a screw bit."


### PR DESCRIPTION
:cl:
fix: fixes eyestabbing people with cutlery while being a pacifist.
/:cl:

The pre-existing pacifism eyestabbing fix was bad, only adding up to the clumsy check copypasta around the items' attack(). Oh yea, and that was a port too from almost 1 year ago. So yea yea, this should also be PR'd on tee gee.