### PR TITLE
Removes Kaira's dark sabre from arcades 

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -32,7 +32,6 @@
 		/obj/item/toy/spinningtoy = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/sword = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/sword/cx = ARCADE_WEIGHT_TRICK,
-		/obj/item/toy/sword/darksabre = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/talking/AI = ARCADE_WEIGHT_USELESS,
 		/obj/item/toy/talking/codex_gigas = ARCADE_WEIGHT_USELESS,
 		/obj/item/toy/talking/griffin = ARCADE_WEIGHT_USELESS,


### PR DESCRIPTION
## About The Pull Request

No longer will Kaira's sabre will be found inside the arcades

## Why It's Good For The Game

bug-fixing - #8662

## Changelog
:cl:
fix: Arcades stealing from noodles
/:cl: