### PR TITLE
[TESTMERGE?] [NOT CLICKBAIT?] Projectiles are now one with the quickness.

### DIFF
--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -4,6 +4,7 @@
 	pass_flags = PASSTABLE | PASSGLASS | PASSGRILLE
 	damage = 20
 	light_range = 2
+	speed = 0.4
 	damage_type = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	hitsound_wall = 'sound/weapons/effects/searwall.ogg'
@@ -74,7 +75,6 @@
 	flag = "energy"
 	hitsound = 'sound/weapons/tap.ogg'
 	eyeblur = 0
-	speed = 0.7
 	impact_effect_type = /obj/effect/temp_visual/impact_effect/blue_laser
 	light_color = LIGHT_COLOR_BLUE
 	tracer_type = /obj/effect/projectile/tracer/disabler

--- a/code/modules/projectiles/projectile/bullets.dm
+++ b/code/modules/projectiles/projectile/bullets.dm
@@ -2,6 +2,7 @@
 	name = "bullet"
 	icon_state = "bullet"
 	damage = 60
+	speed = 0.6
 	damage_type = BRUTE
 	nodamage = FALSE
 	candink = TRUE

--- a/code/modules/projectiles/projectile/energy.dm
+++ b/code/modules/projectiles/projectile/energy.dm
@@ -2,6 +2,7 @@
 	name = "energy"
 	icon_state = "spark"
 	damage = 0
+	speed = 0.4
 	damage_type = BURN
 	flag = "energy"
 	is_reflectable = TRUE
@@ -13,6 +14,7 @@
 	name = "electrode"
 	icon_state = "spark"
 	color = "#FFFF00"
+	speed = 0.8
 	nodamage = 1
 	knockdown = 100
 	stutter = 5

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
@@ -60,7 +60,7 @@
 	stamina = 25
 	armour_penetration = -10
 	light_range = 2
-	speed = 0.7
+	speed = 0.4
 	range = 25
 	light_color = LIGHT_COLOR_BLUE
 
@@ -203,7 +203,7 @@
 	damage = 20
 	armour_penetration = 25
 	light_range = 3
-	speed = 0.7
+	speed = 0.6
 	range = 35
 	light_color = LIGHT_COLOR_RED
 
@@ -215,7 +215,7 @@
 	stamina = 25
 	armour_penetration = -10
 	light_range = 3
-	speed = 0.65
+	speed = 0.4
 	range = 35
 	light_color = LIGHT_COLOR_BLUE
 

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -189,7 +189,6 @@
 	name = "positron blast"
 	damage = 80
 	range = 14
-	speed = 0.6
 	icon_state = "disablerslug"
 	icon = 'modular_citadel/icons/obj/projectiles.dmi'
 

--- a/modular_citadel/code/modules/projectiles/projectile/energy.dm
+++ b/modular_citadel/code/modules/projectiles/projectile/energy.dm
@@ -1,2 +1,3 @@
 /obj/item/projectile/energy/electrode
 	stamina = 36
+	speed = 0.8


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Oh boy where do I start.

* Energy based projectiles are now 2.0x the base speed we're all used to, cause light and all.
* Bullet based projectiles are now 1.5x the base speed we're used to.
* Tasers remain the same because fuck you.
* Magrifles are a special case. Lethals are set to 1.5x, non-lethals are 2.0x.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Since Citadel has sprint we can run faster than projectiles while traveling in a straight line, which seems silly to me. With current speeds it's also easy to sidestep projectiles unless they're point blank. 

With the changes I've proposed, you will no longer be able to run in a straight line and get away scott free, nor will you be able to effortlessly sidestep projectiles.

Note that you CAN still dodge/sidestep projectiles, but this will now be more reaction & skill based while also including in the mind game element of juking and anticipation.
* I want all the feedback I can get from this, but try to be constructive. 
* If I missed any projectiles, tell me! It's an easy fix. 


<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: nyoom
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
