### PR TITLE
Non-stealthed nanites now give the user a special examine message

### DIFF
--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -57,6 +57,7 @@
 		RegisterSignal(parent, COMSIG_MOVABLE_HEAR, .proc/on_hear)
 		RegisterSignal(parent, COMSIG_SPECIES_GAIN, .proc/check_viable_biotype)
 		RegisterSignal(parent, COMSIG_NANITE_SIGNAL, .proc/receive_signal)
+		RegisterSignal(parent, COMSIG_PARENT_EXAMPLE, .proc/on_examine)
 
 /datum/component/nanites/UnregisterFromParent()
 	UnregisterSignal(parent, list(COMSIG_HAS_NANITES,

--- a/code/datums/components/nanites.dm
+++ b/code/datums/components/nanites.dm
@@ -12,6 +12,7 @@
 	var/max_programs = NANITE_PROGRAM_LIMIT
 
 	var/stealth = FALSE //if TRUE, does not appear on HUDs and health scans, and does not display the program list on nanite scans
+	var/visible_examine = TRUE
 
 /datum/component/nanites/Initialize(amount = 100, cloud = 0)
 	if(!isliving(parent) && !istype(parent, /datum/nanite_cloud_backup))
@@ -245,6 +246,10 @@
 
 /datum/component/nanites/proc/get_programs(datum/source, list/nanite_programs)
 	nanite_programs |= programs
+
+/datum/component/nanites/proc/on_examine(datum/source, mob/user)
+	if(!stealth && visible_examine)
+		to_chat(user, "<span class='notice'>Their eyes shine with an electric fluid.</span>")
 
 /datum/component/nanites/proc/nanite_scan(datum/source, mob/user, full_scan)
 	if(!full_scan)


### PR DESCRIPTION
Makes it easier to tell there's nanites until I actually overhaul nanites.