### PR TITLE
nerfs large ebows, traitor ebows drowsy 50 --> 30 and damage 8-->15

### DIFF
--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -13,7 +13,8 @@
 	. = ..()
 	if(isliving(A))
 		var/mob/living/M = A
-		M.radiation = min(M.radiation + radiation_increase, radiation_max)
+		if(M.radiation < radiation_max)
+			M.radiation = min(M.radiation + radiation_increase, radiation_max)
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -15,3 +15,4 @@
 /obj/item/projectile/energy/bolt/large
 	damage = 20
 	knockdown = 79
+	drowsy = 0

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -11,8 +11,8 @@
 
 /obj/item/projectile/energy/bolt/on_hit(atom/A, blocked)
 	. = ..()
-	if(ismob(A))
-		var/mob/M = A
+	if(isliving(A))
+		var/mob/living/M = A
 		M.radiation = min(M.radiation + radiation_increase, radiation_max)
 
 /obj/item/projectile/energy/bolt/halloween

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -22,3 +22,4 @@
 /obj/item/projectile/energy/bolt/large
 	damage = 20
 	knockdown = 79
+	radiation_increase = 0

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,12 +1,19 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 8
+	damage = 15
 	damage_type = TOX
 	nodamage = 0
 	knockdown = 100
 	stutter = 5
-	drowsy = 50
+	var/radiation_max = 900
+	var/radiation_increase = 300
+
+/obj/item/projectile/energy/bolt/on_hit(atom/A, blocked)
+	. = ..()
+	if(ismob(A))
+		var/mob/M = A
+		M.radiation = min(M.radiation + radiation_increase, radiation_max)
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"
@@ -14,3 +21,4 @@
 
 /obj/item/projectile/energy/bolt/large
 	damage = 20
+	knockdown = 79

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -6,15 +6,7 @@
 	nodamage = 0
 	knockdown = 100
 	stutter = 5
-	var/radiation_max = 900
-	var/radiation_increase = 300
-
-/obj/item/projectile/energy/bolt/on_hit(atom/A, blocked)
-	. = ..()
-	if(isliving(A))
-		var/mob/living/M = A
-		if(M.radiation < radiation_max)
-			M.radiation = min(M.radiation + radiation_increase, radiation_max)
+	drowsy = 30
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"
@@ -23,4 +15,3 @@
 /obj/item/projectile/energy/bolt/large
 	damage = 20
 	knockdown = 79
-	radiation_increase = 0


### PR DESCRIPTION
Reduces heavy ebow knockdown to 79 to prevent hardstun/disarm and to do nothing else.
Traitor ebow damage buffed to 15 and now does 300 radiation per hit, capping at 900.

Why: Knockout is overpowered as fuck and these are literally just better tasers that are EMP immune and spammable otherwise. 20 tox is already powerful as fuck considering how hard toxins is to heal in comparison to burn.