### PR TITLE
Revert "Adds a can_inject check to IV Drips"

### DIFF
--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -81,12 +81,6 @@
 		to_chat(usr, "<span class='danger'>The drip beeps: Warning, incompatible creature!</span>")
 		return
 
-	var/mob/living/L
-	if(isliving(target))
-		L = target
-		if(!L.can_inject(usr, 1))
-			return
-
 	if(Adjacent(target) && usr.Adjacent(target))
 		if(beaker)
 			usr.visible_message("<span class='warning'>[usr] attaches [src] to [target].</span>", "<span class='notice'>You attach [src] to [target].</span>")


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#8244

I'm gonna be honest if someone drags these around to abuse 'em and combat clickdrag like a makeshift 2 tile syringe gun, hats off to 'em. Ninjas especially get hit by these if they need to use IVs and I honestly don't see the problem of having IVs inject past suits.