### PR TITLE
Janitors are no longer diabetic - nerfs mop stamina usage to be in-line with how much effort mopping takes IRL

### DIFF
--- a/code/game/objects/items/mop.dm
+++ b/code/game/objects/items/mop.dm
@@ -15,7 +15,7 @@
 	var/mopping = 0
 	var/mopcount = 0
 	var/mopcap = 5
-	var/stamusage = 5
+	var/stamusage = 2
 	force_string = "robust... against germs"
 	var/insertable = TRUE
 
@@ -94,7 +94,7 @@
 	force = 6
 	throwforce = 8
 	throw_range = 4
-	stamusage = 2
+	stamusage = 1
 	var/refill_enabled = TRUE //Self-refill toggle for when a janitor decides to mop with something other than water.
 	var/refill_rate = 1 //Rate per process() tick mop refills itself
 	var/refill_reagent = "water" //Determins what reagent to use for refilling, just in case someone wanted to make a HOLY MOP OF PURGING


### PR DESCRIPTION
Title. The former value of 5 stam per turf mopped was a bit silly, and meant that you ended up running out of stamina while mopping up a single room. This nerfs the base mop to take only 2 stamina, while the advanced mop now takes 1 stamina (both values not taking into account the stamina buffer)

## Changelog
:cl:
balance: Normal mops now only use 2 stamina to mop a tile, nerfed from their previous value of 5 stamina per tile mopped.
balance: Advanced mops now only use 1 stamina to mop turfs, from their former value of 2 stam.
/:cl:
