### PR TITLE
Action button swapping

### DIFF
--- a/code/_onclick/hud/action_button.dm
+++ b/code/_onclick/hud/action_button.dm
@@ -20,10 +20,23 @@
 	else
 		return TRUE
 
-/obj/screen/movable/action_button/MouseDrop()
-	if (!can_use(usr))
+/obj/screen/movable/action_button/MouseDrop(over_object)
+	if(!can_use(usr))
 		return
-	return ..()
+	if((istype(over_object, /obj/screen/movable/action_button) && !istype(over_object, /obj/screen/movable/action_button/hide_toggle)))
+		if(locked)
+			to_chat(usr, "<span class='warning'>Action button \"[name]\" is locked, unlock it first.</span>")
+			return
+		var/obj/screen/movable/action_button/B = over_object
+		var/list/actions = usr.actions
+		actions.Swap(actions.Find(src.linked_action), actions.Find(B.linked_action))
+		moved = FALSE
+		ordered = TRUE
+		B.moved = FALSE
+		B.ordered = TRUE
+		usr.update_action_buttons()
+	else
+		return ..()
 
 /obj/screen/movable/action_button/Click(location,control,params)
 	if (!can_use(usr))


### PR DESCRIPTION
Port of https://github.com/tgstation/tgstation/pull/44658
## About The Pull Request
* This PR adds an option to swap action buttons positions by dragging them on top of each other from /vg/, example gif below:
![](https://user-images.githubusercontent.com/43862960/59773260-a06ce780-92ad-11e9-9aba-1903db3548e6.gif)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Quality of Life change, you can now very easily reorganize your actions buttons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Sishen1542, original by Arkatos
add: Action buttons can now be dragged onto each other to swap places
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
