### PR TITLE
Lowers the minimum integrity to trigger Supermatter alert messages

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -52,7 +52,7 @@
 #define SUPERMATTER_DELAM_PERCENT 5
 #define SUPERMATTER_EMERGENCY_PERCENT 25
 #define SUPERMATTER_DANGER_PERCENT 50
-#define SUPERMATTER_WARNING_PERCENT 100
+#define SUPERMATTER_WARNING_PERCENT 75	//down from 100, makes sabotoge have a chance to ramp up if no-one checks the engine after meteors or something.
 
 #define SUPERMATTER_COUNTDOWN_TIME 30 SECONDS
 


### PR DESCRIPTION
## About The Pull Request

The supermatter gets a free headset, which is already a huge ordeal. The moment it drops from 100% it starts screaming over engineering communications about how it is faltering. Makes sabotage basically impossible to do unless you already have advanced gas mixing and temperature fuckery prepared to do it super quickly. Engineers really ought to be checking it more often as well - Especially after meteors or dust clouds. 

## Why It's Good For The Game

Allows supermatter sabotage to have a chance to ramp up, rather than instantly being spoiled. As there aren't any consoles or alarms to actively manipulate, disabling the instantly revealed notifications is impossible to do. The supermatter is also the only engine that can be saved from the brink if an engineering crew is halfway decent. This promotes new ways of round manipulation to encourage crew participation. It would also keep the gradual decline from spamming engineering radios.


## Changelog

:cl: Poojawa
balance: Supermatter alarms have had their tolerance for tomfoolery loosened. 
/:cl:
