### PR TITLE
Different combat mode message if user is on help intent.

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -37,7 +37,7 @@
 		if(a_intent != INTENT_HELP)
 			visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
 		else
-			visible_message("<span class='notice'>[src] [pick("looks","seems","goes")] [pick("alert","attentive","vigilant","careful")]!</span>")
+			visible_message("<span class='notice'>[src] [pick("looks","seems","goes")] [pick("alert","attentive","vigilant")].</span>")
 	combatmessagecooldown = 10 SECONDS + world.time //This is set 100% of the time to make sure squeezing regen out of process cycles doesn't result in the combat mode message getting spammed
 	SEND_SIGNAL(src, COMSIG_COMBAT_TOGGLED, src, combatmode)
 	return TRUE

--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -33,8 +33,11 @@
 	if(hud_used && hud_used.static_inventory)
 		for(var/obj/screen/combattoggle/selector in hud_used.static_inventory)
 			selector.rebasetointerbay(src)
-	if(a_intent != INTENT_HELP && world.time >= combatmessagecooldown && combatmode)
-		visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
+	if(world.time >= combatmessagecooldown && combatmode)
+		if(a_intent != INTENT_HELP)
+			visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
+		else
+			visible_message("<span class='notice'>[src] [pick("looks","seems","goes")] [pick("alert","attentive","vigilant","careful")]!</span>")
 	combatmessagecooldown = 10 SECONDS + world.time //This is set 100% of the time to make sure squeezing regen out of process cycles doesn't result in the combat mode message getting spammed
 	SEND_SIGNAL(src, COMSIG_COMBAT_TOGGLED, src, combatmode)
 	return TRUE

--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -33,7 +33,7 @@
 	if(hud_used && hud_used.static_inventory)
 		for(var/obj/screen/combattoggle/selector in hud_used.static_inventory)
 			selector.rebasetointerbay(src)
-	if(world.time >= combatmessagecooldown && combatmode)
+	if(a_intent != INTENT_HELP && world.time >= combatmessagecooldown && combatmode)
 		visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
 	combatmessagecooldown = 10 SECONDS + world.time //This is set 100% of the time to make sure squeezing regen out of process cycles doesn't result in the combat mode message getting spammed
 	SEND_SIGNAL(src, COMSIG_COMBAT_TOGGLED, src, combatmode)


### PR DESCRIPTION
:cl:
tweak: A milder combat stance message will show up if the user switch combat mode on while on help intent.
/:cl:

Dedicated to the people switching combat mode on just to wave at other people or drumming the tables.
Sad.
