### PR TITLE
Fixes nanites getting instant nuked by EMPs and shocks and removes the random drain in favor of a scaled drain

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -170,8 +170,6 @@
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
 	adjust_nanites(null, -(nanite_volume * 0.3 + 50))		//Lose 30% variable and 50 flat nanite volume.
-	if(prob(40/severity))
-		cloud_id = 0
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
 		NP.on_emp(severity)
@@ -183,7 +181,7 @@
 		NP.on_shock(shock_damage)
 
 /datum/component/nanites/proc/on_minor_shock(datum/source)
-	adjust_nanites(null, -15)
+	adjust_nanites(null, -25)
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
 		NP.on_minor_shock()

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -169,8 +169,7 @@
 	holder.icon_state = "nanites[nanite_percent]"
 
 /datum/component/nanites/proc/on_emp(datum/source, severity)
-	nanite_volume *= (rand(0.60, 0.90))		//Lose 10-40% of nanites
-	adjust_nanites(null, -(rand(5, 50)))		//Lose 5-50 flat nanite volume
+	adjust_nanites(null, -(nanite_volume * 0.3 + 50))		//Lose 30% variable and 50 flat nanite volume.
 	if(prob(40/severity))
 		cloud_id = 0
 	for(var/X in programs)
@@ -178,14 +177,13 @@
 		NP.on_emp(severity)
 
 /datum/component/nanites/proc/on_shock(datum/source, shock_damage)
-	nanite_volume *= (rand(0.45, 0.80))		//Lose 20-55% of nanites
-	adjust_nanites(null, -(rand(5, 50)))			//Lose 5-50 flat nanite volume
+	adjust_nanites(null, -(nanite_volume * (shock_damage * 0.005) + shock_damage)) //0.5% of shock damage (@ 50 damage it'd drain 25%) + shock damage flat volume
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
 		NP.on_shock(shock_damage)
 
 /datum/component/nanites/proc/on_minor_shock(datum/source)
-	adjust_nanites(null, -(rand(5, 15)))			//Lose 5-15 flat nanite volume
+	adjust_nanites(null, -15)
 	for(var/X in programs)
 		var/datum/nanite_program/NP = X
 		NP.on_minor_shock()


### PR DESCRIPTION
EMPs no longer scramble cloud IDs
EMPs now drain 15%/30% (severity low/high) and 25/50 flat nanite volume (severity low/high). This takes 4-5 EMPs to completely kill nanites from 500. Can make the scaling higher at low volumes if needed. 
EMPs on the new stats drain, on average, more nanites than the old stats in high severity EMPs.

Shocks now drain damage*0.005% and a flat amount based on damage. At 35 damage you'd drain 17.5% and 35 flat. 

Minor shocks like tasers/batons now drain 25 flat all the time, up from being random from 5 to 15.