### PR TITLE
Fixes the sacrificial target icon not displaying on the cult objective alert.

### DIFF
--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -361,6 +361,7 @@
 	reshape.Shift(EAST, 1)
 	reshape.Crop(7,4,26,31)
 	reshape.Crop(-5,-3,26,30)
+	return reshape
 
 /mob/living/carbon/human/get_sac_image()
 	var/datum/job/sacjob = SSjob.GetJob(mind.assigned_role)
@@ -370,6 +371,7 @@
 	reshape.Shift(EAST, 1)
 	reshape.Crop(7,4,26,31)
 	reshape.Crop(-5,-3,26,30)
+	return reshape
 
 /datum/objective/sacrifice
 	var/sacced = FALSE


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. I forgot to make the proc return the newly reshaped icon, and thus end up with the objective alert unly displaying the bg.

## Why It's Good For The Game
Fixing a mistake with #8408.

## Changelog
:cl:
fix: The sacrificial target icon will now display onto the cult objective ui alert once again.
/:cl: