### PR TITLE
Stamina damage melee weaponry fixes.

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -64,7 +64,7 @@
 		to_chat(user, "<span class='warning'>You're too exhausted.</span>") // CIT CHANGE - ditto
 		return // CIT CHANGE - ditto
 
-	if(force && HAS_TRAIT(user, TRAIT_PACIFISM))
+	if(force && damtype != STAMINA && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm other living beings!</span>")
 		return
 

--- a/code/game/objects/obj_defense.dm
+++ b/code/game/objects/obj_defense.dm
@@ -48,7 +48,12 @@
 
 /obj/hitby(atom/movable/AM)
 	..()
-	take_damage(AM.throwforce, BRUTE, "melee", 1, get_dir(src, AM))
+	var/throwdamage = AM.throwforce
+	if(isobj(AM))
+		var/obj/O = AM
+		if(O.damtype == STAMINA)
+			throwdamage = 0
+	take_damage(throwdamage, BRUTE, "melee", 1, get_dir(src, AM))
 
 /obj/ex_act(severity, target)
 	if(resistance_flags & INDESTRUCTIBLE)

--- a/code/game/objects/structures/grille.dm
+++ b/code/game/objects/structures/grille.dm
@@ -262,7 +262,7 @@
 	if(isobj(AM))
 		if(prob(50) && anchored && !broken)
 			var/obj/O = AM
-			if(O.throwforce != 0)//don't want to let people spam tesla bolts, this way it will break after time
+			if(O.throwforce != 0 && O.damtype != STAMINA)//don't want to let people spam tesla bolts, this way it will break after time
 				var/turf/T = get_turf(src)
 				var/obj/structure/cable/C = T.get_cable_node()
 				if(C)


### PR DESCRIPTION
## About The Pull Request
Trilby asked me to check if pacifists would have been able to use the non-lethal riot security bats. Turns out they are not.
Also fixing some inconsistency I noticed with stamina weaponry being able to damage objects when thrown while not when bashed upon.

## Why It's Good For The Game
Fixing some inconsistencies.

## Changelog
:cl:
fix: Fixing stamina damage melee weaponry being unusable by pacifists, and still damaging objects and triggering electrified grilles when thrown.
/:cl: