### PR TITLE
Removes damage from *dab

### DIFF
--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -185,22 +185,6 @@
 	emote_type = EMOTE_AUDIBLE
 	restraint_check = TRUE
 
-
-
-/datum/emote/living/dab/run_emote(mob/living/user, params)
-	if (ishuman(user))
-		var/def_zone = BODY_ZONE_CHEST
-		var/luck = (rand(1,100))
-		if(luck >= 65)
-			user.adjustStaminaLoss(70)
-		if(luck >= 80)
-			def_zone = pick(BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
-			user.apply_damage(20, BRUTE, def_zone)
-		if(luck >= 95)
-			user.adjustBrainLoss(100)
-	. = ..()
-
-
 /datum/emote/living/mothsqueak
 	key = "msqueak"
 	key_third_person = "lets out a tiny squeak"


### PR DESCRIPTION
Why: Meme feature. If I've had to remove it from working while handcuffed/restrained to not have people suicide on arrest with it, and now more issues from forced emotes happening with it, it really shouldn't exist when every other emote doesn't do it. It's funny, but it's overlived its stay.