### PR TITLE
Removes stealth implant box integrity

### DIFF
--- a/code/game/objects/items/implants/implant_stealth.dm
+++ b/code/game/objects/items/implants/implant_stealth.dm
@@ -9,6 +9,7 @@
 	name = "inconspicious box"
 	desc = "It's so normal that you didn't notice it before."
 	icon_state = "agentbox"
+	max_integrity = 1
 	use_mob_movespeed = TRUE
 
 /obj/structure/closet/cardboard/agent/proc/go_invisible()


### PR DESCRIPTION
## About The Pull Request

Partially ports my own nerf/fix to Stealth Implants. This one does not include the box movement bugfix (which appears somewhat more intentional on citadel and also its fucky and I don't know how to implement a real fix)

This nerf lowers the structure integrity of the Stealth Box to 1, meaning any damage deletes it.

## Why It's Good For The Game

Cardboard boxes have 70 health, destroying an invisible one is really hard, especially when they can renew the "shield" in 5 seconds. Stealth implant already gives you a load of boons, like "being invisible".

## Changelog
:cl: Yakumo Chen
balance: Made stealth implant boxes flimsier
/:cl:
