### PR TITLE
Fixes inactive high luminosity eyes turning back on as soon as you move around.

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -169,7 +169,6 @@
 	var/list/obj/effect/abstract/eye_lighting/eye_lighting
 	var/obj/effect/abstract/eye_lighting/on_mob
 	var/image/mob_overlay
-	var/datum/component/mobhook
 
 /obj/item/organ/eyes/robotic/glow/Initialize()
 	. = ..()
@@ -238,26 +237,18 @@
 		return
 	deactivate(silent = TRUE)
 
-/obj/item/organ/eyes/robotic/glow/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
-	. = ..()
-	if (mobhook && mobhook.parent != M)
-		QDEL_NULL(mobhook)
-	if (!mobhook)
-		mobhook = M.AddComponent(/datum/component/redirect, list(COMSIG_ATOM_DIR_CHANGE = CALLBACK(src, .proc/update_visuals)))
-
 /obj/item/organ/eyes/robotic/glow/Remove(mob/living/carbon/M)
 	. = ..()
-	QDEL_NULL(mobhook)
-
-/obj/item/organ/eyes/robotic/glow/Destroy()
-	QDEL_NULL(mobhook) // mobhook is not our component
-	return ..()
+	if(active)
+		UnregisterSignal(M, COMSIG_ATOM_DIR_CHANGE)
+		active = FALSE
 
 /obj/item/organ/eyes/robotic/glow/proc/activate(silent = FALSE)
 	start_visuals()
 	if(!silent)
 		to_chat(owner, "<span class='warning'>Your [src] clicks and makes a whining noise, before shooting out a beam of light!</span>")
 	active = TRUE
+	RegisterSignal(owner, COMSIG_ATOM_DIR_CHANGE, .proc/update_visuals)
 	cycle_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/deactivate(silent = FALSE)
@@ -265,6 +256,7 @@
 	if(!silent)
 		to_chat(owner, "<span class='warning'>Your [src] shuts off!</span>")
 	active = FALSE
+	UnregisterSignal(owner, COMSIG_ATOM_DIR_CHANGE)
 	remove_mob_overlay()
 
 /obj/item/organ/eyes/robotic/glow/proc/update_visuals(datum/source, olddir, newdir)


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. Also the redirect component will have to be removed completely one day anyway.

## Why It's Good For The Game
Fixes a pevee.

## Changelog
:cl:
fix: High luminosity eyes can now be properly deactivated and won't illuminate your surroundings again until turned back on.
/:cl:
