### PR TITLE
Cloning console board memory

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -13,17 +13,20 @@
 	var/scantemp_ckey
 	var/scantemp = "Ready to Scan"
 	var/menu = 1 //Which menu screen to display
-	var/list/records = list()
 	var/datum/data/record/active_record = null
 	var/obj/item/disk/data/diskette = null //Mostly so the geneticist can steal everything.
 	var/loading = 0 // Nice loading text
 	var/autoprocess = 0
+	var/list/records = list()
 
 	light_color = LIGHT_COLOR_BLUE
 
 /obj/machinery/computer/cloning/Initialize()
 	. = ..()
 	updatemodules(TRUE)
+	var/obj/item/circuitboard/computer/cloning/board = circuit
+	records = board.records
+
 
 /obj/machinery/computer/cloning/Destroy()
 	if(pods)
@@ -346,6 +349,8 @@
 					active_record = null
 					playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 					src.menu = 2
+					var/obj/item/circuitboard/computer/cloning/board = circuit
+					board.records = records
 				else
 					src.temp = "<font class='bad'>Access Denied.</font>"
 					playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
@@ -368,6 +373,8 @@
 				for(var/key in diskette.fields)
 					src.active_record.fields[key] = diskette.fields[key]
 				src.temp = "Load successful."
+				var/obj/item/circuitboard/computer/cloning/board = circuit
+				board.records = records
 				playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 			if("eject")
@@ -502,5 +509,7 @@
 	R.fields["imp"] = "[REF(imp)]"
 
 	src.records += R
+	var/obj/item/circuitboard/computer/cloning/board = circuit
+	board.records = records
 	scantemp = "Subject successfully scanned."
 	playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)

--- a/code/game/objects/items/circuitboards/computer_circuitboards.dm
+++ b/code/game/objects/items/circuitboards/computer_circuitboards.dm
@@ -110,6 +110,7 @@
 /obj/item/circuitboard/computer/cloning
 	name = "Cloning (Computer Board)"
 	build_path = /obj/machinery/computer/cloning
+	var/list/records = list()
 
 /obj/item/circuitboard/computer/prototype_cloning
 	name = "Prototype Cloning (Computer Board)"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This addition gives cloning consoles the ability to write their cloning records to the circuit board inside the machine upon any adding or deletion of records. Cloning consoles read the records upon initialisation i.e. construction. This effectively gives cloners local memory, and makes it require a little more effort to get rid of cloning records.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
As it stands, all it takes to delete all of the rather important clone scan records, is two surreptitious clicks with a screwdriver. This update means antags have to gain CMO access or destroy/steal the circuit board to permanently delete all clone records.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds the ability for cloning consoles to read and write record lists to the circuit board, and provides a template for giving other machines local circuit board memory.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
