### PR TITLE
Fixes adrenaline (it didn't actually work). Replaces traitor/ling adrenal omnizine with regenjelly (3x faster, but lasts shorter too), reworks changeling adrenals to scale burst stamina heal rather than flat 100

### DIFF
--- a/code/game/objects/items/implants/implant_misc.dm
+++ b/code/game/objects/items/implants/implant_misc.dm
@@ -33,7 +33,7 @@
 /obj/item/implant/adrenalin/activate()
 	. = ..()
 	uses--
-	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10, "stimulants" = 10), "<span class='boldnotice'>You feel a sudden surge of energy!</span>")
+	imp_in.do_adrenaline(150, TRUE, 0, 0, TRUE, list("inaprovaline" = 3, "synaptizine" = 10, "regen_jelly" = 10, "stimulants" = 10), "<span class='boldnotice'>You feel a sudden surge of energy!</span>")
 	to_chat(imp_in, "<span class='notice'>You feel a sudden surge of energy!</span>")
 	if(!uses)
 		qdel(src)

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -12,5 +12,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	user.do_adrenaline(50, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 50, 0.5, 100)
+	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 20, 0.75, 0)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -12,5 +12,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 20, 0.75, 0)
+	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "regen_jelly" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 20, 0.75, 0)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -12,5 +12,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "regen_jelly" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 20, 0.75, 0)
+	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "regen_jelly" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 0, 0.75, 0)
 	return TRUE

--- a/code/modules/antagonists/changeling/powers/adrenaline.dm
+++ b/code/modules/antagonists/changeling/powers/adrenaline.dm
@@ -12,5 +12,5 @@
 
 //Recover from stuns.
 /obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
-	user.do_adrenaline(100, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>")
+	user.do_adrenaline(50, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "omnizine" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 50, 0.5, 100)
 	return TRUE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1190,7 +1190,10 @@
 			clamp_immobility_to = 0,
 			reset_misc = TRUE,
 			healing_chems = list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10, "stimulants" = 10),
-			message = "<span class='boldnotice'>You feel a surge of energy!</span>"
+			message = "<span class='boldnotice'>You feel a surge of energy!</span>",
+			stamina_buffer_boost = 0,				//restores stamina buffer rather than just health
+			scale_stamina_loss_recovery,			//defaults to null. if this is set, restores loss * this stamina. make sure it's a fraction.
+			stamina_loss_recovery_bypass = 0		//amount of stamina loss to ignore during calculation
 		)
 	if(AmountSleeping() > clamp_unconscious_to)
 		SetSleeping(clamp_unconscious_to)
@@ -1201,6 +1204,9 @@
 	if(AmountKnockdown() > clamp_immobility_to)
 		SetKnockdown(clamp_immobility_to)
 	adjustStaminaLoss(max(0, -stamina_boost))
+	adjustStaminaLossBuffered(max(0, -stamina_buffer_boost))
+	if(scale_stamina_loss_recovery)
+		adjustStaminaLoss(max(-((getStaminaLoss() - stamina_loss_recovery_bypass) * scale_stamina_loss_recovery), 0))
 	if(put_on_feet)
 		resting = FALSE
 		lying = FALSE

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -1189,12 +1189,13 @@
 			clamp_unconscious_to = 0,
 			clamp_immobility_to = 0,
 			reset_misc = TRUE,
-			healing_chems = list("inaprovaline" = 3, "synaptizine" = 10, "omnizine" = 10, "stimulants" = 10),
+			healing_chems = list("inaprovaline" = 3, "synaptizine" = 10, "regen_jelly" = 10, "stimulants" = 10),
 			message = "<span class='boldnotice'>You feel a surge of energy!</span>",
 			stamina_buffer_boost = 0,				//restores stamina buffer rather than just health
 			scale_stamina_loss_recovery,			//defaults to null. if this is set, restores loss * this stamina. make sure it's a fraction.
 			stamina_loss_recovery_bypass = 0		//amount of stamina loss to ignore during calculation
 		)
+	to_chat(src, message)
 	if(AmountSleeping() > clamp_unconscious_to)
 		SetSleeping(clamp_unconscious_to)
 	if(AmountUnconscious() > clamp_unconscious_to)
@@ -1203,10 +1204,10 @@
 		SetStun(clamp_immobility_to)
 	if(AmountKnockdown() > clamp_immobility_to)
 		SetKnockdown(clamp_immobility_to)
-	adjustStaminaLoss(max(0, -stamina_boost))
-	adjustStaminaLossBuffered(max(0, -stamina_buffer_boost))
+	adjustStaminaLoss(min(0, -stamina_boost))
+	adjustStaminaLossBuffered(min(0, -stamina_buffer_boost))
 	if(scale_stamina_loss_recovery)
-		adjustStaminaLoss(max(-((getStaminaLoss() - stamina_loss_recovery_bypass) * scale_stamina_loss_recovery), 0))
+		adjustStaminaLoss(min(-((getStaminaLoss() - stamina_loss_recovery_bypass) * scale_stamina_loss_recovery), 0))
 	if(put_on_feet)
 		resting = FALSE
 		lying = FALSE


### PR DESCRIPTION
Adds a scaling paremeter. 
This makes it more effective in stamcrit but less burst if you have less damage. 

ling adrenals now heal 75% of stam and regen buffer to max.