### PR TITLE
Makes gamemodes less dependant on latejoiners (I think?)

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -131,7 +131,7 @@ Credit where due:
 	config_tag = "clockwork_cult"
 	antag_flag = ROLE_SERVANT_OF_RATVAR
 	false_report_weight = 10
-	required_players = 35
+	required_players = 30
 	required_enemies = 3
 	recommended_enemies = 5
 	enemy_minimum_age = 7

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -37,7 +37,7 @@
 	false_report_weight = 10
 	restricted_jobs = list("Chaplain","AI", "Cyborg", "Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel")
 	protected_jobs = list()
-	required_players = 30
+	required_players = 25
 	required_enemies = 3
 	recommended_enemies = 5
 	enemy_minimum_age = 7

--- a/code/game/gamemodes/nuclear/nuclear.dm
+++ b/code/game/gamemodes/nuclear/nuclear.dm
@@ -2,7 +2,7 @@
 	name = "nuclear emergency"
 	config_tag = "nuclear"
 	false_report_weight = 10
-	required_players = 28 // 30 players - 3 players to be the nuke ops = 25 players remaining
+	required_players = 25
 	required_enemies = 2
 	recommended_enemies = 5
 	antag_flag = ROLE_OPERATIVE

--- a/code/game/gamemodes/revolution/revolution.dm
+++ b/code/game/gamemodes/revolution/revolution.dm
@@ -13,7 +13,7 @@
 	antag_flag = ROLE_REV
 	false_report_weight = 10
 	restricted_jobs = list("Security Officer", "Warden", "Detective", "AI", "Cyborg","Captain", "Head of Personnel", "Head of Security", "Chief Engineer", "Research Director", "Chief Medical Officer")
-	required_players = 30
+	required_players = 25
 	required_enemies = 2
 	recommended_enemies = 3
 	enemy_minimum_age = 14


### PR DESCRIPTION
## About The Pull Request
This lowers payer requirements for certain gamemodes by 5 so that maybe they happen more often without being so dependant on whether someone readies up or not. I remember this was done once and reverted due to complaints about lowpop cult but we are literally almost never "that lowpop" anymore and all we get is still fucking traitorling, yes I'm very angry ree.

## Why It's Good For The Game
Because variety is good.

## Changelog
:cl: Coolgat3
tweak: changed player requirement numbers for cult, clockcult, nukeops and revs.
/:cl: