### PR TITLE
Moves RCDs and RPDs to Protolathes + Techwebs

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_construction.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_construction.dm
@@ -98,11 +98,3 @@
 	materials = list(MAT_METAL = 450, MAT_GLASS = 190)
 	build_path = /obj/item/conveyor_switch_construct
 	category = list("initial", "Construction")
-
-/datum/design/rcd_ammo
-	name = "Compressed Matter Cartridge"
-	id = "rcd_ammo"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 12000, MAT_GLASS=8000)
-	build_path = /obj/item/rcd_ammo
-	category = list("initial","Construction")

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -49,22 +49,6 @@
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
 
-/datum/design/rcd
-	name = "Rapid Construction Device (RCD)"
-	id = "rcd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/construction/rcd
-	category = list("hacked", "Construction")
-
-/datum/design/rpd
-	name = "Rapid Pipe Dispenser (RPD)"
-	id = "rpd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500)
-	build_path = /obj/item/pipe_dispenser
-	category = list("hacked", "Construction")
-
 /datum/design/handcuffs
 	name = "Handcuffs"
 	id = "handcuffs"

--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -76,7 +76,7 @@
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/rcd_ammo
-	name = "Compressed Matter Cartridge"
+	name = "Compressed Matter Cartridge (RCD Ammo)"
 	id = "rcd_ammo"
 	build_type = PROTOLATHE
 	materials = list(MAT_METAL = 12000, MAT_GLASS=8000)

--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -73,7 +73,7 @@
 	construction_time = 100
 	build_path = /obj/item/pipe_dispenser
 	category = list("Equipment")
-	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
 
 /datum/design/rcd_ammo
 	name = "Compressed Matter Cartridge"

--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -53,3 +53,34 @@
 	construction_time = 100
 	category = list("Misc")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
+
+/datum/design/rcd
+	name = "Rapid Construction Device (RCD)"
+	id = "rcd"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 30000)
+	construction_time = 100
+	build_path = /obj/item/construction/rcd
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
+/datum/design/rpd
+	name = "Rapid Pipe Dispenser (RPD)"
+	id = "rpd"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500)
+	construction_time = 100
+	build_path = /obj/item/pipe_dispenser
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING
+
+/datum/design/rcd_ammo
+	name = "Compressed Matter Cartridge"
+	id = "rcd_ammo"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 12000, MAT_GLASS=8000)
+	construction_time = 25
+	build_path = /obj/item/rcd_ammo
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -156,6 +156,7 @@
 	export_price = 5000
 
 /////////////////////////engineering tech/////////////////////////
+
 /datum/techweb_node/engineering
 	id = "engineering"
 	display_name = "Industrial Engineering"
@@ -164,7 +165,16 @@
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 6000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	export_price = 5000
+
+/datum/techweb_node/engineering
+	id = "rapid_construction"
+	display_name = "Rapid Construction"
+	description = "Quick and almost miraculous tools that let you build things fast and easy."
+	design_ids = list("rcd","rpd","rcd_ammo")
+	prereq_ids = list("engineering")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 
 /datum/techweb_node/adv_engi

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -165,15 +165,15 @@
 	design_ids = list("solarcontrol", "recharger", "powermonitor", "rped", "pacman", "adv_capacitor", "adv_scanning", "emitter", "high_cell", "adv_matter_bin",
 	"atmosalerts", "atmos_control", "recycler", "autolathe", "high_micro_laser", "nano_mani", "mesons", "thermomachine", "rad_collector", "tesla_coil", "grounding_rod",
 	"apc_control", "cell_charger", "power control", "airlock_board", "firelock_board", "airalarm_electronics", "firealarm_electronics", "cell_charger", "stack_console", "stack_machine")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 6000)
 	export_price = 5000
 
-/datum/techweb_node/engineering
+/datum/techweb_node/rapid_construction
 	id = "rapid_construction"
 	display_name = "Rapid Construction"
 	description = "Quick and almost miraculous tools that let you build things fast and easy."
-	design_ids = list("rcd","rpd","rcd_ammo")
 	prereq_ids = list("engineering")
+	design_ids = list("rcd","rpd","rcd_ammo")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 


### PR DESCRIPTION
## About The Pull Request
Removes RCDs, RPDs, and RCD ammo from Hacked Autolathes and adds them to techwebs. They can be researched for 2000 points after industrial engineering is researched. RPDs can be accessed at science and engineering lathes, while RCDs and RCD ammo can be accessed at engineering lathes.

![image](https://user-images.githubusercontent.com/8602857/61516068-f1f5b880-a9b8-11e9-8db8-3496c2d0d372.png)

## Why It's Good For The Game
RCDs are exceptionally powerful for how easy it is to print one from a lathe. You don't even need insulated gloves to get one; you just need to print one from a hacked lathe, fill it with materials, and boom you can deconstruct any door or wall at will without having to use insulated gloves or a welding helmet. With the introduction of public auto lathes, it is even easier to get them.

## Changelog
:cl: BurgerBB
balance: RCDs, RPDs, and RCD Ammo are removed from hacked autolathes, and brought to protolathes.
/:cl:
