### PR TITLE
Ninja tweaks and improvements. Take two.

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -542,6 +542,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 	return checking.researched_nodes.len >= target_amount
 
 /datum/objective/capture
+	var/captured_amount = 0
 
 /datum/objective/capture/proc/gen_amount_goal()
 		target_amount = rand(5,10)
@@ -549,8 +550,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		return target_amount
 
 /datum/objective/capture/check_completion()//Basically runs through all the mobs in the area to determine how much they are worth.
-	var/captured_amount = 0
-	var/area/centcom/holding/A = GLOB.areas_by_type[/area/centcom/holding]
+	/*var/area/centcom/holding/A = GLOB.areas_by_type[/area/centcom/holding]
 	for(var/mob/living/carbon/human/M in A)//Humans.
 		if(M.stat == DEAD)//Dead folks are worth less.
 			captured_amount+=0.5
@@ -573,7 +573,7 @@ GLOBAL_LIST_EMPTY(possible_items_special)
 		if(M.stat == DEAD)
 			captured_amount+=1
 			continue
-		captured_amount+=2
+		captured_amount+=2*/ //Removed in favour of adding points on capture, in energy_net_nets.dm
 	return captured_amount >= target_amount
 
 

--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -37,6 +37,8 @@
 	var/mindrain = 200
 	var/maxdrain = 400
 
+	var/stunforce = 140 //same as stunbaton, adjustable
+
 
 /obj/item/clothing/gloves/space_ninja/Touch(atom/A,proximity)
 	if(!candrain || draining)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -108,19 +108,9 @@ It is possible to destroy the net by the occupant or someone else.
 	playsound(affecting, 'sound/effects/sparks2.ogg', 50, 1)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
-/obj/structure/energy_net/attackby(obj/item/I, mob/user, params)
-
-	if(istype(user, /mob/living/carbon/alien/humanoid)) //so that aliums aren't completely cucked by nets
-		return attack_hand(user)
-	if(!I)
-		return
-	if(!I.force)
-		return
-
-	return attack_hand(user)
-
-/*/obj/structure/energy_net/attack_paw(mob/user)
-	return attack_hand()*/ //How about no barehanded breaking of the net?
+/obj/attack_alien(mob/living/carbon/alien/humanoid/user)
+	if(attack_generic(user, 15, BRUTE, "melee", 0)) //Aliens normally deal 60 damage to structures. They'd one-shot nets without this.
+		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 
 /obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)
 	return//We only want our target to be buckled

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -109,7 +109,7 @@ It is possible to destroy the net by the occupant or someone else.
 	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
 /obj/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(attack_generic(user, 15, BRUTE, "melee", 0)) //Aliens normally deal 60 damage to structures. They'd one-shot nets without this.
+	if(attack_generic(user, 15, BRUTE, "melee", 0)) //Aliens normally deal 60 damage to structures. They would one-shot nets without this.
 		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 
 /obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -59,6 +59,9 @@ It is possible to destroy the net by the occupant or someone else.
 				continue
 			H.dropItemToGround(W)
 
+	if(affecting in GLOB.alive_mob_list) //Feel free to suggest a better check if it's alive.
+		affecting.revive(1, 1) //Basically a full heal, including limbs/organs.
+
 	playsound(affecting, 'sound/effects/sparks4.ogg', 50, 1)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)
 

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -108,9 +108,19 @@ It is possible to destroy the net by the occupant or someone else.
 	playsound(affecting, 'sound/effects/sparks2.ogg', 50, 1)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
-/obj/structure/energy_net/attack_paw(mob/user)
-	//return attack_hand() //How about no barehanded breaking of the net?
-	return
+/obj/structure/energy_net/attackby(obj/item/I, mob/user, params)
+
+	if(istype(user, /mob/living/carbon/alien/humanoid)) //so that aliums aren't completely cucked by nets
+		return attack_hand(user)
+	if(!I)
+		return
+	if(!I.force)
+		return
+
+	return attack_hand(user)
+
+/*/obj/structure/energy_net/attack_paw(mob/user)
+	return attack_hand()*/ //How about no barehanded breaking of the net?
 
 /obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)
 	return//We only want our target to be buckled

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -109,7 +109,7 @@ It is possible to destroy the net by the occupant or someone else.
 	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
 /obj/attack_alien(mob/living/carbon/alien/humanoid/user)
-	if(attack_generic(user, 15, BRUTE, "melee", 0)) //Aliens normally deal 60 damage to structures. They would one-shot nets without this.
+	if(attack_generic(user, 15, BRUTE, "melee", 0)) //Aliens normally deal 60 damage to structures. They'd one-shot nets without this.
 		playsound(src.loc, 'sound/weapons/slash.ogg', 100, 1)
 
 /obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -59,9 +59,6 @@ It is possible to destroy the net by the occupant or someone else.
 				continue
 			H.dropItemToGround(W)
 
-	if(affecting.stat != DEAD)
-		affecting.revive(1, 1) //Basically a full heal, including limbs/organs.
-
 	var/datum/antagonist/antag_datum
 	for(var/datum/antagonist/AD in GLOB.antagonists)
 		if(AD.owner == master)
@@ -93,6 +90,9 @@ It is possible to destroy the net by the occupant or someone else.
 				continue
 			capture.captured_amount+=2
 
+
+	affecting.revive(1, 1)	//Basically a revive and full heal, including limbs/organs
+							//In case people who have been captured dead want to hang out at the holding area
 
 	playsound(affecting, 'sound/effects/sparks4.ogg', 50, 1)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -14,7 +14,7 @@ It is possible to destroy the net by the occupant or someone else.
 	mouse_opacity = MOUSE_OPACITY_ICON//So you can hit it with stuff.
 	anchored = TRUE//Can't drag/grab the net.
 	layer = ABOVE_ALL_MOB_LAYER
-	max_integrity = 45 //How much health it has.
+	max_integrity = 50 //How much health it has.
 	can_buckle = 1
 	buckle_lying = 0
 	buckle_prevents_pull = TRUE

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -59,8 +59,39 @@ It is possible to destroy the net by the occupant or someone else.
 				continue
 			H.dropItemToGround(W)
 
-	if(affecting in GLOB.alive_mob_list) //Feel free to suggest a better check if it's alive.
+	if(affecting.stat != DEAD)
 		affecting.revive(1, 1) //Basically a full heal, including limbs/organs.
+
+	var/datum/antagonist/antag_datum
+	for(antag_datum in GLOB.antagonists)
+		if(antag_datum.owner == master)
+			break
+
+	for(var/datum/objective/capture/capture in antag_datum)
+		if(istype(affecting, /mob/living/carbon/human)) //Humans.
+			if(affecting.stat == DEAD)//Dead folks are worth less.
+				capture.captured_amount+=0.5
+				continue
+			capture.captured_amount+=1
+		if(istype(affecting, /mob/living/carbon/monkey)) //Monkeys are almost worthless, you failure.
+			capture.captured_amount+=0.1
+		if(istype(affecting, /mob/living/carbon/alien/larva)) //Larva are important for research.
+			if(affecting.stat == DEAD)
+				capture.captured_amount+=0.5
+				continue
+			capture.captured_amount+=1
+		if(istype(affecting, /mob/living/carbon/alien/humanoid)) //Aliens are worth twice as much as humans.
+			if(istype(affecting, /mob/living/carbon/alien/humanoid/royal/queen)) //Queens are worth three times as much as humans.
+				if(affecting.stat == DEAD)
+					capture.captured_amount+=1.5
+				else
+					capture.captured_amount+=3
+				continue
+			if(affecting.stat == DEAD)
+				capture.captured_amount+=1
+				continue
+			capture.captured_amount+=2
+
 
 	playsound(affecting, 'sound/effects/sparks4.ogg', 50, 1)
 	new /obj/effect/temp_visual/dir_setting/ninja/phase/out(affecting.drop_location(), affecting.dir)

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -14,7 +14,7 @@ It is possible to destroy the net by the occupant or someone else.
 	mouse_opacity = MOUSE_OPACITY_ICON//So you can hit it with stuff.
 	anchored = TRUE//Can't drag/grab the net.
 	layer = ABOVE_ALL_MOB_LAYER
-	max_integrity = 25 //How much health it has.
+	max_integrity = 45 //How much health it has.
 	can_buckle = 1
 	buckle_lying = 0
 	buckle_prevents_pull = TRUE
@@ -63,8 +63,9 @@ It is possible to destroy the net by the occupant or someone else.
 		affecting.revive(1, 1) //Basically a full heal, including limbs/organs.
 
 	var/datum/antagonist/antag_datum
-	for(antag_datum in GLOB.antagonists)
-		if(antag_datum.owner == master)
+	for(var/datum/antagonist/AD in GLOB.antagonists)
+		if(AD.owner == master)
+			antag_datum = AD
 			break
 
 	for(var/datum/objective/capture/capture in antag_datum)
@@ -108,7 +109,8 @@ It is possible to destroy the net by the occupant or someone else.
 	new /obj/effect/temp_visual/dir_setting/ninja/phase(affecting.drop_location(), affecting.dir)
 
 /obj/structure/energy_net/attack_paw(mob/user)
-	return attack_hand()
+	//return attack_hand() //How about no barehanded breaking of the net?
+	return
 
 /obj/structure/energy_net/user_buckle_mob(mob/living/M, mob/living/user)
 	return//We only want our target to be buckled

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
@@ -2,21 +2,34 @@
 //Allows the ninja to kidnap people
 /obj/item/clothing/suit/space/space_ninja/proc/ninjanet()
 	var/mob/living/carbon/human/H = affecting
-	var/mob/living/carbon/C = input("Select who to capture:","Capture who?",null) as null|mob in oview(H)
+	var/mob/living/carbon/C
+
+	//If there's only one valid target, let's actually try to capture it, rather than forcing
+	//the user to fiddle with the dialog displaying a list of one
+	//Also, let's make this smarter and not list mobs you can't currently net.
+	var/Candidates[]
+	for(var/mob/mob in oview(H))
+		if(!mob.client)//Monkeys without a client can still step_to() and bypass the net. Also, netting inactive people is lame.
+			//to_chat(H, "<span class='warning'>[C.p_they(TRUE)] will bring no honor to your Clan!</span>")
+			continue
+		if(locate(/obj/structure/energy_net) in get_turf(mob))//Check if they are already being affected by an energy net.
+			//to_chat(H, "<span class='warning'>[C.p_they(TRUE)] are already trapped inside an energy net!</span>")
+			continue
+		for(var/turf/T in getline(get_turf(H), get_turf(mob)))
+			if(T.density)//Don't want them shooting nets through walls. It's kind of cheesy.
+				//to_chat(H, "<span class='warning'>You may not use an energy net through solid obstacles!</span>")
+				continue
+		Candidates+=mob
+
+	if(Candidates.len == 1)
+		C = Candidates[1]
+	else
+		C = input("Select who to capture:","Capture who?",null) as null|mob in Candidates
+
 
 	if(QDELETED(C)||!(C in oview(H)))
 		return 0
 
-	if(!C.client)//Monkeys without a client can still step_to() and bypass the net. Also, netting inactive people is lame.
-		to_chat(H, "<span class='warning'>[C.p_they(TRUE)] will bring no honor to your Clan!</span>")
-		return
-	if(locate(/obj/structure/energy_net) in get_turf(C))//Check if they are already being affected by an energy net.
-		to_chat(H, "<span class='warning'>[C.p_they(TRUE)] are already trapped inside an energy net!</span>")
-		return
-	for(var/turf/T in getline(get_turf(H), get_turf(C)))
-		if(T.density)//Don't want them shooting nets through walls. It's kind of cheesy.
-			to_chat(H, "<span class='warning'>You may not use an energy net through solid obstacles!</span>")
-			return
 	if(!ninjacost(200,N_STEALTH_CANCEL))
 		H.Beam(C,"n_beam",time=15)
 		H.say("Get over here!", forced = "ninja net")

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -263,13 +263,13 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		visible_message("<span class='danger'>[H] electrocutes [src] with [H.p_their()] touch!</span>", "<span class='userdanger'>[H] electrocutes you with [H.p_their()] touch!</span>")
 		electrocute_act(15, H)
 
