### PR TITLE
Pacifists can nom things now, but not feed to others

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -124,6 +124,18 @@
 	if(user == anchored || !isturf(user.loc))
 		return FALSE
 
+	//pacifist vore check.
+	if(user.pulling && HAS_TRAIT(user, TRAIT_PACIFISM) && user.voremode) //they can only do heals, noisy guts, absorbing (technically not harm)
+		if(ismob(user.pulling))
+			var/mob/P = user.pulling
+			if(src != user)
+				to_chat(user, "<span class='notice'>You can't risk digestion!</span>")
+				return FALSE
+			else
+				user.vore_attack(user, P, user)
+				return
+
+	//normal vore check.
 	if(user.pulling && user.grab_state == GRAB_AGGRESSIVE && user.voremode)
 		if(ismob(user.pulling))
 			var/mob/P = user.pulling

--- a/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
+++ b/modular_citadel/code/modules/vore/eating/bellymodes_vr.dm
@@ -49,13 +49,16 @@
 	var/sound/pred_death = sound(get_sfx("death_pred"))
 	var/turf/source = get_turf(owner)
 
-
 ///////////////////////////// DM_HOLD /////////////////////////////
 	if(digest_mode == DM_HOLD)
 		return SSBELLIES_PROCESSED
 
 //////////////////////////// DM_DIGEST ////////////////////////////
 	else if(digest_mode == DM_DIGEST)
+		if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //obvious.
+			digest_mode = DM_NOISY
+			return
+
 		for (var/mob/living/M in contents)
 			if(prob(25))
 				if((world.time - NORMIE_HEARCHECK) > last_hearcheck)
@@ -210,6 +213,10 @@
 //////////////////////////DM_DRAGON /////////////////////////////////////
 //because dragons need snowflake guts
 	if(digest_mode == DM_DRAGON)
+		if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //imagine var editing this when you're a pacifist. smh
+			digest_mode = DM_NOISY
+			return
+
 		for (var/mob/living/M in contents)
 			if(prob(55)) //if you're hearing this, you're a vore ho anyway.
 				if((world.time - NORMIE_HEARCHECK) > last_hearcheck)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Enables Pacifists to nom people for healing things. Or just being noisy lewd in carrying them about. <3

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Because you can be protective with your noms and not harmful!

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Poojawa
add: Pacifists can eat people for heal belly or noisy. Digestive modes are auto-swapped to noisy
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
