### PR TITLE
Clears up Extinguisher's slippery instructions.

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -111,7 +111,7 @@
 	to_chat(user, "The safety is [safety ? "on" : "off"].")
 
 	if(reagents.total_volume)
-		to_chat(user, "<span class='notice'>Alt-click to empty it.</span>")
+		to_chat(user, "<span class='notice'>You can loose its <b>screws</b> to empty it.</span>")
 
 /obj/item/extinguisher/proc/AttemptRefill(atom/target, mob/user)
 	if(istype(target, tanktype) && target.Adjacent(user))
@@ -245,7 +245,7 @@
 			var/turf/open/theturf = T
 			theturf.MakeSlippery(TURF_WET_WATER, min_wet_time = 10 SECONDS, wet_time_to_add = 5 SECONDS)
 
-		user.visible_message("[user] empties out \the [src] onto the floor using the release valve.", "<span class='info'>You quietly empty out \the [src] using its release valve.</span>")
+		user.visible_message("[user] empties out \the [src] onto the floor using the release valve.", "<span class='info'>You quietly empty out \the [src] by loosing the release valve's screws.</span>")
 
 //firebot assembly
 /obj/item/extinguisher/attackby(obj/O, mob/user, params)


### PR DESCRIPTION
## About The Pull Request
Closes #8577.

## Why It's Good For The Game
Properly rewords up how to empty the extinguisher since Trilby changed it, and the release valve whatever message to the user.

## Changelog
:cl:
spellcheck: Properly rewords the extinguisher's instructions on how to empty it on the floor since it was changed to be a screwdriver action instead of Alt Click a while ago.
/:cl: