### PR TITLE
Fixed WarOps Challenge incorrectly counting players

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -62,7 +62,10 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/D in GLOB.jam_on_wardec)
 		D.jammed = TRUE
 
-	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS + CEILING(PLAYER_SCALING * GLOB.player_list.len, 1))
+	var/list/nukeops = get_antag_minds(/datum/antagonist/nukeop)
+	var/actual_players = GLOB.joined_player_list.len - nukeops.len
+
+	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS + CEILING(PLAYER_SCALING * actual_players, 1))
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
 
@@ -72,7 +75,10 @@ GLOBAL_LIST_EMPTY(jam_on_wardec)
 	if(declaring_war)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
-	if(GLOB.player_list.len < CHALLENGE_MIN_PLAYERS)
+
+	var/list/nukeops = get_antag_minds(/datum/antagonist/nukeop)
+	var/actual_players = GLOB.joined_player_list.len - nukeops.len
+	if(actual_players < CHALLENGE_MIN_PLAYERS)
 		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
 		return FALSE
 	if(!user.onSyndieBase())


### PR DESCRIPTION
## About The Pull Request

Fixes WarOps incorrectly counting the entire ops team as well as any admin-spawned mobs for TC calculations as well as fairness calculations.

## Why It's Good For The Game

Something I noticed while going through the code. It fixes counting the operatives themselves when checking if WarOps is possible.

## Changelog
:cl: BurgerBB
fix: Fixes WarOps miscalculating players.
/:cl:
