### PR TITLE
Wizard rounds end when the wizard dies

### DIFF
--- a/code/game/gamemodes/wizard/wizard.dm
+++ b/code/game/gamemodes/wizard/wizard.dm
@@ -11,12 +11,19 @@
 	required_enemies = 1
 	recommended_enemies = 1
 	enemy_minimum_age = 7
-	round_ends_with_antag_death = 1
 	announce_span = "danger"
 	announce_text = "There is a space wizard attacking the station!\n\
 	<span class='danger'>Wizard</span>: Accomplish your objectives and cause mayhem on the station.\n\
 	<span class='notice'>Crew</span>: Eliminate the wizard before they can succeed!"
 	var/finished = 0
+	var/ends_when_wizard_dead = TRUE
+
+/datum/game_mode/wizard/check_finished()
+	if(ends_when_wizard_dead && are_special_antags_dead())
+		finished = 1
+		return TRUE
+	else
+		return ..()
 
 /datum/game_mode/wizard/pre_setup()
 	var/datum/mind/wizard = antag_pick(antag_candidates)


### PR DESCRIPTION
[Changelogs]:
:cl: BurgerBB
tweak: The wizard gamemode ends when the wizard dies, regardless of other existing antagonists.
/:cl:

[why]: Wizard rounds are exceptionally bad when the wizard dies, but because of other antags created by the wizard, the round keeps on going. This fixes that to treat it like a rev round when the heads die, the round ends.
