### PR TITLE
Fixes Zelus flasks a bit.

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -275,7 +275,7 @@ Credit where due:
 	gloves = /obj/item/clothing/gloves/color/yellow
 	belt = /obj/item/storage/belt/utility/servant
 	backpack_contents = list(/obj/item/storage/box/engineer = 1, \
-	/obj/item/clockwork/replica_fabricator = 1, /obj/item/stack/tile/brass/fifty = 1, /obj/item/paper/servant_primer = 1, /obj/item/reagent_containers/food/drinks/holyoil = 1)
+	/obj/item/clockwork/replica_fabricator = 1, /obj/item/stack/tile/brass/fifty = 1, /obj/item/paper/servant_primer = 1, /obj/item/reagent_containers/food/drinks/bottle/holyoil = 1)
 	id = /obj/item/pda
 	var/plasmaman //We use this to determine if we should activate internals in post_equip()
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -425,7 +425,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	new/datum/stack_recipe("receiver - steam vent", /obj/structure/destructible/clockwork/trap/steam_vent, 3, time = 30, one_per_turf = TRUE, on_floor = TRUE, placement_checks = STACK_CHECK_CARDINALS), \
 	new/datum/stack_recipe("receiver - power nullifier", /obj/structure/destructible/clockwork/trap/power_nullifier, 5, time = 20, one_per_turf = TRUE, on_floor = TRUE, placement_checks = STACK_CHECK_CARDINALS), \
 	null,
-	new/datum/stack_recipe("brass flask", /obj/item/reagent_containers/food/drinks/holyoil/null), \
+	new/datum/stack_recipe("brass flask", /obj/item/reagent_containers/food/drinks/bottle/holyoil/null), \
 
 ))
 

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -425,7 +425,7 @@ GLOBAL_LIST_INIT(brass_recipes, list ( \
 	new/datum/stack_recipe("receiver - steam vent", /obj/structure/destructible/clockwork/trap/steam_vent, 3, time = 30, one_per_turf = TRUE, on_floor = TRUE, placement_checks = STACK_CHECK_CARDINALS), \
 	new/datum/stack_recipe("receiver - power nullifier", /obj/structure/destructible/clockwork/trap/power_nullifier, 5, time = 20, one_per_turf = TRUE, on_floor = TRUE, placement_checks = STACK_CHECK_CARDINALS), \
 	null,
-	new/datum/stack_recipe("brass flask", /obj/item/reagent_containers/food/drinks/bottle/holyoil/null), \
+	new/datum/stack_recipe("brass flask", /obj/item/reagent_containers/food/drinks/bottle/holyoil/empty), \
 
 ))
 

--- a/code/modules/antagonists/clockcult/clock_items/clockwork_armor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clockwork_armor.dm
@@ -69,7 +69,7 @@
 	heat_protection = CHEST|GROIN|LEGS
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	armor = list("melee" = 60, "bullet" = 70, "laser" = -25, "energy" = 0, "bomb" = 60, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
-	allowed = list(/obj/item/clockwork, /obj/item/clothing/glasses/wraith_spectacles, /obj/item/clothing/glasses/judicial_visor, /obj/item/mmi/posibrain/soul_vessel, /obj/item/reagent_containers/food/drinks/holyoil)
+	allowed = list(/obj/item/clockwork, /obj/item/clothing/glasses/wraith_spectacles, /obj/item/clothing/glasses/judicial_visor, /obj/item/mmi/posibrain/soul_vessel, /obj/item/reagent_containers/food/drinks/bottle/holyoil)
 
 /obj/item/clothing/suit/armor/clockwork/Initialize()
 	. = ..()

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -13,8 +13,6 @@
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
 	var/knockdown_duration = 13 //Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
-	var/broken_force = 9
-	var/broken_throwforce = 5
 	isGlass = TRUE
 	foodtype = ALCOHOL
 
@@ -43,8 +41,6 @@
 		if(prob(33))
 			new/obj/item/shard(drop_location())
 		playsound(src, "shatter", 70, 1)
-		B.force = broken_force
-		B.throwforce = broken_throwforce
 	else
 		B.force = 0
 		B.throwforce = 0
@@ -201,8 +197,6 @@
 	force = 18
 	throwforce = 18
 	knockdown_duration = 18
-	broken_force = 12
-	broken_throwforce = 8
 
 /obj/item/reagent_containers/food/drinks/bottle/holyoil/empty
 	list_reagents = list("holyoil" = 0)

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -43,6 +43,8 @@
 		if(prob(33))
 			new/obj/item/shard(drop_location())
 		playsound(src, "shatter", 70, 1)
+		B.force = broken_force
+		B.throwforce = broken_throwforce
 	else
 		B.force = 0
 		B.throwforce = 0

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -202,7 +202,7 @@
 	desc = "A flask of holy water...it's been sitting in the Necropolis a while though."
 	list_reagents = list("hell_water" = 100)
 
-/obj/item/reagent_containers/food/drinks/holyoil
+/obj/item/reagent_containers/food/drinks/bottle/holyoil
 	name = "flask of zelus oil"
 	desc = "A brass flask of Zelus oil, a viscous fluid with a scenting of brass - this flask may be sipped or thrown."
 	icon_state = "zelusflask"
@@ -212,7 +212,7 @@
 	force = 12 //Same as a toolbox
 	throwforce = 18
 
-/obj/item/reagent_containers/food/drinks/holyoil/null
+/obj/item/reagent_containers/food/drinks/bottle/holyoil/null
 	list_reagents = list("holyoil" = 0)
 
 /obj/item/reagent_containers/food/drinks/bottle/vermouth

--- a/code/modules/food_and_drinks/drinks/drinks/bottle.dm
+++ b/code/modules/food_and_drinks/drinks/drinks/bottle.dm
@@ -7,11 +7,14 @@
 /obj/item/reagent_containers/food/drinks/bottle
 	amount_per_transfer_from_this = 10
 	volume = 100
+	force = 15
 	throwforce = 15
 	item_state = "broken_beer" //Generic held-item sprite until unique ones are made.
 	lefthand_file = 'icons/mob/inhands/misc/food_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/food_righthand.dmi'
-	var/const/duration = 13 //Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
+	var/knockdown_duration = 13 //Directly relates to the 'knockdown' duration. Lowered by armor (i.e. helmets)
+	var/broken_force = 9
+	var/broken_throwforce = 5
 	isGlass = TRUE
 	foodtype = ALCOHOL
 
@@ -61,46 +64,30 @@
 		to_chat(user, "<span class='warning'>You don't want to harm [target]!</span>")
 		return
 
-	force = 15 //Smashing bottles over someoen's head hurts.
-
 	var/obj/item/bodypart/affecting = user.zone_selected //Find what the player is aiming at
 
-	var/armor_block = 0 //Get the target's armor values for normal attack damage.
-	var/armor_duration = 0 //The more force the bottle has, the longer the duration.
+	var/headarmor = 0 // Target's head armor
+	var/armor_block = min(90, target.run_armor_check(affecting, "melee", null, null,armour_penetration)) // For normal attack damage
 
-	//Calculating duration and calculating damage.
-	if(ishuman(target))
+	//If they have a hat/helmet and the user is targeting their head.
+	if(affecting == BODY_ZONE_HEAD)
+		var/obj/item/I = target.get_item_by_slot(SLOT_HEAD)
+		if(I)
+			headarmor = I.armor.melee
 
-		var/mob/living/carbon/human/H = target
-		var/headarmor = 0 // Target's head armor
-		armor_block = H.run_armor_check(affecting, "melee", null, null,armour_penetration) // For normal attack damage
-
-		//If they have a hat/helmet and the user is targeting their head.
-		if(istype(H.head, /obj/item/clothing/head) && affecting == BODY_ZONE_HEAD)
-			headarmor = H.head.armor.melee
-		else
-			headarmor = 0
-
-		//Calculate the knockdown duration for the target.
-		armor_duration = (duration - headarmor) + force
-
-	else
-		//Only humans can have armor, right?
-		armor_block = target.run_armor_check(affecting, "melee")
-		if(affecting == BODY_ZONE_HEAD)
-			armor_duration = duration + force
+	//Calculate the knockdown duration for the target.
+	var/armor_duration = (knockdown_duration - headarmor) + force
 
 	//Apply the damage!
-	armor_block = min(90,armor_block)
 	target.apply_damage(force, BRUTE, affecting, armor_block)
 
 	// You are going to knock someone out for longer if they are not wearing a helmet.
 	var/head_attack_message = ""
-	if(affecting == BODY_ZONE_HEAD && istype(target, /mob/living/carbon/))
+	if(affecting == BODY_ZONE_HEAD && iscarbon(target))
 		head_attack_message = " on the head"
 		//Knockdown the target for the duration that we calculated and divide it by 5.
 		if(armor_duration)
-			target.apply_effect(min(armor_duration, 200) , EFFECT_KNOCKDOWN) // Never knockdown more than a flash!
+			target.Knockdown(min(armor_duration, 200)) // Never knockdown more than a flash!
 
 	//Display an attack message.
 	if(target != user)
@@ -206,13 +193,16 @@
 	name = "flask of zelus oil"
 	desc = "A brass flask of Zelus oil, a viscous fluid with a scenting of brass - this flask may be sipped or thrown."
 	icon_state = "zelusflask"
-	list_reagents = list("holyoil" = 30) //Powerfull
+	list_reagents = list("holyoil" = 30)
 	volume = 30
 	foodtype = NONE
-	force = 12 //Same as a toolbox
+	force = 18
 	throwforce = 18
+	knockdown_duration = 18
+	broken_force = 12
+	broken_throwforce = 8
 
-/obj/item/reagent_containers/food/drinks/bottle/holyoil/null
+/obj/item/reagent_containers/food/drinks/bottle/holyoil/empty
 	list_reagents = list("holyoil" = 0)
 
 /obj/item/reagent_containers/food/drinks/bottle/vermouth


### PR DESCRIPTION
## About The Pull Request
They did not listen, shrugging obviously not working bits as intended. I'm fixing and cleaning up the bottle old code to fit the flask in.

## Why It's Good For The Game
Making the zelus flask smashable on people's heads with harm intent, buffing its knockdown to affect people up to 36 points of head melee armor (sec helmets provide 40, for comparision).
Making the resulting broken bottle actually stronger than the average one.

## Changelog
:cl:
balance: Improved the zelus flask to be more viable for bottle smashing than the average barman's selection.
code: Very slight bottle smashing code clean up, stupid const vars.
/:cl: