### PR TITLE
Makes clockwork wall - sonic jackhammer interaction account the wall's superheating.

### DIFF
--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -77,6 +77,19 @@
 
 	return ..()
 
+/turf/closed/wall/clockwork/try_destroy(obj/item/I, mob/user, turf/T)
+	if(!heated)
+		return ..()
+	if(!istype(I, /obj/item/pickaxe/drill/jackhammer))
+		return FALSE
+	to_chat(user, "<span class='notice'>You begin to smash though [src]...</span>")
+	if(!do_after(user, 70, TRUE, src))
+		return FALSE
+	I.play_tool_sound(src)
+	visible_message("<span class='warning'>[user] smashes through [src] with [I]!</span>", "<span class='italics'>You hear the grinding of metal.</span>")
+	dismantle_wall()
+	return TRUE
+
 /turf/closed/wall/clockwork/ReplaceWithLattice()
 	..()
 	for(var/obj/structure/lattice/L in src)


### PR DESCRIPTION
Burger told me to make my own PR for it.

:cl:
balance: Adds in a 7 seconds delay to the jackhammer dismantling a superheated clockwork wall.
/:cl:

Jackhammers are quite buff, and while they require some work to get, easily breach through layers of clockie walls in the infamous TD mode that's CWC. more ranting in #8505. The delay when superheated is just 2 seconds longer than an average rwall.