### PR TITLE
Dab emote now checks restraint flags.

### DIFF
--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -183,6 +183,7 @@
 	key_third_person = "suddenly hits a dab"
 	message = "suddenly hits a dab!"
 	emote_type = EMOTE_AUDIBLE
+	restraint_check = TRUE
 
 
 

--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -183,7 +183,6 @@
 	key_third_person = "suddenly hits a dab"
 	message = "suddenly hits a dab!"
 	emote_type = EMOTE_AUDIBLE
-	restraint_check = TRUE
 
 
 


### PR DESCRIPTION
Added a check to the dab emote so you can no longer use it while buckled or cuffed. 
Now nobody else will need to be banned for dabbing to death in custody. 


![](http://puu.sh/DHbFn/e1cb618221.png)