### PR TITLE
Slimepeople can now morph the shape and size of their genitalia.

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -69,7 +69,7 @@
 
 /datum/action/innate/slime_change/proc/change_form()
 	var/mob/living/carbon/human/H = owner
-	var/select_alteration = input(owner, "Select what part of your form to alter", "Form Alteration", "cancel") in list("Hair Style", "Genitals", "Tail", "Snout", "Markings", "Ears", "Taur body", "Penis", "Vagina", "Cancel")
+	var/select_alteration = input(owner, "Select what part of your form to alter", "Form Alteration", "cancel") in list("Hair Style", "Genitals", "Tail", "Snout", "Markings", "Ears", "Taur body", "Penis", "Vagina", "Penis Length", "Breast Size", "Cancel")
 	if(select_alteration == "Hair Style")
 		if(H.gender == MALE)
 			var/new_style = input(owner, "Select a facial hair style", "Hair Alterations")  as null|anything in GLOB.facial_hair_styles_list
@@ -217,6 +217,28 @@
 		H.update_genitals()
 		H.give_vagina()
 		H.apply_overlay()
+
+	else if (select_alteration == "Penis Length")
+		for(var/obj/item/organ/genital/penis/X in H.internal_organs)
+			qdel(X)
+		var/new_length
+		new_length = input(owner, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX])", "Character Preference") as num|null
+		if(new_length)
+			H.dna.features["cock_length"] = max(min( round(text2num(new_length)), COCK_SIZE_MAX),COCK_SIZE_MIN)
+		H.update_genitals()
+		H.apply_overlay()
+		H.give_penis()
+
+	else if (select_alteration == "Breast Size")
+		for(var/obj/item/organ/genital/breasts/X in H.internal_organs)
+			qdel(X)
+		var/new_size
+		new_size = input(owner, "Breast Size", "Character Preference") as null|anything in GLOB.breasts_size_list
+		if(new_size)
+			H.dna.features["breasts_size"] = new_size
+		H.update_genitals()
+		H.apply_overlay()
+		H.give_breasts()
 
 	else
 		return

--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -69,7 +69,7 @@
 
 /datum/action/innate/slime_change/proc/change_form()
 	var/mob/living/carbon/human/H = owner
-	var/select_alteration = input(owner, "Select what part of your form to alter", "Form Alteration", "cancel") in list("Hair Style", "Genitals", "Tail", "Snout", "Markings", "Ears", "Taur body", "Penis", "Vagina", "Penis Length", "Breast Size", "Cancel")
+	var/select_alteration = input(owner, "Select what part of your form to alter", "Form Alteration", "cancel") in list("Hair Style", "Genitals", "Tail", "Snout", "Markings", "Ears", "Taur body", "Penis", "Vagina", "Penis Length", "Breast Size", "Breast Shape", "Cancel")
 	if(select_alteration == "Hair Style")
 		if(H.gender == MALE)
 			var/new_style = input(owner, "Select a facial hair style", "Hair Alterations")  as null|anything in GLOB.facial_hair_styles_list
@@ -203,6 +203,7 @@
 		if(new_shape)
 			H.dna.features["cock_shape"] = new_shape
 		H.update_genitals()
+		H.give_balls()
 		H.give_penis()
 		H.apply_overlay()
 
@@ -215,6 +216,7 @@
 		if(new_shape)
 			H.dna.features["vag_shape"] = new_shape
 		H.update_genitals()
+		H.give_womb()
 		H.give_vagina()
 		H.apply_overlay()
 
@@ -222,20 +224,32 @@
 		for(var/obj/item/organ/genital/penis/X in H.internal_organs)
 			qdel(X)
 		var/new_length
-		new_length = input(owner, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX])", "Character Preference") as num|null
+		new_length = input(owner, "Penis length in inches:\n([COCK_SIZE_MIN]-[COCK_SIZE_MAX])", "Genital Alteration") as num|null
 		if(new_length)
 			H.dna.features["cock_length"] = max(min( round(text2num(new_length)), COCK_SIZE_MAX),COCK_SIZE_MIN)
 		H.update_genitals()
 		H.apply_overlay()
+		H.give_balls()
 		H.give_penis()
 
 	else if (select_alteration == "Breast Size")
 		for(var/obj/item/organ/genital/breasts/X in H.internal_organs)
 			qdel(X)
 		var/new_size
-		new_size = input(owner, "Breast Size", "Character Preference") as null|anything in GLOB.breasts_size_list
+		new_size = input(owner, "Breast Size", "Genital Alteration") as null|anything in GLOB.breasts_size_list
 		if(new_size)
 			H.dna.features["breasts_size"] = new_size
+		H.update_genitals()
+		H.apply_overlay()
+		H.give_breasts()
+
+	else if (select_alteration == "Breast Shape")
+		for(var/obj/item/organ/genital/breasts/X in H.internal_organs)
+			qdel(X)
+		var/new_shape
+		new_shape = input(owner, "Breast Shape", "Genital Alteration") as null|anything in GLOB.breasts_shapes_list
+		if(new_shape)
+			H.dna.features["breasts_shape"] = new_shape
 		H.update_genitals()
 		H.apply_overlay()
 		H.give_breasts()

--- a/modular_citadel/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -69,7 +69,7 @@
 
 /datum/action/innate/slime_change/proc/change_form()
 	var/mob/living/carbon/human/H = owner
-	var/select_alteration = input(owner, "Select what part of your form to alter", "Form Alteration", "cancel") in list("Hair Style", "Genitals", "Tail", "Snout", "Markings", "Ears", "Taur body", "Cancel")
+	var/select_alteration = input(owner, "Select what part of your form to alter", "Form Alteration", "cancel") in list("Hair Style", "Genitals", "Tail", "Snout", "Markings", "Ears", "Taur body", "Penis", "Vagina", "Cancel")
 	if(select_alteration == "Hair Style")
 		if(H.gender == MALE)
 			var/new_style = input(owner, "Select a facial hair style", "Hair Alterations")  as null|anything in GLOB.facial_hair_styles_list
@@ -114,7 +114,7 @@
 					O.Remove(H)
 				organ.forceMove(get_turf(H))
 				qdel(organ)
-				H.update_body()
+				H.update_genitals()
 
 	else if (select_alteration == "Ears")
 		var/list/snowflake_ears_list = list("Normal" = null)
@@ -194,5 +194,29 @@
 			if(new_taur != "None")
 				H.dna.features["mam_tail"] = "None"
 		H.update_body()
+
+	else if (select_alteration == "Penis")
+		for(var/obj/item/organ/genital/penis/X in H.internal_organs)
+			qdel(X)
+		var/new_shape
+		new_shape = input(owner, "Choose your character's dong", "Genital Alteration") as null|anything in GLOB.cock_shapes_list
+		if(new_shape)
+			H.dna.features["cock_shape"] = new_shape
+		H.update_genitals()
+		H.give_penis()
+		H.apply_overlay()
+
+
+	else if (select_alteration == "Vagina")
+		for(var/obj/item/organ/genital/vagina/X in H.internal_organs)
+			qdel(X)
+		var/new_shape
+		new_shape = input(owner, "Choose your character's pussy", "Genital Alteration") as null|anything in GLOB.vagina_shapes_list
+		if(new_shape)
+			H.dna.features["vag_shape"] = new_shape
+		H.update_genitals()
+		H.give_vagina()
+		H.apply_overlay()
+
 	else
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Added a few more functions to the slimeperson form alteration ability, giving easy access to change genitalia sizes/shapes.
-Fixed a wrong proc call in alter form for removing genitalia.

-Thanks to Pooj for helping me figure some things out.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Slimepeople can already alter their appearances, why not be able to alter your naughty bits as well?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added the ability to alter your genitalia as a slimeperson more than addition/removal.
fix: fixed genitalia removal proc in alter form.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
