### PR TITLE
[TESTMERGE ONLY] heavily applies sqrt() to tank ruptures and removes the bombcap for tank ruptures

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -134,6 +134,7 @@
 #define TANK_RUPTURE_PRESSURE				(35.*ONE_ATMOSPHERE)	//Tank spills all contents into atmosphere
 #define TANK_FRAGMENT_PRESSURE				(40.*ONE_ATMOSPHERE)	//Boom 3x3 base explosion
 #define TANK_FRAGMENT_SCALE	    			(6.*ONE_ATMOSPHERE)		//+1 for each SCALE kPa aboe threshold
+#define TANK_FRAGMENT_MULT					(4)					//What the tank explosion scale gets multiplied by to compensate for the abuse of sqrt()
 #define TANK_MAX_RELEASE_PRESSURE 			(ONE_ATMOSPHERE*3)
 #define TANK_MIN_RELEASE_PRESSURE 			0
 #define TANK_DEFAULT_RELEASE_PRESSURE 		16

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -117,13 +117,11 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 	
 	/*****The Point Calculator*****/
 	
-	if(orig_light < 10)
+	if(orig_light < 1)
 		say("Explosion not large enough for research calculations.")
 		return
-	else if(orig_light < 4500) 
-		point_gain = (83300 * orig_light) / (orig_light + 3000)
 	else
-		point_gain = TECHWEB_BOMB_POINTCAP
+		point_gain = min((((83300 * orig_light) / (orig_light + 3000))*10), TECHWEB_BOMB_POINTCAP)
 
 	/*****The Point Capper*****/
 	if(point_gain > linked_techweb.largest_bomb_value)

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		say("Explosion not large enough for research calculations.")
 		return
 	else
-		point_gain = min((((83300 * orig_light) / (orig_light + 3000))*10), TECHWEB_BOMB_POINTCAP)
+		point_gain = min((((83300 * orig_light) / (orig_light + 3000))*25), TECHWEB_BOMB_POINTCAP)
 
 	/*****The Point Capper*****/
 	if(point_gain > linked_techweb.largest_bomb_value)

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -242,13 +242,13 @@
 		//Give the gas a chance to build up more pressure through reacting
 		air_contents.react(src)
 		air_contents.react(src)
-		//Citadel Edit: removing extra react for "balance"
+		air_contents.react(src) //we're readding this extra react because holy fuck the sqrt's heavy
 		pressure = air_contents.return_pressure()
-		var/range = (pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE
+		var/range = (sqrt(sqrt((pressure-TANK_FRAGMENT_PRESSURE)/TANK_FRAGMENT_SCALE)))*TANK_FRAGMENT_MULT //squirt, squirt, KABOOM
 		var/turf/epicenter = get_turf(loc)
 
 
-		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5))
+		explosion(epicenter, round(range*0.25), round(range*0.5), round(range), round(range*1.5), ignorecap = TRUE)
 		if(istype(src.loc, /obj/item/transfer_valve))
 			qdel(src.loc)
 		else


### PR DESCRIPTION
https://www.youtube.com/watch?v=RnSjQM9A6eU
Kevinz and various others in discord dared me and didn't encourage me to back down.
[LOUD SYNTH CACKLING IN DISTANCE]

## Changelog
:cl:
tweak: Tank ruptures now have two sqrt() operations applied to their explosion radius calculation
tweak: Tank ruptures are now back to their original state of having 3 react() calls, up from their previous 2 react() calls
tweak: Tank ruptures no longer obey the bombcap
tweak: To compensate, point gain from the doppler array has been increased drastically, and the minimum explosion radius has been decreased to 0.25dev.
/:cl:
