### PR TITLE
Fixes the uplink category indexing.

### DIFF
--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -195,7 +195,7 @@
 /obj/item/clothing/gloves/krav_maga/combatglovesplus
 	name = "combat gloves plus"
 	desc = "These tactical gloves are fireproof and shock resistant, and using nanochip technology it teaches you the powers of krav maga."
-	icon_state = "black"
+	icon_state = "combat"
 	item_state = "blackglovesplus"
 	siemens_coefficient = 0
 	permeability_coefficient = 0.05

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -418,7 +418,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	surplus = 30
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/badass/rapid
+/datum/uplink_item/dangerous/rapid
 	name = "Gloves of the North Star"
 	desc = "These gloves let the user punch people very fast. Does not improve weapon attack speed or the meaty fists of a hulk."
 	item = /obj/item/clothing/gloves/rapid


### PR DESCRIPTION
## About The Pull Request
Fixing the `(pointless) badassary` category appearing between the `dangerous and conspicious` and `stealthy and inconspicious` categories.
Also combat gloves plus icon_state.

## Why It's Good For The Game
ATATATATATATATATATATATATA. (I forgt to re-index the gloves of the north star into the dangerous and conspicious category)

## Changelog
:cl:
fix: Fixing the `(pointless) badassary` category appearing between the `dangerous and conspicious` and `stealthy and inconspicious` categories.
fix: Combat gloves plus now properly use the combat gloves sprite.
/:cl: