### PR TITLE
Gamemode Voting Results are now displayed at the end of round screen

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -281,6 +281,17 @@
 		var/statspage = CONFIG_GET(string/roundstatsurl)
 		var/info = statspage ? "<a href='?action=openLink&link=[url_encode(statspage)][GLOB.round_id]'>[GLOB.round_id]</a>" : GLOB.round_id
 		parts += "[GLOB.TAB]Round ID: <b>[info]</b>"
+
+	var/list/voting_results = SSvote.stored_gamemode_votes
+
+	if(length(voting_results))
+		parts += "[GLOB.TAB]Voting: "
+		var/total_score = 0
+		for(var/choice in voting_results)
+			var/score = voting_results[choice]
+			total_score += score
+			parts += "[GLOB.TAB][GLOB.TAB][choice]: [score]"
+
 	parts += "[GLOB.TAB]Shift Duration: <B>[DisplayTimeText(world.time - SSticker.round_start_time)]</B>"
 	parts += "[GLOB.TAB]Station Integrity: <B>[mode.station_was_nuked ? "<span class='redtext'>Destroyed</span>" : "[popcount["station_integrity"]]%"]</B>"
 	var/total_players = GLOB.joined_player_list.len

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -18,6 +18,8 @@ SUBSYSTEM_DEF(vote)
 
 	var/obfuscated = FALSE//CIT CHANGE - adds obfuscated/admin-only votes
 
+	var/list/stored_gamemode_votes = list() //Basically the last voted gamemode is stored here for end-of-round use.
+
 /datum/controller/subsystem/vote/fire()	//called by master_controller
 	if(mode)
 		time_remaining = round((started_time + CONFIG_GET(number/vote_period) - world.time)/10)
@@ -90,10 +92,12 @@ SUBSYSTEM_DEF(vote)
 			text += "<b>[question]</b>"
 		else
 			text += "<b>[capitalize(mode)] Vote</b>"
+		stored_gamemode_votes = list()
 		for(var/i=1,i<=choices.len,i++)
 			var/votes = choices[choices[i]]
 			if(!votes)
 				votes = 0
+			stored_gamemode_votes[choices[i]] = votes
 			text += "\n<b>[choices[i]]:</b> [obfuscated ? "???" : votes]" //CIT CHANGE - adds obfuscated votes
 		if(mode != "custom")
 			if(winners.len > 1 && !obfuscated) //CIT CHANGE - adds obfuscated votes


### PR DESCRIPTION

## About The Pull Request
Adds gamemode voting results at the end of the screen, visible to all.

https://i.imgur.com/fUMQX8f.png

## Why It's Good For The Game
Given how close the voting results are, according to people who have access to it, it would encourage people to vote for their desired gamemode.

## Changelog
:cl: BurgerBB
add: Gamemode voting results are displayed at the end-round screen.
/:cl:
