### PR TITLE
[PORT] Non-station AI can no longer interact off their z-level.

### DIFF
--- a/code/_onclick/ai.dm
+++ b/code/_onclick/ai.dm
@@ -23,6 +23,9 @@
 		return
 	next_click = world.time + 1
 
+	if(!can_interact_with(A))
+		return
+
 	if(multicam_on)
 		var/turf/T = get_turf(A)
 		if(T)
@@ -60,7 +63,6 @@
 			controlled_mech.click_action(A, src, params) //Override AI normal click behavior.
 		return
 
-		return
 	if(modifiers["shift"])
 		ShiftClickOn(A)
 		return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -288,8 +288,17 @@
 
 /mob/living/silicon/ai/can_interact_with(atom/A)
 	. = ..()
+	var/turf/ai = get_turf(src)
+	var/turf/target = get_turf(A)
 	if (.)
 		return
+
+	if(!target)
+		return
+
+	if ((ai.z != target.z) && !is_station_level(ai.z))
+		return FALSE
+
 	if (istype(loc, /obj/item/aicard))
 		var/turf/T0 = get_turf(src)
 		var/turf/T1 = get_turf(A)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
-Ports https://github.com/tgstation/tgstation/pull/43710

Non-station AI have full camera access but cannot interact with machinery/airlocks/etc.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
-Inhibits the ability for people to do antaggy things on station from offstation.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Ported the inability for non-station AI to interact with station z-level.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
