### PR TITLE
Makes Extended slightly more eventful (6.5 minutes of average scheduled delay to 5.5)

### DIFF
--- a/code/controllers/subsystem/events.dm
+++ b/code/controllers/subsystem/events.dm
@@ -8,8 +8,8 @@ SUBSYSTEM_DEF(events)
 	var/list/currentrun = list()
 
 	var/scheduled = 0			//The next world.time that a naturally occuring random event can be selected.
-	var/frequency_lower = 1800	//3 minutes lower bound.
-	var/frequency_upper = 6000	//10 minutes upper bound. Basically an event will happen every 3 to 10 minutes.
+	var/frequency_lower = 3 MINUTES
+	var/frequency_upper = 10 MINUTES //Basically an event will happen every 3 to 10 minutes.
 
 	var/list/holidays			//List of all holidays occuring today or null if no holidays
 	var/wizardmode = 0
@@ -20,7 +20,6 @@ SUBSYSTEM_DEF(events)
 		if(!E.typepath)
 			continue				//don't want this one! leave it for the garbage collector
 		control += E				//add it to the list of all events (controls)
-	reschedule()
 	getHoliday()
 	return ..()
 

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -259,6 +259,12 @@ SUBSYSTEM_DEF(ticker)
 	else
 		message_admins("<span class='notice'>DEBUG: Bypassing prestart checks...</span>")
 
+	if(mode.event_frequency_lower_override)
+		SSevents.frequency_lower = mode.event_frequency_lower_override
+	if(mode.event_frequency_upper_override)
+		SSevents.frequency_upper = mode.event_frequency_lower_override
+	SSevents.reschedule()
+
 	CHECK_TICK
 	/*if(hide_mode) CIT CHANGE - comments this section out to obfuscate gamemodes. Quit self-antagging during extended just because "hurrrrr no antaggs!!!!!! i giv sec thing 2 do!!!!!!!!!" it's bullshit and everyone hates it
 		var/list/modes = new

--- a/code/game/gamemodes/extended/extended.dm
+++ b/code/game/gamemodes/extended/extended.dm
@@ -4,6 +4,9 @@
 	false_report_weight = 5
 	required_players = 0
 
+	event_frequency_lower_override = 2.5 MINUTES
+	event_frequency_upper_override = 8.5 MINUTES
+
 	announce_span = "notice"
 	announce_text = "Just have fun and enjoy the game!"
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -42,6 +42,9 @@
 	var/const/waittime_l = 600
 	var/const/waittime_h = 1800 // started at 1800
 
+	var/event_frequency_lower_override
+	var/event_frequency_upper_override
+
 	var/list/datum/station_goal/station_goals = list()
 
 	var/allow_persistence_save = TRUE


### PR DESCRIPTION
## About The Pull Request
Turns out Extended is just as (un)eventful as the other game modes, if not more, and can get tiring after just a hour or so of gameplay, depending on your mood.

While adding some specific extended events would be a neater solution, I doubt anyone will be working on them anytime soon, and even if that happen, my belief is that it might end up diluting the event pool with recycled contents.

## Why It's Good For The Game
Making extended slighty less braindead. If you actually want to make actual events for the gamemode, I may help.

## Changelog
:cl:
tweak: The events subsystem will start scheduling events as the ticker starts up the game, rather than on Init.
tweak: Extended is made a little move eventful, its the average scheduled delay for random events lowered by one minute. (from 6.5 to 5.5)
/:cl: