### PR TITLE
Makes the autolathe shock wire actually shock you

### DIFF
--- a/code/datums/wires/autolathe.dm
+++ b/code/datums/wires/autolathe.dm
@@ -30,6 +30,7 @@
 			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_SHOCK)
 			A.shocked = !A.shocked
+			A.shock(usr, 50)
 			addtimer(CALLBACK(A, /obj/machinery/autolathe.proc/reset, wire), 60)
 		if(WIRE_DISABLE)
 			A.disabled = !A.disabled
@@ -40,9 +41,11 @@
 	switch(wire)
 		if(WIRE_HACK)
 			A.adjust_hacked(!mend)
-		if(WIRE_HACK)
+		if(WIRE_SHOCK)
 			A.shocked = !mend
+			A.shock(usr, 50)
 		if(WIRE_DISABLE)
 			A.disabled = !mend
 		if(WIRE_ZAP)
 			A.shock(usr, 50)
+


### PR DESCRIPTION
## About The Pull Request
Fixes a bug that made it so the shock wire didn't shock you because of bad code.

## Why It's Good For The Game
Autolathe is the only machine in the game that does not shock you when trying to hack it with a multitool. This is likely due to an oversight in code which I fixed.

## Changelog
:cl:
fix: Fixed autolathe wires not correctly shocking you when pulsed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
