### PR TITLE
Makes upgraded prostics worth getting - Re-balances robotic lims

### DIFF
--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -20,8 +20,8 @@
 	icon_state = "borg_l_arm"
 	status = BODYPART_ROBOTIC
 	
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_reduction = 2
+	burn_reduction = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -41,8 +41,8 @@
 	icon_state = "borg_r_arm"
 	status = BODYPART_ROBOTIC
 	
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_reduction = 2
+	burn_reduction = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -62,8 +62,8 @@
 	icon_state = "borg_l_leg"
 	status = BODYPART_ROBOTIC
 	
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_reduction = 2
+	burn_reduction = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -83,8 +83,8 @@
 	icon_state = "borg_r_leg"
 	status = BODYPART_ROBOTIC
 	
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_reduction = 2
+	burn_reduction = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -103,8 +103,8 @@
 	icon_state = "borg_chest"
 	status = BODYPART_ROBOTIC
 	
-	brute_reduction = 5
-	burn_reduction = 4
+	brute_reduction = 2
+	burn_reduction = 1
 
 	light_brute_msg = ROBOTIC_LIGHT_BRUTE_MSG
 	medium_brute_msg = ROBOTIC_MEDIUM_BRUTE_MSG
@@ -273,32 +273,32 @@
 	name = "reinforced surplus prosthetic left arm"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 6
-	burn_reduction = 5
+	brute_reduction = 3
+	burn_reduction = 2
 	max_damage = 55
 
 /obj/item/bodypart/r_arm/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right arm"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 6
-	burn_reduction = 5
+	brute_reduction = 3
+	burn_reduction = 2
 	max_damage = 55
 
 /obj/item/bodypart/l_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic left leg"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 6
-	burn_reduction = 5
+	brute_reduction = 3
+	burn_reduction = 2
 	max_damage = 55
 
 /obj/item/bodypart/r_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right leg"
 	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 6
-	burn_reduction = 5
+	brute_reduction = 3
+	burn_reduction = 2
 	max_damage = 55
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG

--- a/code/modules/surgery/bodyparts/robot_bodyparts.dm
+++ b/code/modules/surgery/bodyparts/robot_bodyparts.dm
@@ -268,38 +268,38 @@
 	burn_reduction = 0
 	max_damage = 20
 
-// Upgraded Surplus lims
+// Upgraded Surplus lims - Better then robotic lims
 /obj/item/bodypart/l_arm/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic left arm"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection."
+	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 1
-	burn_reduction = 1
-	max_damage = 30
+	brute_reduction = 6
+	burn_reduction = 5
+	max_damage = 55
 
 /obj/item/bodypart/r_arm/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right arm"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection."
+	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 1
-	burn_reduction = 1
-	max_damage = 30
+	brute_reduction = 6
+	burn_reduction = 5
+	max_damage = 55
 
 /obj/item/bodypart/l_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic left leg"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection."
+	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 1
-	burn_reduction = 1
-	max_damage = 30
+	brute_reduction = 6
+	burn_reduction = 5
+	max_damage = 55
 
 /obj/item/bodypart/r_leg/robot/surplus_upgraded
 	name = "reinforced surplus prosthetic right leg"
-	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection."
+	desc = "A skeletal, robotic limb. This one is reinforced to provide better protection, and is made of stronger parts."
 	icon = 'icons/mob/augmentation/surplus_augments.dmi'
-	brute_reduction = 1
-	burn_reduction = 1
-	max_damage = 30
+	brute_reduction = 6
+	burn_reduction = 5
+	max_damage = 55
 
 #undef ROBOTIC_LIGHT_BRUTE_MSG
 #undef ROBOTIC_MEDIUM_BRUTE_MSG


### PR DESCRIPTION
## About The Pull Request

Makes the costly upgraded prostics that are not round start, worth getting and upgrading rather then just going to robotics to get a legitmently better lim

## Why It's Good For The Game

Makes upgraded prostics not worthless point/mat sinks for no reason

## Changelog
:cl:
balance: As all things are not
/:cl:

Nerfs Robotic lims to not be 5 harm 4 burn but 2 harm 1 burn
Makes upgraded lims 3 harm 2 burn