### PR TITLE
Hexacrocin overdose no longer forces climax

### DIFF
--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -152,10 +152,9 @@
 
 /datum/reagent/drug/aphrodisiacplus/overdose_process(mob/living/M)
 	if(M && M.canbearoused && !HAS_TRAIT(M, TRAIT_CROCRIN_IMMUNE) && prob(33))
-		if(M.getArousalLoss() >= 100 && ishuman(M) && M.has_dna())
-			var/mob/living/carbon/human/H = M
-			if(prob(50)) //Less spam
-				to_chat(H, "<span class='love'>Your libido is going haywire!</span>")
+		if(prob(5) && M.getArousalLoss() >= 100 && ishuman(M) && M.has_dna())
+			if(prob(5)) //Less spam
+				to_chat(M, "<span class='love'>Your libido is going haywire!</span>")
 		if(M.min_arousal < 50)
 			M.min_arousal += 1
 		if(M.min_arousal < M.max_arousal)

--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -156,7 +156,6 @@
 			var/mob/living/carbon/human/H = M
 			if(prob(50)) //Less spam
 				to_chat(H, "<span class='love'>Your libido is going haywire!</span>")
-				H.mob_climax(forced_climax=TRUE)
 		if(M.min_arousal < 50)
 			M.min_arousal += 1
 		if(M.min_arousal < M.max_arousal)


### PR DESCRIPTION
## About The Pull Request

Removes the forced climax symptom of hexacrocin overdose.

## Why It's Good For The Game

Every round, someone finds the keg of hexacrocin and drinks it until they spend the rest of the shift spreading ejaculate all over the station. It's gross, it destroys the believability of the setting, and makes the station even more of an unprofessional sex den. People complained about the nudity permits doing this, I think this one has been hiding in plain sight for a long time.

If people still want to spread their juices all over the place, they can remove their clothes and risk arrest for it.

## Changelog
:cl:
tweak: Hexacrocin overdose no longer causes climaxes
/:cl:
