### PR TITLE
Fleshmend and Adrenals now have a loudness of 2.

### DIFF
--- a/adrenaline.dm
+++ b/adrenaline.dm
@@ -1,0 +1,17 @@
+/obj/effect/proc_holder/changeling/adrenaline
+	name = "Adrenaline Sacs"
+	desc = "We evolve additional sacs of adrenaline throughout our body."
+	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Continued use poisons the body. This ability is loud, and might cause our blood to react violently to heat."
+	chemical_cost = 30
+	loudness = 2
+	dna_cost = 2
+	req_human = 1
+	req_stat = UNCONSCIOUS
+	action_icon = 'icons/mob/actions/actions_changeling.dmi'
+	action_icon_state = "ling_adrenals"
+	action_background_icon_state = "bg_ling"
+
+//Recover from stuns.
+/obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
+	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "regen_jelly" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 0, 0.75, 0)
+	return TRUE

--- a/adrenaline.dm
+++ b/adrenaline.dm
@@ -1,0 +1,17 @@
+/obj/effect/proc_holder/changeling/adrenaline
+	name = "Adrenaline Sacs"
+	desc = "We evolve additional sacs of adrenaline throughout our body."
+	helptext = "Removes all stuns instantly and adds a short-term reduction in further stuns. Can be used while unconscious. Continued use poisons the body."
+	chemical_cost = 30
+	loudness = 2
+	dna_cost = 2
+	req_human = 1
+	req_stat = UNCONSCIOUS
+	action_icon = 'icons/mob/actions/actions_changeling.dmi'
+	action_icon_state = "ling_adrenals"
+	action_background_icon_state = "bg_ling"
+
+//Recover from stuns.
+/obj/effect/proc_holder/changeling/adrenaline/sting_action(mob/living/user)
+	user.do_adrenaline(0, FALSE, 70, 0, TRUE, list("epinephrine" = 3, "changelingmeth" = 10, "mannitol" = 10, "regen_jelly" = 10, "changelingadrenaline" = 5), "<span class='notice'>Energy rushes through us.</span>", 0, 0.75, 0)
+	return TRUE

--- a/fleshmend.dm
+++ b/fleshmend.dm
@@ -1,0 +1,23 @@
+/obj/effect/proc_holder/changeling/fleshmend
+	name = "Fleshmend"
+	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Functions while unconscious."
+	helptext = "If we are on fire, the healing effect will not function. Does not regrow limbs or restore lost blood."
+	chemical_cost = 20
+	loudness = 2
+	dna_cost = 2
+	req_stat = UNCONSCIOUS
+	action_icon = 'icons/mob/actions/actions_changeling.dmi'
+	action_icon_state = "ling_fleshmend"
+	action_background_icon_state = "bg_ling"
+
+//Starts healing you every second for 10 seconds.
+//Can be used whilst unconscious.
+/obj/effect/proc_holder/changeling/fleshmend/sting_action(mob/living/user)
+	if(user.has_status_effect(STATUS_EFFECT_FLESHMEND))
+		to_chat(user, "<span class='warning'>We are already fleshmending!</span>")
+		return
+	to_chat(user, "<span class='notice'>We begin to heal rapidly.</span>")
+	user.apply_status_effect(STATUS_EFFECT_FLESHMEND)
+	return TRUE
+
+//Check buffs.dm for the fleshmend status effect code

--- a/fleshmend.dm
+++ b/fleshmend.dm
@@ -1,0 +1,23 @@
+/obj/effect/proc_holder/changeling/fleshmend
+	name = "Fleshmend"
+	desc = "Our flesh rapidly regenerates, healing our burns, bruises, and shortness of breath. Functions while unconscious. This ability is loud, and might cause our blood to react violently to heat."
+	helptext = "If we are on fire, the healing effect will not function. Does not regrow limbs or restore lost blood."
+	chemical_cost = 20
+	loudness = 2
+	dna_cost = 2
+	req_stat = UNCONSCIOUS
+	action_icon = 'icons/mob/actions/actions_changeling.dmi'
+	action_icon_state = "ling_fleshmend"
+	action_background_icon_state = "bg_ling"
+
+//Starts healing you every second for 10 seconds.
+//Can be used whilst unconscious.
+/obj/effect/proc_holder/changeling/fleshmend/sting_action(mob/living/user)
+	if(user.has_status_effect(STATUS_EFFECT_FLESHMEND))
+		to_chat(user, "<span class='warning'>We are already fleshmending!</span>")
+		return
+	to_chat(user, "<span class='notice'>We begin to heal rapidly.</span>")
+	user.apply_status_effect(STATUS_EFFECT_FLESHMEND)
+	return TRUE
+
+//Check buffs.dm for the fleshmend status effect code


### PR DESCRIPTION
## About The Pull Request

fleshmend loudness 0 -> 2
adrenals loudness 0 -> 2

## Why It's Good For The Game

Stealthlings can no longer grab the best parts of the loud options and still fly under the radar of an actual ling blood test.