### PR TITLE
normalises hop and cap's berets to not hide hair

### DIFF
--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -47,6 +47,7 @@
 	name = "captain's beret"
 	desc = "A beret fit for a leader."
 	icon_state = "capberet"
+	dynamic_hair_suffix = ""
 
 	dog_fashion = null
 
@@ -62,6 +63,7 @@
 	name = "head of personnel's beret"
 	desc = "The symbol of true bureaucratic micromanagement, although in a fancy form."
 	icon_state = "hopberet"
+	dynamic_hair_suffix = ""
 
 	dog_fashion = null
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Every other beret in the game doesn't hide your hair except for the HoP and Captain's, so now they don't just like all other berets.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Consistency in fashion.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: consistency in hop and cap berets
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
