### PR TITLE
buffs speedy step quirk by a half

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1300,7 +1300,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		. += H.physiology.speed_mod
 
 	if (H.m_intent == MOVE_INTENT_WALK && HAS_TRAIT(H, TRAIT_SPEEDY_STEP))
-		. -= 1
+		. -= 1.5
 
 	if(HAS_TRAIT(H, TRAIT_IGNORESLOWDOWN))
 		ignoreslow = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes speedy quirk that costs 2 points more worth getting.

## Why It's Good For The Game

A quirk that costs 2 and only works well walking isnt as good as it should be.

Buying it and using it still is rather slow, as heck, well jogging and running still do many laps over you, upping the vaule of this quirk to be worth 2 is better then lowering it to 1. 1.5 on walking should be levels of jogging well on walking intent, dosnt help you running form sec when they are after you, as it only works well walking.

## Changelog
:cl:
tweak: speedy quirk
/:cl: