### PR TITLE
Fixes Plush Doll Loot [FOR REAL THIS TIME]

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1,7 +1,7 @@
 #define ARCADE_WEIGHT_TRICK 4
 #define ARCADE_WEIGHT_USELESS 2
 #define ARCADE_WEIGHT_RARE 1
-#define ARCADE_WEIGHT_PLUSH 3
+#define ARCADE_WEIGHT_PLUSH 45
 
 
 /obj/machinery/computer/arcade

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1,7 +1,7 @@
 #define ARCADE_WEIGHT_TRICK 4
 #define ARCADE_WEIGHT_USELESS 2
 #define ARCADE_WEIGHT_RARE 1
-#define ARCADE_WEIGHT_PLUSH 45
+#define ARCADE_WEIGHT_PLUSH 65
 
 
 /obj/machinery/computer/arcade


### PR DESCRIPTION
I was an idiot and made plushies a 3/157 because I thought odds depended on defined weights instead of the weights being added together.

Plushies are now 65/219 which is ~29.6% chance of receiving one.