### PR TITLE
buffs wheelchair movespeeds/changes a floor in the equation to a round

### DIFF
--- a/code/modules/vehicles/wheelchair.dm
+++ b/code/modules/vehicles/wheelchair.dm
@@ -45,7 +45,7 @@
 		var/datum/component/riding/D = GetComponent(/datum/component/riding)
 		//1.5 (movespeed as of this change) multiplied by 6.7 gets ABOUT 10 (rounded), the old constant for the wheelchair that gets divided by how many arms they have
 		//if that made no sense this simply makes the wheelchair speed change along with movement speed delay
-		D.vehicle_move_delay = round(CONFIG_GET(number/movedelay/run_delay) * 6.7) / min(user.get_num_arms(), 2)
+		D.vehicle_move_delay = round((CONFIG_GET(number/movedelay/run_delay) * 4) / min(user.get_num_arms(), 2), world.tick_lag)
 	return ..()
 
 /obj/vehicle/ridden/wheelchair/Moved()


### PR DESCRIPTION
Wheelchairs are too slow tbh. Let's make 'em slightly (33% at most) faster.