### PR TITLE
Ports "Fixes default supplypods exploding their contents" & co.

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -198,7 +198,8 @@ GLOBAL_LIST_EMPTY(explosions)
 			var/list/items = list()
 			for(var/I in T)
 				var/atom/A = I
-				items += A.GetAllContents()
+				if (!A.prevent_content_explosion()) //The atom/contents_explosion() proc returns null if the contents ex_acting has been handled by the atom, and TRUE if it hasn't.
+					items += A.GetAllContents()
 			for(var/O in items)
 				var/atom/A = O
 				if(!QDELETED(A))

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -289,8 +289,11 @@
 		to_chat(user, "<span class='warning'>You can't move while buckled to [src]!</span>")
 	return
 
+/atom/proc/prevent_content_explosion()
+	return FALSE
+
 /atom/proc/contents_explosion(severity, target)
-	return
+	return //For handling the effects of explosions on contents that would not normally be effected
 
 /atom/proc/ex_act(severity, target)
 	set waitfor = FALSE

--- a/code/modules/cargo/supplypod.dm
+++ b/code/modules/cargo/supplypod.dm
@@ -29,7 +29,7 @@
 	var/effectQuiet = FALSE //The female sniper. If true, the pod makes no noise (including related explosions, opening sounds, etc)
 	var/effectMissile = FALSE //If true, the pod deletes the second it lands. If you give it an explosion, it will act like a missile exploding as it hits the ground
 	var/effectCircle = FALSE //If true, allows the pod to come in at any angle. Bit of a weird feature but whatever its here
-	var/style = STYLE_STANDARD //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the POD_STYLES list in cargo.dm defines to get the proper icon/name/desc for the pod. 
+	var/style = STYLE_STANDARD //Style is a variable that keeps track of what the pod is supposed to look like. It acts as an index to the POD_STYLES list in cargo.dm defines to get the proper icon/name/desc for the pod.
 	var/reversing = FALSE //If true, the pod will not send any items. Instead, after opening, it will close again (picking up items/mobs) and fly back to centcom
 	var/landingSound //Admin sound to play when the pod lands
 	var/openingSound //Admin sound to play when the pod opens
@@ -76,7 +76,7 @@
 
 /obj/structure/closet/supplypod/tool_interact(obj/item/W, mob/user)
 	if (bluespace) //We dont want to worry about interacting with bluespace pods, as they are due to delete themselves soon anyways.
-		return FALSE 
+		return FALSE
 	else
 		..()
 
@@ -86,13 +86,15 @@
 /obj/structure/closet/supplypod/contents_explosion() //Supplypods also protect their contents from the harmful effects of fucking exploding.
 	return
 
+/obj/structure/closet/supplypod/prevent_content_explosion() //Useful for preventing epicenter explosions from damaging contents
+	return TRUE
+
 /obj/structure/closet/supplypod/toggle(mob/living/user) //Supplypods shouldn't be able to be manually opened under any circumstances, as the open() proc generates supply order datums
 	return
 
 /obj/structure/closet/supplypod/proc/preOpen() //Called before the open() proc. Handles anything that occurs right as the pod lands.
 	var/turf/T = get_turf(src)
 	var/list/B = explosionSize //Mostly because B is more readable than explosionSize :p
-	var/boomTotal = 0 //A counter used to check if the explosion does nothing
 	if (landingSound)
 		playsound(get_turf(src), landingSound, soundVolume, 0, 0)
 	for (var/mob/living/M in T)
@@ -108,10 +110,8 @@
 			M.gib() //After adjusting the fuck outta that brute loss we finish the job with some satisfying gibs
 		M.adjustBruteLoss(damage)
 
-	for (var/i in B)
-		boomTotal += i //Count up all the values of the explosion
 
-	if (boomTotal != 0) //If the explosion list isn't all zeroes, call an explosion
+	if (B[1] || B[2] || B[3] || B[4]) //If the explosion list isn't all zeroes, call an explosion
 		explosion(get_turf(src), B[1], B[2], B[3], flame_range = B[4], silent = effectQuiet, ignorecap = istype(src, /obj/structure/closet/supplypod/centcompod)) //less advanced equipment than bluespace pod, so larger explosion when landing
 	else if (!effectQuiet) //If our explosion list IS all zeroes, we still make a nice explosion sound (unless the effectQuiet var is true)
 		playsound(src, "explosion", landingSound ? 15 : 80, 1)
@@ -150,10 +150,10 @@
 		playsound(get_turf(holder), leavingSound, soundVolume, 0, 0)
 	if (reversing) //If we're reversing, we call the close proc. This sends the pod back up to centcom
 		close(holder)
-	else if (bluespace) //If we're a bluespace pod, then delete ourselves (along with our holder, if a seperate holder exists) 
-		if (style != STYLE_INVISIBLE) 
+	else if (bluespace) //If we're a bluespace pod, then delete ourselves (along with our holder, if a seperate holder exists)
+		if (style != STYLE_INVISIBLE)
 			do_sparks(5, TRUE, holder) //Create some sparks right before closing
-		qdel(src) //Delete ourselves and the holder 
+		qdel(src) //Delete ourselves and the holder
 		if (holder != src)
 			qdel(holder)
 

--- a/code/modules/events/immovable_rod.dm
+++ b/code/modules/events/immovable_rod.dm
@@ -100,6 +100,9 @@ In my current plan for it, 'solid' will be defined as anything with density == 1
 /obj/effect/immovablerod/ex_act(severity, target)
 	return 0
 
+/obj/structure/closet/supplypod/prevent_content_explosion()
+	return TRUE
+
 /obj/effect/immovablerod/singularity_act()
 	return
 

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -69,6 +69,9 @@
 /mob/living/silicon/contents_explosion(severity, target)
 	return
 
+/mob/living/silicon/prevent_content_explosion()
+	return TRUE
+
 /mob/living/silicon/proc/cancelAlarm()
 	return
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -41,6 +41,9 @@
 	QDEL_NULL(internal)
 	. = ..()
 
+/mob/living/simple_animal/hostile/megafauna/prevent_content_explosion()
+	return TRUE
+
 /mob/living/simple_animal/hostile/megafauna/death(gibbed)
 	if(health > 0)
 		return

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -653,6 +653,13 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 		else
 			L.show_message("<span class='italics'>You hear an unearthly ringing and notice your skin is covered in fresh radiation burns.</span>", 2)
 
+//Do not blow up our internal radio
+/obj/machinery/power/supermatter_crystal/contents_explosion(severity, target)
+	return
+
+/obj/machinery/power/supermatter_crystal/prevent_content_explosion()
+	return TRUE
+
 /obj/machinery/power/supermatter_crystal/engine
 	is_main_engine = TRUE
 


### PR DESCRIPTION
## About The Pull Request
Ports in TGstation PR  #40491, #40758, #41254, a bit of #44068 and #44613.

## Why It's Good For The Game
Prevents explosions from unintended destruction of some contents.

## Changelog
:cl: Ghommie (original PR by MrDoomBringer, AnturK and YPOQ)
fix: Explosions will no longer damage wizards in rod form, the supermatter monitoring radio and megafauna GPS.
fix: Supplypods no longer detonate their contents.
fix: Fixed silicon items (e.g. cyborg modules) being destroyed by explosion epicenters.
/:cl: