### PR TITLE
Corrects  Plastitanium total object damage

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -192,7 +192,7 @@
 	w_class = WEIGHT_CLASS_HUGE		//heyo no bohing this!
 	force = 18		//spear damage
 
-/obj/item/storage/toolbox/durasteel/afterattack(atom/A, mob/user, proximity)
+/obj/item/storage/toolbox/plastitanium/afterattack(atom/A, mob/user, proximity)
 	. = ..()
 	if(proximity && isobj(A) && !isitem(A))
 		var/obj/O = A


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
Sorry
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Now the Plastitanium tool box does its spare damage on objects as its meant to

## Why It's Good For The Game

My brain massively failed that day it seems. This should correct that.

## Changelog
:cl:
N/A - I dont want the GBP for a self fix
/:cl: