### PR TITLE
Increases the default space ruin z-level count to 2

### DIFF
--- a/code/datums/map_config.dm
+++ b/code/datums/map_config.dm
@@ -18,7 +18,7 @@
 	var/map_file = "BoxStation.dmm"
 
 	var/traits = null
-	var/space_ruin_levels = 1 //Citadel edit - reduces the default space ruin z-level count to 1
+	var/space_ruin_levels = 2
 	var/space_empty_levels = 1
 
 	var/minetype = "lavaland"


### PR DESCRIPTION
## About The Pull Request
Roughly one year ago, Deathride decided to to dunk the number of space ruin z-levels down to 1 (from 7) for extra memory he also wanted to use for some [secret side project] and/or planetstation mining.
One year has almost passed and that sentence seemengly proved to be ideaguying, so I'm here raising the count to 2 because I fairly doubt these projects will ever be done.

Surely some people will complain about possible OOM issues, but it'd still be preferrable to run a TM first instead of arguing on untested consequences of this PR like schmucks.

On a sidenote: CWC going OOM every so frequently often could be an issue with the game mode, but I don't hold the data to be 100% certain.

## Why It's Good For The Game
One single z-level is very mediocre: People flying out the airlock will find themselves on the other side of the station more than half the times; The lone space level can be run through in a dozen and half minutes without great rush; Getting lost in space is a myth; And alas, the map gen's RNG reminds me of abandoned crates'.
Plus I heard BlackMajor wants to dilute it with more "unique" ruins.

## Changelog
:cl:
tweak: The default amount of z-levels reserved specifically for space ruin generation has been increased from 1 to 2
/:cl: