### PR TITLE
Ports the ability to sell fusion gases & generate research points with fusion. Also adds atmos hardsuits purchasable through cargo.

### DIFF
--- a/code/__DEFINES/reactions.dm
+++ b/code/__DEFINES/reactions.dm
@@ -23,6 +23,11 @@
 #define STIMULUM_ABSOLUTE_DROP				0.00000335
 #define REACTION_OPPRESSION_THRESHOLD		5
 #define NOBLIUM_FORMATION_ENERGY			2e9 	//1 Mole of Noblium takes the planck energy to condense.
+//Research point amounts
+#define NOBLIUM_RESEARCH_AMOUNT				1000
+#define BZ_RESEARCH_AMOUNT					150
+#define MIASMA_RESEARCH_AMOUNT				160
+#define STIMULUM_RESEARCH_AMOUNT			50
 //Plasma fusion properties
 #define FUSION_ENERGY_THRESHOLD				3e9 	//Amount of energy it takes to start a fusion reaction
 #define FUSION_TEMPERATURE_THRESHOLD		1000 	//Temperature required to start a fusion reaction

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -141,11 +141,11 @@
 	var/gases = C.air_contents.gases
 
 	worth += gases[/datum/gas/bz]*4	
-	worth += gases[/datum/gas/stimulum]*100
+	worth += gases[/datum/gas/stimulum]*25
 	worth += gases[/datum/gas/hypernoblium]*1000
-	worth += gases[/datum/gas/miasma]*10
-	worth += gases[/datum/gas/tritium]*5
-	worth += gases[/datum/gas/pluoxium]*5
+	worth += gases[/datum/gas/miasma]*15
+	worth += gases[/datum/gas/tritium]*7
+	worth += gases[/datum/gas/pluoxium]*6
 	return worth
 
 /datum/export/large/odysseus

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -146,6 +146,7 @@
 	worth += gases[/datum/gas/miasma]*15
 	worth += gases[/datum/gas/tritium]*7
 	worth += gases[/datum/gas/pluoxium]*6
+	worth += gases[/datum/gas/nitryl]*30
 	return worth
 
 /datum/export/large/odysseus

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -131,6 +131,23 @@
 	unit_name = "security barrier"
 	export_types = list(/obj/item/grenade/barrier, /obj/structure/barricade/security)
 
+/datum/export/large/gas_canister
+	cost = 10 //Base cost of canister. You get more for nice gases inside.
+	unit_name = "Gas Canister"
+	export_types = list(/obj/machinery/portable_atmospherics/canister)
+/datum/export/large/gas_canister/get_cost(obj/O)
+	var/obj/machinery/portable_atmospherics/canister/C = O
+	var/worth = 10
+	var/gases = C.air_contents.gases
+
+	worth += gases[/datum/gas/bz]*4	
+	worth += gases[/datum/gas/stimulum]*100
+	worth += gases[/datum/gas/hypernoblium]*1000
+	worth += gases[/datum/gas/miasma]*10
+	worth += gases[/datum/gas/tritium]*5
+	worth += gases[/datum/gas/pluoxium]*5
+	return worth
+
 /datum/export/large/odysseus
 	cost = 5500
 	unit_name = "working odysseus"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1146,7 +1146,7 @@
 /datum/supply_pack/materials/bz
 	name = "BZ Canister Crate"
 	desc = "Contains a canister of BZ. Requires Toxins access to open."
-	cost = 5000
+	cost = 7500 // Costs 3 credits more than what you can get for selling it. 
 	access = ACCESS_TOX_STORAGE
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "BZ canister crate"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -755,12 +755,21 @@
 
 /datum/supply_pack/engineering/engihardsuit
 	name = "Engineering Hardsuit"
-	desc = "Poly 'Who stole all the hardsuits!' Well now you can get more hardsuits if needed! NOTE ONE HARDSUIT IS IN THIS CRATE, as well as one air tank and maks!"
+	desc = "Poly 'Who stole all the hardsuits!' Well now you can get more hardsuits if needed! NOTE ONE HARDSUIT IS IN THIS CRATE, as well as one air tank and mask!"
 	cost = 2500
 	contains = list(/obj/item/tank/internals/air,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/suit/space/hardsuit/engine)
 	crate_name = "engineering hardsuit"
+
+/datum/supply_pack/engineering/atmoshardsuit
+	name = "Atmospherics Hardsuit"
+	desc = "Too many techs and not enough hardsuits? Time to buy some more! Comes with gas mask and air tank."
+	cost = 3000
+	contains = list(/obj/item/tank/internals/air,
+					/obj/item/clothing/mask/gas,
+					/obj/item/clothing/suit/space/hardsuit/engine/atmos)
+	crate_name = "atmospherics hardsuit"
 
 /datum/supply_pack/engineering/industrialrcd
 	name = "Industrial RCD"

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -764,12 +764,14 @@
 
 /datum/supply_pack/engineering/atmoshardsuit
 	name = "Atmospherics Hardsuit"
-	desc = "Too many techs and not enough hardsuits? Time to buy some more! Comes with gas mask and air tank."
-	cost = 3000
+	desc = "Too many techs and not enough hardsuits? Time to buy some more! Comes with gas mask and air tank. Ask the CE to open."
+	cost = 5000
+	access = ACCESS_CE
 	contains = list(/obj/item/tank/internals/air,
 					/obj/item/clothing/mask/gas,
 					/obj/item/clothing/suit/space/hardsuit/engine/atmos)
 	crate_name = "atmospherics hardsuit"
+	crate_type = /obj/structure/closet/crate/secure/engineering
 
 /datum/supply_pack/engineering/industrialrcd
 	name = "Industrial RCD"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Porting https://github.com/tgstation/tgstation/pull/42194 and tweaking some values. Adjusted BZ canister cost to stop the ability to buy cans and sell back for a profit.
Also added the ability to buy atmos hardsuits.

BIG thanks to Bhijn for helping me get it to work with unomos.

## Why It's Good For The Game
Interdepartmental interactions!
Cargo can set up a miasma farm easy enough, but engineering can assist in building setups or just sell fusion/engine byproducts. 

## Changelog
:cl:
Ported the ability to sell gases.
Ported the ability to generate research points through fusion.
Added the ability to buy atmos hardsuits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
