### PR TITLE
 Merging the end-of-shift and its shuttle autocall announcements into one. 

### DIFF
--- a/code/modules/shuttle/emergency.dm
+++ b/code/modules/shuttle/emergency.dm
@@ -199,7 +199,7 @@
 
 	. = ..()
 
-/obj/docking_port/mobile/emergency/request(obj/docking_port/stationary/S, area/signalOrigin, reason, redAlert, set_coefficient=null)
+/obj/docking_port/mobile/emergency/request(obj/docking_port/stationary/S, area/signalOrigin, reason, redAlert, set_coefficient=null, silent = FALSE)
 	if(!isnum(set_coefficient))
 		var/security_num = seclevel2num(get_security_level())
 		switch(security_num)
@@ -228,7 +228,8 @@
 	else
 		SSshuttle.emergencyLastCallLoc = null
 
-	priority_announce("The emergency shuttle has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/ai/shuttlecalled.ogg', "Priority")
+	if(!silent)
+		priority_announce("The emergency shuttle has been called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [timeLeft(600)] minutes.[reason][SSshuttle.emergencyLastCallLoc ? "\n\nCall signal traced. Results can be viewed on any communications console." : "" ]", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 
 /obj/docking_port/mobile/emergency/cancel(area/signalOrigin)
 	if(mode != SHUTTLE_CALL)

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,8 +1,7 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 2 hours have passed.
 	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //2 hours
 		SSshuttle.emergency.request(silent = TRUE)
-		var/redAlert = seclevel2num(get_security_level()) == SEC_LEVEL_RED ? TRUE : FALSE
-		priority_announce("The shift has come to an end and the shuttle called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
+		priority_announce("The shift has come to an end and the shuttle called. [seclevel2num(get_security_level()) == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 		log_game("Round time limit reached. Shuttle has been auto-called.")
 		message_admins("Round time limit reached. Shuttle called.")
 		emergencyNoRecall = TRUE

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,6 +1,7 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 3 hours has passed.
 	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //3 hours
 		SSshuttle.emergency.request(silent = TRUE)
+		var/RedAlert = seclevel2num(get_security_level()) == SEC_LEVEL_RED ? TRUE : FALSE
 		priority_announce("The shift has come to an end and the shuttle called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 		log_game("Round time limit reached. Shuttle has been auto-called.")
 		message_admins("Round time limit reached. Shuttle called.")

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,6 +1,6 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 3 hours has passed.
 	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //3 hours
-		SSshuttle.emergency.request()
-		priority_announce("The shift has come to an end and the shuttle called.")
+		SSshuttle.emergency.request(silent = TRUE)
+		priority_announce("The shift has come to an end and the shuttle called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 		log_game("Round time limit reached. Shuttle has been auto-called.")
 		message_admins("Round time limit reached. Shuttle called.")

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,7 +1,7 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 3 hours has passed.
 	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //3 hours
 		SSshuttle.emergency.request(silent = TRUE)
-		var/RedAlert = seclevel2num(get_security_level()) == SEC_LEVEL_RED ? TRUE : FALSE
+		var/redAlert = seclevel2num(get_security_level()) == SEC_LEVEL_RED ? TRUE : FALSE
 		priority_announce("The shift has come to an end and the shuttle called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 		log_game("Round time limit reached. Shuttle has been auto-called.")
 		message_admins("Round time limit reached. Shuttle called.")

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,7 +1,8 @@
-/datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 3 hours has passed.
-	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //3 hours
+/datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 2 hours have passed.
+	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //2 hours
 		SSshuttle.emergency.request(silent = TRUE)
 		var/redAlert = seclevel2num(get_security_level()) == SEC_LEVEL_RED ? TRUE : FALSE
 		priority_announce("The shift has come to an end and the shuttle called. [redAlert ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 		log_game("Round time limit reached. Shuttle has been auto-called.")
 		message_admins("Round time limit reached. Shuttle called.")
+		emergencyNoRecall = TRUE


### PR DESCRIPTION
## About The Pull Request
What's said on the tin, currently these are two separate announcements playing two separate sounds.
Merging them together to reduce the clutter.

## Why It's Good For The Game
This could be deemed an improvement I presume.

## Changelog
:cl:
tweak: Merges the end-of-shift and its shuttle autocall announcements into one.
fix: Prevents the end-of-shift shuttle from being recalled (even if to no avail).
/:cl:
