### PR TITLE
Sweaters now cover the groins too.

### DIFF
--- a/modular_citadel/code/modules/clothing/under/turtlenecks.dm
+++ b/modular_citadel/code/modules/clothing/under/turtlenecks.dm
@@ -43,8 +43,8 @@
 	icon_state = "bb_turtle"
 	item_state = "w_suit"
 	item_color = "bb_turtle"
-	body_parts_covered = CHEST|ARMS
-	can_adjust = 1
+	body_parts_covered = CHEST|GROIN|ARMS
+	can_adjust = TRUE
 	icon = 'modular_citadel/icons/obj/clothing/turtlenecks.dmi'
 	alternate_worn_icon = 'modular_citadel/icons/mob/citadel/uniforms.dmi'
 	mutantrace_variation = NO_MUTANTRACE_VARIATION


### PR DESCRIPTION
## About The Pull Request
What said on the tin. How is one supposed to be cozy up north if it doesn't cover their south?
It's fairly annoying.

## Why It's Good For The Game
Unexposes the crotch. No sprite change needed.

## Changelog
:cl:
tweak: Sweaters now cover groins too.
/:cl:
