### PR TITLE
Buffed event space vines to be a bit of an actual threat. Twice as likely to mutate and 50% faster spreading

### DIFF
--- a/code/modules/events/spacevine.dm
+++ b/code/modules/events/spacevine.dm
@@ -373,10 +373,10 @@
 /datum/spacevine_controller
 	var/list/obj/structure/spacevine/vines
 	var/list/growth_queue
-	var/spread_multiplier = 5
-	var/spread_cap = 30
+	var/spread_multiplier = 7
+	var/spread_cap = 45
 	var/list/vine_mutations_list
-	var/mutativeness = 1
+	var/mutativeness = 2
 
 /datum/spacevine_controller/New(turf/location, list/muts, potency, production)
 	vines = list()


### PR DESCRIPTION


## About The Pull Request

Increased mutativeness, spread cap, and spread multiplier

## Why It's Good For The Game
Random event spacevines are barely even a nuisance at the moment. This means that if they aren't dealt with promptly they can mutate into being a bit of an actual threat

## Changelog
:cl:RobinFox
balance: Buffed Spacevines
/:cl: