### PR TITLE
Added a "crush" emote, to crush someone's head between your thighs (does no damage). Cozum O'Connell asked for it in Dchat. Blame him.

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -625,6 +625,32 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	else
 		..()
 
+/obj/item/crush
+	name = "thigh crush"
+	desc = "This is how real thots fight."
+	icon_state = "latexballon"
+	item_state = "nothing"
+	force = 0
+	throwforce = 0
+	item_flags = DROPDEL | ABSTRACT
+	attack_verb = list("crushed")
+	hitsound = 'sound/effects/snap.ogg'
+
+/obj/item/crush/attack(mob/M, mob/living/carbon/human/user)
+	if(ishuman(M))
+		var/mob/living/carbon/human/L = M
+		if(L && L.dna && L.dna.species)
+			L.dna.species.stop_wagging_tail(M)
+	if(user.a_intent != INTENT_HARM && ((user.zone_selected == BODY_ZONE_PRECISE_MOUTH) || (user.zone_selected == BODY_ZONE_PRECISE_EYES) || (user.zone_selected == BODY_ZONE_HEAD)))
+		user.do_attack_animation(M)
+		playsound(M, 'sound/weapons/slap.ogg', 50, 1, -1)
+		user.visible_message("<span class='danger'>[user] crushes [M]'s head between their thighs!</span>",
+		"<span class='notice'>You crush [M]'s head between your thighs!</span>",\
+		"You hear a head being crushed between a thot's thighs.")
+		return
+	else
+		..()
+
 /obj/item/proc/can_trigger_gun(mob/living/user)
 	if(!user.can_use_guns(src))
 		return FALSE

--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -228,3 +228,19 @@
 		user.nextsoundemote = world.time + 7
 		playsound(user, 'modular_citadel/sound/voice/merp.ogg', 50, 1, -1)
 	. = ..()
+
+/datum/emote/living/crush
+	key = "crush"
+	key_third_person = "crushes"
+	restraint_check = TRUE
+
+
+/datum/emote/living/crush/run_emote(mob/user, params)
+	. = ..()
+	if(!.)
+		return
+	var/obj/item/crush/N = new(user)
+	if(user.put_in_hands(N))
+		to_chat(user, "<span class='notice'>You ready your crushing thighs!</span>")
+	else
+to_chat(user, "<span class='warning'>You're incapable of thigh crushing in your current state.</span>")


### PR DESCRIPTION
it's functionally just a relabeled slap, with the ready stage, a placeholder item, and a special attack message.