### PR TITLE
Replaces medical protolathe with medical techfab on Pubbystation.

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -35713,13 +35713,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/machinery/rnd/production/protolathe/department/medical,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/rnd/production/techfab/department/medical,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEw" = (


### PR DESCRIPTION
Fixes issue #8712 and I can see no reason that it shouldn't be normalized.