### PR TITLE
Buffs out certain stun spells.

### DIFF
--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -146,11 +146,15 @@
 	clothes_req = 0
 	invocation = "none"
 	invocation_type = "none"
+	proj_type = /obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile/lesser
 	proj_lifespan = 10
 	max_targets = 6
 	action_icon_state = "magicm"
 	action_background_icon_state = "bg_demon"
 
+/obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile/lesser
+	amt_hardstun = 5
+	amt_knockdown = 80
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
 	name = "Paralysing Smoke"
@@ -304,7 +308,8 @@
 	name = "Gauntlet Echo"
 	alpha = 180
 	amt_dam_brute = 30
-	amt_knockdown = 50
+	amt_knockdown = 80
+	amt_dam_stam = 30
 	sound = 'sound/weapons/punch3.ogg'
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/juggernaut/cast(list/targets,mob/user = usr)

--- a/code/modules/spells/spell_types/construct_spells.dm
+++ b/code/modules/spells/spell_types/construct_spells.dm
@@ -153,8 +153,7 @@
 	action_background_icon_state = "bg_demon"
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile/lesser
-	amt_hardstun = 5
-	amt_knockdown = 80
+	amt_knockdown = 84
 
 /obj/effect/proc_holder/spell/targeted/smoke/disable
 	name = "Paralysing Smoke"
@@ -308,7 +307,7 @@
 	name = "Gauntlet Echo"
 	alpha = 180
 	amt_dam_brute = 30
-	amt_knockdown = 80
+	amt_knockdown = 84
 	amt_dam_stam = 30
 	sound = 'sound/weapons/punch3.ogg'
 

--- a/code/modules/spells/spell_types/inflict_handler.dm
+++ b/code/modules/spells/spell_types/inflict_handler.dm
@@ -3,10 +3,12 @@
 	desc = "This spell blinds and/or destroys/damages/heals and/or knockdowns/stuns the target."
 
 	var/amt_knockdown = 0
+	var/amt_hardstun
 	var/amt_unconscious = 0
 	var/amt_stun = 0
 
 	//set to negatives for healing
+	var/amt_dam_stam
 	var/amt_dam_fire = 0
 	var/amt_dam_brute = 0
 	var/amt_dam_oxy = 0
@@ -41,7 +43,10 @@
 		target.adjustToxLoss(amt_dam_tox)
 		target.adjustOxyLoss(amt_dam_oxy)
 		//disabling
-		target.Knockdown(amt_knockdown)
+		if(!amt_knockdown && amt_dam_stam)
+			target.adjustStaminaLoss(amt_dam_stam)
+		else
+			target.Knockdown(amt_knockdown, override_hardstun = amt_hardstun, amt_dam_stam)
 		target.Unconscious(amt_unconscious)
 		target.Stun(amt_stun)
 

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -29,7 +29,7 @@
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile
 	amt_knockdown = 120
-	amt_hardstun = 10
+	amt_hardstun = 5
 	sound = 'sound/magic/mm_hit.ogg'
 
 /obj/effect/proc_holder/spell/targeted/genetic/mutate
@@ -287,7 +287,7 @@
 		if(distfromcaster == 0)
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Knockdown(100, override_hardstun = 25)
+				M.Knockdown(100, override_hardstun = 20)
 				M.adjustBruteLoss(5)
 				to_chat(M, "<span class='userdanger'>You're slammed into the floor by [user]!</span>")
 		else

--- a/code/modules/spells/spell_types/wizard.dm
+++ b/code/modules/spells/spell_types/wizard.dm
@@ -28,7 +28,8 @@
 	sound = 'sound/magic/magic_missile.ogg'
 
 /obj/effect/proc_holder/spell/targeted/inflict_handler/magic_missile
-	amt_knockdown = 60
+	amt_knockdown = 120
+	amt_hardstun = 10
 	sound = 'sound/magic/mm_hit.ogg'
 
 /obj/effect/proc_holder/spell/targeted/genetic/mutate
@@ -262,7 +263,7 @@
 
 	action_icon_state = "repulse"
 
-/obj/effect/proc_holder/spell/aoe_turf/repulse/cast(list/targets,mob/user = usr, var/stun_amt = 40)
+/obj/effect/proc_holder/spell/aoe_turf/repulse/cast(list/targets,mob/user = usr, stun_amt = 50)
 	var/list/thrownatoms = list()
 	var/atom/throwtarget
 	var/distfromcaster
@@ -286,14 +287,14 @@
 		if(distfromcaster == 0)
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Knockdown(100)
+				M.Knockdown(100, override_hardstun = 25)
 				M.adjustBruteLoss(5)
 				to_chat(M, "<span class='userdanger'>You're slammed into the floor by [user]!</span>")
 		else
 			new sparkle_path(get_turf(AM), get_dir(user, AM)) //created sparkles will disappear on their own
 			if(isliving(AM))
 				var/mob/living/M = AM
-				M.Knockdown(stun_amt)
+				M.Knockdown(stun_amt, override_hardstun = stun_amt * 0.2)
 				to_chat(M, "<span class='userdanger'>You're thrown back by [user]!</span>")
 			AM.throw_at(throwtarget, ((CLAMP((maxthrow - (CLAMP(distfromcaster - 2, 0, distfromcaster))), 3, maxthrow))), 1,user)//So stuff gets tossed around at the same time.
 

--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -5,7 +5,7 @@
 			buckl.unbuckle_mob(new_owner)
 		new_owner.resting = TRUE
 		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
-		if(isnull(override_duration) && (set_duration >= 80))
+		if(isnull(override_duration) && (set_duration > 80))
 			set_duration = set_duration*0.01
 			return ..()
 		else if(!isnull(override_duration))

--- a/modular_citadel/code/datums/status_effects/debuffs.dm
+++ b/modular_citadel/code/datums/status_effects/debuffs.dm
@@ -5,7 +5,7 @@
 			buckl.unbuckle_mob(new_owner)
 		new_owner.resting = TRUE
 		new_owner.adjustStaminaLoss(isnull(override_stam)? set_duration*0.25 : override_stam)
-		if(isnull(override_duration) && (set_duration > 80))
+		if(isnull(override_duration) && (set_duration >= 80))
 			set_duration = set_duration*0.01
 			return ..()
 		else if(!isnull(override_duration))


### PR DESCRIPTION
## About The Pull Request
Buffing Magic Missile (the artificier's to a lesser extend), Repulse and the juggernaut's Gauntlet Echo.

Also changed a check for the required knockdown value to apply the "hardstun" (ergo the weapon unwielding) from `> 80` to `>= 80`.

## Why It's Good For The Game
Yet another bunch of stam combat rework cripples.
Unlike stunbatons and tasers, these spells have a cooldown way longer than 8 deciseconds, so I hope you don't hop to the mediocre conclusion this is an aching powercreep PR because these don't stamcrit people for most.

## Changelog
:cl:
balance: Buffed wizard and artificier's Magic Missile, wizard and xeno queen's Repulse and juggernaut's Gauntlet Echo.
/:cl:
