### PR TITLE
Adds implanter and implanter cases to syndie surgery bags

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -447,6 +447,8 @@
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/mmi/syndie(src)
+	new /obj/item/implantcase(src)
+	new /obj/item/implanter(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery_adv
 	name = "advanced surgery duffel bag"
@@ -464,6 +466,8 @@
 	new /obj/item/clothing/suit/straight_jacket(src)
 	new /obj/item/clothing/mask/muzzle(src)
 	new /obj/item/mmi/syndie(src)
+	new /obj/item/implantcase(src)
+	new /obj/item/implanter(src)
 
 /obj/item/storage/backpack/duffelbag/syndie/ammo
 	name = "ammunition duffel bag"


### PR DESCRIPTION
[Changelogs]
Both a implanter and implant case will spawn in syndie surgery bags, basic and adv
:cl: optional name here
add: items to syndie surgery bags
/:cl:

[why]
Removal of trackers, chem and mindshields form sec/heads to better steal their looks and gain trust with sec.
Removal of other antag's implants to use as your own!
