### PR TITLE
Gives gangs a new shield and makes their boots cheaper

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -173,5 +173,6 @@
 	icon_state = "metal"
 	block_chance = 75 //1/4 shots will hit*
 	force = 10
+	slowdown = 2
 	throwforce = 15 //Massive pice of metal
 	w_class = WEIGHT_CLASS_HUGE

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -20,7 +20,6 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 
-
 /obj/item/shield/riot/attackby(obj/item/W, mob/user, params)
 	if(istype(W, /obj/item/melee/baton))
 		if(cooldown < world.time - 25)
@@ -166,3 +165,13 @@
 	block_chance = 25
 	force = 5
 	throwforce = 7
+
+/obj/item/shield/riot/tower
+	name = "tower shield"
+	desc = "A massive shield that can block a lot of attacks, can take a lot of abuse before braking."
+	armor = list("melee" = 95, "bullet" = 95, "laser" = 75, "energy" = 60, "bomb" = 90, "bio" = 90, "rad" = 0, "fire" = 90, "acid" = 10) //Armor for the item, dosnt transfer to user
+	icon_state = "metal"
+	block_chance = 75 //1/4 shots will hit*
+	force = 10
+	throwforce = 15 //Massive pice of metal
+	w_class = WEIGHT_CLASS_HUGE

--- a/modular_citadel/code/game/gamemodes/gangs/gang_items.dm
+++ b/modular_citadel/code/game/gamemodes/gangs/gang_items.dm
@@ -83,13 +83,11 @@
 			return
 	return TRUE
 
-
 /datum/gang_item/clothing/hat
 	name = "Pimp Hat"
 	id = "hat"
 	cost = 16
 	item_path = /obj/item/clothing/head/collectable/petehat/gang
-
 
 /obj/item/clothing/head/collectable/petehat/gang
 	name = "pimpin' hat"
@@ -109,7 +107,7 @@
 /datum/gang_item/clothing/shoes
 	name = "Bling Boots"
 	id = "boots"
-	cost = 22
+	cost = 20
 	item_path = /obj/item/clothing/shoes/gang
 
 /obj/item/clothing/shoes/gang
@@ -258,7 +256,6 @@ datum/gang_item/clothing/shades //Addition: Why not have cool shades on a gang m
 /datum/gang_item/equipment
 	category = "Purchase Equipment:"
 
-
 /datum/gang_item/equipment/spraycan
 	name = "Territory Spraycan"
 	id = "spraycan"
@@ -274,7 +271,6 @@ datum/gang_item/clothing/shades //Addition: Why not have cool shades on a gang m
 	id = "whetstone"
 	cost = 3
 	item_path = /obj/item/sharpener
-
 
 /datum/gang_item/equipment/emp
 	name = "EMP Grenade"
@@ -329,6 +325,12 @@ datum/gang_item/equipment/shield
 	cost = 25
 	item_path = /obj/item/shield/riot
 
+datum/gang_item/equipment/gangsheild
+	name = "Tower Shield"
+	id = "metal"
+	cost = 45 //High block of melee and even higher for bullets
+	item_path = /obj/item/shield/riot/tower
+
 /datum/gang_item/equipment/pen
 	name = "Recruitment Pen"
 	id = "pen"
@@ -351,7 +353,6 @@ datum/gang_item/equipment/shield
 	if(gangtool && gangtool.free_pen)
 		return "(GET ONE FREE)"
 	return ..()
-
 
 /datum/gang_item/equipment/gangtool
 	id = "gangtool"


### PR DESCRIPTION
## About The Pull Request

Gives gangs their own shield
Lowers boots costs by 2 gang reps
## Why It's Good For The Game

So gangs can have their own shield and not use riots for everything

## Changelog
:cl:
add: gang tower shield
tweak: costs of boots
/:cl:
Why?
Gangs should get their own fancy shield that is better then *sec* shields, this shield is not as powerful when in alone and rng can always mess ya up
