### PR TITLE
Gives cult conversions an alert popup and four extra seconds wait time.

### DIFF
--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -244,13 +244,14 @@ structure_check() searches for nearby cultist structures required for the invoca
 			to_chat(M, "<span class='warning'>Something is shielding [convertee]'s mind!</span>")
 		log_game("Offer rune failed - convertee had anti-magic")
 		return 0
-	to_chat(convertee, "<span class='cult italic'><b>Your blood pulses. Your head throbs. The world goes red. All at once you are aware of a horrible, horrible, truth. The veil of reality has been ripped away \
-	and something evil takes root.</b></span>")
-	to_chat(convertee, "<span class='cult italic'>Do you wish to embrace the Geometer of Blood? <a href='?src=\ref[src];signmeup=1'>Click here to become a follower of Nar'sie.</a> Or you could choose to continue resisting and suffer a fate worse than death...</span>")
+	to_chat(convertee, "<span class='cult italic'><b>The world goes red. All at once you are aware of an evil, eldritch truth taking roots into your mind.\n\
+	<a href='?src=\ref[src];signmeup=1'>Click here to become a follower of Nar'sie</a></b>, or suffer a fate worse than death.</span>")
+	INVOKE_ASYNC(src, .proc/optinalert, convertee)
 	currentconversionman = convertee
-	conversiontimeout = world.time + (10 SECONDS)
-	convertee.Stun(100)
+	conversiontimeout = world.time + (14 SECONDS)
+	convertee.Stun(140)
 	ADD_TRAIT(convertee, TRAIT_MUTE, "conversionrune")
+	flash_color(convertee, list("#960000", "#960000", "#960000", rgb(0,0,0)), 50)
 	conversionresult = FALSE
 	while(world.time < conversiontimeout && convertee && !conversionresult)
 		stoplag(1)
@@ -282,6 +283,17 @@ structure_check() searches for nearby cultist structures required for the invoca
 		H.stuttering = 0
 		H.cultslurring = 0
 	return 1
+
+/obj/effect/rune/convert/proc/optinalert(mob/living/convertee)
+	var/alert = alert(convertee, "Will you embrace the Geometer of Blood or perish in futile resistance?", "Choose your own fate", "Join the Blood Cult", "Suffer a horrible demise")
+	if(alert == "Join the Blood Cult")
+		signmeup(convertee)
+
+/obj/effect/rune/convert/proc/signmeup(mob/living/convertee)
+	if(currentconversionman == usr)
+		conversionresult = TRUE
+	else
+		to_chat(usr, "<span class='cult italic'>Your fate has already been set in stone.</span>")
 
 /obj/effect/rune/convert/proc/do_sacrifice(mob/living/sacrificial, list/invokers, force_a_sac)
 	var/mob/living/first_invoker = invokers[1]
@@ -335,11 +347,7 @@ structure_check() searches for nearby cultist structures required for the invoca
 
 /obj/effect/rune/convert/Topic(href, href_list)
 	if(href_list["signmeup"])
-		if(currentconversionman == usr)
-			conversionresult = TRUE
-		else
-			to_chat(usr, "<span class='cult italic'><b>Your fate has already been set in stone.</b></span>")
-
+		signmeup(usr)
 
 /obj/effect/rune/empower
 	cultist_name = "Empower"


### PR DESCRIPTION
## About The Pull Request
Alt PR to #8905. Basically giving the convertee an alert pop up, without removing the older "click here to..." functionality (should they change their mind mid conversion), and giving the conversion four extra seconds as a middle ground to #8905.

Also added a five seconds red screen flashing to fit in the "The world goes red." bit of the fluff conversion text.

## Why It's Good For The Game
The "click here to..." functionality has the flaws of being hard to click as new chat messages flow in (plus it was boldless italics, now bolded), and overall less noticeable.

## Changelog
:cl:
tweak: Added in an alert pop up to the cult convertees, on top of the older "click here to become a blood cultist" chat message.
tweak: The convertee's screen will now flash red to fit in the aforementioned message's fluff.
spellcheck: Made said message less verbose.
/:cl: