### PR TITLE
Greytide Stationwide!

### DIFF
--- a/modular_citadel/code/modules/client/loadout/_service.dm
+++ b/modular_citadel/code/modules/client/loadout/_service.dm
@@ -1,3 +1,9 @@
+/datum/gear/greytidestationwide
+	name = "Grey jumpsuit"
+	category = SLOT_W_UNIFORM
+	path = /obj/item/clothing/under/color/grey
+	restricted_roles = list("Assistant")
+
 /datum/gear/plushvar
 	name = "Ratvar Plushie"
 	category = SLOT_IN_BACKPACK


### PR DESCRIPTION
## About The Pull Request
Yea, it's the Pride Month, yet I miss the old generic grey jumpsuit assistants from before the rainbow-tide was enabled.

## Why It's Good For The Game
Re-enabling greyshirts. Don't take it seriously, if someone wanted to tide, grief or anything among the lines, they'd do it regardless of the color of their jumpsuit.

## Changelog
:cl:
add: Adds in a grey jumpsuit to the loadout choices, restricted to Assistants.
/:cl: