### PR TITLE
Ports "Adds safer helper for alt-click turf listing"

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -366,11 +366,15 @@
 	SEND_SIGNAL(src, COMSIG_CLICK_ALT, user)
 	var/turf/T = get_turf(src)
 	if(T && user.TurfAdjacent(T))
-		if(user.listed_turf == T)
-			user.listed_turf = null
-		else
-			user.listed_turf = T
-			user.client.statpanel = T.name
+		user.listed_turf = T
+		user.client.statpanel = T.name
+
+// Use this instead of /mob/proc/AltClickOn(atom/A) where you only want turf content listing without additional atom alt-click interaction
+/atom/proc/AltClickNoInteract(mob/user, atom/A)
+	var/turf/T = get_turf(A)
+	if(T && user.TurfAdjacent(T))
+		user.listed_turf = T
+		user.client.statpanel = T.name
 
 /mob/proc/TurfAdjacent(turf/T)
 	return T.Adjacent(src)

--- a/code/_onclick/observer.dm
+++ b/code/_onclick/observer.dm
@@ -31,7 +31,7 @@
 		ShiftClickOn(A)
 		return
 	if(modifiers["alt"])
-		AltClickOn(A)
+		AltClickNoInteract(src, A)
 		return
 	if(modifiers["ctrl"])
 		CtrlClickOn(A)

--- a/code/modules/antagonists/revenant/revenant_abilities.dm
+++ b/code/modules/antagonists/revenant/revenant_abilities.dm
@@ -1,13 +1,21 @@
 
-//Harvest; activated ly clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/ClickOn(atom/A, params) //revenants can't interact with the world directly.
-	A.examine(src)
+	var/list/modifiers = params2list(params)
+	if(modifiers["shift"])
+		ShiftClickOn(A)
+		return
+	if(modifiers["alt"])
+		AltClickNoInteract(src, A)
+		return
+
 	if(ishuman(A))
 		if(A in drained_mobs)
 			to_chat(src, "<span class='revenwarning'>[A]'s soul is dead and empty.</span>" )
 		else if(in_range(src, A))
 			Harvest(A)
 
+
+//Harvest; activated ly clicking the target, will try to drain their essence.
 /mob/living/simple_animal/revenant/proc/Harvest(mob/living/carbon/human/target)
 	if(!castcheck(0))
 		return


### PR DESCRIPTION
## About The Pull Request
Ports in TGstation PR  #41237.

## Why It's Good For The Game
Fixes some issues with ghastly alt click.

## Changelog
:cl: Ghommie (original PR by Skoglol)
code: New helper proc for alt-click turf listing, bypasses any interaction overrides.
code: Ghosts and revenants now use the new proc.
fix: Ghosts can no longer toggleopen sleepers, adjust skateboard speed or close laptops
fix: Revenant can now alt-click turf to list contents.
tweak: Revenant now slightly less nosy, use shift click to examine.
tweak: Alt-clicking the same turf again no longer closes the turf listing tab.
/:cl: