### PR TITLE
Reverts "Autocall now uses realtime rather than world.time"

### DIFF
--- a/code/game/machinery/computer/communications.dm
+++ b/code/game/machinery/computer/communications.dm
@@ -203,7 +203,7 @@
 				state = STATE_CANCELSHUTTLE
 		if("cancelshuttle2")
 			if(authenticated)
-				if((world.realtime - SSshuttle.realtimeofstart) > SSshuttle.auto_call) //Citadel Edit Removing auto_call caused recall.
+				if(world.time > SSshuttle.auto_call) //Citadel Edit Removing auto_call caused recall.
 					say("Warning: Emergency shuttle recalls have been blocked by Central Command due to ongoing crew transfer procedures.")
 				else
 					SSshuttle.cancelEvac(usr)

--- a/modular_citadel/code/controllers/subsystem/shuttle.dm
+++ b/modular_citadel/code/controllers/subsystem/shuttle.dm
@@ -1,5 +1,5 @@
 /datum/controller/subsystem/shuttle/proc/autoEnd() //CIT CHANGE - allows shift to end after 2 hours have passed.
-	if((world.realtime - SSshuttle.realtimeofstart) > auto_call && EMERGENCY_IDLE_OR_RECALLED) //2 hours
+	if(world.time > auto_call && EMERGENCY_IDLE_OR_RECALLED) //2 hours
 		SSshuttle.emergency.request(silent = TRUE)
 		priority_announce("The shift has come to an end and the shuttle called. [seclevel2num(get_security_level()) == SEC_LEVEL_RED ? "Red Alert state confirmed: Dispatching priority shuttle. " : "" ]It will arrive in [emergency.timeLeft(600)] minutes.", null, 'sound/ai/shuttlecalled.ogg', "Priority")
 		log_game("Round time limit reached. Shuttle has been auto-called.")


### PR DESCRIPTION
I made the PR initially because lag was so bad rounds would last up to ~4-5 hours, nowadays honestly an extra 30 minutes won't kill anyone granted that everything in the game uses world.time (except for some niche things like some combat things I think? Movedelay definitely does and all gameplay/ramping stuff does.) 