### PR TITLE
Hallucination Sting Buffs

### DIFF
--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -62,13 +62,13 @@
 
 
 /obj/effect/proc_holder/changeling/sting/transformation
-	name = "Transformation Sting"
-	desc = "We silently sting a human, injecting a retrovirus that forces them to transform."
-	helptext = "The victim will transform much like a changeling would. Does not provide a warning to others. Mutations will not be transferred, and monkeys will become human. This ability is loud, and might cause our blood to react violently to heat."
+	name = "Temporary Transformation Sting"
+	desc = "We silently sting a human, injecting a chemical that forces them to transform into a chosen being for a limited time. Additional stings extend the duration."
+	helptext = "The victim will transform much like a changeling would for a limited time. Does not provide a warning to others. Mutations will not be transferred, and monkeys will become human. This ability is loud, and might cause our blood to react violently to heat."
 	sting_icon = "sting_transform"
-	chemical_cost = 50
-	dna_cost = 3
-	loudness = 2
+	chemical_cost = 10
+	dna_cost = 2
+	loudness = 1
 	var/datum/changelingprofile/selected_dna = null
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_transform"
@@ -97,19 +97,19 @@
 	return 1
 
 /obj/effect/proc_holder/changeling/sting/transformation/sting_action(mob/user, mob/target)
-	log_combat(user, target, "stung", "transformation sting", " new identity is '[selected_dna.dna.real_name]'")
-	var/datum/dna/NewDNA = selected_dna.dna
+
 	if(ismonkey(target))
 		to_chat(user, "<span class='notice'>Our genes cry out as we sting [target.name]!</span>")
 
 	var/mob/living/carbon/C = target
 	. = TRUE
 	if(istype(C))
-		C.real_name = NewDNA.real_name
-		NewDNA.transfer_identity(C)
-		if(ismonkey(C))
-			C.humanize(TR_KEEPITEMS | TR_KEEPIMPLANTS | TR_KEEPORGANS | TR_KEEPDAMAGE | TR_KEEPVIRUS | TR_DEFAULTMSG)
-		C.updateappearance(mutcolor_update=1)
+		if(C.reagents.has_reagent("changeling_sting_real"))
+			C.reagents.add_reagent("changeling_sting_real",120)
+			log_combat(user, target, "stung", "transformation sting", ", extending the duration.")
+		else
+			C.reagents.add_reagent("changeling_sting_real",120,list("desired_dna" = selected_dna.dna))
+			log_combat(user, target, "stung", "transformation sting", " new identity is '[selected_dna.dna.real_name]'")
 
 
 /obj/effect/proc_holder/changeling/sting/false_armblade
@@ -230,23 +230,22 @@
 
 /obj/effect/proc_holder/changeling/sting/LSD
 	name = "Hallucination Sting"
-	desc = "Causes terror in the target."
-	helptext = "We evolve the ability to sting a target with a powerful hallucinogenic chemical. The target does not notice they have been stung, and the effect begins after a few seconds."
+	desc = "Causes terror in the target and deals a minor amount of toxin damage."
+	helptext = "We evolve the ability to sting a target with a powerful toxic hallucinogenic chemical. The target does not notice they have been stung, and the effect begins instantaneously. This ability is somewhat loud, and carries a small risk of our blood gaining violent sensitivity to heat."
 	sting_icon = "sting_lsd"
 	chemical_cost = 10
 	dna_cost = 1
+	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_lsd"
 	action_background_icon_state = "bg_ling"
 
-/obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/living/carbon/target)
+/obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "LSD sting")
-	addtimer(CALLBACK(src, .proc/hallucination_time, target), rand(100,200))
+	if(target.reagents)
+		target.reagents.add_reagent("regenerative_materia", 5)
+		target.reagents.add_reagent("mindbreaker", 5)
 	return TRUE
-
-/obj/effect/proc_holder/changeling/sting/LSD/proc/hallucination_time(mob/living/carbon/target)
-	if(target)
-		target.hallucination = max(90, target.hallucination)
 
 /obj/effect/proc_holder/changeling/sting/cryo
 	name = "Cryogenic Sting"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

hallucination sting now injects mindbreaker toxin so you can repeatedly sting someone to stack it.
also injects regenerative materia, which does 13 toxin damage per 5 units and makes them feel like they're at full health.

## Why It's Good For The Game

hallucination sting pretty much sucked. this makes it suck less.

## Changelog
:cl:
add: regenerative materia to hallucination sting
add: mindbreaker toxin as an actual chemical to hallucination sting
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
