### PR TITLE
Ports "Disembowelment now only works if you are dead/in critical"

### DIFF
--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -546,6 +546,11 @@
 	max_stamina_damage = 200
 	var/obj/item/cavity_item
 
+/obj/item/bodypart/chest/can_dismember(obj/item/I)
+	if(!((owner.stat == DEAD) || owner.InFullCritical()))
+		return FALSE
+	return ..()
+
 /obj/item/bodypart/chest/Destroy()
 	if(cavity_item)
 		qdel(cavity_item)


### PR DESCRIPTION
## About The Pull Request
Porting in tgstation pr #42815. Disembowelment is essentially a game over for most, and making it an indiscriminate dice roll is a salt factory for some. While the mean RNG doesn't overly upset me, it can lead to oneshottin in the current state.

## Why It's Good For The Game
Making the slashy slashy combat less unfair, unless you have some short term plans to make it more engaging.

## Changelog
:cl: Ghommie (original PR by wesoda25)
balance: disembowelment no longer works on mobs that aren't dead or in critical condition
/:cl: