### PR TITLE
Fixes THAT Oldstation Tile

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/oldstation.dmm
+++ b/_maps/RandomRuins/SpaceRuins/oldstation.dmm
@@ -2183,9 +2183,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white{
-	icon_state = "whitepurple"
-	},
+/turf/open/floor/plasteel/white,
 /area/ruin/space/has_grav/ancientstation/rnd)
 "fU" = (
 /obj/effect/decal/cleanable/dirt,


### PR DESCRIPTION
Oldstation had a single tile with a "broken texture" icon state. People complained, so I patched it up.

The evil tile in question.
![](https://puu.sh/DyTBh/0ab3589af4.png)