### PR TITLE
Makes plushies not a 2% prize from the arcades

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1,6 +1,7 @@
 #define ARCADE_WEIGHT_TRICK 4
 #define ARCADE_WEIGHT_USELESS 2
 #define ARCADE_WEIGHT_RARE 1
+#define ARCADE_WEIGHT_PLUSH 3
 
 
 /obj/machinery/computer/arcade
@@ -26,7 +27,7 @@
 		/obj/item/toy/katana = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/minimeteor = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/nuke = ARCADE_WEIGHT_TRICK,
-		/obj/item/toy/plush/random = ARCADE_WEIGHT_USELESS,
+		/obj/item/toy/plush/random = ARCADE_WEIGHT_PLUSH,
 		/obj/item/toy/redbutton = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/spinningtoy = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/sword = ARCADE_WEIGHT_TRICK,


### PR DESCRIPTION
Plushies were previously (as in, before the burger PR) weighted way too heavily. Burger overnerfed them by making random plushies basically a 2% drop. 
This will bring them up to 30% which is less than what they were before, but more than the overnerfed 2%.