### PR TITLE
Added a .172413793% chance of getting an uplink implant with 5 TC from Necropolis Chests

### DIFF
--- a/code/game/objects/items/implants/implantuplink.dm
+++ b/code/game/objects/items/implants/implantuplink.dm
@@ -21,3 +21,10 @@
 
 /obj/item/implant/uplink/precharged
 	starting_tc = 10
+
+/obj/item/implanter/uplink/precharged/mining
+	name = "implanter (precharged mining uplink)"
+	imp_type = /obj/item/implant/uplink/precharged/mining
+
+/obj/item/implant/uplink/precharged/mining
+	starting_tc = 5

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -11,7 +11,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,28)
+	var/loot = rand(1,29)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -77,6 +77,11 @@
 			new /obj/item/bedsheet/cult(src)
 		if(28)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
+		if(29)
+			if(rand(100) >= 95)
+				new /obj/item/implanter/uplink/precharged/mining
+			else
+				PopulateContents()
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION

## Why It's Good For The Game
Because it adds a way for loyal crew to get traitor items, if they are lucky enough. This is both a fun thing to get, and it makes it harder to tell if someone with traitor items are actually a traitor or not.
However, because it's so rare, it's pretty hard to abuse it.


## Changelog
:cl:RobinFox
add:A very, very small chance of getting a 5TC uplink from necropolis chests
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
