### PR TITLE
Allows shoulder holster to hold cap gun and mini-eguns

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -576,6 +576,8 @@
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box,
+		/obj/item/gun/energy/laser/captain,
+		/obj/item/gun/energy/e_gun/mini
 		))
 
 /obj/item/storage/belt/holster/full/PopulateContents()

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -576,7 +576,7 @@
 		/obj/item/gun/ballistic/automatic/pistol,
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box,
-		/obj/item/gun/energy/laser/captain,
+		/obj/item/toy/gun,
 		/obj/item/gun/energy/e_gun/mini
 		))
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the hosters hold more items rather then being really specific 

## Why It's Good For The Game
![image](https://user-images.githubusercontent.com/30435998/60223647-8b183000-984e-11e9-9ba6-f9a3f0181397.png)

People feel cheated and this allows for more options 

## Changelog
:cl:
tweak: holster doing holster things
/:cl: