### PR TITLE
reworks cryo item storage

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -28,7 +28,7 @@ GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 204
 #define HOLOGRAM_1					(1<<12)
 #define TESLA_IGNORE_1				(1<<13) // TESLA_IGNORE grants immunity from being targeted by tesla-style electricity
 #define INITIALIZED_1				(1<<14)  //Whether /atom/Initialize() has already run for the object
-#define ADMIN_SPAWNED_1			(1<<15) 	//was this spawned by an admin? used for stat tracking stuff.
+#define ADMIN_SPAWNED_1				(1<<15) 	//was this spawned by an admin? used for stat tracking stuff.
 
 //turf-only flags
 #define NOJAUNT_1					(1<<0)

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -27,6 +27,8 @@
 #define ABSTRACT				(1<<9) 	// for all things that are technically items but used for various different stuff
 #define IMMUTABLE_SLOW          (1<<10) //When players should not be able to change the slowdown of the item (Speed potions, ect)
 
+#define CRYO_DELETE				(1<<23)			//delete on cryo removal rather than kept.
+
 // Flags for the clothing_flags var on /obj/item/clothing
 
 #define LAVAPROTECT (1<<0)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -39,7 +39,7 @@
 	var/obj/item/__CURRENT = new path(mob);\
 	mob.equip_to_slot_or_del(__CURRENT, slot);\
 	if(cryo_destroy)\
-		__CURRENT.item_flags |= CRYO_DESTROY
+		__CURRENT.item_flags |= CRYO_DELETE
 
 /datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, cryo_destroy = FALSE)
 	pre_equip(H, visualsOnly)

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -35,34 +35,40 @@
 	//to be overridden for toggling internals, id binding, access etc
 	return
 
-/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+#define OUTFIT_SETUP(path, slot, mob, cryo_destroy)\
+	var/obj/item/__CURRENT = new path(mob);\
+	mob.equip_to_slot_or_del(__CURRENT, slot);\
+	if(cryo_destroy)\
+		__CURRENT.item_flags |= CRYO_DESTROY
+
+/datum/outfit/proc/equip(mob/living/carbon/human/H, visualsOnly = FALSE, cryo_destroy = FALSE)
 	pre_equip(H, visualsOnly)
 
 	//Start with uniform,suit,backpack for additional slots
 	if(uniform)
-		H.equip_to_slot_or_del(new uniform(H),SLOT_W_UNIFORM)
+		OUTFIT_SETUP(uniform, SLOT_W_UNIFORM, H, cryo_destroy)
 	if(suit)
-		H.equip_to_slot_or_del(new suit(H),SLOT_WEAR_SUIT)
+		OUTFIT_SETUP(suit, SLOT_WEAR_SUIT, H, cryo_destroy)
 	if(back)
-		H.equip_to_slot_or_del(new back(H),SLOT_BACK)
+		OUTFIT_SETUP(back, SLOT_BACK, H, cryo_destroy)
 	if(belt)
-		H.equip_to_slot_or_del(new belt(H),SLOT_BELT)
+		OUTFIT_SETUP(belt, SLOT_BELT, H, cryo_destroy)
 	if(gloves)
-		H.equip_to_slot_or_del(new gloves(H),SLOT_GLOVES)
+		OUTFIT_SETUP(gloves, SLOT_GLOVES, H, cryo_destroy)
 	if(shoes)
-		H.equip_to_slot_or_del(new shoes(H),SLOT_SHOES)
+		OUTFIT_SETUP(shoes, SLOT_SHOES, H, cryo_destroy)
 	if(head)
-		H.equip_to_slot_or_del(new head(H),SLOT_HEAD)
+		OUTFIT_SETUP(head, SLOT_HEAD, H, cryo_destroy)
 	if(mask)
-		H.equip_to_slot_or_del(new mask(H),SLOT_WEAR_MASK)
+		OUTFIT_SETUP(mask, SLOT_WEAR_MASK, H, cryo_destroy)
 	if(neck)
-		H.equip_to_slot_or_del(new neck(H),SLOT_NECK)
+		OUTFIT_SETUP(neck, SLOT_NECK, H, cryo_destroy)
 	if(ears)
-		H.equip_to_slot_or_del(new ears(H),SLOT_EARS)
+		OUTFIT_SETUP(ears, SLOT_EARS, H, cryo_destroy)
 	if(glasses)
-		H.equip_to_slot_or_del(new glasses(H),SLOT_GLASSES)
+		OUTFIT_SETUP(glasses, SLOT_GLASSES, H, cryo_destroy)
 	if(id)
-		H.equip_to_slot_or_del(new id(H),SLOT_WEAR_ID)
+		OUTFIT_SETUP(id, SLOT_WEAR_ID, H, cryo_destroy)
 	if(suit_store)
 		H.equip_to_slot_or_del(new suit_store(H),SLOT_S_STORE)
 
@@ -89,7 +95,7 @@
 				if(!isnum(number))//Default to 1
 					number = 1
 				for(var/i in 1 to number)
-					H.equip_to_slot_or_del(new path(H),SLOT_IN_BACKPACK)
+					OUTFIT_SETUP(path, SLOT_IN_BACKPACK, H, cryo_destroy)
 
 	if(!H.head && toggle_helmet && istype(H.wear_suit, /obj/item/clothing/suit/space/hardsuit))
 		var/obj/item/clothing/suit/space/hardsuit/HS = H.wear_suit
@@ -109,6 +115,8 @@
 
 	H.update_body()
 	return TRUE
+
+#undef OUTFIT_SETUP
 
 /datum/outfit/proc/apply_fingerprints(mob/living/carbon/human/H)
 	if(!istype(H))

--- a/code/datums/outfit.dm
+++ b/code/datums/outfit.dm
@@ -70,25 +70,40 @@
 	if(id)
 		OUTFIT_SETUP(id, SLOT_WEAR_ID, H, cryo_destroy)
 	if(suit_store)
-		H.equip_to_slot_or_del(new suit_store(H),SLOT_S_STORE)
+		OUTFIT_SETUP(suit_store, SLOT_S_STORE, H, cryo_destroy)
 
 	if(accessory)
 		var/obj/item/clothing/under/U = H.w_uniform
 		if(U)
-			U.attach_accessory(new accessory(H))
+			var/obj/item/A = new accessory(H)
+			if(cryo_destroy)
+				A.item_flags |= CRYO_DELETE
+			U.attach_accessory(A)
 		else
 			WARNING("Unable to equip accessory [accessory] in outfit [name]. No uniform present!")
 
 	if(l_hand)
-		H.put_in_l_hand(new l_hand(H))
+		var/obj/item/I = new l_hand(H)
+		if(cryo_destroy)
+			H.item_flags |= CRYO_DELETE
+		H.put_in_l_hand(I)
 	if(r_hand)
-		H.put_in_r_hand(new r_hand(H))
+		var/obj/item/I = new r_hand(H)
+		if(cryo_destroy)
+			H.item_flags |= CRYO_DELETE
+		H.put_in_r_hand(I)
 
 	if(!visualsOnly) // Items in pockets or backpack don't show up on mob's icon.
 		if(l_pocket)
-			H.equip_to_slot_or_del(new l_pocket(H),SLOT_L_STORE)
+			var/obj/item/I = new l_pocket(H)
+			if(cryo_destroy)
+				H.item_flags |= CRYO_DELETE
+			H.equip_to_slot_or_del(I, SLOT_L_STORE)
 		if(r_pocket)
-			H.equip_to_slot_or_del(new r_pocket(H),SLOT_R_STORE)
+			var/obj/item/I = new r_pocket(H)
+			if(cryo_destroy)
+				H.item_flags |= CRYO_DELETE
+			H.equip_to_slot_or_del(I, SLOT_R_STORE)
 		if(backpack_contents)
 			for(var/path in backpack_contents)
 				var/number = backpack_contents[path]

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -35,7 +35,6 @@
 	var/anchorable = TRUE
 	var/icon_welded = "welded"
 
-
 /obj/structure/closet/Initialize(mapload)
 	. = ..()
 	update_icon()

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -5,6 +5,11 @@
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
 
+/obj/structure/closet/cabinet/cryo_drop
+	name = "empty cryogenic retrieval box"
+	max_integrity = 20			//don't use this as a barricade
+	material_drop_amount = 0
+
 /obj/structure/closet/acloset
 	name = "strange closet"
 	desc = "It looks alien!"

--- a/code/modules/jobs/job_types/job.dm
+++ b/code/modules/jobs/job_types/job.dm
@@ -89,7 +89,7 @@
 	H.dna.species.before_equip_job(src, H, visualsOnly)
 
 	if(outfit_override || outfit)
-		H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly)
+		H.equipOutfit(outfit_override ? outfit_override : outfit, visualsOnly, cryo_destroy = TRUE)
 
 	H.dna.species.after_equip_job(src, H, visualsOnly)
 

--- a/code/modules/mob/living/carbon/human/inventory.dm
+++ b/code/modules/mob/living/carbon/human/inventory.dm
@@ -249,7 +249,7 @@
 	sec_hud_set_security_status()
 	..()
 
-/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE)
+/mob/living/carbon/human/proc/equipOutfit(outfit, visualsOnly = FALSE, cryo_destroy = FALSE)
 	var/datum/outfit/O = null
 
 	if(ispath(outfit))
@@ -261,7 +261,7 @@
 	if(!O)
 		return 0
 
-	return O.equip(src, visualsOnly)
+	return O.equip(src, visualsOnly, cryo_destroy = cryo_destroy)
 
 
 //delete all equipment without dropping anything

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -39,14 +39,17 @@
 		var/obj/item/I = new i(src)
 		basic_modules += I
 		basic_modules -= i
+		I.item_flags |= CRYO_DESTROY
 	for(var/i in emag_modules)
 		var/obj/item/I = new i(src)
 		emag_modules += I
 		emag_modules -= i
+		I.item_flags |= CRYO_DESTROY
 	for(var/i in ratvar_modules)
 		var/obj/item/I = new i(src)
 		ratvar_modules += I
 		ratvar_modules -= i
+		I.item_flags |= CRYO_DESTROY
 
 /obj/item/robot_module/Destroy()
 	basic_modules.Cut()
@@ -120,6 +123,7 @@
 		I.forceMove(src)
 	modules += I
 	I.item_flags |= NODROP
+	I.item_flags |= CRYO_DESTROY
 	I.mouse_opacity = MOUSE_OPACITY_OPAQUE
 	if(nonstandard)
 		added_modules += I

--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -39,17 +39,17 @@
 		var/obj/item/I = new i(src)
 		basic_modules += I
 		basic_modules -= i
-		I.item_flags |= CRYO_DESTROY
+		I.item_flags |= CRYO_DELETE
 	for(var/i in emag_modules)
 		var/obj/item/I = new i(src)
 		emag_modules += I
 		emag_modules -= i
-		I.item_flags |= CRYO_DESTROY
+		I.item_flags |= CRYO_DELETE
 	for(var/i in ratvar_modules)
 		var/obj/item/I = new i(src)
 		ratvar_modules += I
 		ratvar_modules -= i
-		I.item_flags |= CRYO_DESTROY
+		I.item_flags |= CRYO_DELETE
 
 /obj/item/robot_module/Destroy()
 	basic_modules.Cut()
@@ -123,7 +123,7 @@
 		I.forceMove(src)
 	modules += I
 	I.item_flags |= NODROP
-	I.item_flags |= CRYO_DESTROY
+	I.item_flags |= CRYO_DELETE
 	I.mouse_opacity = MOUSE_OPACITY_OPAQUE
 	if(nonstandard)
 		added_modules += I

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -291,10 +291,13 @@
 			var/mob/M = i
 			M.forceMove(drop_location())
 
-	var/list/obj/item/occupant_items = list() | mob_occupant.get_equipped_items(TRUE) | mob_occupant.held_items		//the list is to ensure that even if the first one is null for some reason this works.
+	var/list/obj/item/occupant_items = list() | mob_occupant.get_equipped_items(TRUE)	//the list is to ensure that even if the first one is null for some reason this works.
 	var/list/obj/item/stored = list()
 	var/atom/target_store = (control_computer?.allow_items && control_computer) || src		//the double control computer check makes it return the control computer.
 	var/drop_to_ground = !istype(target_store, /obj/machinery/computer/cryopod)
+
+	for(var/obj/item/I in mob_occupant.held_items)
+		occupant_items += I
 
 	for(var/i in occupant_items)
 		var/obj/item/I = i

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -286,7 +286,7 @@
 	//Lastly, getallcontents and purge
 	//If anyone knows how to cache the getallcontents and not have it delete stuff that it shouldn't delete because equipped items can have recursive storage lemme know I guess.
 
-	for(var/i in mob_occupant.GetAllContents())
+	for(var/i in mob_occupant.GetAllContents() - mob_occupant)
 		if(ismob(i))
 			var/mob/M = i
 			M.forceMove(drop_location())

--- a/modular_citadel/code/game/machinery/cryopod.dm
+++ b/modular_citadel/code/game/machinery/cryopod.dm
@@ -28,6 +28,12 @@
 	var/storage_name = "Cryogenic Oversight Control"
 	var/allow_items = TRUE
 
+/obj/machinery/computer/cryopod/deconstruct()
+	. = ..()
+	for(var/i in stored_packages)
+		var/obj/O = i
+		O.forceMove(drop_location())
+
 /obj/machinery/computer/cryopod/ui_interact(mob/user = usr)
 	. = ..()
 
@@ -69,7 +75,7 @@
 
 		var/dat = "<b>Recently stored objects</b><br/><hr/><br/>"
 		for(var/obj/O in stored_packages)
-			dat += "[I.name]<br/>"
+			dat += "[O.name]<br/>"
 		dat += "<hr/>"
 
 		user << browse(dat, "window=cryoitems")
@@ -280,7 +286,7 @@
 	//Lastly, getallcontents and purge
 	//If anyone knows how to cache the getallcontents and not have it delete stuff that it shouldn't delete because equipped items can have recursive storage lemme know I guess.
 
-	for(var/i in mob_occupant.getAllContents())
+	for(var/i in mob_occupant.GetAllContents())
 		if(ismob(i))
 			var/mob/M = i
 			M.forceMove(drop_location())


### PR DESCRIPTION
Cryo now preserves all items except for those marked with item_flags & CRYO_DELETE
Job equipping marks items with this, so does cyborg modules.

Why: People keep cryoing out with their gear/station gear and destroying said gear. While it'll always be an admin issue for heads doing this as this isn't a perfect solution, it does reduce the need of round replacement of items, and is a far better way of item "blacklisting".

Also I removed the existing blacklist as I don't see a reason for it to be there, considering we already ID lock the cryo console. If someone gets guns from it, so be it.

cryo consoles now drop everything when they're deconstructed/destroyed with in game means.