### PR TITLE
buffs resonator

### DIFF
--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -20,6 +20,7 @@
 	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early."
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
+	force = 20
 	fieldlimit = 8
 	quick_burst_mod = 1
 

--- a/code/modules/mining/equipment/resonator.dm
+++ b/code/modules/mining/equipment/resonator.dm
@@ -8,10 +8,10 @@
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	desc = "A handheld device that creates small fields of energy that resonate until they detonate, crushing rock. It does increased damage in low pressure."
 	w_class = WEIGHT_CLASS_NORMAL
-	force = 15
+	force = 18
 	throwforce = 10
 	var/burst_time = 30
-	var/fieldlimit = 4
+	var/fieldlimit = 6
 	var/list/fields = list()
 	var/quick_burst_mod = 0.8
 
@@ -20,7 +20,7 @@
 	desc = "An upgraded version of the resonator that can produce more fields at once, as well as having no damage penalty for bursting a resonance field early."
 	icon_state = "resonator_u"
 	item_state = "resonator_u"
-	fieldlimit = 6
+	fieldlimit = 8
 	quick_burst_mod = 1
 
 /obj/item/resonator/attack_self(mob/user)


### PR DESCRIPTION
[Changelogs]
Makes resonator them do 18 harm rather then 15, well upgraded resonator do 20
Makes resonator basic hold 6 shields and upgraded hold 8 - Increase of 2 each
:cl: optional name here
fix: resonators being so shitty
/:cl:

[why]
Golems are the only people that actively chose these things over anything.
Lets make them a bit better for people that have, after all it takes a lot to make them.