### PR TITLE
Ports in microwave updates and its radial menu.

### DIFF
--- a/code/datums/wires/microwave.dm
+++ b/code/datums/wires/microwave.dm
@@ -1,0 +1,27 @@
+/datum/wires/microwave
+	holder_type = /obj/machinery/microwave
+	proper_name = "Microwave"
+
+/datum/wires/microwave/New(atom/holder)
+	wires = list(
+		WIRE_ACTIVATE
+	)
+	..()
+
+/datum/wires/microwave/interactable(mob/user)
+	. = FALSE
+	var/obj/machinery/microwave/M = holder
+	if(M.panel_open)
+		. = TRUE
+
+/datum/wires/microwave/on_pulse(wire)
+	var/obj/machinery/microwave/M = holder
+	switch(wire)
+		if(WIRE_ACTIVATE)
+			M.cook()
+
+/datum/wires/microwave/on_cut(wire, mend)
+	var/obj/machinery/microwave/M = holder
+	switch(wire)
+		if(WIRE_ACTIVATE)
+			M.wire_disabled = !mend

--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -168,9 +168,11 @@ Class Procs:
 	update_icon()
 	updateUsrDialog()
 
-/obj/machinery/proc/dropContents()
+/obj/machinery/proc/dropContents(list/subset = null)
 	var/turf/T = get_turf(src)
 	for(var/atom/movable/A in contents)
+		if(subset && !(A in subset))
+			continue
 		A.forceMove(T)
 		if(isliving(A))
 			var/mob/living/L = A

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -686,7 +686,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		..()
 
 /obj/item/proc/microwave_act(obj/machinery/microwave/M)
-	if(M && M.dirty < 100)
+	if(istype(M) && M.dirty < 100)
 		M.dirty++
 
 /obj/item/proc/on_mob_death(mob/living/L, gibbed)

--- a/code/game/objects/items/stacks/stack.dm
+++ b/code/game/objects/items/stacks/stack.dm
@@ -396,7 +396,7 @@
 	//TODO bloody overlay
 
 /obj/item/stack/microwave_act(obj/machinery/microwave/M)
-	if(M && M.dirty < 100)
+	if(istype(M) && M.dirty < 100)
 		M.dirty += amount
 
 /*

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -291,18 +291,22 @@ All foods are distributed among various categories. Use common sense.
 				S.reagents.add_reagent(r_id, amount)
 
 /obj/item/reagent_containers/food/snacks/microwave_act(obj/machinery/microwave/M)
+	var/turf/T = get_turf(src)
+	var/obj/item/result
 	if(cooked_type)
-		var/obj/item/reagent_containers/food/snacks/S = new cooked_type(get_turf(src))
-		if(M)
-			initialize_cooked_food(S, M.efficiency)
+		result = new cooked_type(T)
+		if(istype(M))
+			initialize_cooked_food(result, M.efficiency)
 		else
-			initialize_cooked_food(S, 1)
-		SSblackbox.record_feedback("tally", "food_made", 1, type)
+			initialize_cooked_food(result, 1)
+		SSblackbox.record_feedback("tally", "food_made", 1, result.type)
 	else
-		new /obj/item/reagent_containers/food/snacks/badrecipe(src)
-		if(M && M.dirty < 100)
+		result = new /obj/item/reagent_containers/food/snacks/badrecipe(T)
+		if(istype(M) && M.dirty < 100)
 			M.dirty++
 	qdel(src)
+
+	return result
 
 /obj/item/reagent_containers/food/snacks/Destroy()
 	if(contents)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -12,322 +12,343 @@
 	pass_flags = PASSTABLE
 	light_color = LIGHT_COLOR_YELLOW
 	light_power = 0.9
+	var/wire_disabled = FALSE // is its internal wire cut?
 	var/operating = FALSE // Is it on?
-	var/dirty = 0 // = {0..100} Does it need cleaning?
-	var/broken = 0 // ={0,1,2} How broken is it???
-	var/max_n_of_items = 10 // whatever fat fuck made this a global var needs to look at themselves in the mirror sometime
+	var/dirty = 0 // 0 to 100 // Does it need cleaning?
+	var/dirty_anim_playing = FALSE
+	var/broken = 0 // 0, 1 or 2 // How broken is it???
+	var/max_n_of_items = 10
 	var/efficiency = 0
 	var/datum/looping_sound/microwave/soundloop
+	var/list/ingredients = list() // may only contain /atom/movables
 
-//Microwaving doesn't use recipes, instead it calls the microwave_act of the objects. For food, this creates something based on the food's cooked_type
+	var/static/radial_examine = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_examine")
+	var/static/radial_eject = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_eject")
+	var/static/radial_use = image(icon = 'icons/mob/radial.dmi', icon_state = "radial_use")
 
-/*******************
-*   Initialising
-********************/
+	// we show the button even if the proc will not work
+	var/static/list/radial_options = list("eject" = radial_eject, "use" = radial_use)
+	var/static/list/ai_radial_options = list("eject" = radial_eject, "use" = radial_use, "examine" = radial_examine)
 
 /obj/machinery/microwave/Initialize()
 	. = ..()
+	wires = new /datum/wires/microwave(src)
 	create_reagents(100)
 	soundloop = new(list(src), FALSE)
 
+/obj/machinery/microwave/Destroy()
+	eject()
+	if(wires)
+		QDEL_NULL(wires)
+	. = ..()
+
 /obj/machinery/microwave/RefreshParts()
-	var/E
-	var/max_items = 10
+	efficiency = 0
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
-		E += M.rating
+		efficiency += M.rating
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
-		max_items = 10 * M.rating
-	efficiency = E
-	max_n_of_items = max_items
+		max_n_of_items = 10 * M.rating
+		break
 
 /obj/machinery/microwave/examine(mob/user)
-	..()
+	. = ..()
 	if(!operating)
 		to_chat(user, "<span class='notice'>Alt-click [src] to turn it on.</span>")
 
-/*******************
-*   Item Adding
-********************/
+	if(!in_range(user, src) && !issilicon(user) && !isobserver(user))
+		to_chat(user, "<span class='warning'>You're too far away to examine [src]'s contents and display!</span>")
+		return
+	if(operating)
+		to_chat(user, "<span class='notice'>\The [src] is operating.</span>")
+		return
+
+	if(length(ingredients))
+		if(issilicon(user))
+			to_chat(user, "<span class='notice'>\The [src] camera shows:</span>")
+		else
+			to_chat(user, "<span class='notice'>\The [src] contains:</span>")
+		var/list/items_counts = new
+		for(var/i in ingredients)
+			if(istype(i, /obj/item/stack))
+				var/obj/item/stack/S = i
+				items_counts[S.name] += S.amount
+			else
+				var/atom/movable/AM = i
+				items_counts[AM.name]++
+		for(var/O in items_counts)
+			to_chat(user, "<span class='notice'>- [items_counts[O]]x [O].</span>")
+	else
+		to_chat(user, "<span class='notice'>\The [src] is empty.</span>")
+
+	if(!(stat & (NOPOWER|BROKEN)))
+		to_chat(user, "<span class='notice'>The status display reads:</span>")
+		to_chat(user, "<span class='notice'>- Capacity: <b>[max_n_of_items]</b> items.<span>")
+		to_chat(user, "<span class='notice'>- Cook time reduced by <b>[(efficiency - 1) * 25]%</b>.<span>")
+
+/obj/machinery/microwave/update_icon()
+	if(broken)
+		icon_state = "mwb"
+	else if(dirty_anim_playing)
+		icon_state = "mwbloody1"
+	else if(dirty == 100)
+		icon_state = "mwbloody"
+	else if(operating)
+		icon_state = "mw1"
+	else if(panel_open)
+		icon_state = "mw-o"
+	else
+		icon_state = "mw"
 
 /obj/machinery/microwave/attackby(obj/item/O, mob/user, params)
 	if(operating)
 		return
-	if(!broken && dirty<100)
-		if(default_deconstruction_screwdriver(user, "mw-o", "mw", O))
-			return
-		if(default_unfasten_wrench(user, O))
-			return
-
 	if(default_deconstruction_crowbar(O))
 		return
 
-	if(src.broken > 0)
-		if(src.broken == 2 && istype(O, /obj/item/wirecutters)) // If it's broken and they're using a screwdriver
-			user.visible_message( \
-				"[user] starts to fix part of the microwave.", \
-				"<span class='notice'>You start to fix part of the microwave...</span>" \
-			)
-			if (O.use_tool(src, user, 20))
-				user.visible_message( \
-					"[user] fixes part of the microwave.", \
-					"<span class='notice'>You fix part of the microwave.</span>" \
-				)
-				src.broken = 1 // Fix it a bit
-		else if(src.broken == 1 && istype(O, /obj/item/weldingtool)) // If it's broken and they're doing the wrench
-			user.visible_message( \
-				"[user] starts to fix part of the microwave.", \
-				"<span class='notice'>You start to fix part of the microwave...</span>" \
-			)
-			if (O.use_tool(src, user, 20))
-				user.visible_message( \
-					"[user] fixes the microwave.", \
-					"<span class='notice'>You fix the microwave.</span>" \
-				)
-				src.icon_state = "mw"
-				src.broken = 0 // Fix it!
-				src.dirty = 0 // just to be sure
-				return 0 //to use some fuel
+	if(dirty < 100)
+		if(default_deconstruction_screwdriver(user, icon_state, icon_state, O) || default_unfasten_wrench(user, O))
+			update_icon()
+			return
+
+	if(panel_open && is_wire_tool(O))
+		wires.interact(user)
+		return TRUE
+
+	if(broken > 0)
+		if(broken == 2 && O.tool_behaviour == TOOL_WIRECUTTER) // If it's broken and they're using a screwdriver
+			user.visible_message("[user] starts to fix part of \the [src].", "<span class='notice'>You start to fix part of \the [src]...</span>")
+			if(O.use_tool(src, user, 20))
+				user.visible_message("[user] fixes part of \the [src].", "<span class='notice'>You fix part of \the [src].</span>")
+				broken = 1 // Fix it a bit
+		else if(broken == 1 && O.tool_behaviour == TOOL_WELDER) // If it's broken and they're doing the wrench
+			user.visible_message("[user] starts to fix part of \the [src].", "<span class='notice'>You start to fix part of \the [src]...</span>")
+			if(O.use_tool(src, user, 20))
+				user.visible_message("[user] fixes \the [src].", "<span class='notice'>You fix \the [src].</span>")
+				broken = 0
+				update_icon()
+				return FALSE //to use some fuel
 		else
 			to_chat(user, "<span class='warning'>It's broken!</span>")
-			return 1
-	else if(istype(O, /obj/item/reagent_containers/spray/))
+			return TRUE
+		return
+
+	if(istype(O, /obj/item/reagent_containers/spray))
 		var/obj/item/reagent_containers/spray/clean_spray = O
-		if(clean_spray.reagents.has_reagent("cleaner",clean_spray.amount_per_transfer_from_this))
-			clean_spray.reagents.remove_reagent("cleaner",clean_spray.amount_per_transfer_from_this,1)
+		if(clean_spray.reagents.has_reagent("cleaner", clean_spray.amount_per_transfer_from_this))
+			clean_spray.reagents.remove_reagent("cleaner", clean_spray.amount_per_transfer_from_this,1)
 			playsound(loc, 'sound/effects/spray3.ogg', 50, 1, -6)
-			user.visible_message( \
-				"[user] has cleaned the microwave.", \
-				"<span class='notice'>You clean the microwave.</span>" \
-			)
-			src.dirty = 0 // It's clean!
-			src.broken = 0 // just to be sure
-			src.icon_state = "mw"
-			src.updateUsrDialog()
-			return 1 // Disables the after-attack so we don't spray the floor/user.
+			user.visible_message("[user] has cleaned \the [src].", "<span class='notice'>You clean \the [src].</span>")
+			dirty = 0
+			update_icon()
 		else
 			to_chat(user, "<span class='warning'>You need more space cleaner!</span>")
-			return 1
+		return TRUE
 
-	else if(istype(O, /obj/item/soap/)) // If they're trying to clean it then let them
+	if(istype(O, /obj/item/soap))
 		var/obj/item/soap/P = O
-		user.visible_message( \
-			"[user] starts to clean the microwave.", \
-			"<span class='notice'>You start to clean the microwave...</span>" \
-		)
-		if (do_after(user, P.cleanspeed, target = src))
-			user.visible_message( \
-				"[user] has cleaned the microwave.", \
-				"<span class='notice'>You clean the microwave.</span>" \
-			)
-			src.dirty = 0 // It's clean!
-			src.broken = 0 // just to be sure
-			src.icon_state = "mw"
+		user.visible_message("[user] starts to clean \the [src].", "<span class='notice'>You start to clean \the [src]...</span>")
+		if(do_after(user, P.cleanspeed, target = src))
+			user.visible_message("[user] has cleaned \the [src].", "<span class='notice'>You clean \the [src].</span>")
+			dirty = 0
+			update_icon()
+		return TRUE
 
-	else if(src.dirty==100) // The microwave is all dirty so can't be used!
-		to_chat(user, "<span class='warning'>It's dirty!</span>")
-		return 1
+	if(dirty == 100) // The microwave is all dirty so can't be used!
+		to_chat(user, "<span class='warning'>\The [src] is dirty!</span>")
+		return TRUE
 
-	else if(istype(O, /obj/item/storage/bag/tray))
+	if(istype(O, /obj/item/storage/bag/tray))
 		var/obj/item/storage/T = O
 		var/loaded = 0
 		for(var/obj/item/reagent_containers/food/snacks/S in T.contents)
-			if (contents.len>=max_n_of_items)
-				to_chat(user, "<span class='warning'>[src] is full, you can't put anything in!</span>")
-				return 1
+			if(ingredients.len >= max_n_of_items)
+				to_chat(user, "<span class='warning'>\The [src] is full, you can't put anything in!</span>")
+				return TRUE
 			if(SEND_SIGNAL(T, COMSIG_TRY_STORAGE_TAKE, S, src))
 				loaded++
-
+				ingredients += S
 		if(loaded)
-			to_chat(user, "<span class='notice'>You insert [loaded] items into [src].</span>")
+			to_chat(user, "<span class='notice'>You insert [loaded] items into \the [src].</span>")
+		return
 
+	if(O.w_class <= WEIGHT_CLASS_NORMAL && !istype(O, /obj/item/storage) && user.a_intent == INTENT_HELP)
+		if(ingredients.len >= max_n_of_items)
+			to_chat(user, "<span class='warning'>\The [src] is full, you can't put anything in!</span>")
+			return TRUE
+		if(!user.transferItemToLoc(O, src))
+			to_chat(user, "<span class='warning'>\The [O] is stuck to your hand!</span>")
+			return FALSE
 
-	else if(O.w_class <= WEIGHT_CLASS_NORMAL && !istype(O, /obj/item/storage) && user.a_intent == INTENT_HELP)
-		if (contents.len>=max_n_of_items)
-			to_chat(user, "<span class='warning'>[src] is full, you can't put anything in!</span>")
-			return 1
-		else
-			if(!user.transferItemToLoc(O, src))
-				to_chat(user, "<span class='warning'>\the [O] is stuck to your hand, you cannot put it in \the [src]!</span>")
-				return 0
+		ingredients += O
+		user.visible_message("[user] has added \a [O] to \the [src].", "<span class='notice'>You add [O] to \the [src].</span>")
+		return
 
-			user.visible_message( \
-				"[user] has added \the [O] to \the [src].", \
-				"<span class='notice'>You add \the [O] to \the [src].</span>")
-
-	else
-		..()
-	updateUsrDialog()
+	..()
 
 /obj/machinery/microwave/AltClick(mob/user)
-	if(user.canUseTopic(src, BE_CLOSE) && !(operating || broken > 0 || panel_open || !anchored || dirty == 100))
+	if(user.canUseTopic(src, !issilicon(usr)))
 		cook()
 
-/*******************
-*   Microwave Menu
-********************/
-
-/obj/machinery/microwave/ui_interact(mob/user) // The microwave Menu
+/obj/machinery/microwave/ui_interact(mob/user)
 	. = ..()
-	if(panel_open || !anchored)
+
+	if(operating || panel_open || !anchored || !user.canUseTopic(src, !issilicon(user)))
 		return
-	var/dat = "<div class='statusDisplay'>"
-	if(broken > 0)
-		dat += "ERROR: 09734014-A2379-D18746 --Bad memory<BR>Contact your operator or use command line to rebase memory ///git checkout {HEAD} -a commit pull --rebase push {*NEW HEAD*}</div>"    //Thats how all the git fiddling looks to me
-	else if(operating)
-		dat += "Microwaving in progress!<BR>Please wait...!</div>"
-	else if(dirty==100)
-		dat += "ERROR: >> 0 --Response input zero<BR>Contact your operator of the device manifactor support.</div>"
-	else
-		var/list/items_counts = new
-		for (var/obj/O in contents)
-			if(istype(O, /obj/item/stack/))
-				var/obj/item/stack/S = O
-				items_counts[O.name] += S.amount
-			else
-				items_counts[O.name]++
+	if(isAI(user) && (stat & NOPOWER))
+		return
 
-		for (var/O in items_counts)
-			var/N = items_counts[O]
-			dat += "[capitalize(O)]: [N]<BR>"
-
-		if (items_counts.len==0)
-			dat += "The microwave is empty.</div>"
+	if(!length(ingredients))
+		if(isAI(user))
+			examine(user)
 		else
-			dat = "<h3>Ingredients:</h3>[dat]</div>"
-		dat += "<A href='?src=[REF(src)];action=cook'>Turn on</A>"
-		dat += "<A href='?src=[REF(src)];action=dispose'>Eject ingredients</A><BR>"
+			to_chat(user, "<span class='warning'>\The [src] is empty.</span>")
+		return
 
-	var/datum/browser/popup = new(user, "microwave", name, 300, 300)
-	popup.set_content(dat)
-	popup.open()
+	var/choice = show_radial_menu(user, src, isAI(user) ? ai_radial_options : radial_options, require_near = !issilicon(user))
 
-/***********************************
-*   Microwave Menu Handling/Cooking
-************************************/
+	// post choice verification
+	if(operating || panel_open || !anchored || !user.canUseTopic(src, !issilicon(user)))
+		return
+	if(isAI(user) && (stat & NOPOWER))
+		return
+
+	usr.set_machine(src)
+	switch(choice)
+		if("eject")
+			eject()
+		if("use")
+			cook()
+		if("examine")
+			examine(user)
+
+/obj/machinery/microwave/proc/eject()
+	for(var/i in ingredients)
+		var/atom/movable/AM = i
+		AM.forceMove(drop_location())
+	ingredients.Cut()
 
 /obj/machinery/microwave/proc/cook()
 	if(stat & (NOPOWER|BROKEN))
 		return
+	if(operating || broken > 0 || panel_open || !anchored || dirty == 100)
+		return
+
+	if(wire_disabled)
+		audible_message("[src] buzzes.")
+		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
+		return
+
+	if(prob(max((5 / efficiency) - 5, dirty * 5))) //a clean unupgraded microwave has no risk of failure
+		muck()
+		return
+	for(var/obj/O in ingredients)
+		if(istype(O, /obj/item/reagent_containers/food) || istype(O, /obj/item/grown))
+			continue
+		if(prob(min(dirty * 5, 100)))
+			start_can_fail()
+			return
+		break
 	start()
 
-	if (prob(max(5/efficiency-5,dirty*5))) //a clean unupgraded microwave has no risk of failure
-		muck_start()
-		if (!microwaving(4))
-			muck_finish()
-			return
-		muck_finish()
-		return
+/obj/machinery/microwave/proc/turn_on()
+	visible_message("\The [src] turns on.", "<span class='italics'>You hear a microwave humming.</span>")
+	operating = TRUE
 
-	else
-		if(has_extra_item() && prob(min(dirty*5,100)) && !microwaving(4))
-			broke()
-			return
+	set_light(1.5)
+	soundloop.start()
+	update_icon()
 
-		if(!microwaving(10))
-			abort()
-			return
-		stop()
+/obj/machinery/microwave/proc/spark()
+	visible_message("<span class='warning'>Sparks fly around [src]!</span>")
+	var/datum/effect_system/spark_spread/s = new
+	s.set_up(2, 1, src)
+	s.start()
 
-		var/metal = 0
-		for(var/obj/item/O in contents)
-			O.microwave_act(src)
-			if(O.materials[MAT_METAL])
-				metal += O.materials[MAT_METAL]
-
-		if(metal)
-			visible_message("<span class='warning'>Sparks fly around [src]!</span>")
-			if(prob(max(metal/2, 33)))
-				explosion(loc,0,1,2)
-			broke()
-			return
-
-		dropContents()
-		return
-
-/obj/machinery/microwave/proc/microwaving(seconds as num)
-	for (var/i=1 to seconds)
-		if (stat & (NOPOWER|BROKEN))
-			return 0
-		use_power(500)
-		sleep(max(12-2*efficiency,2)) // standard microwave means sleep(10). The better the efficiency, the faster the cooking
-	return 1
-
-/obj/machinery/microwave/proc/has_extra_item()
-	for (var/obj/O in contents)
-		if ( \
-				!istype(O, /obj/item/reagent_containers/food) && \
-				!istype(O, /obj/item/grown) \
-			)
-			return 1
-	return 0
+#define MICROWAVE_NORMAL 0
+#define MICROWAVE_MUCK 1
+#define MICROWAVE_PRE 2
 
 /obj/machinery/microwave/proc/start()
-	visible_message("The microwave turns on.", "<span class='italics'>You hear a microwave humming.</span>")
-	soundloop.start()
-	operating = TRUE
-	icon_state = "mw1"
-	set_light(1.5)
-	updateUsrDialog()
+	turn_on()
+	loop(MICROWAVE_NORMAL, 10)
 
-/obj/machinery/microwave/proc/abort()
-	operating = FALSE // Turn it off again aferwards
-	icon_state = "mw"
-	updateUsrDialog()
-	set_light(0)
-	soundloop.stop()
+/obj/machinery/microwave/proc/start_can_fail()
+	turn_on()
+	loop(MICROWAVE_PRE, 4)
 
-/obj/machinery/microwave/proc/stop()
-	abort()
+/obj/machinery/microwave/proc/muck()
+	turn_on()
+	playsound(src.loc, 'sound/effects/splat.ogg', 50, 1)
+	dirty_anim_playing = TRUE
+	update_icon()
+	loop(MICROWAVE_MUCK, 4)
 
-/obj/machinery/microwave/proc/dispose()
-	for (var/obj/O in contents)
-		O.forceMove(drop_location())
-	to_chat(usr, "<span class='notice'>You dispose of the microwave contents.</span>")
-	updateUsrDialog()
+/obj/machinery/microwave/proc/loop(type, time, wait = max(12 - 2 * efficiency, 2)) // standard wait is 10
+	if(stat & (NOPOWER|BROKEN))
+		if(MICROWAVE_PRE)
+			pre_fail()
+		return
+	if(!time)
+		switch(type)
+			if(MICROWAVE_NORMAL)
+				loop_finish()
+			if(MICROWAVE_MUCK)
+				muck_finish()
+			if(MICROWAVE_PRE)
+				pre_success()
+		return
+	time--
+	use_power(500)
+	addtimer(CALLBACK(src, .proc/loop, type, time, wait), wait)
 
-/obj/machinery/microwave/proc/muck_start()
-	playsound(src.loc, 'sound/effects/splat.ogg', 50, 1) // Play a splat sound
-	icon_state = "mwbloody1" // Make it look dirty!!
+/obj/machinery/microwave/proc/loop_finish()
+	operating = FALSE
+
+	var/metal = 0
+	for(var/obj/item/O in ingredients)
+		O.microwave_act(src)
+		if(O.materials[MAT_METAL])
+			metal += O.materials[MAT_METAL]
+
+	if(metal)
+		spark()
+		broken = 2
+		if(prob(max(metal / 2, 33)))
+			explosion(loc, 0, 1, 2)
+	else
+		dropContents(ingredients)
+		ingredients.Cut()
+
+	after_finish_loop()
+
+/obj/machinery/microwave/proc/pre_fail()
+	broken = 2
+	operating = FALSE
+	spark()
+	after_finish_loop()
+
+/obj/machinery/microwave/proc/pre_success()
+	loop(MICROWAVE_NORMAL, 10)
 
 /obj/machinery/microwave/proc/muck_finish()
-	visible_message("<span class='warning'>The microwave gets covered in muck!</span>")
-	dirty = 100 // Make it dirty so it can't be used util cleaned
-	icon_state = "mwbloody" // Make it look dirty too
-	operating = FALSE // Turn it off again aferwards
-	updateUsrDialog()
+	visible_message("<span class='warning'>\The [src] gets covered in muck!</span>")
+
+	dirty = 100
+	dirty_anim_playing = FALSE
+	operating = FALSE
+
 	for(var/obj/item/reagent_containers/food/snacks/S in src)
 		if(prob(50))
 			new /obj/item/reagent_containers/food/snacks/badrecipe(src)
 			qdel(S)
+
+	after_finish_loop()
+
+/obj/machinery/microwave/proc/after_finish_loop()
 	set_light(0)
 	soundloop.stop()
+	update_icon()
 
-/obj/machinery/microwave/proc/broke()
-	var/datum/effect_system/spark_spread/s = new
-	s.set_up(2, 1, src)
-	s.start()
-	icon_state = "mwb" // Make it look all busted up and shit
-	visible_message("<span class='warning'>The microwave breaks!</span>") //Let them know they're stupid
-	broken = 2 // Make it broken so it can't be used util fixed
-	flags_1 = null //So you can't add condiments
-	operating = FALSE // Turn it off again aferwards
-	updateUsrDialog()
-	set_light(0)
-	soundloop.stop()
-
-/obj/machinery/microwave/Topic(href, href_list)
-	if(..() || panel_open)
-		return
-
-	usr.set_machine(src)
-	if(operating)
-		updateUsrDialog()
-		return
-
-	switch(href_list["action"])
-		if ("cook")
-			cook()
-
-		if ("dispose")
-			dispose()
-	updateUsrDialog()
+#undef MICROWAVE_NORMAL
+#undef MICROWAVE_MUCK
+#undef MICROWAVE_PRE

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -494,6 +494,7 @@
 #include "code\datums\wires\autolathe.dm"
 #include "code\datums\wires\emitter.dm"
 #include "code\datums\wires\explosive.dm"
+#include "code\datums\wires\microwave.dm"
 #include "code\datums\wires\mulebot.dm"
 #include "code\datums\wires\particle_accelerator.dm"
 #include "code\datums\wires\r_n_d.dm"


### PR DESCRIPTION
## About The Pull Request
Updates microwaves. Most relevant: tgstation PRs #41822,  #41832 and #42013.

## Why It's Good For The Game
Updating stuff, and more radial menus.

## Changelog
:cl: Ghommie (original PRs by nicbn and coiax)
add: Microwave UI uses a radial menu now. You can see the contents by examining.
add: Microwaves have a single wire accessible when open, the activation wire.
When cut, the microwave will no longer function, when pulsed, the microwave
will turn on.
add: Stabilized dark purple extracts now cook items in your hands, rather than dropping
the cooked item on the floor.
/:cl: