### PR TITLE
Adds 2 TC durasteel toolboxes {5 stamcost, 18 mob damage, 18+22+10 structural damage, does not fit in any kind of backpack}

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -183,6 +183,22 @@
 	slab_type = /obj/item/clockwork/slab/debug
 	fabricator_type = /obj/item/clockwork/replica_fabricator/scarab/debug
 
+/obj/item/storage/toolbox/durasteel
+	name = "durasteel toolbox"
+	desc = "A toolbox made out of durasteel. Probably packs a massive punch."
+	total_mass = 5
+	icon_state = "blue"
+	item_state = "toolbox_blue"
+	w_class = WEIGHT_CLASS_HUGE		//heyo no bohing this!
+	force = 18		//spear damage
+
+/obj/item/storage/toolbox/durasteel/afterattack(atom/A, mob/user, proximity)
+	. = ..()
+	if(proximity && isobj(A) && !isitem(A))
+		var/obj/O = A
+		//50 total object damage but split up for stuff like damage deflection.
+		O.take_damage(22)
+		O.take_damage(10)
 
 /obj/item/storage/toolbox/artistic
 	name = "artistic toolbox"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1595,6 +1595,12 @@ datum/uplink_item/stealthy_tools/taeclowndo_shoes
 	cost = 20
 	cant_discount = TRUE
 
+/datum/uplink_item/badass/durasteel_toolbox
+	name = "Durasteel Toolbox"
+	desc = "A very high impact toolbox. Excels at destroying stationary structures."
+	item = /obj/item/storage/toolbox/durasteel
+	cost = 2		//18 damage on mobs, 50 on objects, 4.5 stam/hit
+
 /datum/uplink_item/badass/costumes
 	surplus = 0
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)


### PR DESCRIPTION
Greytide weapon for traitors that is highly obvious and can't be stored.
Can role restrict to assistant if needed.