### PR TITLE
Moving some tablecrafting recipes to the appropriate categories

### DIFF
--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -102,7 +102,7 @@
 #define CAT_SANDWICH	"Sandwiches"
 #define CAT_SOUP	"Soups"
 #define CAT_SPAGHETTI	"Spaghettis"
-#define CAT_SUSHI	"Fish"
+#define CAT_FISH	"Fish"
 #define CAT_ICE	"Frozen"
 
 #define RCD_FLOORWALL 1

--- a/code/modules/crafting/craft.dm
+++ b/code/modules/crafting/craft.dm
@@ -21,7 +21,7 @@
 							CAT_BURGER,
 							CAT_CAKE,
 							CAT_EGG,
-							CAT_SUSHI, //Called Fish
+							CAT_FISH,
 							CAT_ICE,   //Called Frozen
 							CAT_MEAT,
 							CAT_MISCFOOD,

--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -365,28 +365,6 @@
 	parts = list(/obj/item/camera = 1)
 	category = CAT_MISC
 
-/datum/crafting_recipe/lizardhat
-	name = "Lizard Cloche Hat"
-	result = /obj/item/clothing/head/lizard
-	time = 10
-	reqs = list(/obj/item/organ/tail/lizard = 1)
-	category = CAT_MISC
-
-/datum/crafting_recipe/lizardhat_alternate
-	name = "Lizard Cloche Hat"
-	result = /obj/item/clothing/head/lizard
-	time = 10
-	reqs = list(/obj/item/stack/sheet/animalhide/lizard = 1)
-	category = CAT_MISC
-
-/datum/crafting_recipe/kittyears
-	name = "Kitty Ears"
-	result = /obj/item/clothing/head/kitty/genuine
-	time = 10
-	reqs = list(/obj/item/organ/tail/cat = 1,
-				/obj/item/organ/ears/cat = 1)
-	category = CAT_MISC
-
 /datum/crafting_recipe/skateboard
 	name = "Skateboard"
 	result = /obj/vehicle/ridden/scooter/skateboard
@@ -671,6 +649,28 @@
 		        /obj/item/stack/cable_coil = 10)
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
 	category = CAT_MISC
+
+/datum/crafting_recipe/lizardhat
+	name = "Lizard Cloche Hat"
+	result = /obj/item/clothing/head/lizard
+	time = 10
+	reqs = list(/obj/item/organ/tail/lizard = 1)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/lizardhat_alternate
+	name = "Lizard Cloche Hat"
+	result = /obj/item/clothing/head/lizard
+	time = 10
+	reqs = list(/obj/item/stack/sheet/animalhide/lizard = 1)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/kittyears
+	name = "Kitty Ears"
+	result = /obj/item/clothing/head/kitty/genuine
+	time = 10
+	reqs = list(/obj/item/organ/tail/cat = 1,
+				/obj/item/organ/ears/cat = 1)
+	category = CAT_CLOTHING
 
 /datum/crafting_recipe/hudsunsec
 	name = "Security HUDsunglasses"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_meat.dm
@@ -38,37 +38,6 @@
 
 // see code/module/crafting/table.dm
 
-////////////////////////////////////////////////FISH////////////////////////////////////////////////
-
-/datum/crafting_recipe/food/cubancarp
-	name = "Cuban carp"
-	reqs = list(
-		/datum/reagent/consumable/flour = 5,
-		/obj/item/reagent_containers/food/snacks/grown/chili = 1,
-		/obj/item/reagent_containers/food/snacks/carpmeat = 1
-	)
-	result = /obj/item/reagent_containers/food/snacks/cubancarp
-	subcategory = CAT_MEAT
-
-/datum/crafting_recipe/food/fishandchips
-	name = "Fish and chips"
-	reqs = list(
-		/obj/item/reagent_containers/food/snacks/fries = 1,
-		/obj/item/reagent_containers/food/snacks/carpmeat = 1
-	)
-	result = /obj/item/reagent_containers/food/snacks/fishandchips
-	subcategory = CAT_MEAT
-
-/datum/crafting_recipe/food/fishfingers
-	name = "Fish fingers"
-	reqs = list(
-		/datum/reagent/consumable/flour = 5,
-		/obj/item/reagent_containers/food/snacks/bun = 1,
-		/obj/item/reagent_containers/food/snacks/carpmeat = 1
-	)
-	result = /obj/item/reagent_containers/food/snacks/fishfingers
-	subcategory = CAT_MEAT
-
 ////////////////////////////////////////////////MR SPIDER////////////////////////////////////////////////
 
 /datum/crafting_recipe/food/spidereggsham

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_pastry.dm
@@ -22,7 +22,7 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/donut
 	subcategory = CAT_PASTRY
-	
+
 /datum/crafting_recipe/food/donut
 	time = 15
 	name = "Semen donut"
@@ -204,16 +204,6 @@ datum/crafting_recipe/food/donut/meat
 	subcategory = CAT_PASTRY
 
 ////////////////////////////////////////////OTHER////////////////////////////////////////////
-
-/datum/crafting_recipe/food/hotdog
-	name = "Hot dog"
-	reqs = list(
-		/datum/reagent/consumable/ketchup = 5,
-		/obj/item/reagent_containers/food/snacks/bun = 1,
-		/obj/item/reagent_containers/food/snacks/sausage = 1
-	)
-	result = /obj/item/reagent_containers/food/snacks/hotdog
-	subcategory = CAT_PASTRY
 
 /datum/crafting_recipe/food/meatbun
 	name = "Meat bun"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
@@ -62,3 +62,13 @@
 	)
 	result = /obj/item/reagent_containers/food/snacks/tuna_sandwich
 	subcategory = CAT_SANDWICH
+
+/datum/crafting_recipe/food/hotdog
+	name = "Hot dog"
+	reqs = list(
+		/datum/reagent/consumable/ketchup = 5,
+		/obj/item/reagent_containers/food/snacks/bun = 1,
+		/obj/item/reagent_containers/food/snacks/sausage = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/hotdog
+	subcategory = CAT_SANDWICH

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_sandwich.dm
@@ -52,7 +52,7 @@
 	result = /obj/item/reagent_containers/food/snacks/notasandwich
 	subcategory = CAT_SANDWICH
 
-/datum/crafting_recipe/food/notasandwich
+/datum/crafting_recipe/food/tunasandwich
 	name = "Tuna sandwich"
 	reqs = list(
 		/obj/item/reagent_containers/food/snacks/breadslice/plain = 2,

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_sushi.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_sushi.dm
@@ -7,7 +7,7 @@
 		/datum/reagent/consumable/rice = 10
 	)
 	result = /obj/item/reagent_containers/food/snacks/sushi_rice
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/sea_weed
 	name = "Sea Weed Sheet"
@@ -17,7 +17,7 @@
 		/obj/item/reagent_containers/food/snacks/grown/kudzupod = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/sea_weed
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/tuna_can
 	name = "Can of Tuna"
@@ -27,7 +27,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1,
 	)
 	result = /obj/item/reagent_containers/food/snacks/tuna
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 //////////////////////////Sushi/////////////////////////////////
 
@@ -39,7 +39,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sashimi
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/riceball
 	name = "Onigiri"
@@ -49,7 +49,7 @@
 		/obj/item/reagent_containers/food/snacks/sushi_rice = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/riceball
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/sushie_egg
 	name = "Tobiko"
@@ -59,7 +59,7 @@
 		/obj/item/reagent_containers/food/snacks/sea_weed = 2,
 	)
 	result = /obj/item/reagent_containers/food/snacks/tobiko
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/sushie_basic
 	name = "Funa Hosomaki"
@@ -70,7 +70,7 @@
 		/obj/item/reagent_containers/food/snacks/sea_weed = 3,
 	)
 	result = /obj/item/reagent_containers/food/snacks/sushie_basic
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/sushie_adv
 	name = "Funa Nigiri"
@@ -80,7 +80,7 @@
 		/obj/item/reagent_containers/food/snacks/carpmeat = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sushie_adv
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
 
 /datum/crafting_recipe/food/sushie_pro
 	name = "Well made Funa Nigiri"
@@ -91,4 +91,35 @@
 		/obj/item/reagent_containers/food/snacks/sea_weed = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/sushie_pro
-	subcategory = CAT_SUSHI
+	subcategory = CAT_FISH
+
+///////////////Gaijin junk/////////////////////////////////////
+
+/datum/crafting_recipe/food/fishfingers
+	name = "Fish fingers"
+	reqs = list(
+		/datum/reagent/consumable/flour = 5,
+		/obj/item/reagent_containers/food/snacks/bun = 1,
+		/obj/item/reagent_containers/food/snacks/carpmeat = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/fishfingers
+	subcategory = CAT_FISH
+
+/datum/crafting_recipe/food/cubancarp
+	name = "Cuban carp"
+	reqs = list(
+		/datum/reagent/consumable/flour = 5,
+		/obj/item/reagent_containers/food/snacks/grown/chili = 1,
+		/obj/item/reagent_containers/food/snacks/carpmeat = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/cubancarp
+	subcategory = CAT_FISH
+
+/datum/crafting_recipe/food/fishandchips
+	name = "Fish and chips"
+	reqs = list(
+		/obj/item/reagent_containers/food/snacks/fries = 1,
+		/obj/item/reagent_containers/food/snacks/carpmeat = 1
+	)
+	result = /obj/item/reagent_containers/food/snacks/fishandchips
+	subcategory = CAT_FISH


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. Hot dogs are not pastries, unlike pigs in a blanket.

## Why It's Good For The Game
Better indexing.

## Changelog
:cl:
tweak: Moving some tablecrafting recipes to the appropriate categories: Kitty ears and lizard cloche hats to "clothing"; Hot dogs to "Sandwichs"; Cuban carb, fish and chips and fish fingers to "Fish".
fix: Fixes the not-a-sandwich recipe being M.I.A.
/:cl:
