### PR TITLE
ports in "Adds radial menu to arm-mounted implants"

### DIFF
--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -129,11 +129,14 @@
 		holder = null
 		if(contents.len == 1)
 			Extend(contents[1])
-		else // TODO: make it similar to borg's storage-like module selection
-			var/obj/item/choise = input("Activate which item?", "Arm Implant", null, null) as null|anything in items_list
-			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !holder && istype(choise) && (choise in contents))
-				// This monster sanity check is a nice example of how bad input() is.
-				Extend(choise)
+		else
+			var/list/choice_list = list()
+			for(var/obj/item/I in items_list)
+				choice_list[I] = getFlatIcon(I)
+			var/obj/item/choice = show_radial_menu(owner, owner, choice_list)
+			if(owner && owner == usr && owner.stat != DEAD && (src in owner.internal_organs) && !holder && (choice in contents))
+				// This monster sanity check is a nice example of how bad input is.
+				Extend(choice)
 	else
 		Retract()
 


### PR DESCRIPTION
## About The Pull Request
Ports in tgstation PR #41833.

## Why It's Good For The Game
More QoL radials. The old arm implant contents menu was such a sandpit of burden.

## Changelog
:cl: Ghommie (original PR by Swindly)
add: Arm-mounted implants that contain more than one item use a radial menu instead of a list menu.
/:cl:
