### PR TITLE
Refactors food processor recipes selection a little, plus additions.

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -82,6 +82,14 @@
 		var/datum/emote/E = new path()
 		E.emote_list[E.key] = E
 
+	//Food processor
+	for(var/path in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
+		var/datum/food_processor_process/P = new path()
+		for(var/typecache in P.input)
+			if(P.blacklisted_inputs && is_type_in_typecache(typecache, P.blacklisted_inputs))
+				continue
+			GLOB.food_processor_recipes[typecache] = P
+
 	init_subtypes(/datum/crafting_recipe, GLOB.crafting_recipes)
 
 //creates every subtype of prototype (excluding prototype) and adds it to list L.

--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -83,7 +83,7 @@
 		E.emote_list[E.key] = E
 
 	//Food processor
-	for(var/path in subtypesof(/datum/food_processor_process) - /datum/food_processor_process/mob)
+	for(var/path in subtypesof(/datum/food_processor_process) - list(/datum/food_processor_process/mob, /datum/food_processor_process/mob/sausage))
 		var/datum/food_processor_process/P = new path()
 		for(var/typecache in P.input)
 			if(P.blacklisted_inputs && is_type_in_typecache(typecache, P.blacklisted_inputs))

--- a/code/_globalvars/lists/objects.dm
+++ b/code/_globalvars/lists/objects.dm
@@ -20,6 +20,7 @@ GLOBAL_LIST_EMPTY(materials_list)				//list of all /datum/material datums indexe
 GLOBAL_LIST_EMPTY(tech_list)					//list of all /datum/tech datums indexed by id.
 GLOBAL_LIST_EMPTY(surgeries_list)				//list of all surgeries by name, associated with their path.
 GLOBAL_LIST_EMPTY(crafting_recipes)				//list of all table craft recipes
+GLOBAL_LIST_EMPTY(food_processor_recipes)		//food processor recipes
 GLOBAL_LIST_EMPTY(rcd_list)					//list of Rapid Construction Devices.
 GLOBAL_LIST_EMPTY(apcs_list)					//list of all Area Power Controller machines, separate from machines for powernet speeeeeeed.
 GLOBAL_LIST_EMPTY(tracked_implants)			//list of all current implants that are tracked to work out what sort of trek everyone is on. Sadly not on lavaworld not implemented...

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -43,7 +43,7 @@
 		recipe.make_results(src, what)
 	if (ismob(what))
 		var/mob/themob = what
-		themob.gib(TRUE,TRUE,TRUE)
+		themob.gib(TRUE, TRUE, TRUE, TRUE)
 	else
 		qdel(what)
 
@@ -53,6 +53,8 @@
 	var/datum/food_processor_process/recipe = GLOB.food_processor_recipes[X.type]
 	if(recipe?.check_requirements(src, X, user))
 		return recipe
+	else if(ismob(X))
+		to_chat(user, "<span class='warning'>That probably won't blend!</span>")
 
 /obj/machinery/processor/attackby(obj/item/O, mob/user, params)
 	if(processing)
@@ -100,12 +102,13 @@
 	if(processing)
 		to_chat(user, "<span class='warning'>[src] is in the process of processing!</span>")
 		return TRUE
-	if(user.a_intent == INTENT_GRAB && ismob(user.pulling) && select_recipe(user.pulling, user))
+	if(user.a_intent == INTENT_GRAB && ismob(user.pulling))
 		var/mob/living/pushed_mob = user.pulling
-		visible_message("<span class='warner'>[user] stuffs [pushed_mob] into [src]!</span>")
-		pushed_mob.forceMove(src)
-		user.stop_pulling()
-		return
+		if(select_recipe(pushed_mob, user))
+			visible_message("<span class='warning'>[user] stuffs [pushed_mob] into [src]!</span>")
+			pushed_mob.forceMove(src)
+			user.stop_pulling()
+		return TRUE
 	if(contents.len == 0)
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return TRUE

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -36,7 +36,8 @@
 	if(CHECK_BITFIELD(obj_flags, EMAGGED))
 		return
 	ENABLE_BITFIELD(obj_flags, EMAGGED)
-	to_chat(user, "<span class='notice'>You activate \the [src]'s emergency humanitarian protocols.</span>")
+	to_chat(user, "<span class='notice'>You stealthily activate \the [src]'s emergency humanitarian protocols.</span>")
+	return TRUE
 
 /obj/machinery/processor/proc/process_food(datum/food_processor_process/recipe, atom/movable/what)
 	if (!QDELETED(src))

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -6,6 +6,7 @@
 	var/output_multiplier = 1
 	var/min_amount_rating = 1
 	var/required_machine = /obj/machinery/processor
+	var/req_emagged = FALSE
 
 /datum/food_processor_process/New()
 	if(input)
@@ -13,8 +14,12 @@
 	if(blacklisted_inputs)
 		blacklisted_inputs = typecacheof(blacklisted_inputs)
 
+//This proc is called in two occasions: when trying to insert something in the food processor and when it's effectively processing food.
+//the user arg is only set on the first case, thus you'll have to check it before running related statements.
 /datum/food_processor_process/proc/check_requirements(obj/machinery/processor/P, atom/movable/X, mob/user)
 	if(!istype(P, required_machine))
+		return FALSE
+	if(req_emagged && !CHECK_BITFIELD(P.obj_flags, EMAGGED))
 		return FALSE
 	if(P.rating_amount >= min_amount_rating)
 		if(user)
@@ -22,9 +27,10 @@
 		return FALSE
 
 /datum/food_processor_process/proc/make_results(obj/machinery/processor/P, atom/movable/X)
-	if(output)
-		for(var/i in 1 to FLOOR(P.rating_amount * output_multiplier, 1))
-			new output(P.drop_location())
+	if(!output || (X in P))
+		return
+	for(var/i in 1 to FLOOR(P.rating_amount * output_multiplier, 1))
+		new output(P.drop_location())
 
 /datum/food_processor_process/meat
 	input = /obj/item/reagent_containers/food/snacks/meat/slab
@@ -67,28 +73,79 @@
 	output = /obj/item/reagent_containers/food/snacks/roastparsnip
 
 /datum/food_processor_process/mob
+	var/kick_n_scream = TRUE
 	var/instinct_verb = "cries at the coderbus"
 	var/blind_istinct_noise = "animal"
+	var/stuffin_time = 40
+	var/check_items = TRUE
 
 /datum/food_processor_process/mob/check_requirements(obj/machinery/processor/P, mob/living/L, mob/user)
 	. = ..()
-	if(. && user && L.stat != DEAD) //colloquially said, no user around equals to grinding time, so no moral check will cause issues there.
-		user.visible_message("<span class='warning'>\The [L] [instinct_verb] and trashes around as [user] futilely attempts to stuff them into \the [src].</span>", "<span class='warning'>\The [L] [instinct_verb] and trashes around against your futile attempts at stuffing them into \the [src].</span>", "<span class='italics'>You hear angry [blind_istinct_noise] noises...</span>")
+	if(!. || !user)
+		return
+	if(user.grab_state < GRAB_AGGRESSIVE)
+		to_chat(user, "<span class='warning'>You need a better grip to do that!</span>")
 		return FALSE
+	if(L.buckled ||L.has_buckled_mobs())
+		to_chat(user, "<span class='warning'>[L] is attached to something!</span>")
+		return FALSE
+	if(kick_n_scream && !L.mind && !L.incapacitated())
+		user.visible_message("<span class='warning'>[L] [instinct_verb] and trashes around as [user] futilely attempts to stuff them into [P].</span>", "<span class='warning'>[L] [instinct_verb] and trashes around against your futile attempts at stuffing them into [P].</span>", "<span class='italics'>You hear angry [blind_istinct_noise] noises...</span>")
+		return FALSE
+	if(check_items)
+		for(var/A in L.held_items + L.get_equipped_items())
+			var/obj/item/I = A
+			if(!HAS_TRAIT(I, TRAIT_NODROP))
+				to_chat(user, "<span class='danger'>Subject may not have abiotic items on.</span>")
+				playsound(P, 'sound/machines/buzz-sigh.ogg', 30, 1)
+				return FALSE
+	if(stuffin_time)
+		user.visible_message("<span class='warning'>[user] starts stuffing [L] into [P].</span>", "<span class='notice'>You start stuffing [L] into [P]...</span>")
+		if(!do_mob(user, L, stuffin_time))
+			return FALSE
+	user.visible_message("<span class='warning'>[user] stuffs [L] into [P].</span>", "<span class='notice'>You stuff [L] into [P].</span>")
+
+/datum/food_processor_process/mob/make_results(obj/machinery/processor/P, atom/movable/X)
+	var/mob/living/L = X
+	if(!output || !(L in P))
+		return
+	for(var/i in 1 to FLOOR(P.rating_amount * output_multiplier * max(0.25, L.mob_size * 0.5), 1))
+		new output(P.drop_location())
 
 /datum/food_processor_process/mob/slime
 	input = /mob/living/simple_animal/slime
-	output = null
 	required_machine = /obj/machinery/processor/slime
 	instinct_verb = "blorbes"
 	blind_istinct_noise = "slime"
+	stuffin_time = 0
 
-/datum/food_processor_process/mob/poultry_sausage
-	input = /mob/living/simple_animal/chicken
+/datum/food_processor_process/mob/slime/make_results(obj/machinery/processor/P, mob/living/simple_animal/slime/S)
+	if(!(S in P))
+		return
+	for(var/i in 1 to (S.cores + P.rating_amount - 1))
+		var/atom/movable/item = new S.coretype(P.drop_location())
+		P.adjust_item_drop_location(item)
+		SSblackbox.record_feedback("tally", "slime_core_harvested", 1, S.colour)
+
+/datum/food_processor_process/mob/sausage
 	output = /obj/item/reagent_containers/food/snacks/sausage
 	min_amount_rating = 3
-	output_multiplier = 0.5
+
+/datum/food_processor_process/mob/sausage/poultry
+	input = /mob/living/simple_animal/chicken
 	instinct_verb = "clucks"
+
+/datum/food_processor_process/mob/sausage/cow
+	input = /mob/living/simple_animal/cow
+	instinct_verb = "moos hauntingly"
+
+/datum/food_processor_process/mob/sausage/goat
+	input = /mob/living/simple_animal/hostile/retaliate/goat
+	instinct_verb = "brays"
+
+/datum/food_processor_process/mob/sausage/monky
+	input = /mob/living/carbon/monkey
+	kick_n_scream = FALSE
 
 /datum/food_processor_process/mob/carp_tuna
 	input = /mob/living/simple_animal/hostile/carp
@@ -105,3 +162,10 @@
 	output_multiplier = 0.5
 	instinct_verb = "gnashes"
 	blind_istinct_noise = "plant"
+
+/datum/food_processor_process/mob/soylent_green
+	req_emagged = TRUE
+	kick_n_scream = FALSE
+	input = /mob/living/carbon/human
+	output = /obj/item/reagent_containers/food/snacks/soylentgreen
+	output_multiplier = 0.5

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -1,8 +1,30 @@
 /datum/food_processor_process
 	var/input
+	var/blacklisted_inputs
 	var/output
 	var/time = 40
+	var/output_multiplier = 1
+	var/min_amount_rating = 1
 	var/required_machine = /obj/machinery/processor
+
+/datum/food_processor_process/New()
+	if(input)
+		input = typecacheof(input)
+	if(blacklisted_inputs)
+		blacklisted_inputs = typecacheof(blacklisted_inputs)
+
+/datum/food_processor_process/proc/check_requirements(obj/machinery/processor/P, atom/movable/X, mob/user)
+	if(!istype(P, required_machine))
+		return FALSE
+	if(P.rating_amount >= min_amount_rating)
+		if(user)
+			to_chat(user, "<span class='warning'>\The [src] lacks the more advanced stock parts required to process \the [X].</span>")
+		return FALSE
+
+/datum/food_processor_process/proc/make_results(obj/machinery/processor/P, atom/movable/X)
+	if(output)
+		for(var/i in 1 to FLOOR(P.rating_amount * output_multiplier, 1))
+			new output(P.drop_location())
 
 /datum/food_processor_process/meat
 	input = /obj/item/reagent_containers/food/snacks/meat/slab
@@ -44,7 +66,42 @@
 	input = /obj/item/reagent_containers/food/snacks/grown/parsnip
 	output = /obj/item/reagent_containers/food/snacks/roastparsnip
 
+/datum/food_processor_process/mob
+	var/instinct_verb = "cries at the coderbus"
+	var/blind_istinct_noise = "animal"
+
+/datum/food_processor_process/mob/check_requirements(obj/machinery/processor/P, mob/living/L, mob/user)
+	. = ..()
+	if(. && user && L.stat != DEAD) //colloquially said, no user around equals to grinding time, so no moral check will cause issues there.
+		user.visible_message("<span class='warning'>\The [L] [instinct_verb] and trashes around as [user] futilely attempts to stuff them into \the [src].</span>", "<span class='warning'>\The [L] [instinct_verb] and trashes around against your futile attempts at stuffing them into \the [src].</span>", "<span class='italics'>You hear angry [blind_istinct_noise] noises...</span>")
+		return FALSE
+
 /datum/food_processor_process/mob/slime
 	input = /mob/living/simple_animal/slime
 	output = null
 	required_machine = /obj/machinery/processor/slime
+	instinct_verb = "blorbes"
+	blind_istinct_noise = "slime"
+
+/datum/food_processor_process/mob/poultry_sausage
+	input = /mob/living/simple_animal/chicken
+	output = /obj/item/reagent_containers/food/snacks/sausage
+	min_amount_rating = 3
+	output_multiplier = 0.5
+	instinct_verb = "clucks"
+
+/datum/food_processor_process/mob/carp_tuna
+	input = /mob/living/simple_animal/hostile/carp
+	blacklisted_inputs = /mob/living/simple_animal/hostile/carp/eyeball //this shouldn't be a subtype of carp to start with.
+	output = /obj/item/reagent_containers/food/snacks/tuna
+	min_amount_rating = 3
+	output_multiplier = 0.5
+	instinct_verb = "gnashes"
+
+/datum/food_processor_process/mob/killer_soup
+	input = /mob/living/simple_animal/hostile/killertomato
+	output = /obj/item/reagent_containers/food/snacks/soup/tomato
+	min_amount_rating = 3
+	output_multiplier = 0.5
+	instinct_verb = "gnashes"
+	blind_istinct_noise = "plant"

--- a/code/modules/food_and_drinks/recipes/processor_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/processor_recipes.dm
@@ -21,10 +21,11 @@
 		return FALSE
 	if(req_emagged && !CHECK_BITFIELD(P.obj_flags, EMAGGED))
 		return FALSE
-	if(P.rating_amount >= min_amount_rating)
+	if(P.rating_amount < min_amount_rating)
 		if(user)
-			to_chat(user, "<span class='warning'>\The [src] lacks the more advanced stock parts required to process \the [X].</span>")
+			to_chat(user, "<span class='warning'>\The [P] lacks the more advanced stock parts required to process \the [X].</span>")
 		return FALSE
+	return TRUE
 
 /datum/food_processor_process/proc/make_results(obj/machinery/processor/P, atom/movable/X)
 	if(!output || (X in P))
@@ -94,10 +95,11 @@
 		return FALSE
 	if(check_items)
 		for(var/A in L.held_items + L.get_equipped_items())
+			if(!A)
+				continue
 			var/obj/item/I = A
 			if(!HAS_TRAIT(I, TRAIT_NODROP))
 				to_chat(user, "<span class='danger'>Subject may not have abiotic items on.</span>")
-				playsound(P, 'sound/machines/buzz-sigh.ogg', 30, 1)
 				return FALSE
 	if(stuffin_time)
 		user.visible_message("<span class='warning'>[user] starts stuffing [L] into [P].</span>", "<span class='notice'>You start stuffing [L] into [P]...</span>")
@@ -130,6 +132,7 @@
 /datum/food_processor_process/mob/sausage
 	output = /obj/item/reagent_containers/food/snacks/sausage
 	min_amount_rating = 3
+	time = 80
 
 /datum/food_processor_process/mob/sausage/poultry
 	input = /mob/living/simple_animal/chicken
@@ -154,6 +157,7 @@
 	min_amount_rating = 3
 	output_multiplier = 0.5
 	instinct_verb = "gnashes"
+	time = 80
 
 /datum/food_processor_process/mob/killer_soup
 	input = /mob/living/simple_animal/hostile/killertomato
@@ -162,6 +166,7 @@
 	output_multiplier = 0.5
 	instinct_verb = "gnashes"
 	blind_istinct_noise = "plant"
+	time = 80
 
 /datum/food_processor_process/mob/soylent_green
 	req_emagged = TRUE
@@ -169,3 +174,4 @@
 	input = /mob/living/carbon/human
 	output = /obj/item/reagent_containers/food/snacks/soylentgreen
 	output_multiplier = 0.5
+	time = 80

--- a/code/modules/mob/dead/dead.dm
+++ b/code/modules/mob/dead/dead.dm
@@ -23,7 +23,7 @@ INITIALIZE_IMMEDIATE(/mob/dead)
 /mob/dead/dust(just_ash, drop_items, force)	//ghosts can't be vaporised.
 	return
 
-/mob/dead/gib()		//ghosts can't be gibbed.
+/mob/dead/gib(no_brain, no_organs, no_bodyparts, no_drops)		//ghosts can't be gibbed.
 	return
 
 /mob/dead/ConveyorMove()	//lol

--- a/code/modules/mob/death.dm
+++ b/code/modules/mob/death.dm
@@ -1,6 +1,6 @@
 //This is the proc for gibbing a mob. Cannot gib ghosts.
 //added different sort of gibs and animations. N
-/mob/proc/gib()
+/mob/proc/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	return
 
 //This is the proc for turning a mob into ash. Mostly a copy of gib code (above).

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -9,15 +9,15 @@
 		emote("deathgasp")
 
 	. = ..()
-	
+
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/BT = T
 		BT.on_death()
-	
+
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
-/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts)
+/mob/living/carbon/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	var/atom/Tsec = drop_location()
 	for(var/mob/M in src)
 		if(M in stomach_contents)

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -1,4 +1,4 @@
-/mob/living/gib(no_brain, no_organs, no_bodyparts)
+/mob/living/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	var/prev_lying = lying
 	if(stat != DEAD)
 		death(1)

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -144,7 +144,7 @@
 	alert_drones(DRONE_NET_DISCONNECT)
 
 
-/mob/living/simple_animal/drone/gib()
+/mob/living/simple_animal/drone/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	dust()
 
 /mob/living/simple_animal/drone/ratvar_act()

--- a/code/modules/mob/living/simple_animal/friendly/pet.dm
+++ b/code/modules/mob/living/simple_animal/friendly/pet.dm
@@ -61,8 +61,8 @@
 		collar_type = "[initial(collar_type)]_dead"
 	regenerate_icons()
 
-/mob/living/simple_animal/pet/gib()
-	if(pcollar)
+/mob/living/simple_animal/pet/gib(no_brain, no_organs, no_bodyparts, no_drops)
+	if(pcollar && !no_drops)
 		pcollar.forceMove(drop_location())
 		pcollar = null
 	..()

--- a/code/modules/mob/living/simple_animal/guardian/guardian.dm
+++ b/code/modules/mob/living/simple_animal/guardian/guardian.dm
@@ -234,7 +234,7 @@ GLOBAL_LIST_EMPTY(parasites) //all currently existing/living guardians
 		if(3)
 			adjustBruteLoss(30)
 
-/mob/living/simple_animal/hostile/guardian/gib()
+/mob/living/simple_animal/hostile/guardian/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	if(summoner)
 		to_chat(summoner, "<span class='danger'><B>Your [src] was blown up!</span></B>")
 		summoner.gib()

--- a/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
+++ b/code/modules/mob/living/simple_animal/hostile/gorilla/gorilla.dm
@@ -83,7 +83,7 @@
 	return iswallturf(T)
 
 
-/mob/living/simple_animal/hostile/gorilla/gib(no_brain)
+/mob/living/simple_animal/hostile/gorilla/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	if(!no_brain)
 		var/mob/living/brain/B = new(drop_location())
 		B.name = real_name

--- a/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mecha_pilot.dm
@@ -251,7 +251,7 @@
 		mecha.aimob_exit_mech(src)
 	..()
 
-/mob/living/simple_animal/hostile/syndicate/mecha_pilot/gib()
+/mob/living/simple_animal/hostile/syndicate/mecha_pilot/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	if(mecha)
 		mecha.aimob_exit_mech(src)
 	..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -65,7 +65,7 @@
 /mob/living/simple_animal/hostile/megafauna/proc/spawn_crusher_loot()
 	loot = crusher_loot
 
-/mob/living/simple_animal/hostile/megafauna/gib()
+/mob/living/simple_animal/hostile/megafauna/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	if(health > 0)
 		return
 	else

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -138,7 +138,7 @@
 
 // Turn to dust when gibbed
 
-/mob/living/simple_animal/hostile/statue/gib()
+/mob/living/simple_animal/hostile/statue/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	dust()
 
 

--- a/code/modules/mob/living/simple_animal/simple_animal.dm
+++ b/code/modules/mob/living/simple_animal/simple_animal.dm
@@ -259,8 +259,8 @@
 	if((bodytemperature < minbodytemp) || (bodytemperature > maxbodytemp))
 		adjustHealth(unsuitable_atmos_damage)
 
-/mob/living/simple_animal/gib()
-	if(butcher_results)
+/mob/living/simple_animal/gib(no_brain, no_organs, no_bodyparts, no_drops)
+	if(butcher_results && !no_drops)
 		var/atom/Tsec = drop_location()
 		for(var/path in butcher_results)
 			for(var/i in 1 to butcher_results[path])

--- a/code/modules/mob/living/simple_animal/slime/death.dm
+++ b/code/modules/mob/living/simple_animal/slime/death.dm
@@ -31,6 +31,6 @@
 
 	return ..(gibbed)
 
-/mob/living/simple_animal/slime/gib()
+/mob/living/simple_animal/slime/gib(no_brain, no_organs, no_bodyparts, no_drops)
 	death(TRUE)
 	qdel(src)


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. Regardless of any other theorical, possibly more efficient efficient method, this should still be better than generating new food processor recipes everytime you grind or insert something. 
Also added some  recipes involving simple animals. These recipes require better stock parts to be doneable.
So far these three are:
various farm animals plus monkeys -> sausages.
Carp -> Tuna cans.
Killer tomatoes -> Tomato soups.

Edit: Added in a fourth recipe which is basically soylent green. It requires the processor to be emagged.

## Why It's Good For The Game
Improving the food processor code a little, new features.

## Changelog
:cl:
refactor: Refactored food processor recipes selection.
add: Added some special food processor recipes involving mobs.
add: One of these recipes requires humans and a swipe of an emag.
tweak: Alt click food processors to empty them.
/:cl: