### PR TITLE
Removes a Rando plushies from loadout and adds in a few more items

### DIFF
--- a/modular_citadel/code/modules/client/loadout/backpack.dm
+++ b/modular_citadel/code/modules/client/loadout/backpack.dm
@@ -23,11 +23,6 @@
 	category = SLOT_IN_BACKPACK
 	path = /obj/item/toy/plush/lampplushie
 
-/datum/gear/plushrng
-	name = "Random plushie"
-	category = SLOT_IN_BACKPACK
-	path = /obj/item/toy/plush/random
-
 /datum/gear/tennis
 	name = "Classic Tennis Ball"
 	category = SLOT_IN_BACKPACK
@@ -84,8 +79,24 @@
 	path = /obj/item/toy/katana
 	cost = 3
 
-//datum/gear/lumeyes
-//	name = "Luminescent eye auto surgeon"
-//	category = SLOT_IN_BACKPACK
-//	path = /obj/item/autosurgeon/gloweyes
-//	cost = 4
+/datum/gear/box
+	name = "Spare box"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/storage/box
+	cost = 2
+
+/datum/gear/crowbar
+	name = "Pocket Crowbar"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/crowbar
+	cost = 2
+
+/datum/gear/tapeplayer
+	name = "Taperecorder"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/taperecorder
+
+/datum/gear/tape
+	name = "Spare cassette tape"
+	category = SLOT_IN_BACKPACK
+	path = /obj/item/tape/random


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

RNG plushie no more! - was broken
Adds Box - For boxing things.
Adds Crowbar - For not being stuck on the shuttle for 15 years
Adds in a tape - for recording 
Adds in a taperecorder - for recording things for real

## Why It's Good For The Game

Tape and such is for RP and gimmicky things, not that powerful
Box for storing more items, not that powerful as you can loot many boxes/cardboard 
Crowbar is for being not stuck on the shuttle, when its depowerd or fire alarmed
Rng plushie was broken I guess

## Changelog
:cl:
add: More loadout gear
/:cl: