### PR TITLE
Adds Promiscuous Organs crate to cargo

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -113,5 +113,6 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/clothing/shoes/wheelys = 1,
 	/obj/item/clothing/shoes/kindleKicks = 1,
 	/obj/item/autosurgeon/penis = 1,
+	/obj/item/autosurgeon/testicles = 1,
 	"" = 3
 	))

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1157,7 +1157,7 @@
 /datum/supply_pack/materials/bz
 	name = "BZ Canister Crate"
 	desc = "Contains a canister of BZ. Requires Toxins access to open."
-	cost = 7500 // Costs 3 credits more than what you can get for selling it. 
+	cost = 7500 // Costs 3 credits more than what you can get for selling it.
 	access = ACCESS_TOX_STORAGE
 	contains = list(/obj/machinery/portable_atmospherics/canister/bz)
 	crate_name = "BZ canister crate"
@@ -2716,6 +2716,7 @@
 					/obj/item/restraints/handcuffs/fake/kinky,
 					/obj/item/clothing/head/kitty/genuine, // Why its illegal
 					/obj/item/clothing/head/kitty/genuine,
+					/obj/item/storage/pill_bottle/penis_enlargement,
 					/obj/structure/reagent_dispensers/keg/aphro)
 	crate_name = "lewd kit"
 	crate_type = /obj/structure/closet/crate
@@ -2749,6 +2750,19 @@
 					/obj/item/pen/fountain,
 					/obj/item/pen/fountain)
 	crate_name = "Paperwork"
+
+/datum/supply_pack/misc/randomised/promiscuous
+	name = "Promiscuous Organs"
+	desc = "Do YOU want to have more genital? Well we have just the thing for you~. This crate has two autosurgeon, that will let you have a new sex, organ to impress that hot stud and or chick."
+	cost = 4000 //Only get 2!
+	contraband = TRUE
+	var/num_contained = 2
+	contains = list(/obj/item/autosurgeon/penis,
+					/obj/item/autosurgeon/testicles,
+					/obj/item/autosurgeon/vagina,
+					/obj/item/autosurgeon/breasts,
+					/obj/item/autosurgeon/womb)
+	crate_name = "promiscuous organs"
 
 /datum/supply_pack/misc/toner
 	name = "Toner Crate"

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -103,3 +103,23 @@
 	desc = "A single use autosurgeon that contains a penis. A screwdriver can be used to remove it, but implants can't be placed back in."
 	uses = 1
 	starting_organ = /obj/item/organ/genital/penis
+
+/obj/item/autosurgeon/testicles
+	desc = "A single use autosurgeon that contains a set of testicles. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/genital/testicles
+
+/obj/item/autosurgeon/vagina
+	desc = "A single use autosurgeon that contains a vagina. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/genital/vagina
+
+/obj/item/autosurgeon/breasts
+	desc = "A single use autosurgeon that contains a set of breasts. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/genital/breasts
+
+/obj/item/autosurgeon/womb
+	desc = "A single use autosurgeon that contains a womb. A screwdriver can be used to remove it, but implants can't be placed back in."
+	uses = 1
+	starting_organ = /obj/item/organ/genital/womb


### PR DESCRIPTION
Wat dis?

<!-- God is dead. -->
<!-- And we killed him. -->
<!-- https://www.youtube.com/watch?v=dGDH3meSPyk. -->

## About The Pull Request

Promiscuous Organs costs 4000 but give you 2 genital organs, randomized.
Adds Penis enlargement pills to lewd crate
Adds testicle auto-surge to maints for the penis one  

## Why It's Good For The Game

People mite want to do lewd things with surgery but not want to wast time/can get the organs.
This also will help people that lose these organs in cloning or to grow their size with better easy other then to maints crawl for rng

## Changelog
:cl:
add: Promiscuous Organs crate, pills to lewd crate and testicles to maints
/:cl:

