### PR TITLE
Fixes trauma healing nanites.

### DIFF
--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -70,14 +70,13 @@
 	rogue_types = list(/datum/nanite_program/brain_decay)
 
 /datum/nanite_program/brain_heal/check_conditions()
-	var/problems = FALSE
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
 		if(length(C.get_traumas()))
-			problems = TRUE
+			return ..()
 	if(host_mob.getBrainLoss())
-		problems = TRUE
-	return problems ? ..() : FALSE
+		return ..()
+	return FALSE
 
 /datum/nanite_program/brain_heal/active_effect()
 	host_mob.adjustBrainLoss(-1, TRUE)
@@ -192,14 +191,13 @@
 	rogue_types = list(/datum/nanite_program/brain_decay, /datum/nanite_program/brain_misfire)
 
 /datum/nanite_program/brain_heal_advanced/check_conditions()
-	var/problems = FALSE
 	if(iscarbon(host_mob))
 		var/mob/living/carbon/C = host_mob
 		if(length(C.get_traumas()))
-			problems = TRUE
+			return ..()
 	if(host_mob.getBrainLoss())
-		problems = TRUE
-	return problems ? ..() : FALSE
+		return ..()
+	return FALSE
 	
 /datum/nanite_program/brain_heal_advanced/active_effect()
 	host_mob.adjustBrainLoss(-2, TRUE)

--- a/code/modules/research/nanites/nanite_programs/healing.dm
+++ b/code/modules/research/nanites/nanite_programs/healing.dm
@@ -70,9 +70,14 @@
 	rogue_types = list(/datum/nanite_program/brain_decay)
 
 /datum/nanite_program/brain_heal/check_conditions()
-	if(!host_mob.getBrainLoss())
-		return FALSE
-	return ..()
+	var/problems = FALSE
+	if(iscarbon(host_mob))
+		var/mob/living/carbon/C = host_mob
+		if(length(C.get_traumas()))
+			problems = TRUE
+	if(host_mob.getBrainLoss())
+		problems = TRUE
+	return problems ? ..() : FALSE
 
 /datum/nanite_program/brain_heal/active_effect()
 	host_mob.adjustBrainLoss(-1, TRUE)
@@ -187,10 +192,15 @@
 	rogue_types = list(/datum/nanite_program/brain_decay, /datum/nanite_program/brain_misfire)
 
 /datum/nanite_program/brain_heal_advanced/check_conditions()
-	if(!host_mob.getBrainLoss())
-		return FALSE
-	return ..()
-
+	var/problems = FALSE
+	if(iscarbon(host_mob))
+		var/mob/living/carbon/C = host_mob
+		if(length(C.get_traumas()))
+			problems = TRUE
+	if(host_mob.getBrainLoss())
+		problems = TRUE
+	return problems ? ..() : FALSE
+	
 /datum/nanite_program/brain_heal_advanced/active_effect()
 	host_mob.adjustBrainLoss(-2, TRUE)
 	if(iscarbon(host_mob) && prob(10))


### PR DESCRIPTION
Forgot to fix them in my last nanite fix PR, is ported from TG. Has possible balance implications since it makes brain/trauma healing nanites way better.
:cl:
fix: Fixes brain damage/trauma healing nanites so they actually work while there are only traumas.
/:cl:
