### PR TITLE
crew monitor indexing pet peeve.

### DIFF
--- a/code/game/machinery/computer/crew.dm
+++ b/code/game/machinery/computer/crew.dm
@@ -31,7 +31,6 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 
 	var/list/jobs = new/list()
 	jobs["Captain"] = 00
-	jobs["Head of Personnel"] = 50
 	jobs["Head of Security"] = 10
 	jobs["Warden"] = 11
 	jobs["Security Officer"] = 12
@@ -47,9 +46,10 @@ GLOBAL_DATUM_INIT(crewmonitor, /datum/crewmonitor, new)
 	jobs["Chief Engineer"] = 40
 	jobs["Station Engineer"] = 41
 	jobs["Atmospheric Technician"] = 42
-	jobs["Quartermaster"] = 51
-	jobs["Shaft Miner"] = 52
-	jobs["Cargo Technician"] = 53
+	jobs["Quartermaster"] = 50
+	jobs["Shaft Miner"] = 51
+	jobs["Cargo Technician"] = 52
+	jobs["Head of Personnel"] = 60
 	jobs["Bartender"] = 61
 	jobs["Cook"] = 62
 	jobs["Botanist"] = 63


### PR DESCRIPTION
## About The Pull Request
The crew monitor's entry for the Quartermaster will now appear bolded (since they are a head of staff), while HoP's will be of the same color of the service/unknown/other jobs (as they are not the boss of cargonia anymore).

## Why It's Good For The Game
Pet peeves.

## Changelog
:cl:
tweak: The crew monitor's entry for the Quartermaster will now appear bolded, while HoP's will be of the same color of the service/unknown/other jobs.
/:cl: