### PR TITLE
Buffs cult/clockcult wall explosion_block

### DIFF
--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -50,7 +50,7 @@
 /turf/closed/wall/clockwork
 	name = "clockwork wall"
 	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
-	explosion_block = 10
+	explosion_block = 5
 	hardness = 10
 	slicing_duration = 80
 	sheet_type = /obj/item/stack/tile/brass

--- a/code/game/turfs/simulated/wall/misc_walls.dm
+++ b/code/game/turfs/simulated/wall/misc_walls.dm
@@ -7,6 +7,7 @@
 	smooth = SMOOTH_MORE
 	sheet_type = /obj/item/stack/sheet/runed_metal
 	sheet_amount = 1
+	explosion_block = 10
 	girder_type = /obj/structure/girder/cult
 
 /turf/closed/wall/mineral/cult/Initialize()
@@ -49,7 +50,7 @@
 /turf/closed/wall/clockwork
 	name = "clockwork wall"
 	desc = "A huge chunk of warm metal. The clanging of machinery emanates from within."
-	explosion_block = 2
+	explosion_block = 10
 	hardness = 10
 	slicing_duration = 80
 	sheet_type = /obj/item/stack/tile/brass


### PR DESCRIPTION
Clockcults getting instantly erased by someone with a chem dispenser isn't fun for anyone.
I do know that there's other issues see: Clockcult being "spam tables, the game", but honestly bombs shouldn't be the end-all.