### PR TITLE
Tweaks dogborg sleeper insert/resist values, and adds the ability to pry open dogborg sleepers via crowbar

### DIFF
--- a/code/game/objects/items/devices/dogborg_sleeper.dm
+++ b/code/game/objects/items/devices/dogborg_sleeper.dm
@@ -17,7 +17,7 @@
 	var/eject_port = "ingestion"
 	var/escape_in_progress = FALSE
 	var/message_cooldown
-	var/breakout_time = 300
+	var/breakout_time = 150
 	var/tmp/last_hearcheck = 0
 	var/tmp/list/hearing_mobs
 	var/list/items_preserved = list()
@@ -77,7 +77,7 @@
 		to_chat(user, "<span class='warning'>Your [src] is already occupied.</span>")
 		return
 	user.visible_message("<span class='warning'>[hound.name] is carefully inserting [target.name] into their [src].</span>", "<span class='notice'>You start placing [target] into your [src]...</span>")
-	if(!patient && iscarbon(target) && !target.buckled && do_after (user, 50, target = target))
+	if(!patient && iscarbon(target) && !target.buckled && do_after (user, 100, target = target))
 
 		if(!in_range(src, target)) //Proximity is probably old news by now, do a new check.
 			return //If they moved away, you can't eat them.
@@ -420,6 +420,7 @@
 	desc = "Equipment for medical hound. A mounted sleeper that stabilizes patients and can inject reagents in the borg's reserves."
 	icon = 'icons/mob/dogborg.dmi'
 	icon_state = "sleeper"
+	breakout_time = 30 //Medical sleepers should be designed to be as easy as possible to get out of.
 
 /obj/item/dogborg/sleeper/K9 //The K9 portabrig
 	name = "Mobile Brig"
@@ -429,6 +430,7 @@
 	inject_amount = 0
 	min_health = -100
 	injection_chems = null //So they don't have all the same chems as the medihound!
+	breakout_time = 300
 
 /obj/item/storage/attackby(obj/item/dogborg/sleeper/K9, mob/user, proximity)
 	if(istype(K9))

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -580,6 +580,17 @@
 	else
 		return ..()
 
+/mob/living/silicon/robot/crowbar_act(mob/living/user, obj/item/I) //TODO: make fucking everything up there in that attackby() proc use the proper tool_act() procs. But honestly, who has time for that? 'cause I know for sure that you, the person reading this, sure as hell doesn't.
+	var/validbreakout = FALSE
+	for(var/obj/item/dogborg/sleeper/S in held_items)
+		if(!validbreakout)
+			visible_message("<span class='notice'>[user] wedges [I] into the crevice separating [S] from [src]'s chassis, and begins to pry...</span>", "<span class='notice'>You wedge [I] into the crevice separating [S] from [src]'s chassis, and begin to pry...</span>")
+		validbreakout = TRUE
+		S.go_out()
+	if(validbreakout)
+		return TRUE
+	return ..()
+
 /mob/living/silicon/robot/verb/unlock_own_cover()
 	set category = "Robot Commands"
 	set name = "Unlock Cover"

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -583,6 +583,8 @@
 /mob/living/silicon/robot/crowbar_act(mob/living/user, obj/item/I) //TODO: make fucking everything up there in that attackby() proc use the proper tool_act() procs. But honestly, who has time for that? 'cause I know for sure that you, the person reading this, sure as hell doesn't.
 	var/validbreakout = FALSE
 	for(var/obj/item/dogborg/sleeper/S in held_items)
+		if(!LAZYLEN(S.contents))
+			continue
 		if(!validbreakout)
 			visible_message("<span class='notice'>[user] wedges [I] into the crevice separating [S] from [src]'s chassis, and begins to pry...</span>", "<span class='notice'>You wedge [I] into the crevice separating [S] from [src]'s chassis, and begin to pry...</span>")
 		validbreakout = TRUE


### PR DESCRIPTION
## About The Pull Request
This PR does exactly as it says on the tin. It now takes 10 seconds for dogborgs to insert people into their sleepers, which is double their prior value of 5 seconds. The baseline resist value to get out of dogborg sleepers has been decreased from 30 seconds to 15 seconds. Medihounds have a 3 second resist timer to get out of their sleeper. Sechounds in particular retain their original value of 30 seconds. Additionally, this PR also adds the ability to pry open dogborg sleepers by simply using a crowbar on them. If the dogborg has anything in their sleeper, crowbarring them will instantly eject the sleeper's occupants.

## Why It's Good For The Game
It's annoying as hell from all sides, administrative and player alike, when dogborgs refuse to listen to your repeated law 2 requests to eject the contents of their sleeper. It's also incredibly annoying when a dogborg sleepers you while you're in a life-or-death situation that requires your immediate action. The positives of this PR are self-explanatory.

## Changelog
:cl: Bhijn
add: It's now possible to forcefully eject the occupants of a dogborg's sleeper by using a crowbar on them. This action is instant.
tweak: Resist values for dogborg sleepers have been adjusted. The baseline has been decreased from 30 seconds to 15 seconds. Medihound sleepers have a resist timer of 3 seconds. Sechound sleepers retain a resist timer of 30 seconds.
tweak: It now takes 10 full seconds to insert people into your sleeper. This should hopefully give people some more room to breathe and react to a dogborg attempting to sleeper someone either for no reason or in a way that violates law 2.
/:cl:
