### PR TITLE
Alert Level is now displayed at the job selection screen.

### DIFF
--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -429,7 +429,19 @@
 
 
 /mob/dead/new_player/proc/LateChoices()
-	var/dat = "<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]</div>"
+
+	var/level = "green"
+	switch(GLOB.security_level)
+		if(SEC_LEVEL_BLUE)
+			level = "blue"
+		if(SEC_LEVEL_AMBER)
+			level = "amber"
+		if(SEC_LEVEL_RED)
+			level = "red"
+		if(SEC_LEVEL_DELTA)
+			level = "delta"	
+
+	var/dat = "<div class='notice'>Round Duration: [DisplayTimeText(world.time - SSticker.round_start_time)]<br>Alert Level: [capitalize(level)]</div>"
 
 	if(SSshuttle.emergency)
 		switch(SSshuttle.emergency.mode)
@@ -438,7 +450,10 @@
 			if(SHUTTLE_CALL)
 				if(!SSshuttle.canRecall())
 					dat += "<div class='notice red'>The station is currently undergoing evacuation procedures.</div><br>"
+	
 
+	
+		
 	var/available_job_count = 0
 	for(var/datum/job/job in SSjob.occupations)
 		if(job && IsJobUnavailable(job.title, TRUE) == JOB_AVAILABLE)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -450,10 +450,7 @@
 			if(SHUTTLE_CALL)
 				if(!SSshuttle.canRecall())
 					dat += "<div class='notice red'>The station is currently undergoing evacuation procedures.</div><br>"
-	
 
-	
-		
 	var/available_job_count = 0
 	for(var/datum/job/job in SSjob.occupations)
 		if(job && IsJobUnavailable(job.title, TRUE) == JOB_AVAILABLE)


### PR DESCRIPTION
## About The Pull Request

The alert level is now displayed at the job selection screen.

![image](https://user-images.githubusercontent.com/8602857/62255811-b3e29680-b3b3-11e9-8145-f4b539c09781.png)

## Why It's Good For The Game

Basically prevents people who don't want to join on Code Delta to join on code delta. It's similar to how the game tells you that the crew is undergoing evacuation procedures or the shuttle is being called; it just tells you what you're getting into so you can prepare yourself accordingly or just wait until the round ends.

It will be hard to really metagame this, with the exception of code Delta, because the alert level is absolutely unreliable because it can be changed for any reason by anyone with access, and there can be false blues or false greens.

## Changelog
:cl: BurgerBB
add: The alert level is displayed at the job selection screen.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
