### PR TITLE
Fixes rocket launchers, buffing their accuracy etc.

### DIFF
--- a/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/code/game/machinery/computer/arcade/minesweeper.dm
@@ -250,11 +250,11 @@
 						itemname = "a syndicate bomb beacon"
 						new /obj/item/sbeacondrop/bomb(loc)
 					if(2)
-						itemname = "a grenade launcher"
-						new /obj/item/gun/ballistic/revolver/grenadelauncher/unrestricted(loc)
-						new /obj/item/ammo_casing/a40mm(loc)
-						new /obj/item/ammo_casing/a40mm(loc)
-						new /obj/item/ammo_casing/a40mm(loc)
+						itemname = "a rocket launcher"
+						new /obj/item/gun/ballistic/rocketlauncher/unrestricted(loc)
+						new /obj/item/ammo_casing/caseless/rocket(loc)
+						new /obj/item/ammo_casing/caseless/rocket(loc)
+						new /obj/item/ammo_casing/caseless/rocket(loc)
 					if(3)
 						itemname = "two bags of c4"
 						new /obj/item/storage/backpack/duffelbag/syndie/c4(loc)

--- a/code/modules/projectiles/ammunition/caseless/rocket.dm
+++ b/code/modules/projectiles/ammunition/caseless/rocket.dm
@@ -9,7 +9,7 @@
 	name = "\improper PM-9HEDP"
 	desc = "An 84mm High Explosive Dual Purpose rocket. Pointy end toward mechs."
 	caliber = "84mm"
-	icon_state = "s-casing-live"
+	icon_state = "84mm-hedp"
 	projectile_type = /obj/item/projectile/bullet/a84mm
 
 /obj/item/ammo_casing/caseless/a75

--- a/code/modules/projectiles/boxes_magazines/internal/grenade.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/grenade.dm
@@ -11,7 +11,7 @@
 	max_ammo = 1
 
 /obj/item/ammo_box/magazine/internal/rocketlauncher
-	name = "grenade launcher internal magazine"
+	name = "rocket launcher internal magazine"
 	ammo_type = /obj/item/ammo_casing/caseless/rocket
 	caliber = "84mm"
 	max_ammo = 1

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -32,9 +32,10 @@
 	var/fire_delay = 0					//rate of fire for burst firing and semi auto
 	var/firing_burst = 0				//Prevent the weapon from firing again while already firing
 	var/semicd = 0						//cooldown handler
-	var/weapon_weight = WEAPON_LIGHT
+	var/weapon_weight = WEAPON_LIGHT	//currently only used for inaccuracy
 	var/spread = 0						//Spread induced by the gun itself.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
+	var/inaccuracy_modifier = 1
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/guns_righthand.dmi'
@@ -538,3 +539,13 @@
 	if(A == chambered)
 		chambered = null
 		update_icon()
+
+/obj/item/gun/proc/getinaccuracy(mob/living/user)
+	if(!iscarbon(user))
+		return FALSE
+	else
+		var/mob/living/carbon/holdingdude = user
+		if(istype(holdingdude) && holdingdude.combatmode)
+			return (max((holdingdude.lastdirchange + weapon_weight * 25) - world.time,0) * inaccuracy_modifier)
+		else
+			return ((weapon_weight * 25) * inaccuracy_modifier)

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -86,6 +86,7 @@
 	pin = /obj/item/firing_pin/implant/pindicate
 	burst_size = 1
 	fire_delay = 0
+	inaccuracy_modifier = 0.7
 	casing_ejector = FALSE
 	weapon_weight = WEAPON_HEAVY
 	magazine_wording = "rocket"
@@ -108,33 +109,33 @@
 /obj/item/gun/ballistic/rocketlauncher/can_shoot()
 	return chambered?.BB
 
-/obj/item/gun/ballistic/rocketlauncher/process_chamber()
-	if(chambered)
-		chambered = null
-	if(magazine)
-		QDEL_NULL(magazine)
-	update_icon()
-
 /obj/item/gun/ballistic/rocketlauncher/attack_self_tk(mob/user)
 	return //too difficult to remove the rocket with TK
 
 /obj/item/gun/ballistic/rocketlauncher/attack_self(mob/living/user)
 	if(magazine)
-		if(chambered)
-			chambered.forceMove(magazine)
-			magazine.stored_ammo.Insert(1, chambered)
+		var/obj/item/ammo_casing/AC = chambered
+		if(AC)
+			if(!user.put_in_hands(AC))
+				AC.bounce_away(FALSE, NONE)
+			to_chat(user, "<span class='notice'>You remove \the [AC] from \the [src]!</span>")
+			playsound(src, 'sound/weapons/gun_magazine_remove_full.ogg', 70, TRUE)
 			chambered = null
 		else
-			stack_trace("Removed [magazine] from [src] without a chambered round")
-		magazine.forceMove(drop_location())
-		if(user.is_holding(src))
-			user.put_in_hands(magazine)
-		playsound(src, 'sound/weapons/gun_magazine_remove_full.ogg', 70, TRUE)
-		to_chat(user, "<span class='notice'>You work the [magazine] out from [src].</span>")
-		magazine = null
-	else
-		to_chat(user, "<span class='notice'>There's no rocket in [src].</span>")
+			to_chat(user, "<span class='notice'>There's no [magazine_wording] in [src].</span>")
 	update_icon()
+
+/obj/item/gun/ballistic/rocketlauncher/attackby(obj/item/A, mob/user, params)
+	if(magazine && istype(A, /obj/item/ammo_casing))
+		if(user.temporarilyRemoveItemFromInventory(A))
+			if(!chambered)
+				to_chat(user, "<span class='notice'>You load a new [A] into \the [src].</span>")
+				playsound(src, "gun_insert_full_magazine", 70, 1)
+				chamber_round()
+				update_icon()
+				return TRUE
+		else
+			to_chat(user, "<span class='warning'>You cannot seem to get \the [A] out of your hands!</span>")
 
 /obj/item/gun/ballistic/rocketlauncher/update_icon()
 	icon_state = "[initial(icon_state)]-[chambered ? "1" : "0"]"

--- a/code/modules/projectiles/projectile/special/rocket.dm
+++ b/code/modules/projectiles/projectile/special/rocket.dm
@@ -16,6 +16,7 @@
 	var/anti_armour_damage = 200
 	armour_penetration = 100
 	dismemberment = 100
+	ricochets_max = 0
 
 /obj/item/projectile/bullet/a84mm/on_hit(atom/target, blocked = FALSE)
 	..()

--- a/modular_citadel/code/modules/projectiles/gun.dm
+++ b/modular_citadel/code/modules/projectiles/gun.dm
@@ -9,13 +9,3 @@
 		return 0
 	else
 		return ..()
-
-/obj/item/gun/proc/getinaccuracy(mob/living/user)
-	if(!iscarbon(user))
-		return 0
-	else
-		var/mob/living/carbon/holdingdude = user
-		if(istype(holdingdude) && holdingdude.combatmode)
-			return max((holdingdude.lastdirchange + weapon_weight * 25) - world.time,0)
-		else
-			return weapon_weight * 25


### PR DESCRIPTION
## About The Pull Request
Fixing the rocket launcher being single use (it's no LAW) and then unreloadable. Fixes one of the two rocket types having the wrong icon_state. Improves the very mediocre accuracy of the weapon. Brings it back to the possible emagged Minesweeper's loot, like it should have been originally (the Minesweeper port was made before the rawket lawnchair's).

EDIT: Yea, the weapon weight and the new inaccuracy_mod var are both currently only used to calculate accuracy, but I opted for the new var rather than modifying the weapon_weight in case someone wanted to expand the weapon_weight usage to something like actual recoil handling.

## Why It's Good For The Game
Bugfixing. Tweaks.

## Changelog
:cl:
fix: Fixes the rocket launcher being unreloadable.
balance: Buffed its accuracy a bit.
tweak: Replaced the grenade launcher emagged minesweeper loot with the rocket launcher like it was originally supposed to be.
/:cl: