### PR TITLE
[Maybe] Stops Simple Bot Mobs from trying to proc vore.

### DIFF
--- a/modular_citadel/code/modules/mob/living/simple_animal/simplemob_vore_values.dm
+++ b/modular_citadel/code/modules/mob/living/simple_animal/simplemob_vore_values.dm
@@ -17,9 +17,9 @@
 //BOT MOBS
 
 /mob/living/simple_animal/bot
-	devourable = FASLE
-	digestable = FASLE
-	feeding = FASLE
+	devourable = FALSE
+	digestable = FALSE
+	feeding = FALSE
 
 //NUETRAL MOBS
 /mob/living/simple_animal/crab

--- a/modular_citadel/code/modules/mob/living/simple_animal/simplemob_vore_values.dm
+++ b/modular_citadel/code/modules/mob/living/simple_animal/simplemob_vore_values.dm
@@ -14,6 +14,12 @@
 	REFER TO code/modules/mob/living/simple_animal/simple_animal_vr.dm for Var information!
 */
 
+//BOT MOBS
+
+/mob/living/simple_animal/bot
+	devourable = FASLE
+	digestable = FASLE
+	feeding = FASLE
 
 //NUETRAL MOBS
 /mob/living/simple_animal/crab


### PR DESCRIPTION
## About The Pull Request

Ideally we stop bots from trying to access vore context even though they dont have such things. This made runtimes

https://cdn.discordapp.com/attachments/336748540690825216/606591487408603157/unknown.png

## Why It's Good For The Game

Runtimes bad mans. Should stop bot procs making them act faster or something - I dont know this vore code that well

## Changelog
:cl:
fix: maybe medibot doing a big weh and runtiming on vore content 
/:cl: