### PR TITLE
All maps in rotation now have a public autolathe.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -1688,8 +1688,7 @@
 /obj/machinery/button/door{
 	id = "hos";
 	name = "HoS Office Shutters";
-	pixel_y = -25;
-	
+	pixel_y = -25
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -56667,6 +56666,12 @@
 /obj/item/stock_parts/cell/high,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"eef" = (
+/obj/machinery/autolathe{
+	name = "public autolathe"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "evR" = (
 /turf/open/floor/plating,
 /area/maintenance/bar)
@@ -81613,7 +81618,7 @@ cNG
 cNJ
 bLF
 aZK
-bbR
+eef
 bbR
 bqt
 cBq

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -35021,11 +35021,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "blM" = (
-/obj/structure/table,
-/obj/item/storage/box/lights/mixed,
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/autolathe{
+	name = "public autolathe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -35043,6 +35044,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/item/storage/box/lights/mixed,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "blO" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -31526,6 +31526,10 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/closet/crate{
+	icon_state = "crateopen"
+	},
+/obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "biO" = (
@@ -32402,16 +32406,15 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bks" = (
-/obj/structure/closet/crate{
-	icon_state = "crateopen"
-	},
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
+	},
+/obj/machinery/autolathe{
+	name = "public autolathe"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds public autolathes for maps that did not have them.

Fix of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/8780 because merge error on box, yay.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Makes things easy for crew to get goodies if they desire. Will still need to ask cargo for refills/etc
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added public autolathes to all maps.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
