### PR TITLE
Fixes warp whistles

### DIFF
--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -385,9 +385,11 @@
 /obj/item/warpwhistle/attack_self(mob/living/carbon/user)
 	if(!istype(user) || on_cooldown)
 		return
+	var/turf/T = get_turf(user)
+	if(!T)
+		return
 	on_cooldown = TRUE
 	last_user = user
-	var/turf/T = get_turf(user)
 	playsound(T,'sound/magic/warpwhistle.ogg', 200, 1)
 	user.canmove = FALSE
 	new /obj/effect/temp_visual/tornado(T)

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -404,6 +404,8 @@
 		return
 	var/breakout = 0
 	while(breakout < 50)
+		if(!T)
+			break
 		var/turf/potential_T = find_safe_turf()
 		if(T.z != potential_T.z || abs(get_dist_euclidian(potential_T,T)) > 50 - breakout)
 			user.forceMove(potential_T)


### PR DESCRIPTION
Title. Very self-explanatory. The reason why it didn't work before is because it always runtimed. This fixes the runtime in all but very specific edge-case scenarios.

## Changelog
:cl: Bhijn
fix: Warp whistles no longer grant permanent invulnerability and invisibility
/:cl:
