### PR TITLE
Xenomorph larvae no longer gib and inexplicably delete your brain when hatching

### DIFF
--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -63,7 +63,7 @@
 
 
 
-/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(gib_on_success=TRUE)
+/obj/item/organ/body_egg/alien_embryo/proc/AttemptGrow(var/kill_on_sucess=TRUE)
 	if(!owner || bursting)
 		return
 
@@ -102,10 +102,12 @@
 		new_xeno.notransform = 0
 		new_xeno.invisibility = 0
 
-	if(gib_on_success)
-		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner] in a shower of gore!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
-		owner.gib(TRUE)
-	else
+	if(kill_on_sucess) //ITS TOO LATE
+		new_xeno.visible_message("<span class='danger'>[new_xeno] bursts out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>", "<span class='italics'>You hear organic matter ripping and tearing!</span>")
+		owner.apply_damage(rand(100,300),BRUTE,zone,FALSE) //Random high damage to torso so health sensors don't metagame.
+		owner.spill_organs(TRUE,FALSE,TRUE) //Lets still make the death gruesome and impossible to just simply defib someone.
+		owner.death(FALSE) //Just in case some freak occurance occurs where you somehow survive all your organs being removed from you and the 100-300 brute damage.
+	else //When it is removed via surgery at a late stage, rather than forced.
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)
 		owner.cut_overlay(overlay)


### PR DESCRIPTION
## About The Pull Request

Xenomorph larvae hatching no longer gibs you, but instead just kills you, disembowels you, and deals a high amount of brute damage to your chest.

## Why It's Good For The Game

I discovered in a previous round that FOR SOME REASON a larva hatching out of you gibs you, and on top of that, inexplicably deletes your brain. It's pretty stupid and I think only exists as a poor /tg/ attempt to balance things. It likely was intended to get people to play xeno after they die, but this was when /tg/ had like 2 players playing.

No other antagonist has this sort of thing where if you "lose" you get permadeath. When you consider the fact that xenos have instant stuns with neurotoxin and facehugger throws, it's a bit of a huge meme to have especially on a server with a playerbase that does not validhunt or really give a shit about anything that occurs in the round.

Permadeath should never be a thing in ss13, but not because we're a hugbox, but because permadeath encourages people to rush to the cloners any time there is an antagonist who can permanently alter your character's life.

## Changelog
:cl: BurgerBB
balance: Chestbursters no longer give and remove your brain. They just disembowel and kill you now.
/:cl: