### PR TITLE
Changing up the drills/picks/jackhammer a bit

### DIFF
--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -60,7 +60,6 @@
 	toolspeed = 0.6 //available from roundstart, faster than a pickaxe.
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
-	force = 17
 	desc = "An electric mining drill for the especially scrawny."
 
 /obj/item/pickaxe/drill/cyborg
@@ -73,7 +72,6 @@
 	name = "diamond-tipped mining drill"
 	icon_state = "diamonddrill"
 	toolspeed = 0.2
-	force = 19
 	desc = "Yours is the drill that will pierce the heavens!"
 
 /obj/item/pickaxe/drill/cyborg/diamond //This is the BORG version!

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -129,6 +129,7 @@
 	item_state = "spade"
 	lefthand_file = 'icons/mob/inhands/equipment/hydroponics_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
+	toolspeed = 0.5
 	force = 5
 	throwforce = 7
 	materials = list(MAT_METAL=50)

--- a/code/modules/mining/equipment/mining_tools.dm
+++ b/code/modules/mining/equipment/mining_tools.dm
@@ -31,7 +31,7 @@
 	force = 10
 	throwforce = 7
 	slot_flags = ITEM_SLOT_BELT
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_SMALL
 	materials = list(MAT_METAL=1000)
 
 /obj/item/pickaxe/silver
@@ -41,6 +41,7 @@
 	toolspeed = 0.5 //mines faster than a normal pickaxe, bought from mining vendor
 	desc = "A silver-plated pickaxe that mines slightly faster than standard-issue."
 	force = 17
+	materials = list(MAT_SILVER=4000)
 
 /obj/item/pickaxe/diamond
 	name = "diamond-tipped pickaxe"
@@ -49,6 +50,7 @@
 	toolspeed = 0.3
 	desc = "A pickaxe with a diamond pick head. Extremely robust at cracking rock walls and digging up dirt."
 	force = 19
+	materials = list(MAT_DIAMOND=4000)
 
 /obj/item/pickaxe/drill
 	name = "mining drill"
@@ -58,6 +60,7 @@
 	toolspeed = 0.6 //available from roundstart, faster than a pickaxe.
 	usesound = 'sound/weapons/drill.ogg'
 	hitsound = 'sound/weapons/drill.ogg'
+	force = 17
 	desc = "An electric mining drill for the especially scrawny."
 
 /obj/item/pickaxe/drill/cyborg
@@ -70,17 +73,19 @@
 	name = "diamond-tipped mining drill"
 	icon_state = "diamonddrill"
 	toolspeed = 0.2
+	force = 19
 	desc = "Yours is the drill that will pierce the heavens!"
 
 /obj/item/pickaxe/drill/cyborg/diamond //This is the BORG version!
 	name = "diamond-tipped cyborg mining drill" //To inherit the NODROP_1 flag, and easier to change borg specific drill mechanics.
 	icon_state = "diamonddrill"
-	toolspeed = 0.2
+	toolspeed = 0.1
 
 /obj/item/pickaxe/drill/jackhammer
 	name = "sonic jackhammer"
 	icon_state = "jackhammer"
 	item_state = "jackhammer"
+	w_class = WEIGHT_CLASS_HUGE
 	toolspeed = 0.1 //the epitome of powertools. extremely fast mining, laughs at puny walls
 	usesound = 'sound/weapons/sonic_jackhammer.ogg'
 	hitsound = 'sound/weapons/sonic_jackhammer.ogg'
@@ -97,12 +102,12 @@
 	slot_flags = ITEM_SLOT_BELT
 	force = 8
 	tool_behaviour = TOOL_SHOVEL
-	toolspeed = 1
+	toolspeed = 0.1 //Can only dig ash and thats about it, out classed by the picks and drills no more!
 	usesound = 'sound/effects/shovel_dig.ogg'
 	throwforce = 4
 	item_state = "shovel"
 	w_class = WEIGHT_CLASS_NORMAL
-	materials = list(MAT_METAL=50)
+	materials = list(MAT_METAL=350)
 	attack_verb = list("bashed", "bludgeoned", "thrashed", "whacked")
 	sharpness = IS_SHARP
 
@@ -126,4 +131,5 @@
 	righthand_file = 'icons/mob/inhands/equipment/hydroponics_righthand.dmi'
 	force = 5
 	throwforce = 7
+	materials = list(MAT_METAL=50)
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
[Changelogs]
small picks are small
jackhammers are huge!
both silver and diamond picks now give 2 mat each of their type
ups the harm on each item a small bit
Shovels now dig really really really fast
:cl: optional name here
tweak: harm and such
balance: item classes
/:cl:

[why]
Shovels are outclassed by legit everything, even normal picks are better...
Why on earth does a diamond pick give no diamonds, same for the silver not giving silver.
Jackhammers are huge items irl
Why would you not just use plasma cutters over everything?