### PR TITLE
Fixes CWC construct shells being visible as ghost role to latejoiners.

### DIFF
--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -38,4 +38,6 @@ GLOBAL_LIST_EMPTY(wire_name_directory)
 GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
+GLOBAL_LIST_EMPTY(latejoin_mob_spawners)	// All mob_spawn objects that can be viewed and accessed from the lobby.
+
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -38,6 +38,4 @@ GLOBAL_LIST_EMPTY(wire_name_directory)
 GLOBAL_LIST_EMPTY(ai_status_displays)
 
 GLOBAL_LIST_EMPTY(mob_spawners) 		    // All mob_spawn objects
-GLOBAL_LIST_EMPTY(latejoin_mob_spawners)	// All mob_spawn objects that can be viewed and accessed from the lobby.
-
 GLOBAL_LIST_EMPTY(alert_consoles)			// Station alert consoles, /obj/machinery/computer/station_alert

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -28,6 +28,7 @@
 	var/show_flavour = TRUE
 	var/banType = "lavaland"
 	var/ghost_usable = TRUE
+	var/latejoin_visible = TRUE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user, latejoinercalling)
@@ -66,13 +67,22 @@
 		create()
 	else if(ghost_usable)
 		GLOB.poi_list |= src
-		LAZYADD(GLOB.mob_spawners[job_description ? job_description : name], src)
+		var/job_or_name = job_description ? job_description : name
+		LAZYADD(GLOB.mob_spawners[job_or_name], src)
+		if(latejoin_visible)
+			LAZYADD(GLOB.latejoin_mob_spawners[job_or_name], src)
+
 
 /obj/effect/mob_spawn/Destroy()
 	GLOB.poi_list -= src
-	LAZYREMOVE(GLOB.mob_spawners[job_description ? job_description : name], src)
-	if(!LAZYLEN(GLOB.mob_spawners[job_description ? job_description : name]))
-		GLOB.mob_spawners -= job_description ? job_description : name
+	var/job_or_name = job_description ? job_description : name
+	LAZYREMOVE(GLOB.mob_spawners[job_or_name], src)
+	if(!LAZYLEN(GLOB.mob_spawners[job_or_name]))
+		GLOB.mob_spawners -= job_or_name
+	LAZYREMOVE(GLOB.latejoin_mob_spawners[job_or_name], src)
+	if(!LAZYLEN(GLOB.latejoin_mob_spawners[job_or_name]))
+		GLOB.latejoin_mob_spawners -= job_or_name
+
 	return ..()
 
 /obj/effect/mob_spawn/proc/special(mob/M)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -28,7 +28,6 @@
 	var/show_flavour = TRUE
 	var/banType = "lavaland"
 	var/ghost_usable = TRUE
-	var/latejoin_visible = TRUE
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user, latejoinercalling)
@@ -69,21 +68,17 @@
 		GLOB.poi_list |= src
 		var/job_or_name = job_description ? job_description : name
 		LAZYADD(GLOB.mob_spawners[job_or_name], src)
-		if(latejoin_visible)
-			LAZYADD(GLOB.latejoin_mob_spawners[job_or_name], src)
 
 
 /obj/effect/mob_spawn/Destroy()
 	GLOB.poi_list -= src
-	var/job_or_name = job_description ? job_description : name
-	LAZYREMOVE(GLOB.mob_spawners[job_or_name], src)
-	if(!LAZYLEN(GLOB.mob_spawners[job_or_name]))
-		GLOB.mob_spawners -= job_or_name
-	LAZYREMOVE(GLOB.latejoin_mob_spawners[job_or_name], src)
-	if(!LAZYLEN(GLOB.latejoin_mob_spawners[job_or_name]))
-		GLOB.latejoin_mob_spawners -= job_or_name
-
+	LAZYREMOVE(GLOB.mob_spawners[job_description ? job_description : name], src)
+	if(!LAZYLEN(GLOB.mob_spawners[job_description ? job_description : name]))
+		GLOB.mob_spawners -= job_description ? job_description : name
 	return ..()
+
+/obj/effect/mob_spawn/proc/can_latejoin() //If it can be taken from the lobby.
+	return TRUE
 
 /obj/effect/mob_spawn/proc/special(mob/M)
 	return

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -66,8 +66,7 @@
 		create()
 	else if(ghost_usable)
 		GLOB.poi_list |= src
-		var/job_or_name = job_description ? job_description : name
-		LAZYADD(GLOB.mob_spawners[job_or_name], src)
+		LAZYADD(GLOB.mob_spawners[job_description ? job_description : name], src)
 
 
 /obj/effect/mob_spawn/Destroy()

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -163,7 +163,7 @@
 				to_chat(usr, "<span class='warning'>Server is full.</span>")
 				return
 
-		var/obj/effect/mob_spawn/MS = pick(GLOB.mob_spawners[href_list["JoinAsGhostRole"]])
+		var/obj/effect/mob_spawn/MS = pick(GLOB.latejoin_mob_spawners[href_list["JoinAsGhostRole"]])
 		if(istype(MS) && MS.attack_ghost(src, latejoinercalling = TRUE))
 			SSticker.queued_players -= src
 			SSticker.queue_delay = 4
@@ -443,7 +443,7 @@
 	for(var/datum/job/job in SSjob.occupations)
 		if(job && IsJobUnavailable(job.title, TRUE) == JOB_AVAILABLE)
 			available_job_count++
-	for(var/spawner in GLOB.mob_spawners)
+	for(var/spawner in GLOB.latejoin_mob_spawners)
 		available_job_count++
 		break
 
@@ -457,14 +457,14 @@
 			"Engineering" = list(jobs = list(), titles = GLOB.engineering_positions, color = "#ffd699"),
 			"Supply" = list(jobs = list(), titles = GLOB.supply_positions, color = "#ead4ae"),
 			"Miscellaneous" = list(jobs = list(), titles = list(), color = "#ffffff", colBreak = TRUE),
-			"Ghost Role" = list(jobs = list(), titles = GLOB.mob_spawners, color = "#ffffff"),
+			"Ghost Role" = list(jobs = list(), titles = GLOB.latejoin_mob_spawners, color = "#ffffff"),
 			"Synthetic" = list(jobs = list(), titles = GLOB.nonhuman_positions, color = "#ccffcc"),
 			"Service" = list(jobs = list(), titles = GLOB.civilian_positions, color = "#cccccc"),
 			"Medical" = list(jobs = list(), titles = GLOB.medical_positions, color = "#99ffe6", colBreak = TRUE),
 			"Science" = list(jobs = list(), titles = GLOB.science_positions, color = "#e6b3e6"),
 			"Security" = list(jobs = list(), titles = GLOB.security_positions, color = "#ff9999"),
 		)
-		for(var/spawner in GLOB.mob_spawners)
+		for(var/spawner in GLOB.latejoin_mob_spawners)
 			categorizedJobs["Ghost Role"]["jobs"] += spawner
 
 		for(var/datum/job/job in SSjob.occupations)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -163,8 +163,8 @@
 				to_chat(usr, "<span class='warning'>Server is full.</span>")
 				return
 
-		var/obj/effect/mob_spawn/MS = pick(GLOB.latejoin_mob_spawners[href_list["JoinAsGhostRole"]])
-		if(istype(MS) && MS.attack_ghost(src, latejoinercalling = TRUE))
+		var/obj/effect/mob_spawn/MS = pick(GLOB.mob_spawners[href_list["JoinAsGhostRole"]])
+		if(MS?.attack_ghost(src, latejoinercalling = TRUE))
 			SSticker.queued_players -= src
 			SSticker.queue_delay = 4
 			qdel(src)
@@ -443,9 +443,10 @@
 	for(var/datum/job/job in SSjob.occupations)
 		if(job && IsJobUnavailable(job.title, TRUE) == JOB_AVAILABLE)
 			available_job_count++
-	for(var/spawner in GLOB.latejoin_mob_spawners)
-		available_job_count++
-		break
+	for(var/obj/effect/mob_spawn/spawner in GLOB.mob_spawners)
+		if(spawner.can_latejoin())
+			available_job_count++
+			break
 
 	if(!available_job_count)
 		dat += "<div class='notice red'>There are currently no open positions!</div>"
@@ -457,15 +458,16 @@
 			"Engineering" = list(jobs = list(), titles = GLOB.engineering_positions, color = "#ffd699"),
 			"Supply" = list(jobs = list(), titles = GLOB.supply_positions, color = "#ead4ae"),
 			"Miscellaneous" = list(jobs = list(), titles = list(), color = "#ffffff", colBreak = TRUE),
-			"Ghost Role" = list(jobs = list(), titles = GLOB.latejoin_mob_spawners, color = "#ffffff"),
+			"Ghost Role" = list(jobs = list(), titles = GLOB.mob_spawners, color = "#ffffff"),
 			"Synthetic" = list(jobs = list(), titles = GLOB.nonhuman_positions, color = "#ccffcc"),
 			"Service" = list(jobs = list(), titles = GLOB.civilian_positions, color = "#cccccc"),
 			"Medical" = list(jobs = list(), titles = GLOB.medical_positions, color = "#99ffe6", colBreak = TRUE),
 			"Science" = list(jobs = list(), titles = GLOB.science_positions, color = "#e6b3e6"),
 			"Security" = list(jobs = list(), titles = GLOB.security_positions, color = "#ff9999"),
 		)
-		for(var/spawner in GLOB.latejoin_mob_spawners)
-			categorizedJobs["Ghost Role"]["jobs"] += spawner
+		for(var/obj/effect/mob_spawn/spawner in GLOB.mob_spawners)
+			if(spawner.can_latejoin())
+				categorizedJobs["Ghost Role"]["jobs"] += spawner
 
 		for(var/datum/job/job in SSjob.occupations)
 			if(job && IsJobUnavailable(job.title, TRUE) == JOB_AVAILABLE)


### PR DESCRIPTION
## About The Pull Request
Closes issue #8297. Basically cwc constructs are item snowflakes that partly mimick mob_spawn in their interaction with ghost_attack(). I might want to convert them later to effects or, but I don't want to end up removing item functionalities they may or may not have.
So, basically latejoiners will now check a new latejoin_mob_spawners global list instead, added in a var to allow devs to make the role invisible to lobby-men.

## Why It's Good For The Game
Bugfixing, exploit fixing.

## Changelog
:cl:
fix: Fixes CWC construct shells being visible as ghost role to latejoiners.
/:cl: