### PR TITLE
Fixes CHECK_BITFIELD macro.

### DIFF
--- a/code/__DEFINES/flags.dm
+++ b/code/__DEFINES/flags.dm
@@ -7,7 +7,7 @@
 //for convenience
 #define ENABLE_BITFIELD(variable, flag) (variable |= (flag))
 #define DISABLE_BITFIELD(variable, flag) (variable &= ~(flag))
-#define CHECK_BITFIELD(variable, flag) (variable & flag)
+#define CHECK_BITFIELD(variable, flag) (variable & (flag))
 #define TOGGLE_BITFIELD(variable, flag) (variable ^= (flag))
 
 GLOBAL_LIST_INIT(bitflags, list(1, 2, 4, 8, 16, 32, 64, 128, 256, 512, 1024, 2048, 4096, 8192, 16384, 32768))


### PR DESCRIPTION
## About The Pull Request 
Exactly what's said on the tin, allowing multiple flags to be checked by wrapping them.

## Why It's Good For The Game
Making CHECK_BITFIELD(variable, FLAG_1|FLAG_2) actually work.

## Changelog
:cl:
fix: Fixes CHECK_BITFIELD macro.
/:cl:
