### PR TITLE
Ports "Add cancel button to assault pod destination selector"

### DIFF
--- a/code/modules/shuttle/assault_pod.dm
+++ b/code/modules/shuttle/assault_pod.dm
@@ -35,7 +35,9 @@
 
 /obj/item/assault_pod/attack_self(mob/living/user)
 	var/target_area
-	target_area = input("Area to land", "Select a Landing Zone", target_area) in GLOB.teleportlocs
+	target_area = input("Area to land", "Select a Landing Zone", target_area) as null|anything in GLOB.teleportlocs
+	if(!target_area)
+		return
 	var/area/picked_area = GLOB.teleportlocs[target_area]
 	if(!src || QDELETED(src))
 		return


### PR DESCRIPTION
## About The Pull Request
Ports tgstation PR ##41524

## Why It's Good For The Game
It cannot be cancelled otherwise.

## Changelog
:cl: Ghommie (original PR by variableundefined)
fix: Cancel button to assault pod destination selector.
/:cl:
