### PR TITLE
Makes all holy(chaplin) clothing have anti-magic(Holy) built into them

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -13,7 +13,7 @@
 
 /obj/item/clothing/head/helmet/chaplain/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 // CITADEL CHANGES: More variants
 /obj/item/clothing/head/helmet/chaplain/bland
@@ -41,7 +41,7 @@
 
 /obj/item/clothing/suit/armor/riot/chaplain/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 // CITADEL CHANGES: More variants
 /obj/item/clothing/suit/armor/riot/chaplain/teutonic
@@ -211,11 +211,11 @@
 
 /obj/item/clothing/head/hooded/chaplain_hood/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 /obj/item/clothing/suit/hooded/chaplain_hoodie/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 /obj/item/clothing/suit/hooded/chaplain_hoodie/leader
 	name = "leader hoodie"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -11,6 +11,10 @@
 	strip_delay = 80
 	dog_fashion = null
 
+/obj/item/clothing/head/helmet/chaplain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
 // CITADEL CHANGES: More variants
 /obj/item/clothing/head/helmet/chaplain/bland
 	icon_state = "knight_generic"
@@ -34,6 +38,10 @@
 	desc = "God wills it!"
 	icon_state = "knight_templar"
 	item_state = "knight_templar"
+
+/obj/item/clothing/suit/armor/riot/chaplain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
 
 // CITADEL CHANGES: More variants
 /obj/item/clothing/suit/armor/riot/chaplain/teutonic
@@ -201,6 +209,14 @@
 	body_parts_covered = HEAD
 	flags_inv = HIDEHAIR|HIDEFACE|HIDEEARS
 
+/obj/item/clothing/head/hooded/chaplain_hood/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
+/obj/item/clothing/suit/hooded/chaplain_hoodie/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
 /obj/item/clothing/suit/hooded/chaplain_hoodie/leader
 	name = "leader hoodie"
 	desc = "Now you're ready for some 50 dollar bling water."
@@ -212,7 +228,6 @@
 	name = "leader hood"
 	desc = "I mean, you don't /have/ to seek bling water. I just think you should."
 	icon_state = "chaplain_hood_leader"
-
 
 // CHAPLAIN NULLROD AND CUSTOM WEAPONS //
 
@@ -435,7 +450,6 @@
 	attack_verb = list("chopped", "sliced", "cut", "zandatsu'd")
 	hitsound = 'sound/weapons/rapierhit.ogg'
 
-
 /obj/item/nullrod/scythe/spellblade
 	icon_state = "spellblade"
 	item_state = "spellblade"
@@ -504,7 +518,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	attack_verb = list("sawed", "torn", "cut", "chopped", "diced")
 	hitsound = 'sound/weapons/chainsawhit.ogg'
-
 
 /obj/item/nullrod/hammmer
 	icon_state = "hammeron"
@@ -671,7 +684,6 @@
 
 /obj/item/nullrod/tribal_knife/process()
 	slowdown = rand(-2, 2)
-
 
 /obj/item/nullrod/pitchfork
 	icon_state = "pitchfork0"

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -50,15 +50,15 @@
 
 /obj/item/clothing/suit/witchhunter/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 /obj/item/clothing/suit/nun/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 /obj/item/clothing/suit/studentuni/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE)
 
 //Chef
 /obj/item/clothing/suit/toggle/chef

--- a/code/modules/clothing/suits/jobs.dm
+++ b/code/modules/clothing/suits/jobs.dm
@@ -48,6 +48,18 @@
 	body_parts_covered = CHEST|GROIN|LEGS|ARMS
 	allowed = list(/obj/item/storage/book/bible, /obj/item/nullrod, /obj/item/reagent_containers/food/drinks/bottle/holywater, /obj/item/storage/fancy/candle_box, /obj/item/candle, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman)
 
+/obj/item/clothing/suit/witchhunter/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
+/obj/item/clothing/suit/nun/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
+/obj/item/clothing/suit/studentuni/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
 //Chef
 /obj/item/clothing/suit/toggle/chef
 	name = "chef's apron"


### PR DESCRIPTION
[Changelogs]
Gives all chaplin clothing anti-mag - Holy
:cl: optional name here
balance: gives chaplins clothing anti-magics
/:cl:

[why]
Kinda sucks to have a 0 counter to a stun spell. Hopefully this will allow chaplin well not harmed with a null rod get meme luled gotten.
This will also help people that ware chaplin clothing be protected by the faith they bare 
