### PR TITLE
Fixes combatmode disarm pushing people on inaccessible tables and more.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -899,12 +899,9 @@
 		stop_pulling()
 
 /mob/living/carbon/human/proc/is_shove_knockdown_blocked() //If you want to add more things that block shove knockdown, extend this
-	var/list/body_parts = list(head, wear_mask, wear_suit, w_uniform, back, gloves, shoes, belt, s_store, glasses, ears, wear_id) //Everything but pockets. Pockets are l_store and r_store. (if pockets were allowed, putting something armored, gloves or hats for example, would double up on the armor)
-	for(var/bp in body_parts)
-		if(istype(bp, /obj/item/clothing))
-			var/obj/item/clothing/C = bp
-			if(C.blocks_shove_knockdown)
-				return TRUE
+	for(var/obj/item/clothing/C in get_equipped_items()) //doesn't include pockets
+		if(C.blocks_shove_knockdown)
+			return TRUE
 	return FALSE
 
 /mob/living/carbon/human/proc/clear_shove_slowdown()

--- a/modular_citadel/code/modules/mob/living/carbon/human/species.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species.dm
@@ -80,10 +80,21 @@
 		else
 			target.Move(target_shove_turf, shove_dir)
 			if(get_turf(target) == target_oldturf)
-				target_table = locate(/obj/structure/table) in target_shove_turf.contents
-				shove_blocked = TRUE
+				var/thoushallnotpass = FALSE
+				for(var/obj/O in target_shove_turf)
+					if(O.density)
+						shove_blocked = TRUE
+						if(istype(O, /obj/structure/table))
+							target_table = O
+						else
+							thoushallnotpass = TRUE
+				if(thoushallnotpass)
+					target_table = null
 
-		if(shove_blocked && !target.is_shove_knockdown_blocked())
+		if(target.is_shove_knockdown_blocked())
+			return
+
+		if(shove_blocked)
 			var/directional_blocked = FALSE
 			if(shove_dir in GLOB.cardinals) //Directional checks to make sure that we're not shoving through a windoor or something like that
 				var/target_turf = get_turf(target)


### PR DESCRIPTION
## About The Pull Request
Closes #8973 as hackily as the rest of the affected code and also some oversight done Bhjin not doing an early return for the `is_shove_knockdown_blocked()` check causing some features to be unavailable.

## Why It's Good For The Game
Bugfixing.

## Changelog
:cl:
fix: combat pushes will now properly stop targets from using firearms, and will disarm the firearm if performed a second time, and also slow down people by 15%, and won't push people on tables blocked by shutters or other dense object anymore.
/:cl:
