### PR TITLE
Makes staminaloss also apply the oxyloss fullscreen overlay.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -699,9 +699,10 @@
 		clear_fullscreen("critvision")
 
 	//Oxygen damage overlay
-	if(oxyloss)
+	var/windedup = getOxyLoss() + getStaminaLoss() * 0.2 + stamdamageoverlaytemp
+	if(windedup)
 		var/severity = 0
-		switch(oxyloss)
+		switch(windedup)
 			if(10 to 20)
 				severity = 1
 			if(20 to 25)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -61,5 +61,6 @@
 	var/next_hallucination = 0
 	var/cpr_time = 1 //CPR cooldown.
 	var/damageoverlaytemp = 0
+	var/stamdamageoverlaytemp = 0
 
 	var/drunkenness = 0 //Overall drunkenness - check handle_alcohol() in life.dm for effects

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1781,6 +1781,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(CLONE)
 			H.adjustCloneLoss(damage * hit_percent * H.physiology.clone_mod)
 		if(STAMINA)
+			H.stamdamageoverlaytemp = 20
 			if(BP)
 				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, abs(damage * hit_percent * H.physiology.stamina_mod), only_robotic = FALSE, only_organic = FALSE))
 					H.update_stamina()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -4,8 +4,9 @@
 	if(notransform)
 		return
 
-	if(damageoverlaytemp)
+	if(damageoverlaytemp || stamdamageoverlaytemp)
 		damageoverlaytemp = 0
+		stamdamageoverlaytemp = 0
 		update_damage_hud()
 
 	if(stat != DEAD) //Reagent processing needs to come before breathing, to prevent edge cases.


### PR DESCRIPTION
## About The Pull Request
What's said on the tin.

## Why It's Good For The Game
While toying around with those rubber toolbox memes I made a while ago on the server, I noticed how most of the assaulted parties' reaction was pretty much delayed due to the fact stamina loss doesn't throw in any noticeable visual warning they were receiving actual (stamina) damage, to the point I could effortlessly win over those unaware of this feature.

Nevertheless, it is a visual aid to the HUD indicators located on the right side of the screen, as stam loss is a dominant feature of the deprecable combat-thing of this server.
Only 1/5 of it calculated toward the severity of the overlay, to avoid making it overly fastidious.

## Changelog
:cl:
tweak: the oxyloss fullscreen overlays now also take in consideration 1/5 of the user stamina loss.
/:cl:
