### PR TITLE
[Test-Merg-Maybe?] Maybe allows mentors to see runtimes + logging

### DIFF
--- a/code/modules/admin/verbs/debug.dm
+++ b/code/modules/admin/verbs/debug.dm
@@ -1030,6 +1030,10 @@ GLOBAL_PROTECT(AdminProcCallSpamPrevention)
 
 	GLOB.error_cache.show_to(src)
 
+	message_admins("<span class='adminnotice'>[key_name(src)] checked runtimes.</span>")
+	SSblackbox.record_feedback("tally", "admin_verb", 1, "View Runtimes")
+	log_admin("[key_name(src)] checked runtimes.")
+
 /client/proc/pump_random_event()
 	set category = "Debug"
 	set name = "Pump Random Event"

--- a/modular_citadel/code/modules/mentor/mentor_verbs.dm
+++ b/modular_citadel/code/modules/mentor/mentor_verbs.dm
@@ -1,7 +1,8 @@
 GLOBAL_PROTECT(mentor_verbs)
 GLOBAL_LIST_INIT(mentor_verbs, list(
 	/client/proc/cmd_mentor_say,
-	/client/proc/show_mentor_memo
+	/client/proc/show_mentor_memo,
+	/client/proc/view_runtimes
 	))
 
 /client/proc/add_mentor_verbs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Unless I did this wrong, this should allow mentors only to see runtimes for better helping and debugging 
Adds SS13BlackBoxing to Runtime check as well as a boop on admin chats if someone looks at it

## Why It's Good For The Game

A lot of the time something is runtimeing and we just dont know it. Many of the mentors can help debug the game and then fix the problems making the game better. Warp flute, and CWC were runtiming and if we checked them more and had more people able to check runtimes then maybe we could have fixed them faster

## Changelog
:cl:
admin: messed with admin stuff
server: something server ops should know - SS13blackbox messing with
/:cl:
