### PR TITLE
Buffs stun slugs 

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,7 +17,8 @@
 
 /obj/item/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
-	stamina = 30
+	damage = 5
+	stamina = 20
 	knockdown = 100
 	stutter = 5
 	jitter = 20

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -17,7 +17,7 @@
 
 /obj/item/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
-	damage = 5
+	stamina = 30
 	knockdown = 100
 	stutter = 5
 	jitter = 20


### PR DESCRIPTION
[Changelogs]:
stunslug now do 20 stam ontop 
:cl: optional name here
balance: rebalanced stunslugs
/:cl:

[why]:
Stunslugs are so bad, it takes ammo slots in a shotgun that can have the way better beanbag or pettles. It costs more then it should, and takes a node past adv weaponry.