### PR TITLE
Dispensers now act like tg counterparts! Tweak to available chems in chem/soda/booze dispensers.

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -59,7 +59,6 @@
 		"acetone",
 		"phenol",
 		"diethylamine",
-		"saltpetre"
 	)
 
 	var/list/upgrade_reagents3 = list(

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -51,13 +51,15 @@
 //these become available once upgraded.
 	var/list/upgrade_reagents = list(
 		"oil",
-		"ammonia"
+		"ammonia",
+		"ash"
 	)
 
 	var/list/upgrade_reagents2 = list(
 		"acetone",
 		"phenol",
-		"diethylamine"
+		"diethylamine",
+		"saltpetre"
 	)
 
 	var/list/upgrade_reagents3 = list(
@@ -267,7 +269,7 @@
 				if(beaker && dispensable_reagents.Find(r_id)) // but since we verify we have the reagent, it'll be fine
 					var/datum/reagents/R = beaker.reagents
 					var/free = R.maximum_volume - R.total_volume
-					var/actual = min(round(chemicals_to_dispense[key], res), (cell.charge * powerefficiency)*10, free)
+					var/actual = min(max(chemicals_to_dispense[key], res), (cell.charge * powerefficiency)*10, free)
 					if(actual)
 						if(!cell.use(actual / powerefficiency))
 							say("Not enough energy to complete operation!")
@@ -478,9 +480,16 @@
 		"tomatojuice",
 		"lemonjuice",
 		"menthol"
-	) //prevents the soda machine from obtaining chemical upgrades. .
-	upgrade_reagents = null
-	upgrade_reagents2 = null
+	)
+	upgrade_reagents = list(
+		"mushroomhallucinogen",
+		"nothing",
+		"cryoxadone"
+	)
+	upgrade_reagents2 = list(
+		"banana",
+		"berryjuice"
+	)
 	upgrade_reagents3 = null
 	emagged_reagents = list(
 		"thirteenloko",
@@ -533,18 +542,19 @@
 		"creme_de_cacao",
 		"triple_sec",
 		"sake"
-	)//prevents the booze machine from obtaining chemical upgrades.
-	upgrade_reagents = null
+	)
+	upgrade_reagents = list(
+		"ethanol",
+		"fernet"
+	)
 	upgrade_reagents2 = null
 	upgrade_reagents3 = null
 	emagged_reagents = list(
-		"ethanol",
 		"iron",
 		"alexander",
 		"clownstears",
 		"minttoxin",
 		"atomicbomb",
-		"fernet",
 		"aphro",
 		"aphro+"
 	)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -58,7 +58,7 @@
 	var/list/upgrade_reagents2 = list(
 		"acetone",
 		"phenol",
-		"diethylamine",
+		"diethylamine"
 	)
 
 	var/list/upgrade_reagents3 = list(


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Dispensers now act like tg counterparts.
-Addition of a few reagents to chem/soda/booze dispensers.

Chem
t2 - ash

Soda
t2 - mushroom hallucinogen, nothing, cryoxadone
t3 - banana juice, berry juice

Booze
t2 - ethanol, fernet


<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-Citadel dispenser at tier 1 with a macro of water=6 will dispense 5 water, rounding down.
TG dispenser at tier 1 with a macro of water=6 will dispense 6 water.
Citadel dispenser at tier 1 with a macro of water=4 will dispense 5 water, rounding up.
TG dispenser at tier 1 with a macro of water=4 will dispense 5 water, rounding up.

Both dispensers have the same macro resolution tiers and both have a rounding up function, but current citadel has a rounding down function which requires you to either work in numbers that will always be divisible by the macro resolutions or force you to update your macros with each upgrade.

-Addition of ash/saltpetre are to keep in line with tg dispensers.
-Addition of soda/booze upgrades are for increased service department fun, as bartender can make more drinks readily available or assist a cook in creating foods.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Moved around some chems from emag list into upgrades.
balance: Added some fun chems to dispensers.
fix: Gave dispensers old tg functionality.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
