### PR TITLE
Increases click resolution to 0.5 seconds

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -67,7 +67,7 @@
 /mob/proc/ClickOn( atom/A, params )
 	if(world.time <= next_click)
 		return
-	next_click = world.time + 1
+	next_click = world.time + world.tick_lag
 
 	if(check_click_intercept(params,A))
 		return


### PR DESCRIPTION
Hey remember when I made disablers 15% faster to fire well that doesn't work because of this.
Config will probably need mouse spam bumped up a bit but it should be fiiiine.
Don't fire me when someone crashes the server with some exploit that doesn't work without 20 clicks per second :^)