### PR TITLE
Brings back Big Wolf ears for humans

### DIFF
--- a/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -201,6 +201,8 @@
 	name = "Big Wolf (ALT)"
 	icon_state = "bigwolfinner"
 	hasinner = 1
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
+	color_src = MATRIXED
 
 /datum/sprite_accessory/ears/human/bigwolfdark
 	name = "Dark Big Wolf"

--- a/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -194,6 +194,8 @@
 /datum/sprite_accessory/ears/human/bigwolf
 	name = "Big Wolf"
 	icon_state = "bigwolf"
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
+	color_src = MATRIXED
 
 /datum/sprite_accessory/ears/human/bigwolfinner
 	name = "Big Wolf (ALT)"

--- a/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -191,6 +191,24 @@
 	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
 	color_src = MATRIXED
 
+/datum/sprite_accessory/ears/human/bigwolf
+	name = "Big Wolf"
+	icon_state = "bigwolf"
+
+/datum/sprite_accessory/ears/human/bigwolfinner
+	name = "Big Wolf (ALT)"
+	icon_state = "bigwolfinner"
+	hasinner = 1
+
+/datum/sprite_accessory/ears/human/bigwolfdark
+	name = "Dark Big Wolf"
+	icon_state = "bigwolfdark"
+
+/datum/sprite_accessory/ears/human/bigwolfinnerdark
+	name = "Dark Big Wolf (ALT)"
+	icon_state = "bigwolfinnerdark"
+	hasinner = 1
+
 /datum/sprite_accessory/ears/human/cow
 	name = "Cow"
 	icon_state = "cow"

--- a/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -214,6 +214,8 @@
 	name = "Dark Big Wolf (ALT)"
 	icon_state = "bigwolfinnerdark"
 	hasinner = 1
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
+	color_src = MATRIXED
 
 /datum/sprite_accessory/ears/human/cow
 	name = "Cow"

--- a/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
+++ b/modular_citadel/code/modules/mob/dead/new_player/sprite_accessories.dm
@@ -207,6 +207,8 @@
 /datum/sprite_accessory/ears/human/bigwolfdark
 	name = "Dark Big Wolf"
 	icon_state = "bigwolfdark"
+	icon = 'modular_citadel/icons/mob/mam_ears.dmi'
+	color_src = MATRIXED
 
 /datum/sprite_accessory/ears/human/bigwolfinnerdark
 	name = "Dark Big Wolf (ALT)"


### PR DESCRIPTION
This use to be here, and I'm no furry, but it needed to come back.


## Changelog

/datum/sprite_accessory/ears/human/bigwolf
	name = "Big Wolf"
	icon_state = "bigwolf"

/datum/sprite_accessory/ears/human/bigwolfinner
	name = "Big Wolf (ALT)"
	icon_state = "bigwolfinner"
	hasinner = 1

/datum/sprite_accessory/ears/human/bigwolfdark
	name = "Dark Big Wolf"
	icon_state = "bigwolfdark"

/datum/sprite_accessory/ears/human/bigwolfinnerdark
	name = "Dark Big Wolf (ALT)"
	icon_state = "bigwolfinnerdark"
	hasinner = 1