-		src.Knockdown(G.stunforce)
-		src.adjustStaminaLoss(G.stunforce*0.1, affected_zone = (istype(H) ? H.zone_selected : BODY_ZONE_CHEST))
-		src.apply_effect(EFFECT_STUTTER, G.stunforce)
+		Knockdown(G.stunforce)
+		adjustStaminaLoss(G.stunforce*0.1, affected_zone = (istype(H) ? H.zone_selected : BODY_ZONE_CHEST))
+		apply_effect(EFFECT_STUTTER, G.stunforce)
 		SEND_SIGNAL(src, COMSIG_LIVING_MINOR_SHOCK)
 
-		src.lastattacker = H.real_name
-		src.lastattackerckey = H.ckey
+		lastattacker = H.real_name
+		lastattackerckey = H.ckey
 		log_combat(H, src, "stunned")
 
 		playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -262,3 +262,18 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		playsound(src, "sparks", 50, 1)
 		visible_message("<span class='danger'>[H] electrocutes [src] with [H.p_their()] touch!</span>", "<span class='userdanger'>[H] electrocutes you with [H.p_their()] touch!</span>")
 		electrocute_act(25, H)
+
+		src.Knockdown(G.stunforce)
+		src.adjustStaminaLoss(G.stunforce*0.1, affected_zone = (istype(H) ? H.zone_selected : BODY_ZONE_CHEST))
+		src.apply_effect(EFFECT_STUTTER, G.stunforce)
+		SEND_SIGNAL(src, COMSIG_LIVING_MINOR_SHOCK)
+
+		src.lastattacker = H.real_name
+		src.lastattackerckey = H.ckey
+		log_combat(H, src, "stunned")
+
+		playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
+
+		if(ishuman(src))
+			var/mob/living/carbon/human/Hsrc = src
+			Hsrc.forcesay(GLOB.hit_appends)

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -261,7 +261,7 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		spark_system.set_up(5, 0, loc)
 		playsound(src, "sparks", 50, 1)
 		visible_message("<span class='danger'>[H] electrocutes [src] with [H.p_their()] touch!</span>", "<span class='userdanger'>[H] electrocutes you with [H.p_their()] touch!</span>")
-		electrocute_act(25, H)
+		electrocute_act(15, H)
 
 		src.Knockdown(G.stunforce)
 		src.adjustStaminaLoss(G.stunforce*0.1, affected_zone = (istype(H) ? H.zone_selected : BODY_ZONE_CHEST))

--- a/config/admins.txt
+++ b/config/admins.txt
@@ -8,4 +8,4 @@
 # NOTE: syntax was changed to allow hyphenation of ranknames, since spaces are stripped.      #
 ###############################################################################################
 
-Useroth = Host
+yourckeygoeshere = Host


### PR DESCRIPTION
Previous PR: #8298
:cl:

tweak: Makes the netting much less clunky. If there's only one target you can net while you press the
button, it will just net that target instead of bringing up a list of mobs.

tweak: Energy nets now revive and fully heal capturees (even dead ones, after calculating points). If someone's got a scan and wants to get cloned, they can always kill themselves still.

tweak: Capture points are added on capture, rather than round-end, so it no longer matters whether your captures kill themselves in the holding facility or not.

balance: Makes the nets a bit more sturdy. (previously it took mere two welder hits to break one)

balance: Makes stungloves actually stun people (currently comparably with stunbatons, adjustable). Because electrocute_act(25, H) did fuck all, stunwise, and on top of that, people in insulated gloves were completely unaffected.

balance: Reduced the stunglove electrocute_act value to 15 due to above. Could possibly be lowered further.

/:cl:

Also... don't mind the commits. It's the same branch from a month ago and it got a bit fucked.