### PR TITLE
reworked ninja stealth, made ninja shoes completely silent, cleaned up scarily old code.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -128,6 +128,7 @@
 #define TRAIT_HEAVY_SLEEPER		"heavy_sleeper"
 #define TRAIT_NIGHT_VISION		"night_vision"
 #define TRAIT_LIGHT_STEP		"light_step"
+#define TRAIT_SILENT_STEP		"silent_step"
 #define TRAIT_SPEEDY_STEP		"speedy_step"
 #define TRAIT_SPIRITUAL			"spiritual"
 #define TRAIT_VORACIOUS			"voracious"

--- a/code/datums/components/footstep.dm
+++ b/code/datums/components/footstep.dm
@@ -14,15 +14,18 @@
 	var/turf/open/T = get_turf(parent)
 	if(!istype(T))
 		return
-	
+
 	var/mob/living/LM = parent
 	var/v = volume
 	var/e = e_range
 	if(!T.footstep || LM.buckled || LM.lying || !LM.canmove || LM.resting || LM.buckled || LM.throwing || LM.movement_type & (VENTCRAWLING | FLYING))
-		if (LM.lying && !(!T.footstep || LM.movement_type & (VENTCRAWLING | FLYING))) //play crawling sound if we're lying
+		if (LM.lying && !LM.buckled && !(!T.footstep || LM.movement_type & (VENTCRAWLING | FLYING))) //play crawling sound if we're lying
 			playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v)
 		return
-	
+
+	if(HAS_TRAIT(LM, TRAIT_SILENT_STEP))
+		return
+
 	if(iscarbon(LM))
 		var/mob/living/carbon/C = LM
 		if(!C.get_bodypart(BODY_ZONE_L_LEG) && !C.get_bodypart(BODY_ZONE_R_LEG))
@@ -31,18 +34,18 @@
 			v /= 2
 			e -= 5
 	steps++
-	
+
 	if(steps >= 3)
 		steps = 0
-	
+
 	else
 		return
-	
+
 	if(prob(80) && !LM.has_gravity(T)) // don't need to step as often when you hop around
 		return
-		
+
 	//begin playsound shenanigans//
-	
+
 	//for barefooted non-clawed mobs like monkeys
 	if(isbarefoot(LM))
 		playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),
@@ -50,19 +53,19 @@
 			TRUE,
 			GLOB.barefootstep[T.barefootstep][3] + e)
 		return
-	
+
 	//for xenomorphs, dogs, and other clawed mobs
 	if(isclawfoot(LM))
 		if(isalienadult(LM)) //xenos are stealthy and get quieter footsteps
 			v /= 3
 			e -= 5
-		
+
 		playsound(T, pick(GLOB.clawfootstep[T.clawfootstep][1]),
 				GLOB.clawfootstep[T.clawfootstep][2] * v,
 				TRUE,
 				GLOB.clawfootstep[T.clawfootstep][3] + e)
 		return
-	
+
 	//for megafauna and other large and imtimidating mobs such as the bloodminer
 	if(isheavyfoot(LM))
 		playsound(T, pick(GLOB.heavyfootstep[T.heavyfootstep][1]),
@@ -70,12 +73,12 @@
 				TRUE,
 				GLOB.heavyfootstep[T.heavyfootstep][3] + e)
 		return
-	
+
 	//for slimes
-	if(isslime(LM)) 
+	if(isslime(LM))
 		playsound(T, 'sound/effects/footstep/slime1.ogg', 15 * v)
 		return
-		
+
 	//for (simple) humanoid mobs (clowns, russians, pirates, etc.)
 	if(isshoefoot(LM))
 		if(!ishuman(LM))
@@ -87,17 +90,17 @@
 		if(ishuman(LM)) //for proper humans, they're special
 			var/mob/living/carbon/human/H = LM
 			var/feetCover = (H.wear_suit && (H.wear_suit.body_parts_covered & FEET)) || (H.w_uniform && (H.w_uniform.body_parts_covered & FEET))
-			
+
 			if (H.dna.features["taur"] == "Naga" || H.dna.features["taur"] == "Tentacle") //are we a naga or tentacle taur creature
 				playsound(T, 'sound/effects/footstep/crawl1.ogg', 15 * v)
 				return
-			
+
 			if(H.shoes || feetCover) //are we wearing shoes
 				playsound(T, pick(GLOB.footstep[T.footstep][1]),
 					GLOB.footstep[T.footstep][2] * v,
 					TRUE,
 					GLOB.footstep[T.footstep][3] + e)
-			
+
 			if((!H.shoes && !feetCover)) //are we NOT wearing shoes
 				playsound(T, pick(GLOB.barefootstep[T.barefootstep][1]),
 					GLOB.barefootstep[T.barefootstep][2] * v,

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -8,33 +8,37 @@ Contents:
 
 
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_stealth()
-	var/mob/living/carbon/human/U = affecting
-	if(!U)
+	if(!affecting)
 		return
 	if(stealth)
 		cancel_stealth()
 	else
 		if(cell.charge <= 0)
-			to_chat(U, "<span class='warning'>You don't have enough power to enable Stealth!</span>")
+			to_chat(affecting, "<span class='warning'>You don't have enough power to enable Stealth!</span>")
 			return
 		stealth = !stealth
-		animate(U, alpha = 50,time = 15)
-		U.visible_message("<span class='warning'>[U.name] vanishes into thin air!</span>", \
+		animate(affecting, alpha = 10,time = 15)
+		affecting.visible_message("<span class='warning'>[affecting.name] vanishes into thin air!</span>", \
 						"<span class='notice'>You are now mostly invisible to normal detection.</span>")
+		RegisterSignal(affecting, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_PARENT_ATTACKBY), .proc/reduce_stealth)
+		RegisterSignal(affecting, COMSIG_MOVABLE_BUMP, .proc/bumping_stealth)
 
+/obj/item/clothing/suit/space/space_ninja/proc/reduce_stealth()
+	affecting.alpha = min(affecting.alpha + 30, 80)
+
+/obj/item/clothing/suit/space/space_ninja/proc/bumping_stealth(datum/source, atom/A)
+	if(isliving(A))
+		affecting.alpha = min(affecting.alpha + 15, 80)
 
 /obj/item/clothing/suit/space/space_ninja/proc/cancel_stealth()
-	var/mob/living/carbon/human/U = affecting
-	if(!U)
-		return 0
-	if(stealth)
-		stealth = !stealth
-		animate(U, alpha = 255, time = 15)
-		U.visible_message("<span class='warning'>[U.name] appears from thin air!</span>", \
-						"<span class='notice'>You are now visible.</span>")
-		return 1
-	return 0
-
+	if(!affecting || !stealth)
+		return FALSE
+	stealth = !stealth
+	UnregisterSignal(affecting, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_PARENT_ATTACKBY, COMSIG_MOVABLE_BUMP))
+	animate(affecting, alpha = 255, time = 15)
+	affecting.visible_message("<span class='warning'>[affecting.name] appears from thin air!</span>", \
+					"<span class='notice'>You are now visible.</span>")
+	return TRUE
 
 /obj/item/clothing/suit/space/space_ninja/proc/stealth()
 	if(!s_busy)

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -1,4 +1,3 @@
-
 /obj/item/clothing/shoes/space_ninja
 	name = "ninja shoes"
 	desc = "A pair of running shoes. Excellent for running and even better for smashing skulls."
@@ -13,3 +12,11 @@
 	min_cold_protection_temperature = SHOES_MIN_TEMP_PROTECT
 	heat_protection = FEET
 	max_heat_protection_temperature = SHOES_MAX_TEMP_PROTECT
+
+/obj/item/clothing/shoes/space_ninja/equipped(mob/user, slot)
+	. = ..()
+	ADD_TRAIT(user, TRAIT_SILENT_STEP, "ninja_shoes_[REF(src)]")
+
+/obj/item/clothing/shoes/space_ninja/dropped(mob/user)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_SILENT_STEP, "ninja_shoes_[REF(src)]")

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -15,7 +15,8 @@
 
 /obj/item/clothing/shoes/space_ninja/equipped(mob/user, slot)
 	. = ..()
-	ADD_TRAIT(user, TRAIT_SILENT_STEP, "ninja_shoes_[REF(src)]")
+	if(slot == SLOT_SHOES)
+		ADD_TRAIT(user, TRAIT_SILENT_STEP, "ninja_shoes_[REF(src)]")
 
 /obj/item/clothing/shoes/space_ninja/dropped(mob/user)
 	. = ..()

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -149,12 +149,11 @@ Contents:
 
 /obj/item/clothing/suit/space/space_ninja/examine(mob/user)
 	..()
-	if(s_initialized)
-		if(user == affecting)
-			to_chat(user, "All systems operational. Current energy capacity: <B>[DisplayEnergy(cell.charge)]</B>.")
-			to_chat(user, "The CLOAK-tech device is <B>[stealth?"active":"inactive"]</B>.")
-			to_chat(user, "There are <B>[s_bombs]</B> smoke bomb\s remaining.")
-			to_chat(user, "There are <B>[a_boost]</B> adrenaline booster\s remaining.")
+	if(s_initialized && user == affecting)
+		to_chat(user, "All systems operational. Current energy capacity: <B>[DisplayEnergy(cell.charge)]</B>.\n\
+						The CLOAK-tech device is <B>[stealth?"active":"inactive"]</B>.\n\
+						There are <B>[s_bombs]</B> smoke bomb\s remaining.\n\
+						There are <B>[a_boost]</B> adrenaline booster\s remaining.")
 
 /obj/item/clothing/suit/space/space_ninja/ui_action_click(mob/user, action)
 	if(istype(action, /datum/action/item_action/initialize_ninja_suit))

--- a/code/modules/ninja/suit/suit_initialisation.dm
+++ b/code/modules/ninja/suit/suit_initialisation.dm
@@ -48,7 +48,7 @@
 /obj/item/clothing/suit/space/space_ninja/proc/ninitialize_seven(delay, mob/living/carbon/human/U)
 	to_chat(U, "<span class='notice'>All systems operational. Welcome to <B>SpiderOS</B>, [U.real_name].</span>")
 	s_initialized = TRUE
-	ntick()
+	START_PROCESSING(SSprocessing, src)
 	s_busy = FALSE
 
 
@@ -91,4 +91,5 @@
 	unlock_suit()
 	U.regenerate_icons()
 	s_initialized = FALSE
+	STOP_PROCESSING(SSprocessing, src)
 	s_busy = FALSE

--- a/code/modules/ninja/suit/suit_process.dm
+++ b/code/modules/ninja/suit/suit_process.dm
@@ -1,20 +1,17 @@
-/obj/item/clothing/suit/space/space_ninja/proc/ntick(mob/living/carbon/human/U = affecting)
-	//Runs in the background while the suit is initialized.
-	//Requires charge or stealth to process.
-	spawn while(s_initialized)
-		if(!affecting)
-			terminate()//Kills the suit and attached objects.
+/obj/item/clothing/suit/space/space_ninja/process()
+	if(!affecting || !s_initialized)
+		return PROCESS_KILL
 
-		else if(cell.charge > 0)
-			if(s_coold)
-				s_coold--//Checks for ability s_cooldown first.
+	if(cell.charge > 0)
+		if(s_coold)
+			s_coold--//Checks for ability s_cooldown first.
 
-			cell.charge -= s_cost//s_cost is the default energy cost each ntick, usually 5.
-			if(stealth)//If stealth is active.
-				cell.charge -= s_acost
+		cell.charge -= s_cost//s_cost is the default energy cost each tick, usually 5.
+		if(stealth)//If stealth is active.
+			cell.charge -= s_acost
+			affecting.alpha = max(affecting.alpha - 10, 10)
 
-		else
-			cell.charge = 0
+	else
+		cell.charge = 0
+		if(stealth)
 			cancel_stealth()
-
-		sleep(10)//Checks every second.


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. Ninja stealth's base alpha (visibility, from a scale of 0 to 255) is now 10 rather than 50, but with a twist; being hit, throwing things, attacking or bumping people will raise up the alpha up to 80, but will gradually go back by 10 at a rate of 10 for tick.
This way the ninja stealth will actually fulfill its purpose better while not being a superb buff to its combat.
Also made ninja shoes grant silent steps, for better stealth.
Also cleaned up ninja suit's old code processing loop.

## Why It's Good For The Game
Ninja stealth is a joke, its visibility is pretty clear anywhere but the dimmiest of the places. Footsteps are noisy. Ninja code is old.

## Changelog
:cl:
add: reworked ninja's stealth mode. Increased invisibility, but engaging in combat, attacking or throwing things, bumping people will temporarily lower it.
add: Ninja shoes are even stealthier.
code: cleaned up some 2014 tier processing code horror.
/:cl: