### PR TITLE
[PR 105 BOIS]Connects the Monastery on Pubby to the main station

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -139,7 +139,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/status_display/ai{
+/obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
 /turf/open/floor/circuit,
@@ -350,7 +350,7 @@
 	id = "AI";
 	pixel_y = 20
 	},
-/obj/machinery/status_display/ai{
+/obj/machinery/ai_status_display{
 	pixel_y = 37
 	},
 /turf/open/floor/circuit,
@@ -502,17 +502,9 @@
 	name = "AI Core";
 	req_access_txt = "65"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "adc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1032,13 +1024,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aev" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1128,13 +1116,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -1221,23 +1205,11 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/security/prison)
 "aeX" = (
 /obj/machinery/washing_machine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/security/prison)
 "aeY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1316,13 +1288,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
 /obj/structure/cable/yellow{
@@ -1331,13 +1299,9 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
@@ -1351,11 +1315,9 @@
 	dir = 2;
 	network = list("minisat")
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afh" = (
 /obj/structure/cable/yellow{
@@ -1451,24 +1413,12 @@
 /area/security/prison)
 "afr" = (
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/security/prison)
 "afs" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/security/prison)
 "aft" = (
 /obj/machinery/light/small{
@@ -1501,13 +1451,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afx" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afy" = (
 /obj/effect/landmark/start/cyborg,
@@ -1515,11 +1461,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afz" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afA" = (
 /obj/machinery/light/small{
@@ -1685,11 +1629,8 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 8;
-	icon_state = "right";
-	name = "Unisex Showers"
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1715,11 +1656,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agh" = (
 /obj/structure/transit_tube/station/reverse/flipped{
@@ -1760,9 +1699,12 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ago" = (
-/obj/structure/window/reinforced{
+/obj/machinery/door/window/westleft{
+	base_state = "right";
 	dir = 8;
-	layer = 2.9
+	icon_state = "right";
+	name = "Unisex Showers";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1834,17 +1776,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/security/prison)
 "agA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -1863,17 +1795,7 @@
 	name = "Cell 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/security/prison)
 "agC" = (
 /obj/machinery/door/airlock{
@@ -1927,7 +1849,13 @@
 	dir = 1
 	},
 /obj/item/toy/plush/slimeplushie,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/prison)
+"agJ" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agK" = (
 /obj/machinery/light/small{
@@ -1945,7 +1873,7 @@
 	dir = 8
 	},
 /obj/structure/chair,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agL" = (
 /obj/structure/bed,
@@ -1964,7 +1892,7 @@
 	dir = 1
 	},
 /obj/item/toy/plush/lizardplushie,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agM" = (
 /obj/structure/cable{
@@ -1973,7 +1901,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agN" = (
 /obj/machinery/light/small{
@@ -1991,7 +1919,7 @@
 	dir = 8
 	},
 /obj/structure/chair,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agO" = (
 /obj/structure/sink{
@@ -2054,13 +1982,17 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/prison)
+"agX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agY" = (
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "agZ" = (
 /obj/machinery/flasher{
@@ -2068,14 +2000,14 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "aha" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "ahb" = (
 /obj/structure/toilet{
@@ -2106,13 +2038,9 @@
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahk" = (
 /obj/machinery/button/flasher{
@@ -2133,13 +2061,9 @@
 	pixel_x = 6;
 	pixel_y = 36
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahl" = (
 /obj/item/radio/intercom{
@@ -2149,13 +2073,9 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahm" = (
 /obj/machinery/door/airlock/security/glass{
@@ -2166,7 +2086,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "ahn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -2192,7 +2112,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/prison)
 "ahq" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -2221,16 +2141,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/whitered/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahv" = (
 /obj/structure/cable{
@@ -2239,13 +2152,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2293,11 +2202,9 @@
 	pixel_x = 24;
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2462,13 +2369,9 @@
 /area/space/nearstation)
 "ahS" = (
 /obj/structure/table/optable,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahT" = (
 /turf/open/floor/plasteel/white,
@@ -2683,11 +2586,7 @@
 /obj/item/storage/backpack/duffelbag/sec/surgery{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitered/side,
 /area/security/execution/transfer)
 "aiw" = (
 /obj/machinery/power/emitter/anchored{
@@ -2704,13 +2603,9 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "aix" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2722,49 +2617,31 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiz" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiA" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "aiB" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiD" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiF" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -2790,21 +2667,13 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiK" = (
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/electropack,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/prison)
 "aiL" = (
 /obj/structure/table,
@@ -2914,11 +2783,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/security/execution/transfer)
 "aja" = (
 /obj/structure/cable{
@@ -2927,11 +2792,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/security/execution/transfer)
 "ajb" = (
 /obj/structure/closet/secure_closet/injection,
@@ -2943,11 +2804,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ajc" = (
 /obj/structure/closet/secure_closet/brig,
@@ -2960,17 +2819,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/prison)
 "aje" = (
 /obj/structure/cable{
@@ -2987,17 +2836,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/prison)
 "ajg" = (
 /obj/structure/rack,
@@ -3020,14 +2859,23 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/riot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot{
 	pixel_x = 3;
 	pixel_y = -3
+	},
+/obj/item/shield/riot{
+	pixel_x = -3;
+	pixel_y = 3
 	},
 /obj/item/shield/riot,
 /obj/item/shield/riot{
@@ -3058,6 +2906,10 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/storage/box/rubbershot{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -3070,17 +2922,7 @@
 "ajk" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/main)
 "ajl" = (
 /obj/structure/filingcabinet,
@@ -3089,13 +2931,9 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ajm" = (
 /obj/structure/table,
@@ -3105,13 +2943,9 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ajn" = (
 /obj/structure/table,
@@ -3125,39 +2959,27 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ajo" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ajp" = (
 /obj/machinery/photocopier,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ajq" = (
 /obj/effect/landmark/start/security_officer,
@@ -3165,17 +2987,7 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/main)
 "ajr" = (
 /obj/item/reagent_containers/food/snacks/donut/chaos,
@@ -3321,16 +3133,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "ajO" = (
 /obj/structure/closet{
@@ -3339,14 +3144,9 @@
 /obj/structure/sign/poster/official/safety_report{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "ajP" = (
 /obj/structure/rack,
@@ -3355,6 +3155,10 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/e_gun,
+/obj/item/gun/energy/e_gun{
+	pixel_x = 3;
+	pixel_y = -3
+	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3373,6 +3177,15 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/bulletproof,
+/obj/item/clothing/suit/armor/bulletproof{
+	pixel_x = 3;
+	pixel_y = -3
+	},
+/obj/item/clothing/head/helmet/alt{
+	layer = 3.00001;
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
 	},
@@ -3396,6 +3209,7 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
+/obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3
@@ -3412,13 +3226,9 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ajV" = (
 /obj/effect/landmark/start/security_officer,
@@ -3450,11 +3260,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "aka" = (
 /obj/machinery/suit_storage_unit/hos,
@@ -3466,8 +3274,9 @@
 "akb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/plaques/kiddie{
+/obj/structure/sign/plaques/atmos{
 	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
+	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},
@@ -3721,16 +3530,9 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/whitered/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akC" = (
 /obj/item/storage/firstaid/regular{
@@ -3742,13 +3544,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akD" = (
 /obj/item/radio/intercom{
@@ -3759,39 +3557,26 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akE" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/whitered/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akF" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
 /obj/structure/cable{
@@ -3817,17 +3602,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/brig)
 "akJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -3843,11 +3618,9 @@
 	c_tag = "Brig Evidence Room";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "akL" = (
 /obj/structure/rack,
@@ -3860,7 +3633,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akM" = (
@@ -3889,6 +3661,10 @@
 /area/security/armory)
 "akP" = (
 /obj/structure/rack,
+/obj/item/gun/ballistic/shotgun/riot{
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /obj/item/gun/ballistic/shotgun/riot,
 /obj/item/gun/ballistic/shotgun/riot{
 	pixel_x = 3;
@@ -3904,27 +3680,15 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "akR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3938,34 +3702,21 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/corner,
 /area/crew_quarters/heads/hos)
 "akV" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/crew_quarters/heads/hos)
 "akW" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/crew_quarters/heads/hos)
 "akX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/crew_quarters/heads/hos)
 "akZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -4103,23 +3854,17 @@
 	},
 /obj/item/reagent_containers/glass/bottle/charcoal,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/whitered/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "alr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "als" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -4137,11 +3882,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "alu" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -4159,11 +3902,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "alx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4176,41 +3917,23 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "alz" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "alA" = (
 /obj/machinery/flasher/portable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/armory)
 "alB" = (
 /obj/structure/cable{
@@ -4221,13 +3944,9 @@
 	dir = 8;
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "alC" = (
 /obj/structure/table/wood,
@@ -4255,11 +3974,9 @@
 /area/security/main)
 "alG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "alH" = (
 /turf/open/floor/plasteel/dark,
@@ -4385,13 +4102,9 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amb" = (
 /obj/structure/cable{
@@ -4412,11 +4125,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/whitered/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amd" = (
 /obj/structure/cable{
@@ -4452,11 +4163,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "amg" = (
 /turf/closed/wall/r_wall,
@@ -4480,17 +4189,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/security/warden)
 "amj" = (
 /obj/structure/cable{
@@ -4517,17 +4216,7 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/security/warden)
 "aml" = (
 /obj/structure/cable{
@@ -4554,13 +4243,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "amn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -4609,11 +4294,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ams" = (
 /obj/structure/cable{
@@ -4700,6 +4383,7 @@
 /area/crew_quarters/heads/hos)
 "amA" = (
 /obj/structure/transit_tube/curved/flipped{
+	icon_state = "curved1";
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
@@ -4717,6 +4401,7 @@
 /area/space/nearstation)
 "amD" = (
 /obj/structure/transit_tube/curved/flipped{
+	icon_state = "curved1";
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
@@ -4776,17 +4461,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "amL" = (
 /obj/structure/cable{
@@ -4802,24 +4479,15 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/whitered/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitered/side,
 /area/security/brig)
 "amO" = (
 /obj/structure/closet/crate/freezer,
@@ -4832,27 +4500,18 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/whitered/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "amQ" = (
 /obj/structure/cable{
@@ -4867,11 +4526,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "amS" = (
 /obj/structure/closet/secure_closet/warden,
@@ -4954,13 +4611,9 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "anc" = (
 /obj/structure/table/wood,
@@ -4982,11 +4635,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "ang" = (
 /obj/structure/cable{
@@ -5092,17 +4743,9 @@
 /area/security/processing/cremation)
 "anw" = (
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "anx" = (
 /obj/machinery/door/airlock/maintenance{
@@ -5124,13 +4767,9 @@
 	icon_state = "map-pubby";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "anz" = (
 /obj/structure/cable{
@@ -5143,11 +4782,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "anB" = (
 /obj/structure/cable{
@@ -5228,14 +4865,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "anM" = (
 /obj/structure/chair/office/dark{
@@ -5259,14 +4891,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "anP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5297,10 +4924,9 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anS" = (
 /obj/structure/cable{
@@ -5309,25 +4935,17 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anU" = (
 /obj/structure/cable{
@@ -5342,13 +4960,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anV" = (
 /obj/structure/cable{
@@ -5362,13 +4976,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5469,24 +5079,18 @@
 /area/security/brig)
 "aom" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aon" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aoo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aop" = (
 /obj/structure/bed/dogbed,
@@ -5533,13 +5137,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "aou" = (
 /obj/structure/cable{
@@ -5592,11 +5192,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/main)
 "aoz" = (
 /turf/closed/wall,
@@ -5606,17 +5204,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoB" = (
 /obj/machinery/gateway{
@@ -5626,34 +5216,18 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoC" = (
 /obj/machinery/gateway{
 	dir = 5
 	},
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoH" = (
 /obj/structure/lattice,
@@ -5795,27 +5369,13 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/main)
 "apb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/main)
 "apc" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -5831,11 +5391,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/main)
 "ape" = (
 /obj/machinery/airalarm{
@@ -5845,11 +5401,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/main)
 "apf" = (
 /obj/structure/cable{
@@ -5865,17 +5417,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/main)
 "apg" = (
 /obj/structure/cable{
@@ -5980,17 +5522,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apr" = (
 /obj/machinery/gateway/centerstation,
@@ -6001,17 +5535,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apt" = (
 /obj/structure/chair{
@@ -6198,49 +5724,25 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/bot_white/left,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apV" = (
 /obj/machinery/gateway,
 /obj/effect/turf_decal/bot_white,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apW" = (
 /obj/machinery/gateway{
 	dir = 6
 	},
 /obj/effect/turf_decal/bot_white/right,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apX" = (
 /turf/closed/wall,
@@ -6313,10 +5815,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqo" = (
 /obj/structure/cable{
@@ -6328,25 +5829,17 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqq" = (
 /obj/machinery/camera{
@@ -6356,13 +5849,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -6372,25 +5861,17 @@
 /area/security/brig)
 "aqs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6411,13 +5892,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6426,13 +5903,9 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6441,13 +5914,9 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqy" = (
 /obj/structure/disposalpipe/segment,
@@ -6457,27 +5926,18 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqz" = (
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqA" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aqB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -6487,7 +5947,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqD" = (
-/obj/machinery/status_display/ai{
+/obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -6541,17 +6001,9 @@
 /area/bridge)
 "aqL" = (
 /obj/machinery/computer/bank_machine,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aqM" = (
 /obj/machinery/light_switch{
@@ -6588,17 +6040,9 @@
 "aqP" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aqQ" = (
 /obj/structure/window/reinforced,
@@ -6638,13 +6082,7 @@
 /area/gateway)
 "aqT" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "aqU" = (
 /obj/machinery/washing_machine,
@@ -6652,26 +6090,14 @@
 	department = "Crew Quarters";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "aqV" = (
 /obj/machinery/washing_machine,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "aqY" = (
 /obj/docking_port/stationary{
@@ -6802,11 +6228,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aru" = (
 /obj/machinery/door/airlock/security{
@@ -6897,6 +6321,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/transit_tube/curved/flipped{
+	icon_state = "curved1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6916,36 +6341,21 @@
 /area/bridge)
 "arH" = (
 /obj/machinery/modular_computer/console/preset/command,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arI" = (
 /obj/machinery/computer/med_data,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arJ" = (
 /obj/machinery/computer/crew,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arK" = (
 /obj/machinery/status_display{
@@ -6960,13 +6370,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arL" = (
 /obj/machinery/computer/card,
@@ -6974,36 +6380,24 @@
 	c_tag = "Bridge - Central";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arM" = (
 /obj/machinery/computer/communications,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arN" = (
 /obj/machinery/computer/station_alert,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arO" = (
-/obj/machinery/status_display/ai{
+/obj/machinery/ai_status_display{
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
@@ -7012,60 +6406,35 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/recharger,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arP" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arQ" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arR" = (
 /obj/machinery/computer/prisoner,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -7077,17 +6446,9 @@
 /area/ai_monitored/nuke_storage)
 "arU" = (
 /obj/machinery/nuclearbomb/selfdestruct,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7104,18 +6465,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/machinery/ore_silo,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arX" = (
 /obj/machinery/camera{
@@ -7212,26 +6564,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "ase" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "asf" = (
 /obj/effect/landmark/start/assistant,
@@ -7239,13 +6579,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "asg" = (
 /obj/structure/bedsheetbin,
@@ -7255,13 +6589,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "ash" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -7327,14 +6655,9 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "asv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -7347,11 +6670,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asx" = (
 /obj/structure/cable{
@@ -7366,21 +6685,13 @@
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -7391,11 +6702,7 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asA" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
@@ -7411,54 +6718,33 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asE" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "asF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "asG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -7544,13 +6830,9 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "asR" = (
 /obj/structure/chair/office/dark{
@@ -7575,11 +6857,9 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "asU" = (
 /obj/structure/cable{
@@ -7592,17 +6872,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "asW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -7634,17 +6906,9 @@
 /area/ai_monitored/nuke_storage)
 "asZ" = (
 /obj/structure/closet/crate/silvercrate,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "ata" = (
 /obj/machinery/light_switch{
@@ -7696,13 +6960,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "ath" = (
 /obj/machinery/light,
@@ -7710,39 +6968,21 @@
 	c_tag = "Laundry Room";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "ati" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "atj" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "atk" = (
 /turf/open/floor/plating,
@@ -7802,11 +7042,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "atx" = (
 /obj/structure/cable{
@@ -7847,11 +7083,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "atB" = (
 /obj/structure/cable{
@@ -7867,11 +7099,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/brig)
 "atD" = (
 /obj/structure/cable{
@@ -7896,13 +7124,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "atF" = (
 /obj/structure/cable{
@@ -7923,11 +7147,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "atH" = (
 /obj/machinery/door/airlock/security/glass{
@@ -7976,7 +7198,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/bridge)
 "atN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -7997,100 +7219,54 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple,
 /area/bridge)
 "atQ" = (
 /obj/machinery/computer/atmos_alert,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple,
 /area/bridge)
 "atR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atS" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atT" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atU" = (
 /obj/item/beacon,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atV" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atX" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow,
 /area/bridge)
 "atY" = (
 /turf/closed/wall,
@@ -8102,7 +7278,7 @@
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/bridge)
 "aua" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -8111,17 +7287,9 @@
 /obj/item/clothing/head/bearpelt,
 /obj/item/skub,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aub" = (
 /obj/machinery/light,
@@ -8159,17 +7327,9 @@
 /obj/item/disk/nuclear/fake,
 /obj/item/stack/ore/diamond,
 /obj/item/gun/energy/disabler,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auf" = (
 /obj/structure/cable{
@@ -8229,13 +7389,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "aul" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
@@ -8319,7 +7473,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
+/area/security/brig)
+"auy" = (
+/turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "auz" = (
 /obj/machinery/light/small{
@@ -8328,11 +7485,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "auA" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/security/brig)
 "auB" = (
 /obj/machinery/light{
@@ -8343,21 +7500,15 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "auC" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "auD" = (
 /obj/structure/table/reinforced,
@@ -8453,25 +7604,17 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auP" = (
 /obj/structure/cable{
@@ -8480,46 +7623,29 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auQ" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auR" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auS" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auT" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow,
 /area/bridge)
 "auU" = (
 /obj/structure/closet/emcloset/anchored,
@@ -8556,17 +7682,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/ai_monitored/nuke_storage)
 "auZ" = (
 /obj/structure/sign/warning/securearea,
@@ -8607,19 +7723,22 @@
 /area/crew_quarters/dorms)
 "ave" = (
 /obj/structure/bed,
+/obj/item/bedsheet/nanotrasen,
 /obj/machinery/button/door{
 	id = "Dorm3Shutters";
 	name = "Privacy Shutters Control";
 	pixel_y = 26
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "avf" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -8647,13 +7766,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avi" = (
 /obj/structure/disposalpipe/segment{
@@ -8666,13 +7781,9 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8691,10 +7802,9 @@
 	network = list("monastery");
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avk" = (
 /turf/open/floor/plasteel,
@@ -8707,9 +7817,7 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 30
 	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
+/obj/machinery/cryopod,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avm" = (
@@ -8764,29 +7872,17 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/blue,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/security/brig)
 "avt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/security/brig)
 "avu" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
 	name = "Cell 1 Locker"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/security/brig)
 "avv" = (
 /obj/structure/bed,
@@ -8795,29 +7891,17 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/green,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/security/brig)
 "avw" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/security/brig)
 "avx" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/security/brig)
 "avy" = (
 /obj/structure/bed,
@@ -8826,39 +7910,23 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/orange,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/security/brig)
 "avz" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/security/brig)
 "avA" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/security/brig)
 "avB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "avC" = (
 /obj/structure/table/reinforced,
@@ -8949,17 +8017,7 @@
 /area/maintenance/fore)
 "avN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "avO" = (
 /obj/effect/landmark/event_spawn,
@@ -8969,17 +8027,7 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "avP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -8989,17 +8037,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "avQ" = (
 /obj/machinery/door/airlock/command{
@@ -9011,39 +8049,25 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/bridge)
 "avR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avT" = (
 /obj/structure/cable{
@@ -9056,11 +8080,9 @@
 /area/bridge)
 "avU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avV" = (
 /obj/structure/table/glass,
@@ -9095,29 +8117,15 @@
 /area/bridge)
 "awa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "awb" = (
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow,
 /area/bridge)
 "awc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -9128,7 +8136,7 @@
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/bridge)
 "awd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -9247,17 +8255,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "awr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -9307,10 +8307,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -9322,10 +8319,7 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -9344,19 +8338,13 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
 "awB" = (
 /obj/machinery/vending/clothing,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -9455,13 +8443,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "awM" = (
 /obj/structure/cable{
@@ -9486,11 +8470,9 @@
 	req_access_txt = "63"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "awO" = (
 /obj/structure/table/reinforced,
@@ -9605,13 +8587,9 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "awZ" = (
 /obj/structure/cable{
@@ -9626,11 +8604,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axb" = (
 /obj/structure/chair/comfy/black{
@@ -9640,13 +8616,9 @@
 /area/bridge)
 "axc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axd" = (
 /obj/structure/cable{
@@ -9666,11 +8638,9 @@
 /obj/machinery/computer/rdconsole{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -9852,11 +8822,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axN" = (
 /obj/structure/dresser,
@@ -9890,13 +8858,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "axS" = (
 /obj/machinery/power/apc{
@@ -9947,13 +8911,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axY" = (
 /obj/structure/cable{
@@ -9969,8 +8929,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/corner,
 /area/bridge)
 "aya" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9982,28 +8941,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/bridge)
 "ayc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aye" = (
 /obj/machinery/door/airlock/command{
@@ -10015,7 +8967,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/bridge)
 "ayf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -10025,17 +8977,9 @@
 	name = "bridge external shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -10060,20 +9004,23 @@
 /area/crew_quarters/dorms)
 "ayj" = (
 /obj/structure/bed,
+/obj/item/bedsheet/nanotrasen,
 /obj/machinery/button/door{
 	id = "Dorm2Shutters";
 	name = "Privacy Shutters Control";
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ayk" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -10155,7 +9102,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/weightmachine/stacklifter,
+/obj/structure/stacklifter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ayw" = (
@@ -10226,13 +9173,9 @@
 	pixel_x = -25;
 	req_access_txt = "2"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayF" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -10320,11 +9263,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayS" = (
 /obj/structure/bed,
@@ -10411,13 +9352,9 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aze" = (
 /obj/structure/cable{
@@ -10564,11 +9501,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "azp" = (
 /obj/machinery/light,
@@ -10612,17 +9547,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "azv" = (
 /obj/structure/chair/comfy{
@@ -10678,7 +9605,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/weightmachine/weightlifter,
+/obj/structure/weightlifter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "azE" = (
@@ -10805,13 +9732,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAc" = (
 /obj/structure/cable{
@@ -10910,11 +9833,9 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-14"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAp" = (
 /obj/structure/table/wood,
@@ -10945,7 +9866,6 @@
 "aAs" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/fork,
-/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "aAt" = (
@@ -10997,13 +9917,9 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aAA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -11022,17 +9938,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -11058,11 +9964,9 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aAF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -11219,15 +10123,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/corner,
 /area/hallway/primary/fore)
 "aBi" = (
 /turf/closed/wall,
@@ -11305,66 +10207,37 @@
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBt" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBu" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBx" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -11376,14 +10249,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBy" = (
 /obj/machinery/door/firedoor,
@@ -11518,20 +10386,23 @@
 /area/crew_quarters/dorms)
 "aBM" = (
 /obj/structure/bed,
+/obj/item/bedsheet/nanotrasen,
 /obj/machinery/button/door{
 	id = "Dorm1Shutters";
 	name = "Privacy Shutters Control";
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
-/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/dorms)
 "aBN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -11580,41 +10451,26 @@
 /area/crew_quarters/dorms)
 "aBT" = (
 /obj/structure/closet/wardrobe/white,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/crew_quarters/fitness/recreation)
 "aBU" = (
 /obj/structure/closet/wardrobe/mixed,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/crew_quarters/fitness/recreation)
 "aBV" = (
 /obj/structure/closet/wardrobe/green,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/crew_quarters/fitness/recreation)
 "aBW" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/crew_quarters/fitness/recreation)
 "aBX" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/storage/backpack,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/crew_quarters/fitness/recreation)
 "aBY" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -11740,10 +10596,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aCq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -11756,29 +10611,18 @@
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCt" = (
 /obj/structure/table,
@@ -11789,13 +10633,9 @@
 	departmentType = 0;
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCu" = (
 /obj/structure/table,
@@ -11808,13 +10648,9 @@
 /obj/item/screwdriver{
 	pixel_y = 16
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCv" = (
 /obj/structure/table,
@@ -11830,13 +10666,9 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCw" = (
 /obj/structure/table,
@@ -11849,13 +10681,9 @@
 	},
 /obj/item/flashlight,
 /obj/item/electronics/airlock,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCx" = (
 /obj/structure/sign/poster/official/obey{
@@ -11876,13 +10704,9 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCy" = (
 /obj/structure/displaycase/captain,
@@ -11950,10 +10774,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aCG" = (
 /obj/structure/table,
@@ -11968,25 +10791,17 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12007,10 +10822,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCM" = (
 /obj/structure/table,
@@ -12027,14 +10841,9 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12199,17 +11008,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aDf" = (
 /obj/structure/disposalpipe/segment,
@@ -12255,6 +11056,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
+	icon_state = "whitecorner";
 	dir = 8
 	},
 /area/crew_quarters/dorms)
@@ -12314,18 +11116,16 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/corner,
 /area/hallway/primary/fore)
 "aDw" = (
 /obj/structure/cable{
@@ -12336,13 +11136,8 @@
 	name = "Tool Storage APC";
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
 	heat_capacity = 1e+006
 	},
 /area/storage/primary)
@@ -12368,11 +11163,9 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aDC" = (
 /obj/structure/table/wood,
@@ -12449,29 +11242,23 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDK" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDL" = (
 /turf/open/floor/circuit,
@@ -12499,16 +11286,13 @@
 /obj/structure/sign/plaques/kiddie{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/corner,
 /area/bridge)
 "aDP" = (
 /obj/structure/cable{
@@ -12520,10 +11304,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -12772,10 +11555,9 @@
 /area/security/detectives_office)
 "aEs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aEt" = (
 /obj/structure/table,
@@ -12793,13 +11575,8 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
 	heat_capacity = 1e+006
 	},
 /area/storage/primary)
@@ -12826,11 +11603,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aEx" = (
 /obj/structure/table/wood,
@@ -12864,10 +11639,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aEC" = (
 /obj/machinery/light{
@@ -12878,10 +11652,9 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aED" = (
 /obj/structure/table,
@@ -12905,22 +11678,13 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEE" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEF" = (
 /obj/machinery/computer/upload/ai{
@@ -12963,14 +11727,9 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEJ" = (
 /obj/machinery/light{
@@ -12981,16 +11740,14 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/corner,
 /area/bridge)
 "aEK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aEL" = (
 /obj/machinery/disposal/bin,
@@ -13236,10 +11993,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aFs" = (
 /obj/structure/table,
@@ -13249,13 +12005,8 @@
 	},
 /obj/item/electronics/apc,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
 	heat_capacity = 1e+006
 	},
 /area/storage/primary)
@@ -13276,11 +12027,9 @@
 /obj/item/crowbar,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aFw" = (
 /obj/structure/table/wood,
@@ -13295,18 +12044,10 @@
 /area/crew_quarters/heads/captain)
 "aFy" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/crew_quarters/heads/captain)
 "aFz" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/crew_quarters/heads/captain)
 "aFA" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -13575,22 +12316,13 @@
 /obj/item/wirecutters,
 /obj/item/flashlight,
 /obj/item/gps,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGf" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "aGg" = (
 /obj/structure/table,
@@ -13603,83 +12335,43 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/assembly/timer,
 /obj/item/radio,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "aGh" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "aGi" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "aGj" = (
 /obj/structure/disposalpipe/junction/flip,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "aGk" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGl" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGm" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGn" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
@@ -13911,32 +12603,16 @@
 /area/storage/primary)
 "aHb" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -13957,17 +12633,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "aHe" = (
 /obj/machinery/door/poddoor/preopen{
@@ -13984,17 +12650,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "aHf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -14019,17 +12675,7 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "aHh" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -14192,10 +12838,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHI" = (
 /obj/structure/cable{
@@ -14205,10 +12850,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14217,10 +12861,9 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHK" = (
 /obj/machinery/light{
@@ -14233,10 +12876,9 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14245,17 +12887,15 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14288,10 +12928,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHR" = (
 /obj/machinery/door/firedoor,
@@ -14301,10 +12940,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHS" = (
 /obj/structure/disposalpipe/segment{
@@ -14316,10 +12954,9 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHT" = (
 /obj/structure/cable{
@@ -14330,26 +12967,23 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14359,10 +12993,9 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHX" = (
 /obj/structure/cable{
@@ -14371,10 +13004,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHY" = (
 /obj/structure/cable{
@@ -14386,10 +13018,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14398,10 +13029,9 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIa" = (
 /obj/structure/disposalpipe/segment,
@@ -14409,10 +13039,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -14421,10 +13050,9 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIc" = (
 /obj/machinery/door/firedoor,
@@ -14435,10 +13063,9 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14447,10 +13074,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIe" = (
 /obj/structure/cable{
@@ -14961,17 +13587,9 @@
 	c_tag = "Departure Lounge Fore";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aJE" = (
 /turf/open/floor/plasteel,
@@ -14989,17 +13607,9 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aJG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -15081,37 +13691,33 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJS" = (
 /obj/structure/cable{
@@ -15121,20 +13727,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJU" = (
 /obj/structure/disposalpipe/segment,
@@ -15142,19 +13746,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJW" = (
 /obj/machinery/camera{
@@ -15164,10 +13766,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJX" = (
 /obj/structure/sign/directions/security{
@@ -15240,6 +13841,7 @@
 	icon_state = "plant-04"
 	},
 /turf/open/floor/plasteel/white/corner{
+	icon_state = "whitecorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -15277,13 +13879,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"aKm" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "aKn" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -15326,10 +13921,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -15352,10 +13944,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -15363,10 +13952,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -15374,31 +13960,19 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aKH" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aKI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aKJ" = (
 /turf/closed/wall,
@@ -15578,24 +14152,15 @@
 /area/maintenance/disposal)
 "aLu" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aLv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aLw" = (
 /obj/effect/spawner/structure/window,
@@ -15610,17 +14175,7 @@
 	},
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXnineteen,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aLy" = (
 /obj/structure/cable{
@@ -15629,17 +14184,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aLz" = (
 /obj/machinery/photocopier,
@@ -15647,17 +14192,7 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aLA" = (
 /obj/structure/table,
@@ -15849,22 +14384,19 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/teleporter)
 "aMb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMd" = (
 /obj/machinery/requests_console{
@@ -15876,16 +14408,9 @@
 	pixel_y = 30
 	},
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMe" = (
 /obj/machinery/computer/security/mining,
@@ -15899,13 +14424,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMf" = (
 /obj/machinery/computer/secure_data,
@@ -15913,14 +14434,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMg" = (
 /obj/machinery/conveyor{
@@ -15950,6 +14466,10 @@
 	id = "packageSort2"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
+/obj/machinery/status_display{
+	pixel_y = 30;
+	supply_display = 1
+	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aMj" = (
@@ -16020,7 +14540,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMq" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -16030,7 +14550,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMr" = (
 /obj/structure/closet/crate,
@@ -16040,7 +14560,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMs" = (
 /obj/structure/disposalpipe/segment{
@@ -16052,7 +14572,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMt" = (
 /obj/structure/closet/cardboard,
@@ -16069,7 +14589,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMu" = (
 /obj/item/cigbutt/cigarbutt,
@@ -16079,7 +14599,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMv" = (
 /obj/structure/disposalpipe/segment{
@@ -16095,7 +14615,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aMw" = (
 /obj/structure/disposalpipe/segment{
@@ -16206,10 +14726,7 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aML" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -16233,8 +14750,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aMU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -16258,17 +14774,7 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aMW" = (
 /obj/structure/cable{
@@ -16277,17 +14783,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aMX" = (
 /obj/structure/table,
@@ -16300,17 +14796,7 @@
 	name = "Art Storage APC";
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aMY" = (
 /obj/structure/chair{
@@ -16464,8 +14950,8 @@
 /area/storage/eva)
 "aNt" = (
 /obj/structure/rack,
-/obj/item/tank/jetpack/carbondioxide/eva,
-/obj/item/tank/jetpack/carbondioxide/eva{
+/obj/item/tank/jetpack/carbondioxide,
+/obj/item/tank/jetpack/carbondioxide{
 	pixel_x = -4;
 	pixel_y = 1
 	},
@@ -16506,8 +14992,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/teleporter)
 "aNz" = (
 /obj/machinery/door/firedoor,
@@ -16522,20 +15007,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16550,13 +15033,9 @@
 	dir = 4
 	},
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNE" = (
 /obj/structure/chair/office/dark{
@@ -16572,11 +15051,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNH" = (
 /obj/structure/disposalpipe/segment,
@@ -16648,20 +15125,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aNO" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aNP" = (
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aNQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aNR" = (
 /obj/structure/cable{
@@ -16692,6 +15169,19 @@
 	dir = 4;
 	id = "garbagestacked"
 	},
+/obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
+	machinedir = 8;
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aNW" = (
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbagestacked"
+	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aNX" = (
@@ -16714,26 +15204,16 @@
 /area/maintenance/disposal)
 "aOf" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aOg" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -16743,21 +15223,15 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aOk" = (
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aOm" = (
 /obj/structure/cable{
@@ -16777,17 +15251,7 @@
 /obj/item/instrument/glockenspiel{
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aOu" = (
 /obj/structure/table,
@@ -16799,17 +15263,7 @@
 	dir = 1
 	},
 /obj/item/hand_labeler,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aOv" = (
 /obj/structure/table,
@@ -16827,17 +15281,7 @@
 	},
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/canvas/nineteenXnineteen,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/storage/art)
 "aOw" = (
 /obj/structure/grille/broken,
@@ -16930,13 +15374,9 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aOF" = (
 /obj/structure/chair/stool,
@@ -16982,8 +15422,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/teleporter)
 "aOJ" = (
 /obj/machinery/door/firedoor,
@@ -17008,10 +15447,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOL" = (
 /obj/structure/cable{
@@ -17033,10 +15471,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aON" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17053,36 +15490,26 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOP" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOQ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOR" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cargo Security Post";
 	req_access_txt = "63"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aOS" = (
 /obj/structure/disposalpipe/segment{
@@ -17142,33 +15569,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aOZ" = (
 /obj/item/stack/sheet/cardboard,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aPa" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aPc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aPd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17182,7 +15609,7 @@
 /area/maintenance/department/cargo)
 "aPg" = (
 /obj/machinery/conveyor{
-	dir = 4;
+	dir = 8;
 	id = "garbage"
 	},
 /obj/structure/disposaloutlet{
@@ -17193,6 +15620,16 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
+"aPh" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -17207,21 +15644,14 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aPn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
+/turf/open/floor/plasteel/escape{
+	dir = 9
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aPo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/plasteel/escape{
+	dir = 10
 	},
-/turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
 "aPq" = (
 /obj/machinery/light{
@@ -17235,8 +15665,7 @@
 	c_tag = "Departure Lounge Starboard";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aPt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17255,8 +15684,7 @@
 	dir = 1;
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aPx" = (
 /obj/machinery/light/small{
@@ -17294,7 +15722,7 @@
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/obj/effect/spawner/lootdrop/gloves,
+/obj/item/clothing/gloves/color/random,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPD" = (
@@ -17364,54 +15792,33 @@
 /obj/structure/table,
 /obj/item/beacon,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/darkblue/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPN" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/teleporter)
 "aPO" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/teleporter)
 "aPP" = (
 /obj/machinery/teleport/hub,
 /obj/machinery/light,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/teleporter)
 "aPQ" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/teleporter)
 "aPR" = (
 /obj/structure/disposalpipe/segment,
@@ -17422,10 +15829,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPT" = (
 /obj/structure/cable,
@@ -17435,33 +15841,19 @@
 	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/security/cargo,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/supply)
 "aPV" = (
 /obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17515,27 +15907,27 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aQd" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aQe" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aQf" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aQg" = (
 /obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aQj" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -17566,7 +15958,7 @@
 	dir = 8
 	},
 /obj/machinery/conveyor{
-	dir = 1;
+	dir = 2;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -17582,10 +15974,9 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/escape{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aQs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -17632,12 +16023,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"aQB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+"aQA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"aQB" = (
+/obj/structure/disposalpipe/junction/flip{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -17646,25 +16046,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aQD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aQE" = (
 /obj/structure/grille/broken,
@@ -17936,20 +16327,18 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/departments/cargo{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17962,13 +16351,9 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aRh" = (
 /obj/structure/chair/stool,
@@ -18046,7 +16431,7 @@
 /area/quartermaster/warehouse)
 "aRq" = (
 /obj/structure/closet/crate/internals,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/quartermaster/warehouse)
 "aRs" = (
 /obj/structure/disposalpipe/segment,
@@ -18112,31 +16497,13 @@
 /area/maintenance/disposal)
 "aRB" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aRC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit/departure_lounge)
 "aRD" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -18216,17 +16583,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aRJ" = (
 /obj/structure/cable{
@@ -18386,17 +16745,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSc" = (
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aSd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aSe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -18551,7 +16908,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSB" = (
 /obj/structure/cable{
@@ -18559,17 +16916,17 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSC" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSD" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSE" = (
 /obj/machinery/airalarm{
@@ -18579,14 +16936,14 @@
 	c_tag = "Hydroponics Storage"
 	},
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSF" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSG" = (
 /obj/structure/table,
@@ -18595,7 +16952,7 @@
 /obj/item/reagent_containers/glass/bottle/mutagen,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aSH" = (
 /obj/machinery/door/airlock/maintenance{
@@ -18636,30 +16993,14 @@
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aSM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
 /obj/item/assembly/mousetrap,
@@ -18736,10 +17077,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aSY" = (
 /obj/machinery/door/firedoor,
@@ -18769,26 +17109,23 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -18869,6 +17206,17 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"aTo" = (
+/obj/machinery/status_display{
+	pixel_y = 30;
+	supply_display = 1
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "QMLoad"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -19049,10 +17397,9 @@
 /area/space)
 "aTJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aTK" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -19102,14 +17449,13 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aTQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aTR" = (
 /obj/structure/cable{
@@ -19121,13 +17467,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aTS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aTT" = (
 /obj/structure/disposalpipe/segment{
@@ -19136,7 +17482,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aTU" = (
 /obj/structure/disposalpipe/segment{
@@ -19145,7 +17491,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
+/area/hydroponics)
+"aTV" = (
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aTW" = (
 /obj/structure/table,
@@ -19161,7 +17510,7 @@
 	pixel_y = 5
 	},
 /obj/item/watertank,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aTX" = (
 /obj/structure/kitchenspike,
@@ -19203,17 +17552,9 @@
 /area/crew_quarters/kitchen)
 "aUb" = (
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aUc" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -19251,10 +17592,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUj" = (
 /obj/structure/disposalpipe/segment{
@@ -19429,10 +17769,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -19447,10 +17784,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -19465,10 +17799,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -19480,10 +17811,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -19517,8 +17845,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aUN" = (
 /obj/structure/cable{
@@ -19553,17 +17880,9 @@
 /area/maintenance/department/crew_quarters/bar)
 "aUQ" = (
 /obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aUR" = (
 /obj/machinery/door/window/eastright{
@@ -19586,14 +17905,14 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/wirecutters,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUT" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUU" = (
 /obj/machinery/power/apc{
@@ -19603,12 +17922,17 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
+/area/hydroponics)
+"aUV" = (
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUW" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/hydroponics)
 "aUX" = (
 /obj/machinery/icecream_vat,
@@ -19805,10 +18129,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19843,13 +18166,9 @@
 /area/quartermaster/office)
 "aVt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -19867,11 +18186,9 @@
 /obj/machinery/conveyor_switch{
 	id = "cargodeliver"
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVw" = (
 /obj/machinery/navbeacon{
@@ -19978,17 +18295,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aVN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit/departure_lounge)
 "aVO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -20020,8 +18327,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aVS" = (
 /turf/closed/wall,
@@ -20042,17 +18348,9 @@
 	freq = 1400;
 	location = "Janitor"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aVV" = (
 /obj/machinery/door/firedoor,
@@ -20195,17 +18493,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aWo" = (
 /obj/structure/cable{
@@ -20215,17 +18503,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aWp" = (
 /obj/structure/cable{
@@ -20234,17 +18512,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aWq" = (
 /obj/machinery/light/small{
@@ -20260,17 +18528,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aWr" = (
 /obj/structure/cable{
@@ -20288,33 +18546,20 @@
 	pixel_x = 28;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aWs" = (
 /obj/machinery/computer/cargo/request{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/office)
 "aWt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/office)
 "aWu" = (
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/office)
 "aWv" = (
 /obj/machinery/door/firedoor,
@@ -20325,11 +18570,15 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "aWw" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/obj/machinery/status_display{
+	dir = 8;
+	layer = 4;
+	pixel_x = 32;
+	supply_display = 1
+	},
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aWx" = (
 /obj/machinery/navbeacon{
@@ -20371,19 +18620,15 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aWE" = (
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aWF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "aWI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20397,40 +18642,24 @@
 	c_tag = "Departure Lounge Hallway";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "aWJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "aWK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "aWM" = (
 /obj/machinery/washing_machine,
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aWN" = (
 /obj/machinery/camera{
@@ -20449,17 +18678,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aWO" = (
 /obj/structure/bed,
@@ -20468,37 +18687,19 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aWP" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/green/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aWQ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aWR" = (
 /obj/machinery/disposal/bin,
@@ -20528,10 +18729,9 @@
 	name = "utility sink";
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aWU" = (
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -20609,17 +18809,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aXl" = (
 /obj/structure/disposalpipe/segment{
@@ -20632,17 +18822,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aXm" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -20656,34 +18836,14 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aXn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/clown,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aXo" = (
 /obj/structure/disposalpipe/segment{
@@ -20697,17 +18857,7 @@
 	pixel_x = 28;
 	pixel_y = -2
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/redblue,
 /area/crew_quarters/theatre)
 "aXp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -20720,10 +18870,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -20732,10 +18881,9 @@
 /obj/structure/sign/departments/cargo{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXs" = (
 /obj/structure/table/reinforced,
@@ -20771,11 +18919,9 @@
 	c_tag = "Cargo Foyer";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aXw" = (
 /obj/machinery/navbeacon{
@@ -20838,34 +18984,18 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aXG" = (
 /obj/structure/table,
 /obj/effect/holodeck_effect/cards{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aXH" = (
 /turf/closed/wall/r_wall,
@@ -20906,8 +19036,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aXM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20920,34 +19049,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aXO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aXP" = (
 /obj/structure/table,
@@ -20956,17 +19065,7 @@
 /obj/item/grenade/clusterbuster/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aXQ" = (
 /obj/structure/sink{
@@ -20974,38 +19073,22 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXR" = (
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXS" = (
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXT" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
 	heat_capacity = 1e+006
 	},
 /area/hydroponics)
@@ -21015,24 +19098,18 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXW" = (
 /obj/machinery/plantgenes{
 	pixel_y = 6
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXX" = (
 /obj/machinery/hydroponics/constructable,
@@ -21040,13 +19117,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXY" = (
 /obj/machinery/hydroponics/constructable,
@@ -21057,23 +19130,15 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXZ" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYa" = (
 /obj/machinery/door/airlock{
@@ -21107,47 +19172,31 @@
 	icon_state = "plant-18";
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYf" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/wiki/barman_recipes,
-/obj/item/reagent_containers/rag,
-/obj/effect/turf_decal/tile/red{
+/obj/item/book/manual/barman_recipes,
+/obj/item/reagent_containers/glass/rag,
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYg" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/instrument/guitar,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYi" = (
 /obj/structure/table/reinforced,
@@ -21156,13 +19205,9 @@
 	icon_state = "plant-18";
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYj" = (
 /obj/machinery/door/airlock{
@@ -21170,34 +19215,18 @@
 	req_access_txt = "46"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYk" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYl" = (
 /obj/structure/table/wood,
@@ -21205,33 +19234,17 @@
 /obj/structure/table/wood,
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYm" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/lipstick/random,
 /obj/item/clothing/gloves/color/rainbow/clown,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYn" = (
 /obj/machinery/requests_console{
@@ -21242,39 +19255,27 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYo" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYp" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYq" = (
 /obj/item/stamp{
@@ -21286,33 +19287,21 @@
 	pixel_y = -2
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYr" = (
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYu" = (
 /obj/machinery/light{
@@ -21322,11 +19311,9 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYv" = (
 /obj/machinery/navbeacon{
@@ -21431,35 +19418,20 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYI" = (
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYJ" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYK" = (
 /obj/structure/closet/secure_closet/security,
@@ -21467,22 +19439,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYL" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aYM" = (
 /obj/machinery/door/firedoor,
@@ -21490,41 +19456,25 @@
 	name = "Custodial Quarters";
 	req_access_txt = "26"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/janitor)
 "aYN" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYO" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYQ" = (
 /obj/structure/sink{
@@ -21581,13 +19531,9 @@
 	pixel_y = -2
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aYY" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -21614,17 +19560,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZb" = (
 /obj/structure/disposalpipe/segment{
@@ -21643,17 +19581,9 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZd" = (
 /obj/structure/disposalpipe/segment{
@@ -21664,33 +19594,17 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZf" = (
 /obj/structure/disposalpipe/segment{
@@ -21699,17 +19613,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZg" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -21727,24 +19633,25 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZj" = (
-/obj/machinery/status_display/supply{
-	pixel_x = -32
+/obj/machinery/status_display{
+	dir = 4;
+	layer = 4;
+	pixel_x = -32;
+	supply_display = 1
 	},
 /obj/machinery/computer/bounty{
 	dir = 4
@@ -21859,10 +19766,7 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aZy" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21870,10 +19774,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21881,10 +19782,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21896,10 +19794,7 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21910,10 +19805,7 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21921,10 +19813,7 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21943,13 +19832,9 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -21976,11 +19861,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZK" = (
 /obj/machinery/door/airlock/security{
@@ -21993,17 +19876,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/checkpoint/customs)
 "aZL" = (
 /obj/structure/cable{
@@ -22036,8 +19909,7 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "aZO" = (
 /obj/machinery/disposal/bin,
@@ -22045,10 +19917,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "aZP" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "aZQ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -22060,7 +19932,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "aZR" = (
 /obj/machinery/hydroponics/constructable,
@@ -22071,58 +19943,35 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aZS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 8;
 	heat_capacity = 1e+006
 	},
 /area/hydroponics)
 "aZT" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aZU" = (
 /obj/machinery/vending/hydronutrients,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aZV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "aZW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22164,40 +20013,20 @@
 	},
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bae" = (
 /obj/structure/chair/stool/bar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bag" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bah" = (
 /turf/open/floor/plasteel/dark,
@@ -22209,17 +20038,9 @@
 	pixel_y = 1
 	},
 /obj/structure/chair/wood/normal,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bao" = (
 /obj/machinery/computer/slot_machine,
@@ -22254,10 +20075,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bas" = (
 /obj/structure/table,
@@ -22448,10 +20268,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "baQ" = (
 /obj/machinery/computer/secure_data{
@@ -22470,14 +20289,9 @@
 	pixel_x = -26;
 	pixel_y = -4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baR" = (
 /obj/item/pen,
@@ -22485,32 +20299,20 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/customs)
 "baS" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/customs)
 "baT" = (
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /obj/structure/table,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/customs)
 "baU" = (
 /obj/machinery/power/apc{
@@ -22520,14 +20322,9 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baV" = (
 /obj/structure/cable{
@@ -22550,8 +20347,7 @@
 	pixel_x = 25;
 	req_access_txt = "26"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "baX" = (
 /obj/vehicle/ridden/janicart,
@@ -22572,7 +20368,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "baY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -22581,7 +20377,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "baZ" = (
 /obj/structure/closet/l3closet/janitor,
@@ -22593,7 +20389,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bba" = (
 /obj/machinery/holopad,
@@ -22603,43 +20399,26 @@
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bbc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "bbd" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/corner,
 /area/hydroponics)
 "bbe" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hydroponics)
 "bbg" = (
 /obj/effect/landmark/start/cook,
@@ -22667,13 +20446,9 @@
 	name = "kitchen shutters"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bbm" = (
 /obj/structure/chair/stool/bar,
@@ -22697,17 +20472,9 @@
 /area/crew_quarters/bar)
 "bbq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bbr" = (
 /obj/structure/chair/wood/normal{
@@ -22770,10 +20537,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -22826,11 +20592,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown,
 /area/quartermaster/qm)
 "bbH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -22846,20 +20608,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown,
 /area/quartermaster/miningdock)
 "bbK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown,
 /area/quartermaster/miningdock)
 "bbL" = (
 /obj/machinery/power/smes,
@@ -22923,10 +20677,9 @@
 /area/hallway/secondary/entry)
 "bbU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bbV" = (
 /obj/machinery/door/firedoor,
@@ -22960,7 +20713,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bbY" = (
 /obj/machinery/camera{
@@ -22968,21 +20721,13 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/jani_wardrobe,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bbZ" = (
 /obj/machinery/seed_extractor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bca" = (
 /obj/machinery/light{
@@ -22992,11 +20737,9 @@
 	c_tag = "Hydroponics South";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "bcb" = (
 /obj/structure/table/reinforced,
@@ -23089,17 +20832,9 @@
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcs" = (
 /obj/item/clothing/shoes/sandal,
@@ -23109,17 +20844,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23131,17 +20858,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcw" = (
 /obj/machinery/door/firedoor,
@@ -23187,16 +20906,9 @@
 	pixel_x = -23
 	},
 /obj/item/storage/belt/fannypack/yellow,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/open/floor/plasteel/brown{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcB" = (
 /obj/structure/cable{
@@ -23208,27 +20920,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/open/floor/plasteel/brown{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcD" = (
 /obj/structure/closet/wardrobe/miner,
@@ -23236,16 +20939,9 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/open/floor/plasteel/brown{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcE" = (
 /obj/structure/cable{
@@ -23253,23 +20949,15 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcG" = (
 /obj/structure/closet/emcloset,
@@ -23277,14 +20965,9 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/open/floor/plasteel/brown{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcH" = (
 /obj/structure/cable{
@@ -23409,10 +21092,7 @@
 /area/hallway/secondary/entry)
 "bdc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -23445,13 +21125,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bdh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bdi" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -23464,41 +21144,36 @@
 	dir = 9;
 	pixel_x = 22
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bdj" = (
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/corner,
 /area/hydroponics)
 "bdk" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "bdm" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
 "bdn" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdo" = (
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdp" = (
 /obj/structure/table,
@@ -23527,33 +21202,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bdx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bdy" = (
 /obj/machinery/door/firedoor,
@@ -23623,13 +21282,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bdG" = (
 /obj/structure/cable{
@@ -23641,11 +21296,9 @@
 /obj/machinery/computer/bounty{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bdI" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -23655,10 +21308,9 @@
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdK" = (
 /obj/structure/chair/office/dark{
@@ -23687,8 +21339,7 @@
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/miningdock)
 "bdQ" = (
 /obj/structure/cable{
@@ -23773,8 +21424,7 @@
 /obj/structure/sign/departments/custodian{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/primary/central)
 "bec" = (
 /obj/structure/cable{
@@ -23782,14 +21432,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bed" = (
 /obj/structure/table,
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bee" = (
 /obj/structure/table,
@@ -23802,17 +21452,12 @@
 	pixel_x = 24
 	},
 /obj/item/clothing/head/crown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bef" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "beg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -23824,11 +21469,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/hydroponics)
 "bei" = (
 /obj/structure/disposalpipe/segment{
@@ -23873,10 +21514,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bem" = (
 /obj/structure/disposalpipe/segment{
@@ -23895,10 +21535,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "beo" = (
 /obj/machinery/door/firedoor,
@@ -23985,17 +21624,9 @@
 "bez" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beA" = (
 /obj/structure/chair/wood/normal{
@@ -24035,17 +21666,9 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /obj/item/kitchen/fork,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beE" = (
 /obj/structure/chair/wood/normal{
@@ -24057,17 +21680,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beG" = (
 /obj/structure/disposalpipe/segment{
@@ -24087,34 +21702,24 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beI" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "beJ" = (
-/obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/machinery/status_display{
+	dir = 4;
+	layer = 4;
+	pixel_x = -32;
+	supply_display = 1
 	},
-/obj/effect/turf_decal/tile/brown{
+/obj/structure/filingcabinet,
+/turf/open/floor/plasteel/brown{
 	dir = 8
 	},
-/obj/machinery/keycard_auth{
-	pixel_x = -23;
-	pixel_y = 0
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beK" = (
 /obj/structure/chair/office/dark{
@@ -24127,18 +21732,15 @@
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beM" = (
 /obj/machinery/mineral/equipment_vendor,
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "beN" = (
 /obj/structure/cable{
@@ -24157,8 +21759,7 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/miningdock)
 "beR" = (
 /obj/structure/cable{
@@ -24208,10 +21809,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/hallway/secondary/entry)
 "bfb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -24296,31 +21894,21 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/janitor)
 "bfj" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/green/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hydroponics)
 "bfk" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hydroponics)
 "bfl" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/corner,
 /area/hydroponics)
 "bfm" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -24329,15 +21917,13 @@
 /area/hydroponics)
 "bfn" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/corner,
 /area/hydroponics)
 "bfo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfp" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -24371,17 +21957,9 @@
 	name = "bar shutters"
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bfu" = (
 /obj/machinery/door/airlock/maintenance{
@@ -24451,14 +22029,9 @@
 	layer = 2.9
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/open/floor/plasteel/brown{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfC" = (
 /obj/structure/table,
@@ -24482,11 +22055,9 @@
 	},
 /obj/item/coin/silver,
 /obj/item/stamp/qm,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
+/turf/open/floor/plasteel/brown{
+	dir = 2
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfD" = (
 /obj/item/radio/intercom{
@@ -24496,14 +22067,9 @@
 /obj/machinery/computer/security/qm{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/open/floor/plasteel/brown{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfE" = (
 /obj/structure/rack,
@@ -24521,10 +22087,9 @@
 	c_tag = "Cargo Mining Dock";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfF" = (
 /obj/structure/cable{
@@ -24544,8 +22109,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfH" = (
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown/corner,
 /area/quartermaster/miningdock)
 "bfI" = (
 /obj/machinery/door/airlock/external{
@@ -24593,8 +22157,7 @@
 /area/maintenance/department/cargo)
 "bfY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bfZ" = (
 /turf/closed/wall/r_wall,
@@ -24650,10 +22213,9 @@
 "bgf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgg" = (
 /obj/structure/cable{
@@ -24661,10 +22223,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgh" = (
 /obj/structure/chair{
@@ -24674,10 +22235,9 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgi" = (
 /obj/machinery/vending/cola,
@@ -24685,10 +22245,9 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgj" = (
 /obj/effect/spawner/structure/window,
@@ -24719,54 +22278,48 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgo" = (
 /obj/structure/table,
 /obj/item/trash/plate,
 /obj/item/storage/fancy/rollingpapers,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgp" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgq" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgr" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/donut,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgt" = (
 /obj/machinery/door/firedoor,
@@ -24787,18 +22340,16 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-14"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgw" = (
 /obj/structure/chair,
 /obj/item/clothing/head/bowler,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgx" = (
 /obj/machinery/firealarm{
@@ -24807,10 +22358,9 @@
 	},
 /obj/structure/chair,
 /obj/item/clothing/mask/cigarette,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgy" = (
 /obj/machinery/light{
@@ -24819,19 +22369,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgz" = (
 /obj/structure/sign/poster/official/cohiba_robusto_ad{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24858,8 +22406,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgC" = (
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "bgD" = (
 /obj/machinery/door/firedoor,
@@ -24875,7 +22422,7 @@
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/robotics/mechbay)
 "bgF" = (
 /obj/structure/cable{
@@ -24923,10 +22470,9 @@
 	name = "Mining Dock APC";
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/brown{
+/turf/open/floor/plasteel/brown/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bgL" = (
 /obj/structure/cable{
@@ -25089,8 +22635,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "bhj" = (
 /obj/machinery/door/firedoor,
@@ -25218,14 +22763,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/turf/open/floor/plasteel/brown{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bht" = (
 /obj/structure/closet/secure_closet/miner,
@@ -25238,34 +22778,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown,
 /area/quartermaster/miningdock)
 "bhu" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/brown,
 /area/quartermaster/miningdock)
 "bhv" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/turf/open/floor/plasteel/brown{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhz" = (
 /obj/structure/cable{
@@ -25293,8 +22820,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bhF" = (
 /obj/structure/chair/comfy/beige{
@@ -25387,8 +22913,7 @@
 	pixel_x = 25;
 	req_access_txt = "29"
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "bhR" = (
 /obj/machinery/light{
@@ -25503,15 +23028,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
 "bik" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
 "bil" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -25521,15 +23044,13 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
 "bim" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
 "bin" = (
 /obj/machinery/light,
@@ -25538,8 +23059,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/corner,
 /area/hallway/primary/central)
 "bio" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -25552,16 +23072,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "biq" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "bir" = (
 /obj/machinery/camera{
@@ -25571,13 +23089,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "bis" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/central)
 "bit" = (
 /obj/machinery/door/firedoor,
@@ -25661,7 +23177,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "biF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -25676,8 +23192,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "biJ" = (
 /obj/effect/spawner/structure/window,
@@ -25743,11 +23258,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "biP" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -25765,11 +23276,7 @@
 /obj/structure/sign/departments/examroom{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "biR" = (
 /obj/machinery/light,
@@ -25777,28 +23284,22 @@
 	c_tag = "Central Primary Hallway Genetics";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "biS" = (
 /obj/structure/closet/emcloset,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biT" = (
 /obj/structure/closet/firecloset,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25848,38 +23349,22 @@
 "bjf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/medical/medbay/central)
 "bjg" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/medical/medbay/central)
 "bjh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/medical/medbay/central)
 "bji" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "bjj" = (
 /obj/structure/disposalpipe/segment{
@@ -25891,11 +23376,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/central)
 "bjk" = (
 /obj/machinery/camera{
@@ -25903,50 +23384,32 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "bjl" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/central)
 "bjm" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/central)
 "bjn" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/central)
 "bjp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bjr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/corner,
 /area/hallway/primary/aft)
 "bju" = (
 /turf/open/floor/plasteel,
@@ -25974,7 +23437,7 @@
 /area/maintenance/department/cargo)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "bjD" = (
 /obj/structure/cable{
@@ -26088,16 +23551,9 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjY" = (
 /obj/structure/table,
@@ -26109,37 +23565,24 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjZ" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bka" = (
 /obj/machinery/computer/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bkb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -26151,50 +23594,31 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkd" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bke" = (
 /obj/structure/chair,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26208,13 +23632,9 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26222,13 +23642,9 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bkn" = (
 /obj/machinery/navbeacon{
@@ -26239,26 +23655,16 @@
 /area/hallway/primary/aft)
 "bko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bkp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bkq" = (
 /obj/structure/table,
@@ -26412,8 +23818,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bkW" = (
 /obj/item/hemostat,
@@ -26510,13 +23915,9 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bli" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26537,20 +23938,17 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bll" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "blm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26586,82 +23984,57 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "blr" = (
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/healthanalyzer,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bls" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "blt" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blu" = (
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "blv" = (
 /obj/structure/table,
 /obj/item/paicard,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/green/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blw" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blx" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bly" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26670,108 +24043,73 @@
 	pixel_x = -26;
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blC" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blD" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/green/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blE" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "blF" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/roboticist,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blG" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blH" = (
 /obj/machinery/camera{
@@ -26783,13 +24121,9 @@
 	name = "utility sink";
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blI" = (
 /obj/machinery/requests_console{
@@ -26799,13 +24133,9 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blJ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -26819,13 +24149,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blK" = (
 /obj/structure/disposalpipe/segment{
@@ -26839,30 +24165,18 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "blM" = (
 /obj/machinery/rnd/server,
@@ -26879,7 +24193,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark/telecomms/server/walkway,
 /area/science/server)
 "blP" = (
 /obj/effect/landmark/event_spawn,
@@ -26903,7 +24217,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/book/manual/wiki/experimentor,
+/obj/item/book/manual/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "blT" = (
@@ -26913,17 +24227,9 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blU" = (
 /obj/structure/table/reinforced,
@@ -26934,34 +24240,18 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blV" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/item/stack/sheet/metal/ten,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blW" = (
 /obj/structure/table/reinforced,
@@ -26972,30 +24262,18 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blX" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "blZ" = (
 /obj/machinery/computer/camera_advanced/xenobio,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bmc" = (
 /obj/structure/table,
@@ -27133,14 +24411,9 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/med,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmt" = (
 /obj/structure/cable{
@@ -27149,42 +24422,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/medical)
 "bmu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/medical)
 "bmv" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmw" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-05"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bmx" = (
 /obj/structure/disposalpipe/segment,
@@ -27203,27 +24462,28 @@
 /area/medical/medbay/central)
 "bmz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bmA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bmB" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21";
+	pixel_y = 3
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner{
+	dir = 1
+	},
 /area/hallway/primary/central)
 "bmC" = (
 /turf/open/floor/plasteel,
@@ -27268,17 +24528,9 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bmM" = (
 /turf/open/floor/plasteel,
@@ -27340,7 +24592,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/telecomms,
+/turf/open/floor/plasteel/dark/telecomms/server/walkway,
 /area/science/server)
 "bmU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -27379,34 +24631,18 @@
 	pixel_x = -28;
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bna" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/box/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bnb" = (
 /obj/structure/table/reinforced,
@@ -27417,17 +24653,9 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bnc" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -27497,8 +24725,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bnt" = (
 /obj/structure/chair/comfy{
@@ -27543,13 +24770,9 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/mask/surgical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
 "bny" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -27564,11 +24787,9 @@
 	dir = 1;
 	light_color = "#ffc1c1"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
 "bnz" = (
 /obj/structure/table,
@@ -27594,38 +24815,23 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/checkpoint/medical)
 "bnC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/britcup{
 	desc = "Kingston's personal cup."
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bnD" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnE" = (
 /obj/structure/disposalpipe/segment,
@@ -27642,14 +24848,9 @@
 /area/medical/medbay/central)
 "bnG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -27661,11 +24862,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
 "bnL" = (
 /obj/structure/disposalpipe/segment{
@@ -27674,11 +24871,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
 "bnM" = (
 /obj/structure/disposalpipe/segment{
@@ -27687,10 +24880,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bnN" = (
 /obj/structure/disposalpipe/segment{
@@ -27707,17 +24899,9 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bnP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27810,17 +24994,9 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "boa" = (
 /obj/structure/disposalpipe/segment,
@@ -27879,20 +25055,14 @@
 	},
 /area/maintenance/department/cargo)
 "bon" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/hallway/secondary/entry)
 "boo" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Aft";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/arrival,
 /area/hallway/secondary/entry)
 "bop" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -27927,25 +25097,17 @@
 /area/medical/genetics)
 "bov" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bow" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "box" = (
 /obj/structure/cable{
@@ -27955,23 +25117,15 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boy" = (
 /obj/structure/closet/wardrobe/mixed,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boz" = (
 /obj/machinery/vending/clothing,
@@ -27979,34 +25133,24 @@
 	dir = 1;
 	pixel_y = 27
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "boB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "boC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -28020,16 +25164,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boF" = (
 /obj/structure/cable{
@@ -28038,26 +25175,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boH" = (
 /obj/machinery/requests_console{
@@ -28075,39 +25203,26 @@
 	name = "Station Intercom (Medbay)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boI" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boJ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boK" = (
 /obj/structure/disposalpipe/segment,
@@ -28116,11 +25231,7 @@
 /area/medical/medbay/central)
 "boL" = (
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "boM" = (
 /obj/structure/bed/roller,
@@ -28129,28 +25240,16 @@
 	network = list("ss13","medbay");
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "boN" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "boO" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "boP" = (
 /obj/structure/closet/emcloset,
@@ -28175,34 +25274,18 @@
 "boS" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boT" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boU" = (
 /obj/machinery/firealarm{
@@ -28218,17 +25301,9 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boX" = (
 /obj/machinery/computer/rdconsole/robotics{
@@ -28307,17 +25382,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpe" = (
 /obj/machinery/computer/rdconsole/experiment,
@@ -28325,17 +25392,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -28348,17 +25407,9 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bph" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28382,17 +25433,9 @@
 	dir = 2;
 	network = list("ss13","rd")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpi" = (
 /obj/structure/closet/crate,
@@ -28406,17 +25449,9 @@
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpn" = (
 /turf/open/floor/plasteel/white,
@@ -28491,17 +25526,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/genetics)
 "bpz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28537,13 +25562,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bpE" = (
 /obj/structure/cable{
@@ -28559,11 +25580,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bpG" = (
 /obj/machinery/door/firedoor,
@@ -28653,13 +25672,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpO" = (
 /obj/structure/cable{
@@ -28672,11 +25687,9 @@
 /area/medical/medbay/central)
 "bpP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpQ" = (
 /obj/machinery/door/firedoor,
@@ -28690,34 +25703,26 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpS" = (
 /obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bpV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -28741,17 +25746,9 @@
 	},
 /obj/item/folder/white,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bpX" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -28793,13 +25790,9 @@
 	name = "Research Division"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bqe" = (
 /obj/machinery/door/firedoor,
@@ -28817,15 +25810,13 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bqg" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/robotics_cyborgs{
+/obj/item/book/manual/robotics_cyborgs{
 	pixel_x = 2;
 	pixel_y = 5
 	},
@@ -28838,17 +25829,9 @@
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bqh" = (
 /obj/structure/disposalpipe/segment{
@@ -28879,17 +25862,9 @@
 /area/science/robotics/lab)
 "bqk" = (
 /obj/machinery/aug_manipulator,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bql" = (
 /obj/machinery/power/apc{
@@ -28922,29 +25897,18 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqq" = (
 /obj/effect/landmark/start/scientist,
@@ -28952,25 +25916,17 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqs" = (
 /turf/open/floor/plasteel/white,
@@ -28988,13 +25944,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29004,13 +25956,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqx" = (
 /obj/item/stack/sheet/glass/fifty{
@@ -29028,13 +25976,9 @@
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -29057,22 +26001,14 @@
 /obj/structure/window/reinforced,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "bqF" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "bqG" = (
 /obj/machinery/door/poddoor/preopen{
@@ -29183,8 +26119,7 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bqT" = (
 /obj/structure/flora/grass/jungle/b,
@@ -29219,17 +26154,7 @@
 /obj/machinery/computer/cloning{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/genetics)
 "bqX" = (
 /obj/machinery/holopad,
@@ -29288,13 +26213,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "brc" = (
 /obj/structure/cable{
@@ -29326,10 +26247,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bre" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29341,10 +26261,9 @@
 	name = "Medbay APC";
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -29359,93 +26278,75 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brh" = (
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bri" = (
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brj" = (
 /obj/machinery/chem_master,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brk" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brl" = (
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
+/obj/structure/table/glass,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/glass/beaker/large,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/obj/structure/table,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brm" = (
 /obj/machinery/chem_master,
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = 32;
-	receive_ore_updates = 1
+/obj/machinery/button/door{
+	id = "chemistry_shutters";
+	name = "Shutters Control";
+	pixel_x = 26;
+	pixel_y = 4;
+	req_access_txt = "5; 33"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 5
+	},
+/area/medical/chemistry)
+"bro" = (
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel,
+/area/maintenance/department/engine)
+"brp" = (
+/obj/item/storage/toolbox/mechanical,
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/area/science/lab)
 "brq" = (
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
@@ -29453,14 +26354,9 @@
 	pixel_y = 28
 	},
 /obj/item/stack/cable_coil/orange,
-/obj/item/storage/toolbox/mechanical,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brr" = (
 /obj/machinery/disposal/bin,
@@ -29473,38 +26369,26 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brt" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/lab)
 "bru" = (
 /obj/machinery/holopad,
@@ -29512,13 +26396,9 @@
 	pixel_x = 25
 	},
 /obj/item/reagent_containers/glass/bucket,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -29526,27 +26406,15 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "brw" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "brx" = (
 /obj/structure/cable{
@@ -29657,13 +26525,9 @@
 	pixel_x = -25
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "brH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -29707,13 +26571,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "brU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29723,13 +26583,9 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "brV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -29741,23 +26597,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "brX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bsa" = (
 /obj/machinery/disposal/bin,
@@ -29846,13 +26694,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
@@ -29871,8 +26715,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bsn" = (
 /obj/structure/girder,
@@ -29904,17 +26747,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/genetics)
 "bss" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29960,10 +26793,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bsy" = (
 /obj/structure/cable{
@@ -29976,10 +26808,9 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bsA" = (
 /turf/closed/wall,
@@ -29994,32 +26825,12 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bsC" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bsD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -30031,17 +26842,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bsE" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -30058,26 +26859,15 @@
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bsF" = (
 /obj/machinery/shower{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsG" = (
 /obj/structure/extinguisher_cabinet{
@@ -30086,10 +26876,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30098,10 +26887,9 @@
 	id_tag = "medbaybolts";
 	name = "Medbay"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsI" = (
 /obj/structure/disposalpipe/segment,
@@ -30111,8 +26899,7 @@
 	id_tag = "medbaybolts";
 	name = "Medbay"
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bsJ" = (
 /obj/machinery/chem_dispenser{
@@ -30121,20 +26908,16 @@
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsK" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsL" = (
 /obj/item/storage/box/beakers,
-/obj/structure/table,
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsM" = (
@@ -30149,11 +26932,9 @@
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsR" = (
 /obj/effect/turf_decal/stripes/line,
@@ -30178,13 +26959,9 @@
 /area/science/lab)
 "bsU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsV" = (
 /obj/structure/chair{
@@ -30195,25 +26972,15 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsW" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bsX" = (
 /obj/structure/cable{
@@ -30221,18 +26988,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/science/robotics/lab)
 "bsY" = (
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/science/robotics/lab)
 "bsZ" = (
 /obj/item/storage/firstaid/regular{
@@ -30253,11 +27012,7 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/science/robotics/lab)
 "bta" = (
 /obj/item/retractor,
@@ -30326,13 +27081,9 @@
 	},
 /obj/item/multitool,
 /obj/item/multitool,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bth" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -30375,11 +27126,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "btt" = (
 /obj/machinery/door/firedoor,
@@ -30417,13 +27166,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btx" = (
 /obj/structure/cable{
@@ -30432,13 +27177,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btA" = (
 /obj/structure/chair{
@@ -30454,7 +27195,7 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "btB" = (
 /obj/structure/cable{
@@ -30463,7 +27204,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "btE" = (
 /obj/structure/disposalpipe/segment{
@@ -30501,7 +27242,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "btK" = (
 /obj/docking_port/stationary{
@@ -30541,8 +27282,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "btO" = (
 /obj/structure/cable{
@@ -30596,45 +27336,29 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/genetics)
 "btV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/genetics)
 "btW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/genetics)
 "btX" = (
 /obj/structure/table,
-/obj/item/book/manual/wiki/medical_cloning{
+/obj/item/book/manual/medical_cloning{
 	pixel_y = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/genetics)
 "btY" = (
 /obj/structure/table,
@@ -30652,18 +27376,13 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/genetics)
 "btZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bua" = (
 /obj/machinery/door/firedoor,
@@ -30715,10 +27434,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "buh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -30732,10 +27450,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "buj" = (
+/obj/machinery/chem_heater,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -30746,23 +27464,21 @@
 	c_tag = "Chemistry";
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "buk" = (
 /obj/structure/disposalpipe/segment{
-	dir = 10
+	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bul" = (
-/obj/machinery/chem_heater,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bum" = (
@@ -30770,18 +27486,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bun" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bup" = (
 /obj/machinery/rnd/destructive_analyzer,
@@ -30822,13 +27529,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "buu" = (
 /obj/structure/chair{
@@ -30836,11 +27539,9 @@
 	},
 /obj/item/clothing/mask/cigarette,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "buv" = (
 /obj/structure/disposalpipe/segment,
@@ -30862,13 +27563,9 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bux" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30881,11 +27578,10 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "buz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30895,11 +27591,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/explab)
 "buB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -30923,46 +27615,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/explab)
 "buE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/explab)
 "buF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/explab)
 "buG" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/explab)
 "buH" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buI" = (
 /obj/structure/disposalpipe/segment{
@@ -30980,11 +27651,7 @@
 "buK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "buL" = (
 /obj/structure/disposalpipe/segment{
@@ -31054,11 +27721,7 @@
 	dir = 1;
 	pixel_y = -29
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
 "buW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31067,11 +27730,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
 "bva" = (
 /turf/closed/wall,
@@ -31095,17 +27754,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/genetics)
 "bve" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31215,8 +27864,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bvq" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -31246,14 +27894,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "bvw" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -31293,10 +27938,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31305,13 +27949,9 @@
 /obj/machinery/newscaster{
 	pixel_y = 34
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31320,13 +27960,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvE" = (
 /obj/structure/disposalpipe/segment{
@@ -31339,13 +27975,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31357,14 +27989,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/green/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvG" = (
 /obj/machinery/door/poddoor/preopen{
@@ -31433,20 +28060,15 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvN" = (
 /obj/structure/cable{
@@ -31462,10 +28084,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/corner{
+	icon_state = "darkpurplecorners";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31475,49 +28097,33 @@
 	pixel_y = 30
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvT" = (
 /obj/structure/window/reinforced{
@@ -31526,29 +28132,17 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvU" = (
 /obj/machinery/recharger,
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvV" = (
 /turf/open/floor/plasteel,
@@ -31558,17 +28152,9 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/target_stake,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -31604,11 +28190,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
 "bwf" = (
 /obj/structure/cable{
@@ -31617,19 +28199,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
 "bwh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
 "bwm" = (
 /turf/closed/wall,
@@ -31663,8 +28237,7 @@
 	name = "Monastery Transit"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/entry)
 "bws" = (
 /obj/structure/closet,
@@ -31695,49 +28268,30 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bww" = (
 /obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwx" = (
 /obj/machinery/dna_scannernew,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwz" = (
 /obj/machinery/disposal/bin,
@@ -31745,13 +28299,9 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwA" = (
 /obj/structure/table,
@@ -31760,14 +28310,9 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/bodybags,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwB" = (
 /obj/machinery/requests_console{
@@ -31818,11 +28363,7 @@
 	icon_state = "plant-21";
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/sleeper)
 "bwG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -31841,11 +28382,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/sleeper)
 "bwK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -31872,16 +28409,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bwO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bwP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -31889,15 +28424,13 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bwQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bwS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -31907,10 +28440,9 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwT" = (
 /obj/structure/disposalpipe/segment,
@@ -31924,8 +28456,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwV" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteyellow/corner,
 /area/medical/chemistry)
 "bwW" = (
 /obj/structure/rack,
@@ -31933,18 +28464,19 @@
 /obj/item/hand_labeler,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/light_switch{
+	pixel_x = 25
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxa" = (
 /obj/structure/table/glass,
-/obj/item/book/manual/wiki/research_and_development,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/obj/item/book/manual/research_and_development,
 /obj/item/disk/tech_disk,
 /obj/item/disk/design_disk,
 /turf/open/floor/plasteel/dark,
@@ -32047,13 +28579,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxj" = (
 /obj/structure/cable{
@@ -32130,11 +28658,9 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxp" = (
 /obj/machinery/door/poddoor/preopen{
@@ -32279,25 +28805,16 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxD" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -32311,17 +28828,9 @@
 /area/science/explab)
 "bxH" = (
 /obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxJ" = (
 /obj/structure/window/reinforced{
@@ -32457,17 +28966,19 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bxY" = (
-/obj/structure/closet/emcloset,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bxZ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bya" = (
 /obj/structure/extinguisher_cabinet{
@@ -32476,7 +28987,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "byb" = (
 /obj/structure/table,
@@ -32516,13 +29027,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "byg" = (
 /obj/structure/chair/stool,
@@ -32563,11 +29070,9 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "byl" = (
 /obj/structure/extinguisher_cabinet{
@@ -32583,10 +29088,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bym" = (
 /obj/structure/cable{
@@ -32607,8 +29111,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/zone3)
 "byo" = (
 /obj/effect/spawner/structure/window,
@@ -32621,10 +29124,9 @@
 /area/medical/sleeper)
 "byr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bys" = (
 /obj/structure/disposalpipe/segment,
@@ -32635,8 +29137,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "byu" = (
 /turf/closed/wall,
@@ -32664,13 +29165,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/headset/headset_med,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "byx" = (
 /obj/structure/cable{
@@ -32678,6 +29175,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"byy" = (
+/obj/structure/chair/office/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 4
+	},
 /area/medical/chemistry)
 "byz" = (
 /obj/structure/window/reinforced{
@@ -32712,34 +29217,28 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/door/airlock/research{
-	name = "R&D Lab";
-	req_access_txt = "0";
-	req_one_access_txt = "7;29;30"
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/dark,
 /area/science/lab)
 "byE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "byF" = (
 /obj/structure/chair/office/light{
@@ -32756,22 +29255,14 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "byH" = (
 /obj/structure/table,
 /obj/item/multitool,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "byI" = (
 /obj/structure/table,
@@ -32779,43 +29270,30 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "byJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/purple/side{
+	icon_state = "purple";
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
 "byL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -32842,11 +29320,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byO" = (
 /obj/machinery/door/poddoor/preopen{
@@ -32912,22 +29388,14 @@
 	pixel_y = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/explab)
 "byU" = (
 /obj/structure/chair/comfy{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/explab)
 "byV" = (
 /obj/structure/table,
@@ -32935,11 +29403,7 @@
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/explab)
 "byW" = (
 /obj/structure/chair/comfy{
@@ -32948,11 +29412,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/explab)
 "byX" = (
 /obj/machinery/camera{
@@ -32963,20 +29423,16 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/explab)
 "byY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/corner{
+	icon_state = "darkpurplecorners";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -32992,8 +29448,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/corner,
 /area/science/explab)
 "bzb" = (
 /obj/structure/closet/radiation,
@@ -33004,28 +29459,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzc" = (
 /obj/structure/reagent_dispensers/fueltank,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzd" = (
 /obj/effect/turf_decal/stripes/line,
@@ -33038,11 +29481,7 @@
 /area/science/explab)
 "bzg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "bzh" = (
 /obj/structure/table,
@@ -33190,17 +29629,14 @@
 /area/space/nearstation)
 "bzz" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/structure/sign/departments/holy{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bzA" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bzB" = (
 /obj/effect/turf_decal/stripes/line,
@@ -33211,7 +29647,7 @@
 	network = list("monastery");
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "bzC" = (
 /obj/structure/table,
@@ -33256,13 +29692,9 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bzG" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzH" = (
 /turf/open/floor/plasteel/white,
@@ -33296,41 +29728,27 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzM" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/medical/medbay/zone3)
 "bzN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/medical/medbay/zone3)
 "bzO" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/medical/medbay/zone3)
 "bzP" = (
 /obj/machinery/sleeper{
@@ -33342,17 +29760,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bzQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -33366,13 +29774,9 @@
 /area/medical/sleeper)
 "bzS" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzT" = (
 /obj/structure/table/glass,
@@ -33382,13 +29786,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzU" = (
 /obj/effect/spawner/structure/window,
@@ -33402,10 +29802,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzW" = (
 /obj/structure/disposalpipe/segment,
@@ -33418,8 +29817,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "bzY" = (
 /obj/structure/sign/departments/medbay/alt,
@@ -33430,13 +29828,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAa" = (
 /obj/machinery/computer/crew,
@@ -33450,39 +29842,21 @@
 	name = "Chief Medical Officer RC";
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAb" = (
 /obj/machinery/computer/med_data,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAc" = (
 /obj/machinery/computer/card/minor/cmo,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAd" = (
 /obj/machinery/disposal/bin,
@@ -33500,27 +29874,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bAe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAf" = (
 /obj/structure/cable{
@@ -33530,11 +29893,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteyellow/side,
 /area/medical/chemistry)
 "bAg" = (
 /obj/structure/table/glass,
@@ -33545,18 +29904,21 @@
 	},
 /obj/item/stack/cable_coil/random,
 /obj/item/book/manual/wiki/chemistry,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
+/turf/open/floor/plasteel/whiteyellow/side,
+/area/medical/chemistry)
+"bAh" = (
+/obj/structure/table/glass,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 2;
 	layer = 2.9
 	},
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
 /obj/item/screwdriver,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 6
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAi" = (
 /obj/machinery/smoke_machine,
@@ -33572,16 +29934,24 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAm" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29"
+	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bAo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -33611,13 +29981,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bAq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33658,13 +30024,9 @@
 "bAv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAw" = (
 /obj/structure/disposalpipe/segment,
@@ -33683,11 +30045,9 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAy" = (
 /turf/closed/wall/r_wall,
@@ -33701,13 +30061,9 @@
 /area/science/storage)
 "bAC" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bAD" = (
 /obj/machinery/door/firedoor,
@@ -33720,11 +30076,10 @@
 "bAE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bAF" = (
 /turf/closed/wall,
@@ -33742,14 +30097,16 @@
 /area/science/xenobiology)
 "bAI" = (
 /obj/structure/transit_tube/curved/flipped{
+	icon_state = "curved1";
 	dir = 4
 	},
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/structure/window/reinforced/fulltile,
+/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/entry)
 "bAK" = (
 /obj/structure/transit_tube/horizontal,
@@ -33802,13 +30159,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bAR" = (
 /obj/structure/chair/stool,
@@ -33849,11 +30202,9 @@
 	name = "Genetics Requests Console";
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bAW" = (
 /turf/closed/wall,
@@ -33912,23 +30263,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBf" = (
+/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
-	},
-/obj/structure/disposalpipe/junction/flip{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -33942,26 +30284,14 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBi" = (
 /obj/effect/landmark/start/chief_medical_officer,
@@ -33977,13 +30307,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33992,13 +30316,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBk" = (
 /obj/structure/disposalpipe/segment,
@@ -34019,13 +30337,7 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bBl" = (
 /obj/machinery/door/airlock/maintenance{
@@ -34041,10 +30353,9 @@
 /area/maintenance/department/engine)
 "bBm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bBo" = (
 /turf/closed/wall,
@@ -34062,16 +30373,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBr" = (
 /obj/structure/cable{
@@ -34080,9 +30384,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBs" = (
@@ -34129,32 +30431,23 @@
 	pixel_y = 5;
 	req_access_txt = "47"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBw" = (
 /obj/machinery/computer/security,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBx" = (
 /obj/machinery/computer/security/mining,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/science)
 "bBy" = (
 /obj/machinery/computer/secure_data,
@@ -34169,14 +30462,9 @@
 	pixel_x = 28;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBz" = (
 /obj/structure/disposalpipe/segment,
@@ -34189,28 +30477,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bBB" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-20";
 	pixel_y = 3
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bBC" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -34251,13 +30529,9 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBI" = (
 /obj/structure/cable{
@@ -34268,11 +30542,10 @@
 /area/science/explab)
 "bBJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBK" = (
 /obj/structure/closet/bombcloset,
@@ -34287,8 +30560,8 @@
 /area/science/mixing)
 "bBL" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/airalarm/unlocked{
-	pixel_y = 24
+/obj/machinery/airalarm{
+	pixel_y = 22
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -34296,13 +30569,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bBN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34312,18 +30581,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bBP" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBQ" = (
@@ -34349,18 +30616,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBS" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -34372,17 +30630,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBT" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -34395,18 +30645,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBU" = (
 /mob/living/simple_animal/slime,
@@ -34414,6 +30655,7 @@
 /area/science/xenobiology)
 "bBV" = (
 /obj/structure/transit_tube/curved,
+/obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "bBW" = (
@@ -34438,24 +30680,15 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCa" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
 "bCb" = (
 /obj/machinery/dna_scannernew,
@@ -34464,20 +30697,15 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
 "bCc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCd" = (
 /obj/structure/cable{
@@ -34494,11 +30722,9 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -34542,33 +30768,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bCj" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue,
 /area/medical/sleeper)
 "bCl" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -34579,32 +30785,20 @@
 	pixel_x = -2;
 	pixel_y = -27
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/sleeper)
 "bCm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/sleeper)
 "bCn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCo" = (
 /obj/structure/disposalpipe/segment{
@@ -34619,11 +30813,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCq" = (
 /obj/structure/disposalpipe/segment{
@@ -34637,13 +30829,7 @@
 	name = "Chief Medical Office";
 	req_access_txt = "40"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/heads/cmo)
 "bCr" = (
 /obj/structure/disposalpipe/segment{
@@ -34655,13 +30841,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bCs" = (
 /obj/structure/table/glass,
@@ -34675,13 +30855,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bCt" = (
 /obj/structure/table/glass,
@@ -34690,13 +30864,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bCu" = (
 /obj/structure/table/glass,
@@ -34705,13 +30873,7 @@
 	},
 /obj/item/stack/medical/gauze,
 /obj/item/clothing/neck/stethoscope,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bCv" = (
 /obj/structure/cable{
@@ -34727,13 +30889,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bCw" = (
 /obj/machinery/door/airlock/maintenance{
@@ -34824,8 +30980,7 @@
 /area/maintenance/department/engine)
 "bCC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bCD" = (
 /obj/structure/disposalpipe/segment{
@@ -34847,13 +31002,9 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bCF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -34878,11 +31029,10 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bCJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -34906,14 +31056,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCL" = (
 /obj/effect/landmark/start/depsec/science,
@@ -34926,25 +31071,15 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCM" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCN" = (
 /obj/structure/chair/comfy,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bCO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -34970,13 +31105,9 @@
 /turf/closed/wall,
 /area/science/storage)
 "bCT" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bCU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -35022,33 +31153,17 @@
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -35063,17 +31178,9 @@
 	dir = 4
 	},
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDe" = (
 /obj/machinery/light{
@@ -35114,14 +31221,9 @@
 /area/maintenance/department/engine)
 "bDl" = (
 /obj/structure/closet/secure_closet/medical1,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bDm" = (
 /obj/structure/closet/secure_closet/personal/patient,
@@ -35130,22 +31232,13 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/medical/genetics)
 "bDn" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bDo" = (
 /obj/machinery/shower{
@@ -35181,13 +31274,9 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35196,25 +31285,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bDu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bDv" = (
 /obj/structure/chair/office/light{
@@ -35223,25 +31300,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bDw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bDx" = (
 /obj/machinery/power/apc{
@@ -35251,13 +31316,7 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bDy" = (
 /turf/closed/wall,
@@ -35275,12 +31334,8 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bDB" = (
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -35289,13 +31344,9 @@
 /obj/machinery/computer/rdconsole{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDC" = (
 /obj/structure/chair/office/light{
@@ -35318,11 +31369,10 @@
 /obj/machinery/computer/card/minor/rd{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDG" = (
 /obj/structure/table,
@@ -35332,13 +31382,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bDH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -35353,11 +31399,9 @@
 "bDI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bDK" = (
 /obj/structure/table,
@@ -35369,17 +31413,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bDL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -35439,13 +31475,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDS" = (
 /obj/structure/cable{
@@ -35464,11 +31496,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
@@ -35485,17 +31516,9 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDV" = (
 /obj/structure/cable{
@@ -35544,33 +31567,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEc" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEd" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -35586,17 +31593,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEf" = (
 /obj/machinery/airalarm{
@@ -35606,17 +31605,9 @@
 /obj/item/pickaxe,
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -35719,14 +31710,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/machinery/rnd/production/protolathe/department/medical,
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/rnd/production/techfab/department/medical,
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEw" = (
 /obj/structure/table,
@@ -35743,13 +31730,9 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEx" = (
 /obj/structure/table,
@@ -35766,13 +31749,9 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEy" = (
 /obj/structure/table,
@@ -35789,13 +31768,9 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEz" = (
 /obj/structure/table,
@@ -35809,21 +31784,16 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEB" = (
 /obj/machinery/door/firedoor,
@@ -35832,33 +31802,20 @@
 "bEC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bED" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/valentine,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEE" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEF" = (
 /obj/item/cartridge/medical{
@@ -35876,13 +31833,7 @@
 /obj/structure/table,
 /obj/machinery/light,
 /obj/item/wrench/medical,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEG" = (
 /obj/item/folder/blue,
@@ -35892,13 +31843,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEH" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -35907,13 +31852,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/cmo,
 /area/crew_quarters/heads/cmo)
 "bEI" = (
 /obj/structure/cable{
@@ -35998,10 +31937,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bEQ" = (
 /obj/structure/closet/crate{
@@ -36009,12 +31947,8 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "bER" = (
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -36027,14 +31961,10 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bES" = (
 /obj/item/aicard,
@@ -36049,11 +31979,7 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/crew_quarters/heads/hor)
 "bET" = (
 /obj/item/paper_bin{
@@ -36064,8 +31990,9 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/item/stamp/rd,
-/obj/machinery/status_display/ai{
-	pixel_y = -32
+/obj/machinery/status_display{
+	pixel_y = -30;
+	supply_display = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -36073,11 +32000,7 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/crew_quarters/heads/hor)
 "bEU" = (
 /obj/item/cartridge/signal/toxins,
@@ -36094,11 +32017,7 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/crew_quarters/heads/hor)
 "bEV" = (
 /obj/machinery/newscaster{
@@ -36107,28 +32026,19 @@
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEW" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
 /obj/structure/filingcabinet/security,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -36138,11 +32048,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/science)
 "bEY" = (
 /obj/machinery/power/apc{
@@ -36155,30 +32061,17 @@
 	icon_state = "0-8"
 	},
 /obj/structure/closet/secure_closet/security/science,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEZ" = (
 /obj/structure/chair/comfy{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bFa" = (
 /obj/effect/turf_decal/bot,
@@ -36206,11 +32099,10 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bFf" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bFh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -36269,67 +32161,39 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bFp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bFr" = (
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFu" = (
 /obj/machinery/button/massdriver{
@@ -36340,13 +32204,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFx" = (
 /obj/structure/chair{
@@ -36513,17 +32373,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFU" = (
 /turf/closed/wall,
@@ -36589,17 +32447,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/checkpoint/science)
 "bGc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -36611,13 +32459,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGe" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -36625,17 +32469,9 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bGf" = (
 /obj/effect/turf_decal/bot,
@@ -36675,13 +32511,9 @@
 /area/science/storage)
 "bGj" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bGk" = (
 /obj/machinery/light,
@@ -36690,11 +32522,10 @@
 /area/science/explab)
 "bGl" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
+	icon_state = "darkpurple";
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bGm" = (
 /obj/structure/closet/emcloset,
@@ -36703,22 +32534,14 @@
 	pixel_x = -24;
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGn" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGo" = (
 /obj/item/assembly/signaler{
@@ -36740,11 +32563,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGp" = (
 /obj/item/transfer_valve{
@@ -36771,11 +32590,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGq" = (
 /obj/item/assembly/timer{
@@ -36795,22 +32610,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGr" = (
 /obj/structure/tank_dispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -36819,11 +32626,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/mixing)
 "bGt" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -36831,30 +32634,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGv" = (
 /obj/machinery/meter,
@@ -36864,17 +32651,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGw" = (
 /obj/machinery/door/firedoor/heavy,
@@ -37009,16 +32788,9 @@
 	pixel_x = -4;
 	pixel_y = 24
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGT" = (
 /obj/structure/cable{
@@ -37040,17 +32812,13 @@
 /obj/machinery/light_switch{
 	pixel_x = 22
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGV" = (
 /obj/machinery/shower{
+	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -37088,13 +32856,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHa" = (
 /obj/machinery/light{
@@ -37107,11 +32871,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHb" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -37147,22 +32909,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHh" = (
 /obj/machinery/light{
@@ -37171,26 +32928,18 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHi" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHj" = (
 /obj/item/storage/belt/utility,
@@ -37199,13 +32948,9 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHk" = (
 /obj/item/gps{
@@ -37220,13 +32965,9 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHl" = (
 /obj/structure/chair,
@@ -37234,25 +32975,17 @@
 	dir = 4
 	},
 /obj/item/clothing/mask/gas,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -37262,46 +32995,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHr" = (
 /obj/structure/disposalpipe/segment{
@@ -37322,28 +33042,18 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bHu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -37374,17 +33084,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHA" = (
 /obj/machinery/atmospherics/components/binary/valve,
@@ -37403,17 +33105,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHC" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -37429,11 +33123,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/science/mixing)
 "bHE" = (
 /obj/structure/window/reinforced,
@@ -37446,11 +33136,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/science/mixing)
 "bHI" = (
 /obj/structure/grille/broken,
@@ -37482,6 +33168,7 @@
 	dir = 8;
 	layer = 2.9
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bHP" = (
@@ -37509,40 +33196,25 @@
 /area/maintenance/department/engine)
 "bHU" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHY" = (
 /obj/machinery/camera{
@@ -37556,22 +33228,17 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37594,26 +33261,17 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIc" = (
 /obj/machinery/vending/medical,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bId" = (
 /obj/structure/closet/secure_closet/medical3,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIe" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -37623,19 +33281,11 @@
 	network = list("ss13","medbay");
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIf" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIg" = (
 /obj/structure/table,
@@ -37660,11 +33310,7 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/medbay/central)
 "bIh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -37676,11 +33322,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIj" = (
 /obj/effect/spawner/structure/window,
@@ -37728,17 +33372,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bIp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37747,13 +33381,9 @@
 /obj/structure/sink{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIq" = (
 /obj/machinery/light{
@@ -37770,13 +33400,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -37787,30 +33413,16 @@
 	pixel_y = 28;
 	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 1, /obj/item/reagent_containers/pill/patch/silver_sulf = 1, /obj/item/reagent_containers/medspray/sterilizine = 1)
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIs" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bIt" = (
 /obj/structure/disposalpipe/segment{
@@ -37906,17 +33518,9 @@
 /area/hallway/primary/aft)
 "bIE" = (
 /obj/machinery/vending/assist,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bIF" = (
 /obj/machinery/power/apc{
@@ -37973,7 +33577,9 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bIL" = (
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/science/mixing)
 "bIM" = (
@@ -37989,11 +33595,7 @@
 	network = list("toxins");
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/science/mixing)
 "bIP" = (
 /obj/structure/grille,
@@ -38035,42 +33637,18 @@
 /area/chapel/dock)
 "bIW" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bIX" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
-"bIY" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "bIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -38080,90 +33658,42 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJc" = (
 /obj/structure/chair/comfy/black,
 /obj/item/trash/pistachios,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJe" = (
 /obj/structure/chair/comfy/black,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJf" = (
 /obj/structure/chair/comfy/black,
 /obj/item/cigbutt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJg" = (
 /obj/item/trash/popcorn,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJh" = (
 /obj/structure/sign/poster/contraband/random{
@@ -38199,13 +33729,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bJl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38239,23 +33765,17 @@
 	pixel_x = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJq" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -38300,13 +33820,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bJv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38329,11 +33845,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bJz" = (
 /obj/machinery/door/airlock/maintenance{
@@ -38380,12 +33894,7 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38394,22 +33903,14 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJG" = (
 /obj/structure/disposalpipe/segment,
@@ -38418,11 +33919,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -38437,30 +33934,18 @@
 /obj/machinery/light{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
 "bJJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -38470,22 +33955,14 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "bJM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -38498,14 +33975,9 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel/green/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJN" = (
 /turf/closed/wall/r_wall,
@@ -38626,15 +34098,11 @@
 /area/chapel/dock)
 "bKe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/white,
 /area/chapel/dock)
 "bKf" = (
-/obj/structure/chair,
-/turf/open/floor/plasteel/dark,
-/area/chapel/dock)
-"bKg" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/chapel/dock)
 "bKh" = (
 /obj/machinery/door/window/eastright{
@@ -38675,20 +34143,13 @@
 /area/maintenance/department/engine)
 "bKl" = (
 /obj/item/stack/medical/gauze,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bKm" = (
 /obj/structure/light_construct{
+	icon_state = "tube-construct-stage1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -38735,11 +34196,9 @@
 /area/medical/virology)
 "bKu" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bKv" = (
 /obj/item/bedsheet/medical,
@@ -38802,11 +34261,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bKB" = (
 /obj/structure/bed/roller,
@@ -38829,13 +34286,9 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKF" = (
 /obj/structure/table/optable,
@@ -38851,11 +34304,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKH" = (
 /obj/structure/cable{
@@ -38867,10 +34318,9 @@
 "bKI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bKJ" = (
 /obj/machinery/door/firedoor,
@@ -38885,8 +34335,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bKM" = (
 /obj/effect/spawner/structure/window,
@@ -38932,13 +34381,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -38951,13 +34396,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -38973,13 +34414,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -38995,13 +34432,9 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -39013,13 +34446,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -39032,14 +34461,9 @@
 	dir = 8;
 	name = "Mix Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -39082,7 +34506,11 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bLf" = (
+/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/mixing)
 "bLh" = (
@@ -39109,17 +34537,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -39135,23 +34555,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel/white,
 /area/chapel/dock)
 "bLs" = (
 /obj/structure/lattice,
@@ -39229,11 +34639,9 @@
 	layer = 2.9
 	},
 /obj/item/pen/red,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/whitegreen/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bLF" = (
 /obj/structure/table,
@@ -39280,23 +34688,17 @@
 /area/medical/medbay/central)
 "bLJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLK" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLL" = (
 /obj/machinery/light,
@@ -39313,13 +34715,9 @@
 /obj/machinery/light_switch{
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -39343,25 +34741,21 @@
 "bLQ" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLR" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bLS" = (
 /obj/machinery/vending/cola,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bLT" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -39370,24 +34764,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bLU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
+/turf/open/floor/plasteel/escape{
+	dir = 9
 	},
 /area/hallway/primary/aft)
 "bLV" = (
@@ -39424,26 +34811,18 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bLZ" = (
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMa" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -39453,49 +34832,33 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMb" = (
 /obj/machinery/meter/atmos/distro_loop,
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Mix to Distro"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMe" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -39521,11 +34884,9 @@
 	output_tag = "mix_in";
 	sensors = list("mix_sensor" = "Tank")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -39605,33 +34966,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -39651,7 +34996,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white,
 /area/chapel/dock)
 "bMx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -39661,16 +35006,11 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/dock)
-"bMy" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
+/obj/structure/chair{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plasteel/white,
+/area/chapel/dock)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/engine,
@@ -39681,17 +35021,9 @@
 /area/maintenance/department/engine)
 "bMC" = (
 /obj/item/stack/spacecash/c10,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bMD" = (
 /obj/effect/decal/cleanable/oil,
@@ -39739,70 +35071,35 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel/whitegreen/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bMK" = (
 /obj/item/soap/nanotrasen,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/gun/syringe,
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMM" = (
 /obj/structure/closet/l3closet,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMN" = (
 /obj/structure/table,
 /obj/item/hemostat,
 /obj/item/stack/medical/gauze,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bMO" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bMP" = (
 /obj/structure/table,
@@ -39811,17 +35108,7 @@
 	},
 /obj/item/circular_saw,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bMQ" = (
 /obj/structure/table,
@@ -39831,32 +35118,12 @@
 /obj/item/razor{
 	pixel_y = 5
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bMR" = (
 /obj/structure/table,
 /obj/item/retractor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue,
 /area/medical/surgery)
 "bMS" = (
 /obj/structure/cable{
@@ -39902,10 +35169,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/turf/open/floor/plasteel/escape{
+	dir = 10
 	},
-/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/aft)
 "bMX" = (
 /obj/machinery/meter,
@@ -39917,13 +35183,9 @@
 	dir = 4;
 	name = "External to Filter"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMZ" = (
 /obj/structure/disposalpipe/segment,
@@ -39937,11 +35199,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -40020,11 +35280,9 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -40058,7 +35316,7 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/science/mixing)
+/area/space/nearstation)
 "bNr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40084,17 +35342,9 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bNu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -40114,23 +35364,16 @@
 	pixel_x = 27
 	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bNw" = (
 /turf/closed/wall,
 /area/chapel/dock)
 "bNx" = (
 /obj/structure/transit_tube/station/reverse{
+	icon_state = "closed_terminus0";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -40236,31 +35479,19 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/reagentgrinder,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
 "bNQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
 "bNR" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitegreen/side,
 /area/medical/virology)
 "bNS" = (
 /obj/structure/closet/emcloset,
@@ -40326,10 +35557,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bOb" = (
 /obj/structure/cable{
@@ -40360,14 +35590,8 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
+/turf/open/floor/plasteel/arrival{
+	dir = 9
 	},
 /area/hallway/primary/aft)
 "bOf" = (
@@ -40382,13 +35606,9 @@
 	dir = 8;
 	name = "Air to External"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -40402,11 +35622,9 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -40495,7 +35713,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/science/mixing)
+/area/space/nearstation)
 "bOv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -40510,46 +35728,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/chapel/dock)
 "bOy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/chapel/dock)
 "bOz" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bOA" = (
 /obj/structure/chair/stool,
@@ -40636,10 +35826,9 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bOL" = (
 /obj/structure/chair/stool,
@@ -40650,10 +35839,9 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/turf/open/floor/plasteel/arrival{
+	dir = 10
 	},
-/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/aft)
 "bON" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -40668,13 +35856,9 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOP" = (
 /obj/structure/disposalpipe/segment,
@@ -40685,11 +35869,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -40706,11 +35888,7 @@
 	dir = 1
 	},
 /obj/machinery/space_heater,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bOT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -40738,11 +35916,7 @@
 /obj/item/multitool{
 	layer = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bOW" = (
 /obj/structure/table,
@@ -40751,11 +35925,7 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bOX" = (
 /obj/structure/table,
@@ -40767,11 +35937,7 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/rods/fifty,
 /obj/item/pipe_dispenser,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bOY" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -40818,11 +35984,9 @@
 	dir = 8;
 	name = "N2O Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -40859,34 +36023,18 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel";
 	opacity = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPp" = (
 /obj/structure/sign/poster/contraband/random{
@@ -40999,10 +36147,9 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bPH" = (
 /obj/structure/cable{
@@ -41036,20 +36183,15 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bPN" = (
 /obj/machinery/conveyor_switch{
 	id = "atmosdeliver"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPO" = (
 /obj/structure/disposalpipe/segment,
@@ -41057,11 +36199,9 @@
 /area/engine/atmos)
 "bPP" = (
 /obj/structure/tank_dispenser,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPQ" = (
 /turf/closed/wall,
@@ -41114,11 +36254,9 @@
 	output_tag = "n2o_out";
 	sensors = list("n2o_sensor" = "Tank")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -41157,7 +36295,8 @@
 /area/chapel/asteroid/monastery)
 "bQe" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
+	icon_state = "lantern-on";
+	on = 1
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
@@ -41165,12 +36304,14 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid{
+	icon_plating = "asteroid"
+	},
 /area/chapel/asteroid/monastery)
 "bQg" = (
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid{
+	icon_plating = "asteroid"
+	},
 /area/chapel/asteroid/monastery)
 "bQh" = (
 /obj/machinery/camera{
@@ -41252,17 +36393,7 @@
 /obj/item/aicard,
 /obj/item/aiModule/reset,
 /obj/item/assembly/flash/handheld,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQu" = (
 /obj/structure/table,
@@ -41274,17 +36405,7 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQv" = (
 /obj/structure/rack,
@@ -41292,17 +36413,7 @@
 	pixel_y = 32
 	},
 /obj/effect/spawner/lootdrop/techstorage/engineering,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQw" = (
 /obj/structure/rack,
@@ -41320,32 +36431,12 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/rnd,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQy" = (
 /obj/structure/rack,
@@ -41358,45 +36449,15 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQz" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQA" = (
 /obj/machinery/vending/assist,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bQB" = (
 /obj/machinery/power/apc{
@@ -41409,10 +36470,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bQC" = (
 /obj/structure/cable{
@@ -41428,8 +36488,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bQD" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bQE" = (
 /obj/structure/table/reinforced,
@@ -41452,23 +36511,17 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQG" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQH" = (
 /obj/machinery/pipedispenser,
@@ -41550,6 +36603,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
+/obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "bQS" = (
@@ -41791,8 +36845,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bRr" = (
 /obj/structure/table/reinforced,
@@ -41821,13 +36874,9 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRt" = (
 /obj/structure/disposalpipe/segment,
@@ -41849,11 +36898,9 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRv" = (
 /obj/machinery/pipedispenser/disposal,
@@ -41901,11 +36948,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRC" = (
 /obj/structure/lattice,
@@ -42010,47 +37055,17 @@
 "bRO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bRP" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bRQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bRR" = (
 /obj/machinery/holopad,
@@ -42096,10 +37111,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRW" = (
 /obj/structure/cable{
@@ -42151,11 +37165,7 @@
 	freq = 1400;
 	location = "Atmospherics"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bSc" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -42165,22 +37175,14 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bSd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bSe" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
@@ -42211,11 +37213,9 @@
 	dir = 8;
 	name = "Plasma Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSi" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -42245,12 +37245,6 @@
 /obj/structure/flora/ausbushes,
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
-"bSn" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space,
-/area/space/nearstation)
 "bSo" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -42440,15 +37434,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bSN" = (
 /obj/machinery/camera{
@@ -42462,8 +37454,7 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bSO" = (
 /obj/structure/cable{
@@ -42472,8 +37463,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bSP" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -42483,8 +37473,7 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/hallway/primary/aft)
 "bSQ" = (
 /obj/machinery/door/firedoor/heavy,
@@ -42533,11 +37522,9 @@
 	output_tag = "tox_out";
 	sensors = list("tox_sensor" = "Tank")
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSW" = (
 /obj/machinery/air_sensor{
@@ -42745,17 +37732,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bTx" = (
 /obj/structure/rack,
@@ -42766,17 +37743,7 @@
 /obj/machinery/light{
 	light_color = "#cee5d2"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bTy" = (
 /obj/structure/rack,
@@ -42784,17 +37751,7 @@
 /obj/item/stock_parts/subspace/amplifier,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bTz" = (
 /obj/structure/rack,
@@ -42804,17 +37761,7 @@
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/t_scanner,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bTA" = (
 /obj/structure/rack,
@@ -42828,17 +37775,7 @@
 	pixel_y = -32
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bTB" = (
 /obj/machinery/power/apc{
@@ -42849,17 +37786,7 @@
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate/solarpanel_small,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen,
 /area/storage/tech)
 "bTC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -42888,38 +37815,26 @@
 /turf/closed/wall,
 /area/engine/break_room)
 "bTH" = (
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -42935,13 +37850,9 @@
 	c_tag = "Atmospherics Entrance";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -42951,13 +37862,9 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
@@ -42979,13 +37886,9 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -42995,13 +37898,9 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -43012,13 +37911,9 @@
 	c_tag = "Atmospherics Mixing";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTR" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -43120,37 +38015,21 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUj" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUk" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUl" = (
 /obj/machinery/light{
@@ -43211,7 +38090,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUp" = (
@@ -43246,7 +38124,9 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUu" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUv" = (
@@ -43277,11 +38157,9 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -43350,16 +38228,9 @@
 	name = "Chief Engineer RC";
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -43373,13 +38244,9 @@
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUK" = (
 /obj/machinery/airalarm{
@@ -43387,37 +38254,24 @@
 	pixel_y = 22
 	},
 /obj/machinery/computer/apc_control,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUL" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUM" = (
 /obj/machinery/computer/card/minor/ce,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43441,13 +38295,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUR" = (
 /obj/structure/cable{
@@ -43461,26 +38311,18 @@
 	c_tag = "Engineering Power Storage";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUS" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUT" = (
 /turf/closed/wall,
@@ -43502,13 +38344,9 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUW" = (
 /obj/structure/chair/office/dark{
@@ -43530,11 +38368,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUY" = (
 /obj/machinery/door/airlock/security/glass{
@@ -43547,17 +38383,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red,
 /area/security/checkpoint/engineering)
 "bUZ" = (
 /obj/structure/cable{
@@ -43678,11 +38504,9 @@
 	dir = 8;
 	name = "CO2 Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -43792,14 +38616,10 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bVE" = (
 /turf/open/floor/plasteel,
@@ -43829,11 +38649,9 @@
 	icon_state = "0-8"
 	},
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bVI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -43878,13 +38696,10 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bVM" = (
 /obj/machinery/power/terminal{
@@ -43900,11 +38715,9 @@
 /area/engine/engine_smes)
 "bVN" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bVO" = (
 /obj/structure/table,
@@ -43920,13 +38733,9 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bVP" = (
 /obj/structure/cable{
@@ -43942,11 +38751,9 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/red,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bVR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44032,11 +38839,9 @@
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -44102,13 +38907,9 @@
 	pixel_x = -27
 	},
 /obj/item/clothing/glasses/meson/gar,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bWo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -44137,26 +38938,14 @@
 	dir = 2;
 	pixel_x = 22
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bWs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/storage/tech)
 "bWt" = (
 /obj/structure/rack,
@@ -44165,32 +38954,12 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/techstorage/command,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/storage/tech)
 "bWu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/storage/tech)
 "bWv" = (
 /obj/structure/table,
@@ -44223,13 +38992,10 @@
 	network = list("engine");
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWw" = (
 /obj/structure/cable/yellow{
@@ -44271,11 +39037,9 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWA" = (
 /obj/structure/filingcabinet,
@@ -44286,38 +39050,24 @@
 	network = list("engine");
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/red/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/red/side,
 /area/security/checkpoint/engineering)
 "bWC" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
 /obj/structure/closet/secure_closet/security/engine,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/red/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWD" = (
 /turf/closed/wall/r_wall,
@@ -44333,11 +39083,8 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/obj/machinery/shower{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bWF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -44351,7 +39098,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bWG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -44362,18 +39109,14 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
-/obj/machinery/shower{
-	dir = 8;
-	pixel_y = -4
-	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "bWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/closed/wall,
-/area/engine/break_room)
+/area/engine/engineering)
 "bWI" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -44488,7 +39231,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
 "bXe" = (
 /obj/structure/cable{
@@ -44498,29 +39241,16 @@
 /area/maintenance/department/engine)
 "bXf" = (
 /obj/machinery/suit_storage_unit/ce,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXg" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/crew_quarters/heads/chief)
 "bXh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/crew_quarters/heads/chief)
 "bXi" = (
 /obj/structure/cable{
@@ -44530,11 +39260,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/crew_quarters/heads/chief)
 "bXj" = (
 /obj/machinery/disposal/bin,
@@ -44551,14 +39277,9 @@
 	pixel_x = 24;
 	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXk" = (
 /turf/closed/wall/r_wall,
@@ -44578,13 +39299,10 @@
 /obj/structure/cable,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bXm" = (
 /obj/structure/cable{
@@ -44625,103 +39343,58 @@
 "bXr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXs" = (
 /obj/machinery/portable_atmospherics/pump,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXu" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXw" = (
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXx" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXz" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXA" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXB" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXC" = (
 /obj/machinery/light,
@@ -44729,11 +39402,7 @@
 	dir = 4;
 	name = "Air Outlet Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXD" = (
 /obj/structure/cable{
@@ -44742,11 +39411,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -44756,24 +39421,15 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/atmos)
 "bXF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -44784,12 +39440,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
-"bXI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
 "bXJ" = (
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
@@ -44945,7 +39595,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYn" = (
@@ -44964,13 +39613,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYp" = (
@@ -45033,6 +39675,13 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
+"bYC" = (
+/obj/structure/chair/office/dark{
+	dir = 1
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bYF" = (
 /obj/item/trash/pistachios,
 /obj/structure/rack,
@@ -45046,13 +39695,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYJ" = (
 /obj/structure/disposalpipe/segment{
@@ -45064,13 +39709,9 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYK" = (
 /obj/structure/cable{
@@ -45083,13 +39724,9 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYL" = (
 /obj/structure/cable{
@@ -45103,13 +39740,26 @@
 	sortType = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/area/engine/engineering)
+"bYM" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
+	},
 /area/engine/engineering)
 "bYN" = (
 /obj/structure/cable{
@@ -45122,20 +39772,16 @@
 	c_tag = "Engineering Port Fore";
 	dir = 2
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
 /obj/structure/sign/map{
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYO" = (
 /obj/structure/cable{
@@ -45144,16 +39790,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYP" = (
 /obj/structure/cable{
@@ -45165,16 +39807,12 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYQ" = (
 /obj/structure/cable{
@@ -45186,13 +39824,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYR" = (
 /obj/structure/cable{
@@ -45211,13 +39845,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYS" = (
 /obj/structure/cable{
@@ -45232,13 +39862,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYT" = (
 /obj/structure/cable{
@@ -45256,16 +39882,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYU" = (
 /obj/structure/cable{
@@ -45284,13 +39903,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYV" = (
 /obj/structure/cable{
@@ -45312,19 +39927,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYX" = (
 /obj/structure/cable{
@@ -45343,13 +39954,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYY" = (
 /obj/structure/cable{
@@ -45369,17 +39976,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -45397,22 +40003,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZc" = (
-/obj/structure/table/glass,
-/obj/item/paper_bin,
-/obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/rack,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/head/hardhat/orange,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZd" = (
 /obj/structure/lattice,
@@ -45440,13 +40046,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZg" = (
 /obj/structure/cable{
@@ -45474,11 +40077,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZi" = (
 /obj/machinery/meter,
@@ -45550,13 +40151,9 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/clothing/glasses/meson/engine,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45586,6 +40183,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"bZC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "bZD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -45593,6 +40197,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZE" = (
+/obj/machinery/holopad,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -45607,20 +40212,33 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"bZH" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZI" = (
-/obj/structure/chair/office/dark{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZJ" = (
@@ -45663,13 +40281,10 @@
 	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZP" = (
 /obj/structure/cable/yellow{
@@ -45690,11 +40305,9 @@
 	pixel_x = 24;
 	pixel_y = -6
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -45746,7 +40359,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
+/area/maintenance/department/engine)
+"cad" = (
+/obj/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cae" = (
 /obj/effect/spawner/structure/window,
@@ -45763,20 +40380,24 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cai" = (
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "caj" = (
-/obj/structure/table,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/apc,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stack/cable_coil,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/chair/office/dark,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cak" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45788,26 +40409,73 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "can" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"caq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"cao" = (
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
+/obj/effect/turf_decal/stripes/line,
+/obj/item/airlock_painter,
+/obj/item/clothing/glasses/meson/engine,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cap" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"caq" = (
 /obj/structure/cable/yellow{
-	icon_state = "4-8"
+	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "car" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Central";
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cat" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cau" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cav" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -45817,7 +40485,16 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cax" = (
-/obj/structure/disposalpipe/segment,
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/item/stack/cable_coil,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "caz" = (
@@ -45886,13 +40563,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caJ" = (
 /obj/structure/cable/yellow{
@@ -45910,11 +40584,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caL" = (
 /obj/structure/cable/yellow{
@@ -46048,60 +40720,82 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbe" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
-/obj/item/storage/belt/utility,
+/obj/item/pen,
+/obj/item/paper_bin{
+	layer = 2.9
+	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbf" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cbg" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cbh" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cbi" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas{
+/obj/item/book/manual/wiki/engineering_hacking{
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cbg" = (
+/obj/item/book/manual/engineering_singularity_safety{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/engineering_particle_accelerator{
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line,
+/obj/structure/table/glass,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cbh" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cbi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbj" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
+/obj/structure/sign/warning/radiation/rad_area,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cbk" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"cbl" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbm" = (
@@ -46111,43 +40805,29 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbn" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/bot,
+/obj/structure/table,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbo" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/wrench,
-/obj/item/weldingtool,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
+/obj/structure/table,
+/obj/machinery/cell_charger,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/obj/item/airlock_painter,
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbp" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbq" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbs" = (
@@ -46184,13 +40864,10 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbB" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -46209,11 +40886,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -46299,7 +40974,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbX" = (
@@ -46328,13 +41002,9 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cca" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 1;
-	pixel_y = 5
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2
+/obj/effect/landmark/start/station_engineer,
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -46342,38 +41012,100 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccb" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 1;
-	pixel_y = 5
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -2
+/obj/structure/chair/office/dark{
+	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccc" = (
-/obj/structure/sign/warning/nosmoking,
-/turf/closed/wall/r_wall,
+/obj/structure/closet/radiation,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccd" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cci" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"cce" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"ccf" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Center";
+	dir = 2;
+	network = list("ss13","engine");
+	pixel_x = 23
+	},
 /obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"ccg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cch" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -27
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cci" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ccj" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cck" = (
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 2;
+	pixel_y = 4
+	},
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -46393,13 +41125,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccq" = (
 /obj/structure/chair/office/dark,
@@ -46411,11 +41140,9 @@
 	dir = 2;
 	name = "Incinerator Output Pump"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccs" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
@@ -46456,10 +41183,12 @@
 /area/chapel/main/monastery)
 "ccL" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
+	icon_state = "lantern-on";
+	on = 1
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid{
+	icon_plating = "asteroid"
+	},
 /area/chapel/asteroid/monastery)
 "ccM" = (
 /obj/structure/chair,
@@ -46495,41 +41224,54 @@
 /obj/item/gps/engineering,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"ccW" = (
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/structure/table,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ccX" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
+"ccS" = (
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ccV" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ccW" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"ccX" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccY" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"ccZ" = (
+/obj/structure/particle_accelerator/end_cap,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cda" = (
-/obj/structure/reflector/single/anchored{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdc" = (
@@ -46538,18 +41280,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cdf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cdg" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdh" = (
 /obj/structure/table/glass,
@@ -46557,22 +41301,14 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow/side,
 /area/maintenance/disposal/incinerator)
 "cdi" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/turf/open/floor/plasteel/darkyellow/side{
+	icon_state = "darkyellow";
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdj" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -46689,76 +41425,156 @@
 /area/maintenance/department/engine)
 "cdI" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cdK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/structure/disposaloutlet{
 	dir = 8
 	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cdL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cdM" = (
+/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/machinery/camera{
-	c_tag = "Engineering Port Aft";
-	dir = 1;
-	pixel_x = 23
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cdN" = (
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdO" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cdP" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cdQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/camera{
+	c_tag = "Engineering Port Aft";
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "cdR" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Laser Room";
-	req_access_txt = "10"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 25;
+	req_access_txt = "11"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
-"cdT" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
+"cdS" = (
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -25;
+	req_access_txt = "11"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cdT" = (
+/obj/machinery/particle_accelerator/control_box,
+/obj/structure/cable/yellow,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cdU" = (
+/obj/structure/particle_accelerator/fuel_chamber,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cdW" = (
-/obj/structure/reflector/box/anchored,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 25;
+	req_access_txt = "11"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cdX" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = -25;
+	req_access_txt = "11"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cdY" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"cdZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "ceb" = (
 /obj/machinery/computer/rdconsole/production{
@@ -46782,15 +41598,13 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid,
 /area/chapel/office)
 "cef" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid,
 /area/chapel/office)
 "ceg" = (
 /obj/machinery/door/airlock/centcom{
@@ -46875,39 +41689,56 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cet" = (
-/obj/structure/closet/radiation,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 1
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ceu" = (
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/stack/cable_coil{
+	pixel_x = 3;
+	pixel_y = -7
+	},
+/obj/item/crowbar,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cev" = (
+/obj/structure/chair/stool,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cew" = (
+/obj/structure/particle_accelerator/power_box,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cex" = (
+/obj/item/screwdriver,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cey" = (
-/obj/structure/girder,
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "ceA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -46939,17 +41770,9 @@
 /area/chapel/office)
 "ceF" = (
 /obj/structure/filingcabinet,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ceH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -47010,6 +41833,9 @@
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ceU" = (
@@ -47024,6 +41850,9 @@
 	network = list("tcomms");
 	pixel_y = 28
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceV" = (
@@ -47033,44 +41862,77 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceX" = (
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#fff4bc"
 	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/emcloset/anchored,
+/obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"ceY" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cfa" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfb" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfc" = (
+/obj/structure/particle_accelerator/particle_emitter/left,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cfd" = (
-/obj/machinery/firealarm{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/particle_accelerator/particle_emitter/center,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfe" = (
+/obj/structure/particle_accelerator/particle_emitter/right,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cff" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = -32
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfg" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#fff4bc"
+	},
+/obj/structure/closet/emcloset/anchored,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cfk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47095,47 +41957,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfp" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfr" = (
 /obj/structure/transit_tube_pod,
@@ -47154,16 +41992,42 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfu" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine Room";
-	req_access_txt = "10"
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/engine,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfw" = (
+/obj/item/wirecutters,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfx" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cfy" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "cfC" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cfD" = (
 /obj/structure/cable{
@@ -47174,17 +42038,9 @@
 /area/chapel/main/monastery)
 "cfE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47198,33 +42054,17 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -47243,20 +42083,16 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
+"cfK" = (
+/turf/open/floor/plasteel/asteroid,
+/area/chapel/asteroid/monastery)
 "cfL" = (
-/obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/camera{
 	c_tag = "Monastery Asteroid Starboard Aft";
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/chapel/asteroid/monastery)
-"cfM" = (
-/obj/structure/flora/ausbushes,
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid,
 /area/chapel/asteroid/monastery)
 "cfN" = (
 /turf/closed/mineral,
@@ -47284,78 +42120,89 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfS" = (
-/obj/structure/table/reinforced,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/tank/internals/emergency_oxygen/engi,
-/obj/item/clothing/mask/breath{
-	pixel_x = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/structure/disposaloutlet,
+/obj/structure/disposalpipe/trunk{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cfT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"cfU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
+/obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cfU" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Fore";
+	dir = 2;
+	network = list("engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cfV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cfW" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfX" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 1
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cfY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Engine"
+/obj/machinery/disposal/deliveryChute,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cgb" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
 /obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cgd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cgf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47367,17 +42214,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
+"cgi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
 /area/chapel/main/monastery)
 "cgj" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -47431,26 +42278,31 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cgu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cgv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"cgx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 9
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cgw" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cgx" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cgG" = (
 /obj/structure/window/reinforced/fulltile,
@@ -47488,7 +42340,10 @@
 /area/chapel/main/monastery)
 "cgM" = (
 /obj/structure/dresser,
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
@@ -47530,50 +42385,51 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"cgT" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cgU" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cgV" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cgY" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "chb" = (
 /obj/machinery/camera{
 	c_tag = "Monastery Kitchen";
 	dir = 4;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chc" = (
 /obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chd" = (
 /obj/item/clothing/suit/apron/chef,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chf" = (
 /obj/machinery/light/small{
@@ -47610,17 +42466,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cho" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47679,27 +42527,31 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "chw" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "chA" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "chB" = (
 /obj/item/seeds/banana,
 /obj/item/seeds/grass,
 /obj/item/seeds/grape,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chC" = (
 /obj/structure/table,
@@ -47712,16 +42564,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chD" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47781,12 +42633,12 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chV" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chW" = (
 /obj/structure/table,
@@ -47798,7 +42650,7 @@
 /obj/item/storage/box/ingredients/wildcard{
 	layer = 3.1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chX" = (
 /obj/structure/table,
@@ -47806,15 +42658,21 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chY" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "chZ" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
+/area/chapel/main/monastery)
+"cia" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
 /area/chapel/main/monastery)
 "cib" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -47868,17 +42726,27 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/chapel/main/monastery)
-"cit" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+"cir" = (
+/obj/effect/turf_decal/stripes/end{
+	dir = 8
 	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cit" = (
+/obj/machinery/the_singularitygen/tesla,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "civ" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ciy" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -47886,7 +42754,7 @@
 	dir = 9
 	},
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "ciz" = (
 /obj/structure/closet/crate/coffin,
@@ -47903,17 +42771,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ciE" = (
 /obj/structure/flora/ausbushes/genericbush,
@@ -47933,22 +42793,23 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main/monastery)
 "ciG" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Aft";
-	dir = 1;
-	network = list("ss13","engine")
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"ciH" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ciI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Gas to Chamber"
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ciJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
@@ -48098,12 +42959,17 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"cjt" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
-	dir = 8
+"cjs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cjt" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cju" = (
 /turf/closed/mineral,
@@ -48297,6 +43163,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"ckr" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Port Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"cks" = (
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Aft";
+	dir = 1;
+	network = list("engine")
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "ckt" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid/airless,
@@ -48375,17 +43257,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ckF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48538,7 +43412,8 @@
 /area/library)
 "clj" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
+	icon_state = "lantern-on";
+	on = 1
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
@@ -48801,16 +43676,9 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmg" = (
 /obj/machinery/requests_console{
@@ -48823,13 +43691,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmh" = (
 /obj/machinery/door/airlock/engineering{
@@ -48853,13 +43717,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmk" = (
 /obj/machinery/power/apc{
@@ -48874,24 +43734,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cml" = (
 /obj/machinery/announcement_system,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmm" = (
 /obj/machinery/light/small{
@@ -48901,42 +43752,29 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/chair/office/dark,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/corner,
 /area/tcommsat/computer)
 "cmo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/tcommsat/computer)
 "cmp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/tcommsat/computer)
 "cmq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -48950,10 +43788,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cms" = (
 /obj/machinery/light/small{
@@ -48962,11 +43799,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmt" = (
 /obj/structure/lattice,
@@ -48987,28 +43822,18 @@
 	pixel_y = 5
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmv" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 1;
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -49019,44 +43844,26 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cmx" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
 	network = "tcommsat"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
+/turf/open/floor/plasteel/yellow/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmy" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/turf/open/floor/plasteel/yellow/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmz" = (
 /obj/structure/lattice,
@@ -49074,17 +43881,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cmG" = (
 /obj/machinery/blackbox_recorder,
@@ -49291,13 +44090,9 @@
 	pixel_x = -5;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cnD" = (
 /turf/open/space/basic,
@@ -49344,7 +44139,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnT" = (
-/obj/structure/weightmachine/weightlifter,
+/obj/structure/weightlifter,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnV" = (
@@ -49370,13 +44165,7 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
+/turf/open/floor/plasteel/barber,
 /area/crew_quarters/dorms)
 "coe" = (
 /obj/machinery/power/apc{
@@ -49477,11 +44266,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
 "coy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -49497,10 +44282,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "coB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49513,10 +44297,9 @@
 	c_tag = "Central Primary Hallway Bridge";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/blue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "coF" = (
 /obj/structure/cable{
@@ -49568,22 +44351,13 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "coN" = (
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "coV" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "coW" = (
 /obj/structure/cable{
@@ -49645,17 +44419,9 @@
 	pixel_y = 26;
 	req_access_txt = "28"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cph" = (
 /obj/structure/disposalpipe/segment{
@@ -49685,17 +44451,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -49747,17 +44505,9 @@
 /area/crew_quarters/kitchen)
 "cpt" = (
 /obj/item/beacon,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpu" = (
 /obj/machinery/deepfryer,
@@ -49928,70 +44678,45 @@
 /area/hallway/primary/central)
 "cpT" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/blue/side,
 /area/hallway/primary/central)
 "cpU" = (
 /obj/item/twohanded/required/kirbyplants,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/central)
 "cpX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cpY" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cpZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/turf/open/floor/plasteel/whiteblue/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqa" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqc" = (
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqd" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqe" = (
 /obj/effect/turf_decal/plaque,
@@ -50005,34 +44730,24 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqh" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/corner,
 /area/hallway/primary/aft)
 "cqi" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
 "cqk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/purple/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cql" = (
 /obj/structure/disposalpipe/segment,
@@ -50045,29 +44760,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/whiteblue/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/corner,
 /area/medical/medbay/central)
 "cqt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -50080,11 +44789,7 @@
 /obj/machinery/light{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
 "cqv" = (
 /obj/structure/disposalpipe/segment,
@@ -50118,20 +44823,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "cqD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "cqE" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -50141,29 +44838,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hallway/primary/aft)
 "cqG" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/atmos)
 "cqH" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
+/area/chapel/dock)
+"cqI" = (
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
 /area/chapel/dock)
 "cqS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -50431,25 +45125,21 @@
 /area/chapel/office)
 "csf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow/corner,
 /area/chapel/office)
 "csg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow/corner,
 /area/chapel/office)
 "csh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow/corner,
 /area/chapel/office)
 "csi" = (
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow/corner,
 /area/chapel/office)
 "csk" = (
 /obj/structure/table/wood,
@@ -50473,17 +45163,9 @@
 /obj/item/clothing/head/nun_hood,
 /obj/item/clothing/suit/nun,
 /obj/item/clothing/suit/holidaypriest,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cso" = (
 /obj/structure/table/wood,
@@ -50500,41 +45182,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "css" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csu" = (
 /obj/structure/disposalpipe/segment{
@@ -50576,49 +45243,19 @@
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/chapel/office)
 "csF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/chapel/office)
 "csG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/chapel/office)
 "csM" = (
 /obj/structure/cable{
@@ -50629,8 +45266,7 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/asteroid,
 /area/chapel/office)
 "csN" = (
 /obj/structure/cable{
@@ -50687,47 +45323,25 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cta" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cte" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50748,28 +45362,25 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctr" = (
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctu" = (
 /obj/machinery/light/small{
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/darkyellow/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -50805,17 +45416,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctM" = (
 /obj/machinery/light/small{
@@ -50824,17 +45427,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctN" = (
 /obj/machinery/light/small{
@@ -50848,17 +45443,9 @@
 	dir = 2;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -50867,17 +45454,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -50906,6 +45485,14 @@
 /obj/machinery/vending/wardrobe/chap_wardrobe,
 /turf/open/floor/carpet,
 /area/chapel/office)
+"cua" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/vault{
+	dir = 8
+	},
+/area/chapel/main/monastery)
 "cuc" = (
 /obj/machinery/light,
 /obj/machinery/camera{
@@ -50920,19 +45507,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkpurple/side,
 /area/science/xenobiology)
-"cui" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "cuk" = (
 /obj/structure/closet{
 	name = "beekeeping wardrobe"
@@ -50946,18 +45522,18 @@
 /obj/item/melee/flyswatter,
 /obj/item/melee/flyswatter,
 /obj/item/melee/flyswatter,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cul" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cum" = (
 /obj/machinery/seed_extractor,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cun" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -50991,11 +45567,11 @@
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/honey_frame,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cut" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuu" = (
 /obj/item/storage/bag/plants,
@@ -51007,7 +45583,7 @@
 	},
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants/portaseeder,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuv" = (
 /obj/structure/chair/wood/normal{
@@ -51081,19 +45657,19 @@
 /obj/machinery/light/small{
 	dir = 2
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuH" = (
 /obj/item/hatchet,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuI" = (
 /obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuJ" = (
 /obj/item/shovel/spade,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuK" = (
 /obj/machinery/light/small{
@@ -51133,17 +45709,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51155,7 +45723,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cuS" = (
 /obj/machinery/door/airlock{
@@ -51201,37 +45769,21 @@
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuY" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuZ" = (
 /obj/item/wrench,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/hydrofloor,
 /area/chapel/main/monastery)
 "cvb" = (
 /obj/machinery/hydroponics/soil,
@@ -51243,17 +45795,9 @@
 /area/hydroponics/garden/monastery)
 "cvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvd" = (
 /obj/structure/chair/wood/normal{
@@ -51268,11 +45812,11 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvf" = (
-/obj/machinery/recycler,
 /obj/machinery/conveyor{
-	dir = 4;
+	dir = 8;
 	id = "garbage"
 	},
+/obj/machinery/recycler,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cvg" = (
@@ -51363,49 +45907,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/area/chapel/main/monastery)
+"cvv" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvA" = (
 /obj/machinery/door/airlock/external{
@@ -51448,17 +45974,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvH" = (
 /obj/structure/cable{
@@ -51470,17 +45988,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvI" = (
 /obj/machinery/light/small,
@@ -51496,17 +46006,9 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvJ" = (
 /obj/machinery/light/small,
@@ -51516,17 +46018,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51536,17 +46030,17 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/area/chapel/main/monastery)
+"cvL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvM" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -51803,6 +46297,13 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
+"cwP" = (
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/turf/closed/wall,
+/area/medical/chemistry)
 "cwR" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -51821,11 +46322,7 @@
 /area/library/lounge)
 "cxb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/science/mixing)
 "cxe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -51877,17 +46374,9 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "cxz" = (
 /obj/machinery/door/airlock/grunge{
@@ -51914,17 +46403,9 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxD" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -51936,17 +46417,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -51966,17 +46439,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -51985,17 +46450,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxM" = (
 /obj/structure/window/reinforced/fulltile,
@@ -52011,17 +46468,9 @@
 	dir = 4;
 	network = list("ss13","monastery")
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52033,33 +46482,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cym" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52069,25 +46502,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"cyp" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "cyy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -52101,17 +46519,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyA" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -52123,17 +46533,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -52272,6 +46674,7 @@
 "czC" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern{
+	on = 1;
 	icon_state = "lantern-on";
 	pixel_y = 8
 	},
@@ -52366,45 +46769,24 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault,
+/area/library)
+"cAh" = (
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAr" = (
 /obj/machinery/light/small{
@@ -52417,11 +46799,7 @@
 	name = "Curator Desk Door";
 	req_access_txt = "37"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/library)
 "cAs" = (
 /obj/structure/table/wood,
@@ -52429,66 +46807,34 @@
 	icon_state = "plant-05";
 	pixel_y = 10
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
 	pixel_y = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAu" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/pharaoh,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAv" = (
 /obj/structure/table/wood,
 /obj/item/camera,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAy" = (
 /obj/machinery/light/small{
@@ -52501,20 +46847,12 @@
 	name = "Curator Desk Door";
 	req_access_txt = "37"
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred/side,
 /area/library)
 "cAB" = (
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/library)
 "cAC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -52557,15 +46895,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"cAQ" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cAS" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
 /turf/open/floor/plasteel/dark,
@@ -52727,18 +47056,27 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
+"cBQ" = (
+/obj/machinery/power/rad_collector,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cBR" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cBS" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cBT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -52768,9 +47106,11 @@
 /turf/open/floor/plasteel/white,
 /area/engine/gravity_generator)
 "cCI" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "cCO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -52799,12 +47139,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cCU" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/tcomms{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_guide,
+/obj/machinery/rnd/production/circuit_imprinter,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cCV" = (
@@ -52867,10 +47202,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -52881,23 +47215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"cKV" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cLw" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -52915,10 +47232,9 @@
 	pixel_x = -32;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cPO" = (
 /obj/item/chair/stool,
@@ -52935,12 +47251,14 @@
 /obj/structure/window/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
+"cQZ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "cSJ" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -2;
@@ -52973,11 +47291,7 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whiteblue/side,
 /area/medical/sleeper)
 "cSK" = (
 /obj/effect/turf_decal/delivery,
@@ -53005,15 +47319,14 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
 /obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "daY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -53046,15 +47359,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dgj" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dgz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53082,19 +47388,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -53108,17 +47403,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "dmP" = (
 /obj/structure/chair{
@@ -53137,20 +47424,14 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dnS" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Mix Bypass"
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "doo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53177,10 +47458,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -53191,10 +47469,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"dps" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/quartermaster/qm)
 "dqw" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
@@ -53230,13 +47504,6 @@
 /obj/machinery/reagentgrinder,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"dsz" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "dtm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53272,10 +47539,7 @@
 	c_tag = "Departure Lounge Aft";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "dxc" = (
 /obj/structure/disposalpipe/segment{
@@ -53302,6 +47566,20 @@
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dzA" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/rack,
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#fff4bc"
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "dAF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -53316,54 +47594,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
-"dEy" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"dFJ" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"dHr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = 24;
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"dHZ" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chemist,
-/obj/machinery/button/door{
-	id = "chemistry_shutters";
-	name = "Shutters Control";
-	pixel_x = 26;
-	pixel_y = 4;
-	req_access_txt = "5; 33"
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"dJk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "dJm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53393,12 +47623,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "dMG" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -26
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "dMI" = (
 /obj/item/clothing/suit/apron/surgical,
@@ -53423,12 +47652,11 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dSp" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+"dRs" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -53470,20 +47698,26 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dZj" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible,
-/obj/machinery/airalarm/engine{
-	pixel_y = 22
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"dZy" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg1"
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/area/maintenance/department/chapel/monastery)
 "eaw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"eaQ" = (
+/turf/closed/wall,
+/area/hallway/secondary/entry)
 "ebD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -53496,19 +47730,25 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "edJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"eex" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/office)
+"eeF" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/yellow/corner{
+	dir = 4
+	},
+/area/hallway/primary/central)
 "eeQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53544,13 +47784,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"eiV" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+"ekQ" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/structure/lattice,
 /turf/open/space/basic,
-/area/space/nearstation)
+/area/space)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -53561,23 +47801,15 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/lawoffice)
-"epj" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+"emV" = (
+/turf/open/space,
+/area/space/nearstation)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
 	},
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
-"epV" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eqD" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_x = -32
@@ -53614,10 +47846,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"eyj" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "ezF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -53637,35 +47865,8 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"eAH" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"eAZ" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
+/turf/open/floor/plasteel/neutral,
+/area/maintenance/department/security/brig)
 "eCw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53704,42 +47905,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"eFG" = (
-/obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
-	machinedir = 8;
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbagestacked"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "eHI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "eIL" = (
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "eLt" = (
 /obj/structure/closet/firecloset,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eMC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53794,32 +47973,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
-"eRp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"eSB" = (
-/obj/machinery/computer/cryopod{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "eSL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/beacon,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
@@ -53827,11 +47986,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"eWi" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+"eVW" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plating,
+/area/engine/engineering)
+"eWi" = (
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
@@ -53844,14 +48007,18 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/area/science/explab)
+"eYM" = (
+/obj/machinery/disposal/deliveryChute{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/science/explab)
+/obj/structure/disposalpipe/trunk,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "eZA" = (
 /obj/item/stack/cable_coil/cut/random,
 /turf/open/floor/plating,
@@ -53866,8 +48033,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fdS" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -53882,17 +48049,10 @@
 	location = "Engineering"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/window/reinforced,
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "fef" = (
 /obj/machinery/door/airlock/maintenance{
@@ -53908,11 +48068,7 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "fhM" = (
 /obj/item/storage/secure/safe{
@@ -53931,21 +48087,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
-"fjD" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "fkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53961,14 +48106,6 @@
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"fmL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fmU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -53976,10 +48113,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -53992,13 +48126,9 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "fpT" = (
 /obj/structure/cable{
@@ -54008,22 +48138,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"frj" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "ftp" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
 "ftW" = (
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fuP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54054,8 +48177,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "fwl" = (
 /obj/structure/disposalpipe/segment{
@@ -54063,6 +48185,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
+"fwo" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/chapel/main/monastery)
 "fwr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -54076,40 +48204,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fxC" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"fym" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+"fwR" = (
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "fyF" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 10
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 8
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "fyO" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/turf/open/space/basic,
+/area/engine/engineering)
 "fzu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -54118,7 +48225,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
 "fAx" = (
 /obj/structure/cable{
@@ -54138,48 +48245,25 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "fBz" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"fBZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "fFv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -24
-	},
-/turf/open/floor/plasteel/dark,
+/obj/structure/lattice,
+/turf/open/space/basic,
 /area/engine/engineering)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/cryopod{
-	dir = 8
-	},
+/obj/machinery/cryopod,
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "fIN" = (
@@ -54234,10 +48318,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fUA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -54245,19 +48326,6 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"fZK" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -54272,10 +48340,7 @@
 /area/crew_quarters/kitchen)
 "gcj" = (
 /obj/machinery/vending/kink,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -54287,11 +48352,7 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "gdL" = (
 /obj/structure/disposalpipe/segment,
@@ -54299,16 +48360,9 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "geU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -54326,12 +48380,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ggg" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "giI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -54380,21 +48428,16 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/neutral/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "gkS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "gkX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage";
@@ -54410,17 +48453,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "gmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54436,11 +48471,7 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/hallway/secondary/exit/departure_lounge)
 "gna" = (
 /turf/open/floor/plasteel/stairs/medium,
@@ -54453,25 +48484,18 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "gpC" = (
 /obj/structure/chair,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/side{
+	dir = 1;
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -54497,13 +48521,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gvf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel{
+/turf/open/floor/plasteel/neutral/corner{
+	dir = 8;
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"gvO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/chapel/dock)
 "gwn" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -54529,17 +48557,9 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gxK" = (
 /obj/machinery/light/small{
@@ -54556,24 +48576,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"gBb" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"gDR" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway Escape";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "gDZ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -54581,23 +48583,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
-"gEo" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gFo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
@@ -54631,16 +48620,20 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gGA" = (
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/whiteyellow/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "gHZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54663,16 +48656,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "gIG" = (
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gKz" = (
 /obj/structure/table/wood,
@@ -54694,17 +48683,9 @@
 /area/maintenance/department/security/brig)
 "gLF" = (
 /obj/machinery/vending/snack/random,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gMm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -54714,6 +48695,7 @@
 /area/science/mixing)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
+/obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gNv" = (
@@ -54743,12 +48725,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"gQf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "gSH" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -54778,31 +48754,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gXZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "gYo" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"haA" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -54843,38 +48798,15 @@
 	codes_txt = "patrol;next_patrol=Sci4";
 	location = "Sci3"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/purple/side,
 /area/hallway/primary/aft)
-"hjk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"hjD" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hkQ" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "hnu" = (
 /obj/machinery/button/door{
@@ -54889,26 +48821,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"hon" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Filter"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"hoS" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hqo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54919,10 +48831,9 @@
 	pixel_y = 24;
 	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
@@ -54943,13 +48854,9 @@
 	c_tag = "Departure Lounge Port";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "hwj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -54964,13 +48871,6 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hyh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "hzc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55032,43 +48932,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hGB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hHr" = (
 /obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hIZ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hKp" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55106,17 +48975,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"hQy" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/supermatter)
 "hQz" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/cable/yellow{
@@ -55126,30 +48984,7 @@
 /area/tcommsat/computer)
 "hQC" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"hSt" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Cooling Loop"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"hSC" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -55175,18 +49010,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hTr" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/maintenance/department/engine)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"hUw" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "hUJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55202,31 +49037,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"hWa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "hXt" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hXK" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hYe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkred,
 /area/chapel/office)
+"hYm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/chair/stool,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hZB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55242,32 +49071,19 @@
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"iaZ" = (
+/turf/open/space/basic,
+/area/hallway/secondary/entry)
 "ick" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"iej" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -55294,13 +49110,9 @@
 /area/maintenance/department/engine)
 "ihk" = (
 /obj/structure/chair/office/light,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -55320,26 +49132,10 @@
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"ikO" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ilD" = (
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"imE" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ioj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -55356,40 +49152,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"iop" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"ioF" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iqc" = (
 /turf/open/floor/plasteel/stairs/right,
 /area/maintenance/department/crew_quarters/dorms)
-"irM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+"irs" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "itl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55397,13 +49166,9 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iuM" = (
 /obj/machinery/door/window/southleft{
@@ -55414,21 +49179,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"iwe" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "iyg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55440,15 +49194,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iyJ" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"izm" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
+/obj/structure/disposalpipe/segment,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "izB" = (
 /obj/machinery/door/airlock/external{
@@ -55498,10 +49245,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "iCs" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "iCV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -55510,6 +49260,10 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"iEa" = (
+/obj/structure/window/reinforced,
+/turf/open/space/basic,
+/area/space)
 "iEQ" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -55532,6 +49286,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
+"iHI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "iJi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -55545,13 +49303,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"iLh" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iLl" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -55580,14 +49331,9 @@
 	dir = 4;
 	network = list("xeno","rd")
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iPO" = (
 /obj/machinery/door/poddoor/shutters{
@@ -55625,10 +49371,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"iTF" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "iVJ" = (
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
@@ -55647,6 +49389,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"jep" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space)
 "jeq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55654,10 +49401,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -55706,6 +49450,24 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"jkm" = (
+/obj/structure/closet/emcloset,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
+"jlb" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"jmz" = (
+/obj/structure/flora/ausbushes/reedbush,
+/obj/structure/flora/ausbushes/leafybush,
+/turf/open/floor/plating/asteroid,
+/area/chapel/asteroid/monastery)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55739,7 +49501,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "jsD" = (
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -55752,14 +49517,9 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "jvi" = (
 /obj/structure/cable{
@@ -55769,13 +49529,9 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/darkred/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "jwe" = (
 /obj/machinery/door/firedoor,
@@ -55795,28 +49551,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
 "jzz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"jzE" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "jAy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -55833,25 +49574,38 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jBn" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+/obj/machinery/camera/emp_proof{
+	c_tag = "Engine Containment Starboard Fore";
+	dir = 2;
+	network = list("engine")
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "jCv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
+/obj/structure/sign/poster/random{
+	pixel_y = 32
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-17"
+	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "jDA" = (
 /obj/item/chair,
@@ -55902,8 +49656,12 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/kitchen/knife,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
+"jPo" = (
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55923,6 +49681,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"jSA" = (
+/obj/structure/sign/departments/science,
+/turf/closed/wall,
+/area/maintenance/department/engine)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55944,16 +49706,6 @@
 	},
 /turf/open/floor/carpet,
 /area/lawoffice)
-"jTU" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "jUV" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -55974,12 +49726,6 @@
 /obj/item/stack/ore/iron,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"jXF" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "jXV" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -56004,23 +49750,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"jZG" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/chemistry)
-"kaR" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -56075,10 +49804,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"klb" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/sorting)
 "klo" = (
 /obj/structure/dresser,
 /obj/structure/mirror{
@@ -56087,32 +49812,30 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "klB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "klV" = (
 /obj/item/clothing/under/rank/clown/sexy,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"kmd" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "kmn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"koz" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
+"knw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -56123,7 +49846,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
 "ksf" = (
 /obj/item/stack/tile/carpet,
@@ -56133,32 +49856,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kvj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit/departure_lounge)
 "kwm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "kxj" = (
 /obj/structure/chair/office/dark{
@@ -56181,30 +49887,26 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"kCc" = (
+/obj/structure/plasticflaps/opaque,
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "EngLoad"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "kDf" = (
 /obj/machinery/light/small{
 	dir = 2
@@ -56217,6 +49919,9 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
+	},
+/obj/machinery/conveyor_switch/oneway{
+	id = "EngLoad"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -56231,10 +49936,9 @@
 	dir = 1;
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/green/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kEW" = (
 /obj/machinery/smartfridge/disks{
@@ -56281,16 +49985,9 @@
 	dir = 8;
 	pixel_x = -27
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "kIo" = (
 /obj/structure/table,
@@ -56377,21 +50074,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kRq" = (
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
 "kRK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/bz,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "kSF" = (
 /obj/structure/cable{
@@ -56416,43 +50106,25 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
-"kTj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"kWQ" = (
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
-"kTR" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+"kYR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"kWQ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"kYM" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "lcU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -56480,49 +50152,23 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"lfx" = (
-/obj/structure/table,
-/obj/item/clothing/suit/hooded/wintercoat/engineering,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lhA" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"lhP" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "liR" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "lje" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ljG" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -56531,33 +50177,15 @@
 /area/maintenance/department/engine)
 "lnn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/storage/primary)
-"lnr" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"lnD" = (
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"loz" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/maintenance/department/chapel/monastery)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -56572,13 +50200,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"lrM" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -56587,8 +50208,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkyellow/corner,
 /area/chapel/office)
 "lAs" = (
 /turf/closed/wall,
@@ -56597,13 +50217,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "lBP" = (
 /obj/machinery/disposal/bin,
@@ -56631,7 +50247,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "lGp" = (
-/obj/structure/weightmachine/weightlifter,
+/obj/structure/weightlifter,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lGv" = (
@@ -56648,13 +50264,9 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "lHc" = (
 /obj/structure/girder,
@@ -56682,12 +50294,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"lJI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "lKL" = (
 /obj/machinery/door/airlock/abandoned{
 	name = "Starboard Emergency Storage";
@@ -56728,17 +50334,9 @@
 	name = "bridge external shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/bridge)
 "lQX" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -56747,12 +50345,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lRX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+"lRY" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "lTC" = (
 /obj/item/shard,
@@ -56764,10 +50361,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lUO" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "lWy" = (
 /turf/open/floor/plating,
 /area/maintenance/department/science)
@@ -56789,28 +50382,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"lXb" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Mix"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+"lWR" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced,
+/turf/open/space,
+/area/space/nearstation)
 "lXc" = (
 /obj/structure/table,
 /obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"lXJ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "mal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56818,10 +50399,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -56843,16 +50421,25 @@
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
+/area/engine/engineering)
+"mbW" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space)
+"mcf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "mci" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "mdL" = (
@@ -56861,28 +50448,14 @@
 /obj/item/pen{
 	layer = 3.1
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "meF" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"mfC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mgz" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "mhl" = (
 /obj/machinery/power/emitter,
@@ -56890,40 +50463,6 @@
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/engine/engineering)
-"mhn" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"miw" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"mjn" = (
-/obj/machinery/jukebox,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"mjK" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "mlr" = (
 /obj/structure/lattice,
@@ -56949,18 +50488,9 @@
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
 "mpd" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+/obj/structure/lattice,
+/turf/open/space,
+/area/engine/engineering)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -56971,27 +50501,10 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"mqp" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57028,7 +50541,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "mwg" = (
 /obj/structure/closet/crate{
@@ -57041,12 +50554,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "mwG" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/obj/structure/sign/warning/vacuum/external{
+	pixel_x = 32
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "mxy" = (
 /obj/machinery/power/terminal{
@@ -57074,17 +50588,7 @@
 	dir = 1;
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/vault,
 /area/bridge)
 "mzl" = (
 /obj/structure/chair,
@@ -57112,16 +50616,6 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"mEu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "mES" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Surgical Room"
@@ -57162,6 +50656,12 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/security/brig)
+"mMc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/space/basic,
+/area/maintenance/department/engine)
 "mMz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -57211,16 +50711,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"ncm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ndI" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/plating{
@@ -57244,10 +50734,7 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -57278,17 +50765,9 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "nku" = (
 /obj/machinery/door/airlock/centcom{
@@ -57299,6 +50778,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"nnf" = (
+/turf/open/floor/plasteel/whiteyellow/side,
+/area/medical/chemistry)
 "nnh" = (
 /obj/structure/chair{
 	dir = 8
@@ -57320,13 +50802,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nqu" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "nqV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57366,14 +50841,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"nsJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ntj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57390,11 +50857,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
@@ -57405,10 +50868,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/primary/central)
 "nyO" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -57429,18 +50889,17 @@
 	},
 /area/maintenance/department/science)
 "nAs" = (
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"nAY" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "nBw" = (
 /obj/machinery/computer/crew{
@@ -57455,10 +50914,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "nDo" = (
 /obj/structure/bed,
@@ -57466,17 +50924,9 @@
 /area/maintenance/department/engine)
 "nDx" = (
 /obj/machinery/vending/coffee,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "nEb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -57497,11 +50947,8 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/escape{
 	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "nIm" = (
@@ -57524,11 +50971,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/lab)
 "nJI" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -57564,13 +51007,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "nNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57594,13 +51033,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/darkblue/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nPA" = (
 /obj/item/chair,
@@ -57616,14 +51051,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nRM" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nSj" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57636,16 +51063,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
-"nTr" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nUQ" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "nVU" = (
 /obj/item/twohanded/spear,
 /turf/open/floor/plating,
@@ -57696,22 +51113,13 @@
 "oep" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
 "ofX" = (
 /obj/structure/cable{
@@ -57725,6 +51133,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ogX" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Starboard Aft";
+	dir = 1
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -57739,6 +51156,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"omI" = (
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1"
+	},
+/turf/open/floor/plating{
+	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01"
+	},
+/area/maintenance/department/chapel/monastery)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -57773,18 +51200,28 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/area/tcommsat/computer)
+"ory" = (
+/obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/tcommsat/computer)
+/obj/item/stack/cable_coil,
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
+"orZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/turf/open/floor/plasteel/yellow/side,
+/area/engine/engineering)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -57796,8 +51233,17 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"oto" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "ous" = (
 /obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/loading_area{
+	dir = 8
+	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
@@ -57805,12 +51251,7 @@
 	pixel_y = -24;
 	req_access_txt = "11"
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "ouv" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -57826,30 +51267,15 @@
 	c_tag = "Arrivals Port Fore";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/arrival{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
 "owS" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"oxw" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -57896,11 +51322,9 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "oDP" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "oEA" = (
 /turf/closed/wall,
@@ -57959,24 +51383,13 @@
 /obj/structure/closet,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
-"oHa" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
+"oGm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"oJr" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "oKa" = (
 /obj/structure/rack,
@@ -57993,23 +51406,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"oKv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"oKJ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "oLR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/escape{
+	dir = 5
 	},
-/turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
 "oMN" = (
 /turf/open/floor/plasteel/stairs/left,
@@ -58020,10 +51420,9 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oPx" = (
 /obj/structure/cable{
@@ -58126,14 +51525,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"oWu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "oWw" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58145,31 +51536,10 @@
 /obj/structure/table/glass,
 /obj/item/mmi,
 /obj/item/clothing/mask/balaclava,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/whitered/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
-"oXq" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cooling Loop Bypass"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "oYj" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -58182,12 +51552,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"paU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "pbm" = (
 /obj/machinery/door/airlock/external{
 	name = "Pod Docking Bay"
@@ -58243,18 +51607,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"pgH" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+"pga" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
+"phg" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "phJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "pjH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -58271,28 +51640,21 @@
 /obj/structure/piano,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"pmB" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
-"poP" = (
+"poK" = (
+/obj/structure/window/reinforced,
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+/obj/structure/window/reinforced{
 	dir = 4
 	},
-/turf/open/space,
+/turf/open/space/basic,
 /area/space/nearstation)
 "pps" = (
 /turf/closed/wall,
@@ -58301,46 +51663,27 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "prQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"psd" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Gas to Filter"
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"puw" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "pvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "pwj" = (
 /obj/structure/cable{
@@ -58358,17 +51701,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pxD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "chemistry_shutters";
-	name = "chemistry shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/medical/chemistry)
 "pBD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58379,35 +51711,11 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"pBJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"pCo" = (
-/obj/structure/reflector/single/anchored{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "pDP" = (
 /obj/machinery/vending/assist,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -58417,14 +51725,9 @@
 /area/lawoffice)
 "pFe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "pFy" = (
 /obj/structure/cable{
@@ -58439,11 +51742,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/side,
 /area/hallway/secondary/exit/departure_lounge)
 "pHo" = (
 /obj/machinery/computer/bounty{
@@ -58468,10 +51767,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "pNy" = (
 /obj/structure/closet/firecloset,
@@ -58483,17 +51781,9 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "pOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58503,10 +51793,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -58516,6 +51803,12 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"pSc" = (
+/obj/machinery/chem_heater,
+/turf/open/floor/plasteel/whiteyellow/side{
+	dir = 5
+	},
+/area/medical/chemistry)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58551,11 +51844,7 @@
 "pWT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/green/side,
 /area/hydroponics)
 "pXc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -58573,11 +51862,7 @@
 	},
 /obj/item/extinguisher,
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "pXT" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -58590,16 +51875,9 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/lawoffice)
-"pYh" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "pYw" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-03"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
@@ -58608,7 +51886,7 @@
 	pixel_y = -32
 	},
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/maintenance/department/engine)
 "qar" = (
 /obj/structure/chair/office/light{
@@ -58618,11 +51896,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "qbp" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/dark,
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
+"qbV" = (
+/obj/structure/lattice,
+/turf/open/space,
+/area/space)
 "qbZ" = (
 /obj/structure/rack,
 /obj/item/clothing/mask/gas,
@@ -58630,23 +51916,15 @@
 /area/storage/emergency/starboard)
 "qcD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/effect/turf_decal/tile/green{
+/turf/open/floor/plasteel/darkgreen/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qcH" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
 /obj/item/pen,
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkgreen/side,
 /area/science/xenobiology)
 "qdi" = (
 /obj/structure/disposalpipe/segment{
@@ -58670,66 +51948,29 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "qdj" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qeY" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"qhE" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+"qfj" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/space/basic,
+/area/space/nearstation)
 "qjx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
-"qkM" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qpd" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"qpS" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qtA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -58748,15 +51989,14 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qtO" = (
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -58790,17 +52030,9 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
@@ -58810,13 +52042,8 @@
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "qFu" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qGu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58870,21 +52097,6 @@
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qLI" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qMi" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -58921,11 +52133,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qOS" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "qPB" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -58933,39 +52140,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"qRl" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
+"qQr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"qTV" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "qUw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral,
 /area/hallway/secondary/exit/departure_lounge)
 "qVP" = (
 /obj/machinery/door/firedoor,
@@ -58990,11 +52177,7 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -2
 	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "qXq" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
@@ -59010,10 +52193,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qYi" = (
 /obj/structure/disposalpipe/segment{
@@ -59029,14 +52211,9 @@
 	icon_state = "2-4"
 	},
 /obj/item/wrench,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
+/turf/open/floor/plasteel/darkgreen/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qYS" = (
 /obj/structure/cable{
@@ -59054,6 +52231,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"rax" = (
+/obj/machinery/conveyor{
+	dir = 2;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -59077,17 +52261,9 @@
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rhr" = (
 /obj/machinery/light/small{
@@ -59099,17 +52275,9 @@
 /area/maintenance/department/engine)
 "riF" = (
 /obj/machinery/computer/arcade,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "riW" = (
 /obj/structure/cable{
@@ -59156,16 +52324,9 @@
 	},
 /area/maintenance/department/security/brig)
 "rrU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/open/floor/plasteel/darkred/side{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "rse" = (
 /obj/machinery/power/smes/engineering,
@@ -59264,6 +52425,15 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"rHv" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "rHA" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -59334,10 +52504,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/science)
 "rPg" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "rPW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -59347,13 +52523,6 @@
 /obj/item/trash/can,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"rTd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "rWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -59380,6 +52549,23 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"rYY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/obj/machinery/door/airlock/external{
+	name = "Engineering External Access";
+	req_access_txt = "10;13"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"saW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -59424,63 +52610,19 @@
 /area/space/nearstation)
 "sgc" = (
 /obj/machinery/vending/cigarette,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"shH" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
 "sij" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"sjC" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "skw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
-"slJ" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"smv" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Cooling Loop to Gas"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -59500,6 +52642,12 @@
 "sqQ" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"srv" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space)
 "srZ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -59526,12 +52674,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
-"svA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "svN" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/sign/departments/restroom{
@@ -59539,11 +52681,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"swg" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "sww" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
@@ -59562,7 +52699,10 @@
 /area/maintenance/department/security/brig)
 "syQ" = (
 /obj/machinery/vending/games,
-/obj/structure/sign/plaques/deempisi{
+/obj/structure/sign/warning/securearea{
+	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
+	icon_state = "monkey_painting";
+	name = "Mr. Deempisi portrait";
 	pixel_y = 28
 	},
 /turf/open/floor/plating{
@@ -59590,13 +52730,9 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/red{
+/turf/open/floor/plasteel/red/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/security/brig)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -59628,13 +52764,9 @@
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "sNz" = (
 /obj/structure/cable{
@@ -59649,6 +52781,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"sOQ" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -59669,34 +52808,10 @@
 	},
 /area/maintenance/department/engine)
 "sWj" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"sWW" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "sXi" = (
 /obj/machinery/disposal/bin,
@@ -59712,16 +52827,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"sYQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"sYp" = (
+/obj/structure/lattice,
+/obj/machinery/light{
+	dir = 2
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/space,
+/area/engine/engineering)
 "sZh" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -59759,13 +52871,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"tbw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "tcY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59792,31 +52897,18 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/explab)
 "tdB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tdL" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "tfw" = (
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -59862,17 +52954,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"tkL" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -59883,19 +52964,18 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "tlN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"tlV" = (
-/obj/structure/reflector/double/anchored{
-	dir = 9
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "tnY" = (
 /obj/machinery/button/door{
@@ -59906,11 +52986,7 @@
 	req_one_access_txt = "32;47;48"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "tpb" = (
 /obj/item/reagent_containers/food/snacks/donut,
@@ -59918,15 +52994,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
-"tqO" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "tqX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -59955,6 +53022,13 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"tuL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/the_singularitygen,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -59970,16 +53044,18 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "twv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "typ" = (
 /obj/structure/table/glass,
@@ -59994,14 +53070,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"tzH" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/lab)
 "tAK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -60019,13 +53087,6 @@
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tDE" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Engine"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "tHk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60036,37 +53097,16 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tIS" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"tPm" = (
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"tJr" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/turf/open/floor/plasteel,
-/area/science/lab)
-"tLP" = (
-/obj/machinery/status_display/supply,
 /turf/closed/wall,
-/area/quartermaster/warehouse)
-"tOD" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"tQT" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
 /area/engine/engineering)
 "tRc" = (
 /obj/structure/ore_box,
@@ -60074,6 +53114,12 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"tRK" = (
+/turf/open/floor/plating{
+	luminosity = 2;
+	initial_gas_mix = "o2=0.01;n2=0.01"
+	},
+/area/maintenance/department/chapel/monastery)
 "tSL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -60081,8 +53127,8 @@
 /area/maintenance/department/science)
 "tTl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -60091,15 +53137,26 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
+/turf/open/floor/plasteel/whitepurple/side{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tYx" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/effect/decal/cleanable/ash,
+/obj/effect/decal/cleanable/robot_debris/old,
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
+"uaa" = (
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "uaC" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -60112,34 +53169,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"uaO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "uaP" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"udl" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60168,15 +53213,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"ueX" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_construction,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ufa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60188,13 +53224,9 @@
 	icon_state = "officechair_white";
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/whitepurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
@@ -60215,33 +53247,23 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/engine)
-"ukp" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Gas"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/plasteel/neutral/side{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "ulY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/grounding_rod{
+	anchored = 1
+	},
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ume" = (
 /obj/machinery/door/firedoor,
@@ -60267,16 +53289,8 @@
 	},
 /area/maintenance/department/science)
 "uoq" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/turf/open/space,
+/area/engine/engineering)
 "uos" = (
 /obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/stripes/line{
@@ -60284,16 +53298,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"uot" = (
+/obj/effect/decal/cleanable/oil{
+	icon_state = "floor6"
+	},
+/turf/closed/wall,
+/area/maintenance/department/chapel/monastery)
 "uoS" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"upc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -60360,59 +53373,25 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uxP" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Starboard";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"uzh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "uzn" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"uAL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "uAU" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
@@ -60434,6 +53413,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"uBu" = (
+/turf/open/floor/plating{
+	icon_state = "platingdmg3"
+	},
+/area/maintenance/department/chapel/monastery)
 "uCS" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "aux_base_shutters";
@@ -60454,12 +53438,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uIB" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60468,10 +53446,7 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -60485,12 +53460,10 @@
 /area/maintenance/department/engine)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/loading_area{
 	dir = 8
 	},
-/obj/structure/closet/crate/solarpanel_small,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "uMt" = (
 /obj/effect/turf_decal/plaque,
@@ -60501,13 +53474,14 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "uRk" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 5
+/obj/machinery/field/generator{
+	anchored = 1;
+	state = 2
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -60535,6 +53509,15 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"uVW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "uXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60546,7 +53529,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "uXH" = (
 /obj/structure/cable{
@@ -60563,22 +53546,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vbQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "veM" = (
 /obj/machinery/suit_storage_unit/rd,
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "vgp" = (
 /obj/machinery/door/firedoor,
@@ -60595,7 +53574,7 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/floorgrime,
 /area/science/xenobiology)
 "vhk" = (
 /obj/structure/chair,
@@ -60610,31 +53589,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"vli" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/machinery/light,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"vlC" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vlF" = (
 /obj/item/coin/silver,
 /obj/effect/decal/cleanable/oil{
@@ -60648,17 +53602,9 @@
 "vmG" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "vmY" = (
 /obj/structure/sign/warning/deathsposal{
@@ -60669,20 +53615,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"voh" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"vor" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "vpz" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -60700,37 +53632,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"vsw" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"vsG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "7;29"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -60771,17 +53677,6 @@
 /obj/item/assembly/mousetrap,
 /turf/open/floor/engine,
 /area/science/explab)
-"vxr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -60792,15 +53687,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vzA" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "vzP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
@@ -60831,19 +53717,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vBE" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "vCC" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -60869,16 +53742,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vKq" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/official/random{
+"vIU" = (
+/obj/structure/transit_tube/horizontal,
+/obj/structure/sign/departments/holy{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -60933,23 +53803,15 @@
 	c_tag = "Engineering Port Storage";
 	dir = 2
 	},
-/obj/effect/turf_decal/tile/yellow{
+/turf/open/floor/plasteel/yellow/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/engine/engineering)
 "vTL" = (
 /obj/machinery/vending/tool,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/storage/primary)
 "vTN" = (
 /obj/machinery/door/firedoor/heavy,
@@ -60958,27 +53820,19 @@
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/turf/open/floor/plasteel/vault{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"vVO" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
+"vXt" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/engine,
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/clothing/glasses/welding,
+/turf/open/floor/plasteel/yellow/side,
 /area/engine/engineering)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -60987,26 +53841,23 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit/telecomms,
+/turf/open/floor/circuit/killroom,
 /area/science/xenobiology)
-"wbB" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "External Gas to Loop"
+"waN" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
 	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"wbF" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/camera{
-	c_tag = "Engineering Starboard Aft";
-	dir = 8
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/maintenance/department/chapel/monastery)
 "wcs" = (
-/turf/open/floor/plasteel/dark,
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "wdx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61041,24 +53892,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"wfG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hor)
 "wfO" = (
 /mob/living/simple_animal/hostile/retaliate/poison/snake,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wfP" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wig" = (
 /obj/machinery/vending/cigarette,
 /turf/open/floor/plating{
@@ -61072,24 +53909,6 @@
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wjm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wkZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -61101,41 +53920,49 @@
 	dir = 4;
 	name = "emergency shower"
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/xenobiology)
 "wlK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
+/turf/open/floor/plasteel/whitepurple/side,
+/area/science/explab)
+"wmA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel/white,
-/area/science/explab)
+/area/hallway/secondary/entry)
 "wnJ" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
 /area/science/mixing)
 "woh" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/decal/cleanable/oil,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "woq" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wpI" = (
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wqu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -61163,13 +53990,9 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wwr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/side{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wwG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -61177,6 +54000,9 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wwK" = (
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "wxb" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -61211,11 +54037,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/whitepurple/side,
 /area/science/explab)
 "wBg" = (
 /obj/machinery/door/airlock/maintenance{
@@ -61224,11 +54046,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wDl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "wDm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -61247,10 +54064,7 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -61260,18 +54074,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"wHI" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"wIo" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "wIv" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -61295,6 +54097,10 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
+"wKK" = (
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wLo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -61306,12 +54112,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"wLK" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "wMF" = (
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -61327,10 +54127,6 @@
 /obj/structure/grille,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wMX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/supermatter)
 "wNq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -61345,8 +54141,7 @@
 /area/maintenance/department/engine)
 "wOa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/neutral/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "wOf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -61401,6 +54196,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wSU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "wTD" = (
 /obj/structure/table/wood,
 /obj/item/folder/red,
@@ -61460,10 +54262,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"wYK" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "xah" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61491,17 +54289,9 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/vault{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
@@ -61511,13 +54301,6 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"xer" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "xeB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment,
@@ -61540,19 +54323,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
+/turf/open/floor/plasteel/escape{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"xhI" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -61572,10 +54346,12 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "xje" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xjK" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -61592,27 +54368,26 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/purple{
+/turf/open/floor/plasteel/darkpurple/side{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xlA" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xlY" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "xmp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
+/turf/open/floor/plasteel/escape,
 /area/hallway/secondary/exit/departure_lounge)
 "xmE" = (
 /obj/structure/chair{
@@ -61622,6 +54397,9 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xnm" = (
@@ -61633,15 +54411,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"xpf" = (
+/obj/item/trash/tray,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "xpr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
 "xpD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61716,19 +54494,8 @@
 	},
 /area/maintenance/department/security/brig)
 "xzp" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/darkblue/side,
 /area/science/xenobiology)
-"xzR" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -61744,14 +54511,11 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/machinery/light{
-	dir = 8
+/obj/structure/chair{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
@@ -61773,8 +54537,9 @@
 /area/science/mixing)
 "xJy" = (
 /obj/structure/chair/comfy/black,
-/obj/structure/sign/plaques/kiddie{
+/obj/structure/sign/plaques/atmos{
 	desc = "An embossed piece of paper from the Third University of Harvard.";
+	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},
@@ -61782,21 +54547,24 @@
 	dir = 1;
 	light_color = "#ffc1c1"
 	},
-/obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
+"xJG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light/small{
+	dir = 8;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "xKc" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "xLi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
+/turf/open/floor/plasteel/escape{
+	dir = 6
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "xLC" = (
 /obj/machinery/door/firedoor,
@@ -61813,13 +54581,6 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/space/basic,
 /area/space/nearstation)
-"xNy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone";
@@ -61857,11 +54618,22 @@
 /area/chapel/office)
 "xSZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
+/turf/open/floor/plasteel/neutral/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"xTi" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "EngLoad"
+	},
+/obj/structure/sign/warning/deathsposal{
+	desc = "A warning sign which reads 'DISPOSAL: LEADS TO ENGINE'.";
+	name = "\improper DISPOSAL: LEADS TO ENGINE";
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xWl" = (
 /obj/item/pen,
 /obj/item/paper_bin{
@@ -61873,6 +54645,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"xXh" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "ybX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -61896,11 +54672,7 @@
 /area/maintenance/department/engine)
 "yfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/yellow/side,
 /area/construction/mining/aux_base)
 "ygZ" = (
 /obj/structure/closet/crate,
@@ -75971,7 +68743,7 @@ cfN
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 ccu
 cbG
@@ -76228,7 +69000,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQg
 bUC
 bOw
 cbG
@@ -76480,14 +69252,14 @@ bOv
 bNs
 bNs
 bWh
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
 bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
+jmz
 cbG
 cee
 ceB
@@ -76737,7 +69509,7 @@ bNs
 bNs
 bQe
 bOw
-bOw
+bQg
 bOw
 bOw
 bOw
@@ -76994,7 +69766,7 @@ bNs
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bOw
@@ -77251,7 +70023,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bWV
@@ -77506,9 +70278,9 @@ bSm
 bOw
 bOw
 bOw
-bOw
-bOw
-bOw
+bQg
+bQg
+bQg
 bOw
 bUC
 bWV
@@ -77525,13 +70297,13 @@ cgg
 cfE
 cfE
 cfp
-cfE
+cia
 cuW
+cia
 cfE
 cfE
 cfE
-cfE
-cfo
+cvv
 cvF
 cvZ
 cwm
@@ -77763,7 +70535,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bWV
@@ -78020,7 +70792,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bWV
@@ -78035,7 +70807,7 @@ csN
 bWV
 cfm
 cfF
-cfn
+cgi
 cgG
 chi
 cid
@@ -78045,7 +70817,7 @@ cvb
 ciT
 cvh
 cgG
-cfn
+cgi
 cvF
 cwa
 cwo
@@ -78277,7 +71049,7 @@ bOw
 bQd
 bOw
 bQd
-bOw
+bQg
 bQd
 bWV
 bWV
@@ -78534,7 +71306,7 @@ bOw
 bQe
 bOw
 bOw
-bOw
+bQg
 bQe
 bWV
 bXJ
@@ -78549,7 +71321,7 @@ csQ
 ceL
 cfm
 ctM
-cfn
+cgi
 bWV
 cun
 cuB
@@ -78794,7 +71566,7 @@ bQf
 bQf
 bQf
 bWW
-bXI
+bZn
 bZn
 bZn
 bZn
@@ -79036,7 +71808,7 @@ bGG
 bHL
 bIW
 bKc
-bOy
+cqI
 bMt
 bLn
 bOy
@@ -79051,7 +71823,7 @@ bQg
 bQg
 bQg
 bWX
-bXJ
+bZo
 bZo
 bZo
 bZo
@@ -79305,7 +72077,7 @@ bOw
 bQe
 bOw
 bOw
-bOw
+bQg
 bQe
 bWV
 bXJ
@@ -79320,7 +72092,7 @@ ceP
 cth
 cfm
 ctN
-cfn
+cgi
 bWV
 cup
 cuE
@@ -79330,7 +72102,7 @@ cgH
 cgj
 cvj
 bWV
-cfn
+cgi
 cvJ
 cwe
 cjP
@@ -79356,7 +72128,7 @@ ckH
 ckH
 ckH
 czW
-cAg
+cAh
 cAt
 ckH
 czW
@@ -79562,7 +72334,7 @@ bOw
 bQd
 bOw
 bQd
-bOw
+bQg
 bWi
 bWV
 bWV
@@ -79789,7 +72561,7 @@ aaa
 aaa
 aaa
 aaa
-aaa
+btK
 aaa
 aaa
 aaa
@@ -79819,7 +72591,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bWV
@@ -79834,7 +72606,7 @@ csS
 bWV
 cfm
 ctO
-cfn
+cgi
 cgG
 cgm
 cuE
@@ -80044,10 +72816,10 @@ aaa
 aaa
 aaa
 aaa
+iaZ
+bsl
+btL
 aZx
-aZx
-aZx
-aZx
 aaa
 aaa
 aaa
@@ -80060,11 +72832,11 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bGI
+irs
+aqG
 bGE
 bKf
-bLn
+gvO
 bMw
 bNy
 bNw
@@ -80076,7 +72848,7 @@ bOw
 bSm
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bWV
@@ -80127,7 +72899,7 @@ ckH
 ckH
 ckH
 cAa
-cAg
+cAh
 cAt
 ckH
 cAa
@@ -80301,9 +73073,9 @@ aaa
 aaa
 aaa
 aaa
+iaZ
 aZx
-baJ
-bon
+bcX
 aZx
 aaa
 aaa
@@ -80316,12 +73088,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bGI
+irs
+irs
+aqG
 bGE
-bKg
-bLn
+bKf
+gvO
 bMx
 bNz
 bHM
@@ -80333,7 +73105,7 @@ bOw
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bOw
@@ -80348,18 +73120,18 @@ ccJ
 cdw
 cel
 ceM
-cfp
+cua
 cfE
 cfE
 chn
-cfE
+cia
 cdw
-cfE
+cia
 chn
 cfE
 cfE
 cvy
-cfG
+cvL
 cwe
 cwe
 fWv
@@ -80558,31 +73330,31 @@ aaa
 aaa
 jzz
 aZx
-jzz
-baK
-bon
+aZx
+bsl
+btM
 aZx
 aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bGI
-bHM
+srv
+srv
+srv
+srv
+srv
+srv
+ekQ
+ekQ
+ekQ
+poK
 bGE
+bKf
+gvO
 bGE
-bHM
 bNA
 bHM
-abI
+bLs
 bQi
 bQR
 bNs
@@ -80590,7 +73362,7 @@ bNs
 bOw
 bOw
 bOw
-bOw
+bQg
 bOw
 bOw
 bOw
@@ -80822,23 +73594,23 @@ aZx
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-bIY
-bIY
-bLs
-bMy
+iEa
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+saW
+kYR
+aZx
 bNB
-bMy
+abI
 abI
 aby
 abI
@@ -80847,15 +73619,15 @@ bNs
 bNs
 bNs
 bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
-bOw
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
+bQg
 bQg
 cbR
 bXJ
@@ -80873,7 +73645,7 @@ ciF
 cuQ
 cfm
 cfm
-cfm
+fwo
 cfm
 cwe
 ckp
@@ -81079,28 +73851,28 @@ aZx
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aby
-aby
-aaa
-aaa
+iEa
+aZx
+jkm
+iHI
+iHI
+xJG
+iHI
+iHI
+iHI
+hWa
+wwK
+wwK
+wwK
+wmA
+aZx
 amC
 aaa
 aht
 aby
 aby
 abI
-bSn
+bQi
 bSZ
 cqS
 bNs
@@ -81129,9 +73901,9 @@ cio
 chq
 ciX
 cfm
-cfN
-cfN
-cfN
+cjm
+cwA
+cjm
 cwe
 cwe
 cwe
@@ -81336,21 +74108,21 @@ aZx
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iEa
+aZx
+oto
+wwK
+wwK
+wwK
+wwK
+uAL
+vbQ
+vbQ
+vbQ
+wSU
+vbQ
+pga
+aZx
 amB
 aht
 aht
@@ -81359,7 +74131,7 @@ aaa
 abI
 abI
 abI
-abI
+lWR
 bNs
 bNs
 bNs
@@ -81369,8 +74141,8 @@ crl
 bXL
 bNs
 bOw
-bOw
-bOw
+bSm
+bQg
 bWV
 csU
 bWV
@@ -81386,9 +74158,9 @@ cgM
 chr
 chL
 cfm
-cfN
-cfN
-cfN
+cjm
+cwA
+cjm
 cfN
 cfN
 cfN
@@ -81593,31 +74365,31 @@ aZx
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+iEa
+aZx
+oto
+wwK
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
 amC
 aaa
 aht
 aaa
 aaa
-aaa
-aaa
+mbW
+mbW
 abI
-aaa
-aaa
+irs
+sOQ
 bQR
 bNs
 bNs
@@ -81627,13 +74399,13 @@ bXM
 bNs
 bOw
 bOw
-bOw
+bQg
 bOw
 ccM
 cdD
 ceo
 bOw
-bQg
+cfK
 cfm
 cgN
 chs
@@ -81643,9 +74415,9 @@ cip
 chs
 ciY
 cfm
-cfN
-cfN
-cfN
+cjm
+omI
+cjm
 cfN
 cfN
 cfN
@@ -81850,21 +74622,21 @@ aZx
 aaa
 aaa
 aaa
+iEa
+aZx
+oto
+wwK
+aZx
+irs
+irs
 aaa
+irs
+irs
 aaa
+irs
+irs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+irs
 amB
 aht
 aht
@@ -81884,12 +74656,12 @@ bXN
 bNs
 bOw
 bOw
-bOw
-bOw
-bOw
-bQe
-bOw
-bOw
+bQg
+bQg
+bQg
+ccL
+bQg
+bQg
 cfL
 cfm
 cfm
@@ -81900,9 +74672,9 @@ cfm
 cht
 cfm
 cfm
-cfN
-cfN
-cfN
+cjm
+tRK
+cjm
 cfN
 cfN
 cfN
@@ -82037,8 +74809,8 @@ afD
 aga
 aga
 agz
-aie
-aiH
+agJ
+agX
 ahm
 ahD
 aib
@@ -82107,18 +74879,18 @@ aZx
 aaa
 aaa
 aaa
+iEa
+aZx
+oto
+wwK
+aZx
+irs
 aaa
 aaa
 aaa
+irs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+irs
 aaa
 aaa
 aaa
@@ -82132,8 +74904,8 @@ aaa
 aaa
 aaa
 aht
-aaa
-aaa
+mbW
+mbW
 abI
 aaa
 bSZ
@@ -82145,9 +74917,9 @@ bUC
 bOw
 bOw
 bOw
-bOw
 bUC
-cfM
+bUC
+cfK
 cfm
 cgO
 chu
@@ -82157,9 +74929,9 @@ ciq
 chu
 ciZ
 cfm
-cfN
-cfN
-cfN
+cjm
+cwA
+cjm
 cfN
 cfN
 cfN
@@ -82363,12 +75135,12 @@ bon
 aZx
 aaa
 aaa
-btK
 aaa
-aaa
-aaa
-aaa
-aaa
+iEa
+aZx
+oto
+wwK
+aZx
 bBV
 bDf
 bDf
@@ -82414,9 +75186,9 @@ cfm
 cfm
 cfm
 cfm
-cfN
-cfN
-cfN
+cjm
+cwA
+cjm
 cfN
 cfN
 cfN
@@ -82619,14 +75391,14 @@ bnp
 bon
 aZx
 aZx
-bsl
-btL
 aZx
-aaa
-aaa
-aaa
+aZx
+aZx
+aZx
+oto
+wwK
 bAI
-bBW
+qbV
 abI
 aaa
 abI
@@ -82654,16 +75426,16 @@ abI
 ahi
 bSZ
 crO
+qfj
+qfj
+qfj
+qfj
+qfj
 crO
 crO
 crO
-crO
-crO
-crO
-crO
-crO
-crO
-crO
+mZE
+aht
 cfN
 cfN
 cfN
@@ -82671,9 +75443,9 @@ cfN
 cfN
 cfN
 cfN
-cfN
-cfN
-cfN
+cjm
+uaa
+cjm
 cfN
 cfN
 aaa
@@ -82806,7 +75578,7 @@ aeU
 afo
 afG
 aeU
-eSB
+aeU
 agy
 agL
 agZ
@@ -82828,7 +75600,7 @@ aqm
 aon
 asv
 atw
-aon
+auy
 avt
 awJ
 axG
@@ -82876,12 +75648,12 @@ bnp
 baK
 bbR
 bbR
-aZx
-bcX
-aZx
-aYG
-aZx
-aYG
+bbR
+bbR
+bbR
+eaQ
+rHv
+saW
 bAJ
 bBX
 bBX
@@ -82920,18 +75692,18 @@ aaa
 aaa
 aaa
 aaa
+irs
 aaa
-aaa
 cfN
 cfN
 cfN
 cfN
 cfN
 cfN
-cfN
-cfN
-cfN
-aaa
+cjm
+uaa
+cjm
+irs
 aaa
 aaa
 aaa
@@ -83133,13 +75905,13 @@ bnq
 baM
 baK
 baK
-bsl
-btM
-aZx
-aYG
+baK
+baK
+baK
+eaQ
 bxY
 bzz
-bAK
+vIU
 bBX
 bDg
 bEj
@@ -83173,23 +75945,23 @@ caZ
 cbS
 ccN
 bIZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-cfN
-cfN
-cfN
-cfN
-aaa
-aaa
-aaa
-aaa
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+cjm
+uBu
+cjm
+cjm
+irs
 aaa
 aaa
 aaa
@@ -83320,7 +76092,7 @@ lGp
 aeU
 afI
 aeU
-jXF
+aeU
 agy
 agN
 agY
@@ -83429,24 +76201,24 @@ bIZ
 cba
 cbT
 bDi
-bIZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cQZ
+cwA
+xpf
+cwA
+cwA
+cwA
+cwA
+tYx
+cwA
+cwA
+cwA
+cwA
+uaa
+dZy
+xlY
+waN
+cjm
+irs
 aaa
 aaa
 aaa
@@ -83687,23 +76459,23 @@ cbb
 bDi
 ccO
 bIZ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjm
+cjm
+cjm
+xXh
+xXh
+cjm
+uot
+xXh
+xXh
+cjm
+cjm
+xXh
+cjm
+lnD
+dzA
+cjm
+jep
 aaa
 aaa
 aaa
@@ -83947,20 +76719,20 @@ bva
 aaa
 cFB
 aaa
+irs
+jep
+dRs
+irs
+dRs
+dRs
+irs
+irs
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+cjm
+cjm
+cjm
+cjm
+jep
 aaa
 aaa
 aaa
@@ -84195,7 +76967,7 @@ aaa
 bva
 crB
 bva
-aaa
+irs
 aaa
 bIZ
 csy
@@ -84212,12 +76984,12 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+irs
+irs
+mbW
+dRs
+dRs
+irs
 aaa
 aaa
 aaa
@@ -85676,7 +78448,7 @@ aAL
 aMR
 aAL
 aAL
-aHE
+aQA
 aAL
 aAL
 aTO
@@ -87795,11 +80567,11 @@ bOB
 bSw
 bDi
 bDi
-bDi
-bIZ
+cad
+eYM
+bQl
+mMc
 mZE
-aaa
-aaa
 aaa
 aaa
 eNF
@@ -88053,10 +80825,10 @@ fpT
 wNq
 bva
 gMO
-bBX
+kCc
+bva
+hTr
 mZE
-mZE
-aaa
 aaa
 aaa
 eNF
@@ -88310,17 +81082,17 @@ bBX
 uUQ
 bBX
 fdS
-bBX
-bBX
-mZE
-aaa
-aaa
-aaa
-eNF
-aaa
-aaa
-aaa
-aaa
+xTi
+bXk
+jlb
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
 aaa
 aaa
 aaa
@@ -88507,7 +81279,7 @@ aQJ
 aRL
 aSD
 aTT
-aXS
+aTV
 aRL
 aWR
 aXT
@@ -88569,15 +81341,15 @@ kDJ
 oYj
 uMo
 bXk
+mci
+cbX
+ceq
+ceq
+ceq
+mhl
+ceq
+ceq
 bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -88764,7 +81536,7 @@ aQK
 aRL
 aSE
 aTU
-aXU
+aUV
 aVV
 aWS
 aXU
@@ -88824,17 +81596,17 @@ eQN
 tcY
 cam
 cam
-sjC
-bXk
-mci
+cdI
+cri
+eVW
 cbX
-ceq
-mhl
-ceq
-ceq
+wKK
+wKK
+wKK
+wKK
+wKK
+wKK
 bXk
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89020,8 +81792,8 @@ aLL
 aQL
 aRL
 aSF
-aXS
-aXS
+aTV
+aTV
 aRL
 aWT
 aXV
@@ -89083,15 +81855,15 @@ cbW
 cbd
 cdI
 cri
+eVW
 cbX
-cbX
-cbV
-cbV
-ceq
-ceq
+cBQ
+cBQ
+cBQ
+cBQ
+cBQ
+cBQ
 bXk
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89340,15 +82112,15 @@ bZA
 cam
 ous
 bXk
+tuL
 ccR
-cbX
+cbV
+cbV
 ccQ
 ccQ
 ccQ
 ccQ
 bXk
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -89597,6 +82369,7 @@ vjd
 oAw
 cdK
 bXk
+jlb
 bXk
 bXk
 bXk
@@ -89604,8 +82377,7 @@ bXk
 bXk
 bXk
 bXk
-aht
-aht
+bXk
 aht
 abI
 abI
@@ -89852,7 +82624,7 @@ cae
 eta
 mmv
 cae
-bTE
+tPm
 bXk
 ceT
 cfr
@@ -90375,16 +83147,16 @@ cgs
 cgQ
 chv
 mKk
-cdm
-cdm
-aaa
 aht
 aaa
 aht
-aaa
 aht
 aaa
+aaa
 aht
+aht
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -90619,9 +83391,9 @@ bXh
 bXZ
 bYK
 bZz
-nAY
+cah
 cbd
-nRM
+bZA
 cam
 cdM
 bXq
@@ -90631,19 +83403,15 @@ cfQ
 bXk
 qWG
 bXk
-paU
-dSp
-cdm
-aaa
+mVM
 aht
 aaa
 aht
-aaa
-aht
-aaa
 aht
 aaa
 aaa
+aht
+aht
 aaa
 aaa
 aaa
@@ -90654,6 +83422,10 @@ aaa
 aaa
 aaa
 aaa
+aaa
+aaa
+aaa
+emV
 iBJ
 clB
 hQz
@@ -90876,41 +83648,41 @@ bXi
 bYa
 bYL
 bZA
-caw
+cai
 cbe
 cca
 cam
 qtO
 bXk
+jlb
 bXk
 bXk
-svA
-mjK
-mjK
-mjK
-wHI
-eyj
-eyj
 bXk
-shH
-shH
-shH
-shH
-shH
-shH
-shH
-shH
-fon
-fon
-mau
-fon
-aht
-aht
-mau
-fon
-fon
-aht
-aht
+bXk
+bXk
+bXk
+cbj
+bXk
+cbj
+bXk
+bXk
+bXk
+bXk
+ckJ
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 ouv
 clw
 clw
@@ -91131,32 +83903,32 @@ bVH
 bWr
 bXj
 qGZ
-bYQ
-bZD
+bYM
+bZB
 caj
 cbf
 ccb
-cah
+ccS
 cdO
-ioF
+bXk
 ceX
-qOS
+iyJ
 cfS
 fFv
-fmL
-gXZ
-kmd
-lXJ
-lXJ
-bXk
+fFv
+fFv
+fFv
+fFv
+cir
+fFv
+fFv
+fFv
+fFv
+fFv
+bTE
 aaa
-aht
 aaa
-aht
 aaa
-aht
-aaa
-aht
 aaa
 aaa
 aaa
@@ -91389,31 +84161,31 @@ bUH
 bUH
 bYb
 bYN
-bZF
+bZA
 cak
 cbg
+bYC
 cam
-cam
-cam
-cam
+cdP
+rYY
 mwG
 nAs
 cfT
-wcs
-ggg
+fFv
+fFv
 qbp
-qbp
-gEo
+fFv
+fFv
 dMG
-bXk
+fFv
+fFv
+qbp
+fFv
+fFv
+bTE
 aaa
-aht
 aaa
-aht
 aaa
-aht
-aaa
-aht
 aaa
 aaa
 aaa
@@ -91646,31 +84418,31 @@ bWs
 bXk
 bYc
 bYO
-bZA
-xhI
+bZC
+cal
 cbh
-cbh
-cbh
-cbh
-cbh
-hjD
-vor
+cam
+cam
+cdQ
+bXk
+bTE
+bXk
 cfU
 tIS
 iCs
 rPg
-rPg
 cBR
-iCs
-bXk
+cBR
+knw
+cBR
+cBR
+uVW
+lRY
+ckr
+bTE
 aaa
-aht
 aaa
-aht
 aaa
-aht
-aaa
-aht
 aaa
 aaa
 aaa
@@ -91903,31 +84675,31 @@ bWt
 bXk
 bYd
 bYP
-bZF
-rTd
-wDl
-vxr
-irM
-irM
+bZA
+cam
+cam
+cam
+cam
+orZ
 qFu
 cet
 ulY
 cfV
 cgu
 cgU
-izm
+cgU
 chw
-eyj
-jzE
-bXk
-bXk
-bXk
-bXk
-bXk
+chw
+chw
+chw
+cjs
+cfV
+cfV
+cfV
+bTE
+abI
 aaa
-fon
-fon
-fon
+aaa
 aaa
 aaa
 aaa
@@ -92164,27 +84936,27 @@ bZA
 can
 cbi
 ccc
-eyj
+ccV
 cdR
-tQT
-bXk
-bXk
-sWW
+qFu
+cet
+ulY
+cfV
 cgv
-lXb
-cgv
+cfV
+sWj
 uaP
-cgv
-ukp
 cgV
-cgv
-cgv
-gQf
-bXk
-aht
-fon
-shH
-fon
+uaP
+cgV
+uaP
+ciG
+cfV
+cfV
+bTE
+abI
+abI
+aaa
 aaa
 aaa
 aaa
@@ -92418,30 +85190,30 @@ bXk
 bTE
 bYR
 bZA
-can
+cao
 cbj
-eyj
-cbX
+bXk
+ccW
 wcs
 iyJ
 cfa
-eyj
+cfa
 twv
-hoS
+cgv
 sWj
 dnS
-hSC
-jTU
-fZK
-pgH
-pgH
+uoq
+fyO
+mpd
+fyO
+uoq
 uRk
 ciG
-bXk
+cfV
+bTE
+abI
 aaa
-fon
-shH
-fon
+aaa
 aaa
 aaa
 aaa
@@ -92674,32 +85446,32 @@ bWv
 bXl
 bYf
 bYS
-bZA
-can
-qpS
+bZD
+cap
+bXk
 ccd
 ccX
-ccX
+cdS
 ceu
-cbX
+cfb
 cfu
 tlN
-ncm
+cgv
 cCI
 uoq
-hQy
-chA
-meF
-oKv
-wbB
-xzR
+fyO
+fyO
+mpd
+fyO
+fyO
+uoq
 hQC
-bXk
-aht
-fon
-shH
-fon
-aht
+mpd
+bTE
+abI
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -92898,7 +85670,7 @@ bmz
 bnG
 boN
 bpW
-dHZ
+brk
 bsK
 buk
 bvs
@@ -92931,31 +85703,31 @@ bWw
 bXm
 bYg
 bYT
-bZB
+bZA
 caq
 cbk
-eyj
+cce
 ccY
 cdT
-ccY
-cbX
-eyj
-vlC
-iej
-qeY
+cev
+cfc
+cfv
+tlN
+cgv
+cCI
 fyO
 fyO
+sWj
+cgT
+ciG
 fyO
-qeY
-oKv
-wbB
-wfP
+fyO
 hQC
-bXk
+mpd
+bTE
+abI
 aaa
-fon
-shH
-fon
+aaa
 aaa
 aaa
 aaa
@@ -93190,29 +85962,29 @@ bYh
 bYU
 bZE
 car
-mgz
-eyj
-cbX
-wcs
-wcs
+bXk
+ccf
+ccZ
+cdU
+cew
 cfd
-bXk
-tlN
-ncm
-lUO
+cfw
+cfW
+cgw
+cCI
 mpd
-hKp
-hKp
+mpd
+cCI
 cit
-qeY
-puw
-vBE
+ciH
+mpd
+mpd
 hQC
-bXk
-aht
-fon
-shH
-fon
+sYp
+bTE
+abI
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93417,8 +86189,8 @@ bsM
 bum
 bvt
 bwV
-byz
-ooh
+byy
+bAh
 bpY
 bCA
 bDy
@@ -93446,30 +86218,30 @@ bXo
 bYi
 bYV
 bZA
-cam
+cdN
 ccW
-bXk
+ceY
 cda
-wcs
-wcs
-wcs
-eyj
-eAH
-lnr
-qeY
-fBZ
-fBZ
-fBZ
+cbX
+cex
+cfe
+cfx
+tlN
+cgv
+cCI
+fyO
+fyO
+fyF
 cgY
 ciI
-tdL
-dHr
+fyO
+fyO
 hQC
-bXk
+mpd
+bTE
 aaa
-fon
-shH
-fon
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93649,7 +86421,7 @@ aSS
 aUg
 aVf
 aWi
-mjn
+bah
 aYe
 aZb
 bag
@@ -93672,10 +86444,10 @@ bpV
 brm
 bsN
 bun
-gGA
-bwW
-byA
-bAi
+mcf
+nnf
+byz
+ooh
 bpY
 bCB
 bDz
@@ -93702,31 +86474,31 @@ bWz
 bVN
 bYf
 bYW
-oWu
-cam
-vli
-ckJ
+bZF
+cat
+bXk
+ccg
 cey
 cdW
-wcs
-cdW
-eyj
-kTR
-mEu
-wMX
-dFJ
-wYK
-dFJ
-uzh
-nUQ
-fym
-hon
+cey
+cey
+cfy
+tlN
+cgv
+cCI
+uoq
+fyO
+fyO
+mpd
+fyO
+fyO
+uoq
 hQC
-bXk
-aht
-fon
-shH
-fon
+mpd
+bTE
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -93927,14 +86699,14 @@ bmA
 bjd
 bpY
 bpY
+cwP
+pSc
+gGA
+bwW
+byA
+bAi
 bpY
-bpY
-pxD
-jZG
-bpY
-bpY
-bpY
-vsG
+pwj
 bva
 bva
 bva
@@ -93960,30 +86732,30 @@ bUU
 bUT
 bYX
 bZA
-cam
-lfx
+cau
+cbj
 bXk
-pCo
-wcs
-wcs
-tlV
-eyj
-qkM
-miw
-qeY
+ccW
+bXk
+bXk
+cet
+cet
+tlN
+cgv
+fyF
 prQ
-prQ
-prQ
-dgj
-psd
-fxC
+fyO
+fyO
+mpd
+fyO
+fyO
 dZj
-hQC
-bXk
+ciI
+cfV
+bTE
 aaa
-fon
-shH
-fon
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94182,19 +86954,19 @@ bls
 aBI
 aBI
 bmB
-vKq
-nTr
-gDR
-vzA
+bva
+bsn
+bva
+bva
 bvu
-hIZ
-tqO
-mqp
-cKV
-iwe
-qTV
+bva
+bva
+bva
+bva
+pwj
+hVx
 xDj
-blt
+bva
 jCv
 bOK
 bEN
@@ -94217,30 +86989,30 @@ mCe
 bYj
 bYQ
 bZA
-cam
-mgz
-eyj
-cbX
-wcs
-wcs
-dEy
-bXk
-tlN
-ncm
-puw
+cav
+cbl
+cch
+cdc
+cdX
+fwR
+cet
+ulY
+oGm
+cgv
+cfV
 fyF
 cZt
+wpI
 cZt
-fjD
-qeY
-iTF
-slJ
-hQC
-bXk
-aht
-fon
-shH
-fon
+wpI
+cZt
+ciI
+cfV
+cfV
+bTE
+abI
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -94447,11 +87219,11 @@ gkS
 tTl
 tTl
 tTl
-koz
+tTl
 dgg
 phJ
 phJ
-lJI
+xje
 bAk
 bIt
 bJB
@@ -94472,33 +87244,33 @@ bVP
 bWB
 mCe
 bYk
-wjm
-bZF
-cbm
-mgz
-eyj
-oHa
-oHa
+bYQ
+bZA
+cam
+cam
+cam
+cam
+cdI
 eWi
-cbX
-eyj
-vlC
+cet
+ulY
+oGm
 cgx
-qeY
-fyO
-fyO
-fyO
-qeY
+cgU
+cgU
+cBS
+cBS
+cBS
 cBS
 cjt
-kaR
-hQC
-bXk
-aaa
-fon
-shH
-fon
-aht
+cfV
+cfV
+cfV
+bTE
+abI
+abI
+abI
+abI
 aaa
 aaa
 aaa
@@ -94695,20 +87467,20 @@ aGV
 blu
 aDZ
 aDZ
-bjm
-mhn
-cqi
-cqi
-cqi
-cqi
-cqi
-imE
-kYM
-mfC
+eeF
+bBX
+bBX
+bBX
+bro
+bBX
+bBX
+bBX
+bBX
+bva
 fdQ
-bmD
-bmD
-eRp
+npE
+npE
+bFZ
 bAl
 bIu
 bJC
@@ -94730,31 +87502,31 @@ bWC
 mCe
 bYl
 bYO
-bZA
+bZC
+hYm
+cbm
+cci
 cam
-lrM
-ccd
-cAQ
-cAQ
-cLw
-cbX
-cfu
+ogX
+bXk
+bXk
+bXk
 jBn
-oxw
+tIS
 meF
 chA
-chA
 woh
-cCI
-cBS
-iLh
+woh
+qQr
+woh
+woh
 liR
-hQC
-bXk
-aht
-fon
-shH
-fon
+phg
+cks
+bTE
+abI
+aaa
+abI
 aaa
 aaa
 aaa
@@ -94954,20 +87726,20 @@ blt
 cqh
 bKM
 cCl
-cCl
-cCl
-tJr
-tzH
-tzH
+pYw
+gFo
+cSK
+duF
+bxa
 byD
 bAm
 dhz
-uxP
+bCD
 bDA
 bEQ
-bGa
-bHp
-sYQ
+jSA
+bHg
+bIv
 bJD
 bBo
 bBo
@@ -94988,30 +87760,30 @@ bWD
 bTE
 bYY
 bZA
-cam
+caw
 cbn
-eyj
-cbX
-wcs
-cfP
+ccj
+cam
+cdY
+rYY
 cff
-eyj
+nAs
 cfX
-vVO
-iop
+fFv
+fFv
 kWQ
-oXq
-qpd
-tkL
-tOD
-tOD
-ikO
-hQC
-bXk
+fFv
+fFv
+dMG
+fFv
+fFv
+kWQ
+fFv
+fFv
+bTE
+abI
 aaa
-fon
-shH
-fon
+aaa
 aaa
 aaa
 aaa
@@ -95211,14 +87983,14 @@ bmC
 cqi
 boP
 bqb
-pYw
-gFo
-cSK
-duF
-bxa
+brp
+byF
+cCt
+byF
+cCt
 byE
 bBp
-wfG
+bBp
 bBp
 bBp
 bBp
@@ -95247,28 +88019,28 @@ bYZ
 bZG
 cax
 cbo
-ccc
-eyj
-cdR
-oJr
-bXq
-bXq
-cfY
-xNy
-smv
-xNy
-hGB
-hSt
-civ
-civ
-vsw
-qRl
-oKJ
+cck
+cdf
+cdZ
 bXk
-aht
-fon
-fon
-fon
+cfg
+bXk
+cfY
+fFv
+fFv
+fFv
+fFv
+fFv
+civ
+fFv
+fFv
+fFv
+fFv
+fFv
+bTE
+abI
+abI
+abI
 aaa
 aaa
 aaa
@@ -95469,9 +88241,9 @@ cqi
 boQ
 cCl
 brq
-byF
 cCt
-byF
+cCt
+cCt
 bxc
 nIU
 bAo
@@ -95501,30 +88273,30 @@ bWF
 bXp
 bYn
 bZa
-bZF
-cal
+bZH
+cam
 cbp
 cci
-kTj
-kTj
-qhE
-loz
-frj
-lRX
-eyj
-uIB
-eyj
-eyj
-uIB
-eyj
-eyj
+cam
+cdI
 bXk
 bXk
 bXk
 bXk
-aht
-aht
-aht
+bXk
+bXk
+bXk
+bXk
+cbj
+bXk
+cbj
+bXk
+bXk
+bXk
+bXk
+ckJ
+abI
+aaa
 aaa
 aaa
 aaa
@@ -95757,30 +88529,30 @@ bVU
 bWG
 bXq
 bYo
-hXK
+cah
 bZI
-hXK
+cah
 cbq
-cbd
 cam
 cam
-cam
-haA
-aKm
-upc
-wIo
-hyh
-upc
-voh
-pBJ
-wIo
-voh
-cdm
+vXt
+bXk
 aaa
 aaa
-aht
-aht
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abI
 aaa
 aaa
 aaa
@@ -96015,29 +88787,29 @@ bWH
 bXk
 bTE
 bZc
-ueX
-cCU
 bZJ
-wbF
+cCU
 cCV
 ceb
-epV
-qLI
-aKm
-eiV
-upc
-dsz
-eiV
-eiV
-uaO
-voh
-eiV
-cdm
+jPo
+ory
+bXk
 aaa
 aaa
-fon
-fon
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+abI
 aaa
 aaa
 aaa
@@ -96271,30 +89043,30 @@ bJN
 bJN
 bJN
 bJN
-frj
-pYh
-pYh
-pYh
-pYh
-pYh
-pYh
-pYh
-pYh
-hUw
-nqu
-nsJ
-gBb
-nsJ
-nsJ
-gBb
-nsJ
-nsJ
-dsz
-aht
-aht
-fon
-shH
-fon
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+abI
+adR
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96528,7 +89300,7 @@ bVV
 bWI
 bXr
 bKQ
-udl
+acN
 bZK
 abI
 abI
@@ -96537,21 +89309,21 @@ abI
 aaa
 aaa
 aaa
-uaO
-wIo
-nsJ
-gBb
-nsJ
-nsJ
-gBb
-nsJ
-nsJ
-hyh
+adR
 aaa
 aaa
-fon
-shH
-fon
+acO
+adR
+adR
+adR
+adR
+adR
+adR
+adR
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -96785,7 +89557,7 @@ bQI
 bWJ
 bXs
 bJN
-cui
+abI
 bJP
 bJP
 bJP
@@ -96793,22 +89565,22 @@ bJP
 bJP
 abI
 abI
-aht
-pBJ
-wIo
-nsJ
-gBb
-nsJ
-nsJ
-gBb
-nsJ
-nsJ
-dsz
-aht
-aht
-fon
-shH
-fon
+abI
+adR
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97042,7 +89814,7 @@ bMf
 fuR
 bXt
 bYp
-eAZ
+bZd
 bZL
 caz
 cbs
@@ -97051,21 +89823,21 @@ bJP
 aaa
 aaa
 aaa
-uaO
-wIo
-nsJ
-gBb
-nsJ
-nsJ
-gBb
-nsJ
-nsJ
-hyh
+adR
 aaa
 aaa
-fon
-shH
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97299,7 +90071,7 @@ bVW
 bWL
 bXu
 bLW
-cui
+abI
 bMi
 caA
 cbt
@@ -97308,21 +90080,21 @@ bJP
 aaa
 aaa
 aaa
-pBJ
-swg
-hyh
-pBJ
-hyh
-pBJ
-hyh
-pBJ
-hyh
-cdm
-aht
-aht
-fon
-shH
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97556,7 +90328,7 @@ bVX
 bWM
 bXv
 bWc
-poP
+bZe
 bZL
 caB
 cbs
@@ -97565,21 +90337,21 @@ bJP
 aaa
 aaa
 aaa
-aht
-aaa
-aht
-aaa
-aht
-aaa
-aht
-aaa
-aht
 aaa
 aaa
 aaa
-fon
-fon
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -97808,33 +90580,33 @@ bQI
 bQI
 bTM
 bUs
-ljG
-hjk
-pmB
+bMf
+bOk
+bWL
 bXw
-dJk
-tbw
+bLW
+abI
 bJP
 bJP
 bJP
 bJP
 bJP
 aaa
-aaa
-aaa
-aht
-aaa
-aht
-aaa
-aht
-aaa
-aht
-aaa
-aht
+aby
 aaa
 aaa
 aaa
-aht
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98065,7 +90837,7 @@ bMf
 bMf
 bTN
 bUt
-wLK
+bMf
 bOk
 bWK
 bXt
@@ -98076,24 +90848,24 @@ caC
 cbu
 cbu
 bJP
-aht
-aht
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-aht
-aht
-aht
-aht
+abI
+aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98321,8 +91093,8 @@ bRx
 bQJ
 bPQ
 bTO
-ljG
-lhP
+bMf
+bMf
 bOk
 bWL
 bXx
@@ -98334,24 +91106,24 @@ cbv
 ccn
 bJP
 aaa
+aby
 aaa
-fon
-shH
-shH
-shH
-shH
-shH
-shH
-shH
-shH
-shH
-shH
-fon
 aaa
-aht
-shH
-shH
-fon
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98578,7 +91350,7 @@ bPQ
 bPQ
 bPQ
 bTP
-wLK
+bMf
 bVh
 bVY
 bWM
@@ -98590,25 +91362,25 @@ caE
 cbu
 cbu
 bJP
-aht
-aht
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
-fon
 aaa
-aht
-shH
-fon
-fon
+aby
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -98835,7 +91607,7 @@ bQK
 bQK
 bPQ
 bTQ
-wLK
+bMf
 bKX
 bOk
 bWN
@@ -98847,6 +91619,8 @@ bJP
 bJP
 bJP
 bJP
+abI
+aby
 aaa
 aaa
 aaa
@@ -98863,8 +91637,6 @@ aaa
 aaa
 aaa
 aaa
-fon
-fon
 aaa
 aaa
 aaa
@@ -99092,7 +91864,7 @@ bRy
 bSf
 bSR
 bTM
-wLK
+bMf
 bKX
 bVZ
 bWO
@@ -99107,7 +91879,7 @@ bJP
 aaa
 aaa
 aaa
-fon
+aby
 aaa
 aaa
 aaa
@@ -99349,7 +92121,7 @@ bRz
 bMf
 bSS
 bTR
-tDE
+bMf
 bKX
 bWa
 bMf
@@ -99361,10 +92133,10 @@ caG
 cbx
 cco
 bJP
-aht
-aht
-aht
-fon
+abI
+abI
+abI
+aby
 aaa
 aaa
 aaa
@@ -99621,7 +92393,7 @@ bJP
 aaa
 aaa
 aaa
-fon
+aby
 aaa
 aaa
 aaa
@@ -99806,7 +92578,7 @@ aHn
 aIi
 aJi
 aKe
-klb
+lAs
 aMi
 aNJ
 fwl
@@ -99878,7 +92650,7 @@ bYw
 bYw
 aht
 aht
-fon
+aby
 aaa
 aaa
 aaa
@@ -100135,7 +92907,7 @@ cdg
 cbz
 aaa
 aaa
-mau
+aby
 aaa
 aaa
 aaa
@@ -100844,7 +93616,7 @@ lAs
 eeQ
 aUs
 aLf
-eex
+aLf
 aLf
 aLf
 aUl
@@ -101368,7 +94140,7 @@ bcA
 bdF
 beJ
 bfB
-dps
+bbE
 aZv
 aUC
 biz
@@ -102105,7 +94877,7 @@ apX
 apX
 avl
 fIu
-epj
+dbi
 aIh
 azA
 dbi
@@ -102639,8 +95411,8 @@ aNP
 aPb
 aNO
 aNP
-tLP
-aTq
+cDa
+aTo
 aSk
 aTm
 aTm
@@ -107517,7 +100289,7 @@ aaa
 aaa
 aLn
 aNT
-xer
+rax
 aQo
 aPg
 aRu
@@ -107775,8 +100547,8 @@ aaa
 aLm
 aLm
 aNU
-cyp
 dqY
+aPh
 aRv
 sZh
 aLm
@@ -108031,9 +100803,9 @@ aaa
 aaa
 aLm
 aME
-eFG
-cyp
+aNV
 dqY
+aPh
 aRw
 sqQ
 aLm
@@ -108288,8 +101060,8 @@ aaa
 aaa
 aLo
 aMF
-aNV
-cyp
+aNW
+dqY
 cvf
 aQn
 sqQ
@@ -108546,8 +101318,8 @@ aaa
 aLo
 aMG
 aNX
-cyp
-xer
+dqY
+rax
 aRy
 aSn
 aSn

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -38614,11 +38614,15 @@
 /area/chapel/dock)
 "bKe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/dark,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/chapel/dock)
 "bKf" = (
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/chapel/dock)
 "bKh" = (
 /obj/machinery/door/window/eastright{
@@ -39133,7 +39137,9 @@
 /area/chapel/dock)
 "bLr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/chapel/dock)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
@@ -39625,7 +39631,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/chapel/dock)
 "bMx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -39638,7 +39646,9 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/chapel/dock)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
@@ -44047,6 +44057,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"bWm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "bWn" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/extinguisher_cabinet{
@@ -46205,6 +46221,10 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
+"cbH" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "cbK" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -48067,6 +48087,16 @@
 "cjx" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
+"cjz" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cjB" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -49776,19 +49806,6 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
-"cpE" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "cpH" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -51979,19 +51996,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/library/lounge)
-"cxN" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cxX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -52820,24 +52824,30 @@
 "cDa" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
+"cDm" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cDB" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"cEJ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cFB" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
-"cHb" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cHS" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Firing Range"
@@ -52864,18 +52874,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"cLh" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -52919,10 +52917,43 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cQC" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cQZ" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"cRD" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cRR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Starboard";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cSJ" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -2;
@@ -52978,22 +53009,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"cVw" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
+"cUO" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
 	},
-/turf/open/space,
-/area/space/nearstation)
-"cVO" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cXW" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53023,28 +53047,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"dbw" = (
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/entry)
 "dci" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"dcp" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dcL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"ddh" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "dgg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53098,12 +53119,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"diq" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"dkD" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "dkR" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -53154,10 +53192,6 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
-"dnW" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "doo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53273,6 +53307,10 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"dwM" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/office)
 "dxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53332,14 +53370,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dJO" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "dKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53350,6 +53380,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"dLA" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dLY" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -53372,13 +53409,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"dML" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dMO" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -53396,28 +53426,11 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"dNR" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "dRs" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
-"dSc" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -53458,10 +53471,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"dWF" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/office)
+"dYd" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dZj" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/airalarm/engine{
@@ -53472,12 +53488,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dZs" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
+"dZk" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"eav" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/hallway/primary/aft)
 "eaw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -53504,6 +53527,22 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"eeB" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/machinery/light,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "eeQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53514,6 +53553,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
+"eeY" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "efu" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
@@ -53539,10 +53593,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"eiw" = (
-/obj/machinery/jukebox,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+"eiG" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"ejC" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -53595,19 +53657,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"evB" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"ewH" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ezF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -53623,6 +53672,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"eAj" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "eAp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -53639,6 +53695,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"eCn" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eCw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53671,12 +53734,29 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"eFg" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "eFj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"eFK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eHI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -53709,19 +53789,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"eML" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"eNo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "eNq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53869,13 +53936,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"feL" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -53886,12 +53946,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"fhf" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fhM" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22
@@ -53905,20 +53959,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"fjr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+"fin" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "7;29"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "fjs" = (
 /obj/machinery/light{
 	dir = 8
@@ -53932,10 +53979,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"fjT" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+"fjE" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "fkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53948,11 +53999,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
-"flN" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
@@ -53987,6 +54033,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
+"fpe" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "fpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54129,11 +54185,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"fEM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "fFv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/firealarm{
@@ -54210,16 +54261,39 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"fVS" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "fWv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"fXn" = (
-/obj/machinery/cryopod{
-	dir = 8
+"fWQ" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"fYL" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
+/area/engine/engineering)
+"fZq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -54378,6 +54452,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"glJ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "gmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -54401,6 +54481,19 @@
 "gna" = (
 /turf/open/floor/plasteel/stairs/medium,
 /area/maintenance/department/crew_quarters/dorms)
+"gnb" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "gnq" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -54437,38 +54530,16 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"gqg" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"gqo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+"gqH" = (
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"gsu" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/primary/aft)
+"gsW" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "gue" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -54484,12 +54555,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"gus" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+"guh" = (
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/plasteel/dark,
+/area/hallway/secondary/entry)
+"guq" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "gvf" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -54503,14 +54578,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/dock)
-"gvX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
 	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
+/area/chapel/dock)
 "gwn" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -54563,23 +54634,6 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"gBq" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"gDN" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "gDZ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -54599,16 +54653,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
-"gEs" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Cooling Loop"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "gFo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
@@ -54684,6 +54728,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"gJy" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "gKz" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/required/kirbyplants{
@@ -54722,10 +54773,6 @@
 	},
 /turf/closed/wall,
 /area/science/mixing)
-"gMu" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/supermatter)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
 /turf/open/floor/plating,
@@ -54751,29 +54798,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gPc" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+"gOZ" = (
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"gPR" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+/turf/open/space,
+/area/space/nearstation)
 "gPV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"gQN" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "gSH" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -54785,12 +54821,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"gTV" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "gUb" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -54802,16 +54832,6 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
-"gVZ" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "gXg" = (
 /obj/item/extinguisher,
 /obj/structure/closet/crate{
@@ -54819,16 +54839,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"gYh" = (
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
 "gYo" = (
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"hdG" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -54840,6 +54863,16 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"heL" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hfZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
@@ -54851,17 +54884,26 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"hgs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"hgf" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "hgD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/department/science)
+"hhA" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Gas"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hiw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -54882,19 +54924,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"hkC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 1;
-	name = "Cooling Loop Bypass"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+"hko" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -54907,6 +54942,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"hlX" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hnu" = (
 /obj/machinery/button/door{
 	id = "lawyer_shutters";
@@ -54920,6 +54962,13 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"hpJ" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "hqo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54935,14 +54984,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hrX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+"hrj" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -55012,6 +55057,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"hAX" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Auxillary Base Construction";
@@ -55050,6 +55102,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"hLv" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55094,13 +55150,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"hQA" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hQC" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
@@ -55129,14 +55178,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hTu" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space/nearstation)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -55168,18 +55209,6 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hXK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hYe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/red{
@@ -55194,10 +55223,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"hZx" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "hZB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55210,13 +55235,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"hZL" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
@@ -55241,6 +55259,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"ifO" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -55261,15 +55285,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"igO" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ihj" = (
 /obj/item/clothing/suit/toggle/labcoat/science,
 /turf/open/floor/plating,
@@ -55298,6 +55313,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"ijY" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ikB" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
@@ -55306,14 +55328,17 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"imN" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+"imS" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ioj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -55330,16 +55355,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"ioV" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "iqc" = (
 /turf/open/floor/plasteel/stairs/right,
 /area/maintenance/department/crew_quarters/dorms)
@@ -55347,6 +55362,17 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
+"isM" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
+"ite" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "itl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55362,6 +55388,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"itZ" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "iuM" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -55379,6 +55415,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ivD" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "iyg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55501,17 +55544,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"iLA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"iNn" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+"iOJ" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
+/area/engine/engineering)
 "iPj" = (
 /obj/machinery/igniter{
 	id = "xenoigniter";
@@ -55578,6 +55622,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"iVa" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Loop Bypass"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "iVJ" = (
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
@@ -55590,13 +55650,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"jcM" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
+"jcG" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -55628,13 +55690,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"jgQ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "jhk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55676,9 +55731,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"jlc" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
+"jkZ" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"jmk" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
 /area/engine/supermatter)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -55698,16 +55760,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"jrW" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/chapel/monastery)
 "jsf" = (
 /obj/item/toy/katana,
 /turf/open/floor/plating,
@@ -55745,28 +55797,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"jtu" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"jue" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55783,15 +55813,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
-"jvq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "jwe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55803,6 +55824,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jwU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jxl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55816,20 +55844,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"jyr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"jzb" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"jzw" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/sorting)
 "jzz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -55841,17 +55855,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"jAQ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "jBh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty{
@@ -55908,6 +55911,12 @@
 	},
 /turf/open/floor/carpet,
 /area/library/lounge)
+"jHd" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "jHP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -55920,17 +55929,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jKh" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
+"jLw" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"jKs" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "jLW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
@@ -55964,16 +55976,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"jRO" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56039,38 +56041,49 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"kdu" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
+"kaL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/lab)
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"kbw" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"kcR" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kea" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "kfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"kfp" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kfr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kfM" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -56087,12 +56100,31 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"kha" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "khk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"kjJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -56133,6 +56165,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"klM" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "klV" = (
 /obj/item/clothing/under/rank/clown/sexy,
 /turf/open/floor/plasteel/dark,
@@ -56141,6 +56182,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"knc" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -56200,6 +56250,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"kxV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kyv" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
@@ -56216,6 +56271,13 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
+/area/engine/engineering)
+"kyF" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Filter"
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "kAa" = (
 /obj/structure/chair{
@@ -56334,19 +56396,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kJn" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kJo" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56367,6 +56416,12 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"kKN" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "kNf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -56384,14 +56439,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"kNu" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "kPi" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -56406,10 +56453,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"kQj" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/quartermaster/qm)
 "kQy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -56446,6 +56489,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"kSl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hor)
 "kSF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56469,15 +56518,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
-"kVV" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kWQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -56485,6 +56525,16 @@
 	},
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"kXK" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Mix"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56526,9 +56576,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"lgk" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
+"leM" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "lhA" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
@@ -56543,15 +56597,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"liY" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "lje" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"llg" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -56580,32 +56638,26 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"lun" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
+"lsu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lva" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
-	dir = 1
+/obj/machinery/computer/cryopod{
+	dir = 1;
+	pixel_y = -26
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"lxy" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/blue{
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"lwj" = (
+/obj/machinery/cryopod{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/crew_quarters/dorms)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -56620,13 +56672,6 @@
 "lAs" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
-"lAC" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "lAR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -56652,13 +56697,6 @@
 	},
 /obj/structure/lattice,
 /obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space/nearstation)
-"lED" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/space/nearstation)
 "lFh" = (
@@ -56736,6 +56774,13 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"lLm" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lMU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -56782,16 +56827,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lTB" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/engine/supermatter)
+"lRD" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -56828,6 +56867,19 @@
 /obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"lXn" = (
+/obj/structure/table,
+/obj/item/clothing/suit/hooded/wintercoat/engineering,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56896,11 +56948,21 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"mgo" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
+"meU" = (
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"mgb" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "mhl" = (
 /obj/machinery/power/emitter,
@@ -56909,10 +56971,12 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"mlj" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
+"mjv" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -56936,30 +57000,6 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
-"mnW" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"moQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"moW" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "mpd" = (
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
@@ -56973,12 +57013,26 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"mpi" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
 /turf/open/floor/wood,
 /area/lawoffice)
+"mpD" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "mql" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -56991,6 +57045,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"mqu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57054,6 +57115,12 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"mxM" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "myu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -57085,11 +57152,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"myZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "mzl" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -57097,26 +57159,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"mzy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"mzP" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mzU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -57136,38 +57178,12 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"mEs" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"mEG" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/machinery/light,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mES" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Surgical Room"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"mFn" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -57181,17 +57197,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"mJv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"mIg" = (
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Escape";
+	dir = 4
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mIV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -57222,17 +57245,6 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
-"mNz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mQm" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -57252,6 +57264,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"mVp" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57261,6 +57279,13 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/lawoffice)
+"mZq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mZE" = (
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -57279,13 +57304,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"nei" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "nev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -57298,30 +57316,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ney" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Starboard";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "nfi" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
@@ -57334,6 +57328,13 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"nfj" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/disk/tech_disk,
+/obj/item/disk/design_disk,
+/turf/open/floor/plasteel/dark,
+/area/science/lab)
 "nfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57373,6 +57374,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"njv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "nku" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
@@ -57404,26 +57416,6 @@
 /obj/item/stack/spacecash/c10,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"nnU" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"nom" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Engine"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "noC" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/wood,
@@ -57434,10 +57426,40 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"npo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "npE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nqb" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"nqs" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nqV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57448,14 +57470,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"nrl" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nsy" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -57479,6 +57493,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"nsA" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nsD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -57565,13 +57584,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"nCb" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "nDo" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
@@ -57590,13 +57602,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"nDW" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nEb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57656,6 +57661,20 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
+"nJT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"nKS" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nLl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -57663,6 +57682,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nLC" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "nMG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -57747,6 +57773,13 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
+"nTC" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nVU" = (
 /obj/item/twohanded/spear,
 /turf/open/floor/plating,
@@ -57755,6 +57788,15 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nXI" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nYb" = (
 /obj/structure/table_frame/wood,
 /turf/open/floor/wood,
@@ -57794,14 +57836,6 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
-"ocB" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "oep" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -57814,12 +57848,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ofE" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+"ofc" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/obj/structure/lattice,
+/turf/open/space,
 /area/space/nearstation)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
@@ -57841,25 +57876,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ohg" = (
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"oix" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Gas to Filter"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
-"ojx" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom";
@@ -57870,6 +57893,22 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"omJ" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -57893,9 +57932,6 @@
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
 /area/medical/chemistry)
-"opv" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "opz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -57919,16 +57955,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"oqJ" = (
-/obj/machinery/light/small{
-	dir = 8
+"opK" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
-"ora" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/warehouse)
+/turf/open/space,
+/area/space/nearstation)
+"oqc" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -57983,16 +58024,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"owI" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "owS" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -58003,15 +58034,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"owX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"ozc" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "oAw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58033,21 +58067,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"oBw" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"oBx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
 "oCn" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -58055,12 +58074,6 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"oCs" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "oCX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -58081,6 +58094,24 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"oEt" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oEy" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "oEA" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -58134,12 +58165,24 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"oFB" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/space,
+/area/space/nearstation)
 "oFI" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"oHg" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "oKa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -58276,6 +58319,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oVG" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Cooling Loop to Gas"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oVI" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "oWw" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -58302,18 +58362,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"oYI" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "External Gas to Loop"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"oZU" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "oZW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"pae" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space,
-/area/space/nearstation)
 "pbm" = (
 /obj/machinery/door/airlock/external{
 	name = "Pod Docking Bay"
@@ -58386,16 +58456,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
-"pjV" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
@@ -58406,13 +58466,6 @@
 /obj/structure/piano,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"pmW" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
@@ -58433,12 +58486,25 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
+"ppX" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "prQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
+"pvn" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/camera{
+	c_tag = "Engineering Starboard Aft";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -58473,17 +58539,6 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"pBj" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "pBD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58534,22 +58589,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"pFH" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "pGe" = (
 /obj/structure/chair{
 	dir = 1
@@ -58566,12 +58605,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
-"pJV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hor)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -58580,14 +58613,6 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"pKi" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "pMG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -58639,12 +58664,24 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"pPC" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
+"pSH" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58677,11 +58714,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"pWS" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "pWT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
@@ -58731,25 +58763,6 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
-"pZu" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"qan" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/research_and_development,
-/obj/item/disk/tech_disk,
-/obj/item/disk/design_disk,
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
 "qar" = (
 /obj/structure/chair/office/light{
 	icon_state = "officechair_white";
@@ -58757,15 +58770,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"qbh" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -58839,35 +58843,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"qky" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qnw" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"qpc" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Gas"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"qqt" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "qtA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -58896,6 +58875,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"qvJ" = (
+/obj/effect/landmark/carpspawn,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"qxm" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	name = "Air Out"
@@ -58905,19 +58899,6 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"qyx" = (
-/obj/structure/table,
-/obj/item/clothing/suit/hooded/wintercoat/engineering,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "qyF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59039,6 +59020,13 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"qNP" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "qOE" = (
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
@@ -59089,6 +59077,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"qWb" = (
+/obj/structure/reflector/single/anchored{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "qWG" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -59172,12 +59169,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"rbd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -59185,12 +59176,6 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"reU" = (
-/obj/structure/reflector/double/anchored{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "reV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -59276,6 +59261,12 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
+"rqS" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rrb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59297,12 +59288,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"rrX" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "rse" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -59329,6 +59314,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rvl" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "rvH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -59370,6 +59364,19 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"rzd" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "10"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -59379,6 +59386,16 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"rAZ" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "rBh" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -59414,6 +59431,17 @@
 "rHA" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"rIZ" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rJg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light/small{
@@ -59480,14 +59508,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rNC" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "External Gas to Loop"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "rPg" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -59498,37 +59518,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"rSl" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"rTj" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
+"rUC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"rVh" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "rWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -59555,16 +59553,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"rZw" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "saW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
@@ -59573,17 +59561,6 @@
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/entry)
-"sbf" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Cooling Loop to Gas"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -59618,6 +59595,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"scR" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "sdk" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -59626,17 +59613,6 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
-"sen" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -59656,39 +59632,10 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"siE" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_construction,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "skw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
-"smo" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"spr" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -59708,12 +59655,6 @@
 "sqQ" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"sqY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "srZ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -59752,14 +59693,6 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"sxO" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "syn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59793,6 +59726,12 @@
 /obj/item/clothing/mask/gas/plaguedoctor,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"sAU" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "sBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59809,6 +59748,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
+"sEu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -59826,13 +59774,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"sGB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
+"sHl" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"sHX" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
 	dir = 4
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sJp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -59841,9 +59795,6 @@
 "sJr" = (
 /turf/open/floor/wood,
 /area/lawoffice)
-"sJv" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "sKa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -59857,15 +59808,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"sMb" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sNz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59873,6 +59815,12 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"sOv" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "sOC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59885,6 +59833,17 @@
 	},
 /turf/open/space/basic,
 /area/space)
+"sQp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -59895,12 +59854,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"sUe" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "sUP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -59910,15 +59863,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"sVF" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sWj" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 4
@@ -59999,16 +59943,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"tdf" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Mix"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tdp" = (
 /obj/structure/rack,
 /obj/item/stack/packageWrap,
@@ -60032,6 +59966,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"tdt" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tdB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
@@ -60089,6 +60030,13 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"tjv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -60170,6 +60118,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"twk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "twv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -60182,6 +60136,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"twG" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "typ" = (
 /obj/structure/table/glass,
 /obj/item/hemostat,
@@ -60189,53 +60156,33 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"tyu" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tyL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"tzc" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = 24;
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/stripes/line{
+"tzC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"tzR" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"tAJ" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tzI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tAK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -60249,10 +60196,24 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"tCY" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tDn" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"tDR" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "tHk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60268,26 +60229,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"tMG" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"tOw" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tRc" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
+"tRS" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "tSL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -60297,6 +60249,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"tVM" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -60314,6 +60273,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"tYR" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "uaa" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -60340,10 +60304,18 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"uaY" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/sorting)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"ucV" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/warehouse)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60391,28 +60363,12 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"ugS" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"uje" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ujI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -60426,22 +60382,6 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/engine)
-"ukC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ulg" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
@@ -60474,13 +60414,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"umf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "uoj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -60511,16 +60444,24 @@
 "uoS" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"uqd" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"uqL" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "urP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -60584,13 +60525,6 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"uwJ" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -60608,13 +60542,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
-"uzu" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Filter"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "uAL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
@@ -60653,6 +60580,19 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"uGJ" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "uHG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60665,6 +60605,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uLD" = (
+/obj/structure/reflector/double/anchored{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60701,14 +60647,6 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uPS" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/camera{
-	c_tag = "Engineering Starboard Aft";
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -60721,6 +60659,10 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
+/area/engine/engineering)
+"uTl" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -60748,17 +60690,6 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"uWI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "uXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60787,13 +60718,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"vaH" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vbQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -60836,19 +60760,14 @@
 /obj/structure/chair,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"vhF" = (
-/obj/effect/landmark/carpspawn,
+"viX" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"vil" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/space,
+/area/space/nearstation)
 "vjd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60892,13 +60811,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"voA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "vpz" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -60906,6 +60818,12 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
+"vrd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61012,6 +60930,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"vEk" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "vGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -61034,13 +60956,6 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"vKO" = (
-/obj/machinery/computer/cryopod{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -61064,10 +60979,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
-"vPL" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "vRi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61136,13 +61047,24 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"vTZ" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+"vVo" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
+"vVq" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"vWA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -61170,6 +61092,20 @@
 	dir = 6
 	},
 /obj/machinery/meter,
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
+"wdJ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29"
+	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "weL" = (
@@ -61215,13 +61151,6 @@
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wko" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wkZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -61274,13 +61203,6 @@
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"wqq" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "wqu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -61295,6 +61217,19 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"wtF" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wun" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -61307,6 +61242,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wuo" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall,
+/area/quartermaster/qm)
+"wuB" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -61348,20 +61296,20 @@
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"wzA" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "wAI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"wAX" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "Gas to Filter"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "wBb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61380,19 +61328,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
-"wBQ" = (
-/obj/structure/reflector/single/anchored{
-	dir = 6
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wDm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"wDp" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "wDZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -61414,12 +61361,14 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"wFy" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"wEY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 4;
+	network = list("ss13","engine")
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wFT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61439,6 +61388,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wJu" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wJP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -61461,6 +61420,14 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
+"wMo" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/lab)
 "wMF" = (
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -61595,15 +61562,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wVS" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -61663,6 +61621,20 @@
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"xcC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"xdH" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xee" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -61697,12 +61669,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"xif" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -61754,21 +61720,25 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"xlV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xlY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/chapel/monastery)
-"xmm" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/turf/open/floor/plasteel,
-/area/science/lab)
 "xmp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -61819,16 +61789,13 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
-"xtN" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway Escape";
+"xua" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xuv" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
@@ -61843,19 +61810,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xwf" = (
-/obj/structure/chair/office/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2
@@ -61892,6 +61846,14 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"xxW" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "xyl" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
@@ -61933,6 +61895,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"xEz" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"xEW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
@@ -61946,19 +61924,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"xGO" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -61991,6 +61956,19 @@
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"xKS" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"xKU" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -62015,6 +61993,24 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/space/basic,
 /area/space/nearstation)
+"xOi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"xOs" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone";
@@ -62057,13 +62053,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"xVA" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "xWl" = (
 /obj/item/pen,
 /obj/item/paper_bin{
@@ -62075,20 +62064,23 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"xXd" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "xXh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
-"ybc" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "ybX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -62118,6 +62110,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"ygN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ygZ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -62126,6 +62125,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"ylD" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ymb" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
@@ -79010,7 +79022,7 @@ bQf
 bQf
 bQf
 bWW
-oBx
+twk
 bZn
 bZn
 bZn
@@ -80279,7 +80291,7 @@ aaa
 aaa
 bGI
 bGE
-bLn
+bKf
 gvO
 bMw
 bNy
@@ -80793,8 +80805,8 @@ aaa
 aaa
 bGI
 bGE
-kNu
-uWI
+xxW
+xEW
 bHM
 bNA
 bHM
@@ -81048,13 +81060,13 @@ bVp
 bVp
 bVp
 bVp
-dML
+dLA
 aZx
-dbw
+guh
 kYR
 aZx
 bNB
-tMG
+ofc
 abI
 aby
 abI
@@ -81307,7 +81319,7 @@ aZx
 aZx
 aZx
 aZx
-dbw
+guh
 kYR
 aZx
 amC
@@ -81316,8 +81328,8 @@ aht
 aby
 aby
 abI
-pae
-hTu
+gOZ
+oFB
 cqS
 bNs
 bQe
@@ -81564,7 +81576,7 @@ iHI
 hWa
 wwK
 wwK
-dbw
+guh
 wmA
 aZx
 amB
@@ -81575,7 +81587,7 @@ aaa
 abI
 abI
 abI
-hTu
+oFB
 bNs
 bNs
 bNs
@@ -81603,7 +81615,7 @@ chr
 chL
 cfm
 cfN
-mlj
+lRD
 cfN
 cfN
 cfN
@@ -83022,7 +83034,7 @@ aeU
 afo
 afG
 aeU
-vKO
+lva
 agy
 agL
 agZ
@@ -83536,7 +83548,7 @@ lGp
 aeU
 afI
 aeU
-sUe
+ifO
 agy
 agN
 agY
@@ -83650,7 +83662,7 @@ cwA
 cwA
 cwA
 cwA
-oqJ
+kKN
 cwA
 cwA
 cwA
@@ -83660,7 +83672,7 @@ uaa
 uaa
 uBu
 xlY
-jrW
+rAZ
 cjm
 aht
 aaa
@@ -84161,7 +84173,7 @@ bNK
 bva
 bva
 irs
-vhF
+qvJ
 dRs
 dRs
 aht
@@ -84433,7 +84445,7 @@ dRs
 dRs
 irs
 irs
-mFn
+ejC
 aaa
 aaa
 aaa
@@ -89297,7 +89309,7 @@ bpL
 fQf
 cbW
 cbd
-vil
+wDp
 cri
 cbX
 cbX
@@ -90835,9 +90847,9 @@ bXh
 bXZ
 bYK
 bZz
-gsu
+cRD
 cbd
-nrl
+oZU
 cam
 cdM
 bXq
@@ -90847,8 +90859,8 @@ cfQ
 bXk
 qWG
 bXk
-xif
-lva
+vrd
+mVp
 cdm
 aaa
 aht
@@ -91100,22 +91112,22 @@ qtO
 bXk
 bXk
 bXk
-sqY
-iLA
-iLA
-iLA
-ddh
-dNR
-dNR
+bWm
+nJT
+nJT
+nJT
+ivD
+cEJ
+cEJ
 bXk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
+isM
+isM
+isM
+isM
+isM
+isM
+isM
+isM
 fon
 fon
 mau
@@ -91354,16 +91366,16 @@ cbf
 ccb
 cah
 cdO
-sxO
+fYL
 ceX
-mEs
+tYR
 cfS
 fFv
-wzA
-jvq
-fhf
-vTZ
-vTZ
+mIV
+wEY
+sOv
+dZk
+dZk
 bXk
 aaa
 aht
@@ -91616,10 +91628,10 @@ mwG
 nAs
 cfT
 wcs
-jKh
+fVS
 qbp
 qbp
-flN
+tRS
 dMG
 bXk
 aaa
@@ -91863,14 +91875,14 @@ bXk
 bYc
 bYO
 bZA
-ewH
+guq
 cbh
 cbh
 cbh
 cbh
 cbh
-gqo
-gQN
+sQp
+xdH
 cfU
 tIS
 iCs
@@ -92120,21 +92132,21 @@ bXk
 bYd
 bYP
 bZF
-hgs
-fEM
-mNz
-vaH
-vaH
+tjv
+rUC
+kjJ
+xcC
+xcC
 qFu
 cet
 ulY
 cfV
 cgu
 cgU
-liY
+ppX
 chw
-dNR
-jAQ
+cEJ
+dkD
 bXk
 bXk
 bXk
@@ -92380,26 +92392,26 @@ bZA
 can
 cbi
 ccc
-dNR
+cEJ
 cdR
-hZL
+hAX
 bXk
 bXk
-mzy
+npo
 cgv
-tdf
+kXK
 cgv
 uaP
 cgv
-qpc
+hhA
 cgV
 cgv
 cgv
-tOw
+mpD
 bXk
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -92636,27 +92648,27 @@ bYR
 bZA
 can
 cbj
-dNR
+cEJ
 cbX
 wcs
 iyJ
 cfa
-dNR
+cEJ
 twv
-cxN
+xXd
 sWj
 dnS
-dSc
-rTj
-kJn
-hQA
-hQA
+twG
+fpe
+wtF
+xua
+xua
 uRk
 ciG
 bXk
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -92892,7 +92904,7 @@ bYf
 bYS
 bZA
 can
-jue
+tdt
 ccd
 ccX
 ccX
@@ -92900,20 +92912,20 @@ ceu
 cbX
 cfu
 tlN
-lun
+qxm
 cCI
 uoq
-mJv
+njv
 chA
 meF
-mnW
-rNC
-nDW
+mjv
+oYI
+eiG
 hQC
 bXk
 aht
 fon
-lgk
+isM
 fon
 aht
 aaa
@@ -93150,27 +93162,27 @@ bYT
 bZB
 caq
 cbk
-dNR
+cEJ
 ccY
 cdT
 ccY
 cbX
-dNR
-sVF
-tzR
-sJv
+cEJ
+knc
+fjE
+cQC
 fyO
 fyO
 fyO
-sJv
-mnW
-rNC
-dJO
+cQC
+mjv
+oYI
+mpi
 hQC
 bXk
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -93406,28 +93418,28 @@ bYh
 bYU
 bZE
 car
-voA
-dNR
+kaL
+cEJ
 cbX
 wcs
 wcs
 cfd
 bXk
 tlN
-lun
-fjT
+qxm
+oHg
 mpd
-cpE
-cpE
+gnb
+gnb
 cit
-sJv
-qnw
-tyu
+cQC
+hLv
+xlV
 hQC
 bXk
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -93628,7 +93640,7 @@ bkh
 bkh
 boN
 bpW
-xwf
+uGJ
 bsM
 bum
 bvt
@@ -93669,22 +93681,22 @@ cda
 wcs
 wcs
 wcs
-dNR
-kVV
-ioV
-sJv
-rSl
-rSl
-rSl
+cEJ
+wuB
+tCY
+cQC
+diq
+diq
+diq
 cgY
 ciI
-hZx
-tzc
+tDR
+rzd
 hQC
 bXk
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -93865,7 +93877,7 @@ aSS
 aUg
 aVf
 aWi
-eiw
+cbH
 aYe
 aZb
 bag
@@ -93918,30 +93930,30 @@ bWz
 bVN
 bYf
 bYW
-hrX
+vVo
 cam
-mEG
+eeB
 ckJ
 cey
 cdW
 wcs
 cdW
-dNR
-umf
-rZw
-gMu
-opv
-vPL
-opv
-lTB
-jlc
-rVh
-uzu
+cEJ
+xOi
+eFK
+jmk
+ohg
+vEk
+ohg
+itZ
+hrj
+cDm
+kyF
 hQC
 bXk
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -94150,7 +94162,7 @@ bwW
 bpY
 bpY
 bpY
-fjr
+wdJ
 bva
 bva
 bva
@@ -94177,28 +94189,28 @@ bUT
 bYX
 bZA
 cam
-qyx
+lXn
 bXk
-wBQ
+qWb
 wcs
 wcs
-reU
-dNR
-smo
-gqg
-sJv
+uLD
+cEJ
+jcG
+eeY
+cQC
 prQ
 prQ
 prQ
-nei
-oix
-jzb
+nLC
+wAX
+gsW
 dZj
 hQC
 bXk
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -94398,17 +94410,17 @@ bls
 aBI
 aBI
 bmB
-lxy
-qqt
-xtN
-cHb
+cjz
+gqH
+mIg
+dcp
 bvu
-ukC
-qbh
-xGO
-moQ
-ulg
-gDN
+tzC
+cUO
+ylD
+kcR
+lLm
+scR
 xDj
 blt
 jCv
@@ -94434,28 +94446,28 @@ bYj
 bYM
 bZA
 cam
-voA
-dNR
+kaL
+cEJ
 cbX
 wcs
 wcs
-gus
+eCn
 bXk
 tlN
-lun
-qnw
+qxm
+hLv
 fyF
 cZt
 cZt
-hdG
-sJv
-gPR
-nnU
+glJ
+cQC
+vVq
+uqd
 hQC
 bXk
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -94663,11 +94675,11 @@ gkS
 tTl
 tTl
 tTl
-oCs
+rqS
 dgg
 phJ
 phJ
-eNo
+eav
 bAk
 bIt
 bJB
@@ -94691,28 +94703,28 @@ bYk
 bYQ
 bZF
 cbm
-voA
-dNR
-jRO
-jRO
+kaL
+cEJ
+wJu
+wJu
 eWi
 cbX
-dNR
-sVF
+cEJ
+knc
 cgx
-sJv
+cQC
 fyO
 fyO
 fyO
-sJv
+cQC
 cBS
 cjt
-igO
+hko
 hQC
 bXk
 aaa
 fon
-lgk
+isM
 fon
 aht
 aaa
@@ -94912,19 +94924,19 @@ blu
 aDZ
 aDZ
 bjm
-kfp
+rIZ
 cqi
 cqi
 cqi
 cqi
 cqi
-uwJ
-ybc
-rbd
+ijY
+nKS
+vWA
 fdQ
 bmD
 bmD
-qky
+kxV
 bAl
 bIu
 bJC
@@ -94948,28 +94960,28 @@ bYl
 bYO
 bZA
 cam
-gBq
+nTC
 ccd
-oBw
-oBw
-gPc
+rvl
+rvl
+meU
 cbX
 cfu
 jBn
-pmW
+dYd
 meF
 chA
 chA
 woh
 cCI
 cBS
-eML
+fin
 liR
 hQC
 bXk
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -95172,18 +95184,18 @@ bKM
 cCl
 cCl
 cCl
-xmm
-kdu
-kdu
+gYh
+wMo
+wMo
 byD
 bAm
 dhz
-ney
+cRR
 bDA
 bEQ
 bGa
 bHg
-owI
+heL
 bJD
 bBo
 bBo
@@ -95206,27 +95218,27 @@ bYY
 bZA
 cam
 cbn
-dNR
+cEJ
 cbX
 wcs
 cfP
 cff
-dNR
+cEJ
 cfX
-gVZ
-pFH
+nqs
+omJ
 kWQ
-hkC
-cLh
-spr
-wFy
-wFy
-wVS
+iVa
+kbw
+imS
+eFg
+eFg
+nXI
 hQC
 bXk
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -95431,10 +95443,10 @@ brp
 gFo
 cSK
 duF
-qan
+nfj
 byE
 bBp
-pJV
+kSl
 bBp
 bBp
 bBp
@@ -95464,22 +95476,22 @@ bZG
 cax
 cbo
 ccc
-dNR
+cEJ
 cdR
-wko
+leM
 bXq
 bXq
 cfY
-sGB
-sbf
-sGB
-sMb
-gEs
+jwU
+oVG
+jwU
+sEu
+mgb
 civ
 civ
-sen
-pjV
-jyr
+oEt
+fWQ
+xKS
 bXk
 aht
 fon
@@ -95721,19 +95733,19 @@ bZF
 cal
 cbp
 cci
-kfr
-kfr
-uje
-pBj
-gvX
-nCb
-dNR
-jKs
-dNR
-dNR
-jKs
-dNR
-dNR
+ygN
+ygN
+llg
+xOs
+oVI
+eAj
+cEJ
+hgf
+cEJ
+cEJ
+hgf
+cEJ
+cEJ
 bXk
 bXk
 bXk
@@ -95973,24 +95985,24 @@ bVU
 bWG
 bXq
 bYo
-ojx
+hlX
 bZI
-ojx
+hlX
 cbq
 cbd
 cam
 cam
 cam
-pZu
-jgQ
-xVA
-pWS
-lED
-xVA
-tAJ
-evB
-pWS
-tAJ
+iOJ
+xKU
+tVM
+fZq
+kea
+tVM
+pPC
+lsu
+fZq
+pPC
 cdm
 aaa
 aaa
@@ -96231,23 +96243,23 @@ bWH
 bXk
 bTE
 bZc
-siE
+klM
 cCU
 bZJ
-uPS
+pvn
 cCV
 ceb
-uqL
-jtu
-jgQ
-mzP
-xVA
-ofE
-mzP
-mzP
-jcM
-tAJ
-mzP
+nsA
+jLw
+xKU
+sHX
+tVM
+nqb
+sHX
+sHX
+mqu
+pPC
+sHX
 cdm
 aaa
 aaa
@@ -96487,29 +96499,29 @@ bJN
 bJN
 bJN
 bJN
-gvX
-dnW
-dnW
-dnW
-dnW
-dnW
-dnW
-dnW
-dnW
-mgo
-wqq
-cVO
-imN
-cVO
-cVO
-imN
-cVO
-cVO
-ofE
+oVI
+uTl
+uTl
+uTl
+uTl
+uTl
+uTl
+uTl
+uTl
+mxM
+mZq
+owX
+kha
+owX
+owX
+kha
+owX
+owX
+nqb
 aht
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -96744,7 +96756,7 @@ bVV
 bWI
 bXr
 bKQ
-ocB
+ite
 bZK
 abI
 abI
@@ -96753,20 +96765,20 @@ abI
 aaa
 aaa
 aaa
-jcM
-pWS
-cVO
-imN
-cVO
-cVO
-imN
-cVO
-cVO
-lED
+mqu
+fZq
+owX
+kha
+owX
+owX
+kha
+owX
+owX
+kea
 aaa
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -97001,7 +97013,7 @@ bQI
 bWJ
 bXs
 bJN
-moW
+qNP
 bJP
 bJP
 bJP
@@ -97010,20 +97022,20 @@ bJP
 abI
 abI
 aht
-evB
-pWS
-cVO
-imN
-cVO
-cVO
-imN
-cVO
-cVO
-ofE
+lsu
+fZq
+owX
+kha
+owX
+owX
+kha
+owX
+owX
+nqb
 aht
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -97238,7 +97250,7 @@ bCK
 bDG
 bEW
 bAt
-hXK
+tzI
 cqw
 cqD
 bKO
@@ -97258,7 +97270,7 @@ bMf
 fuR
 bXt
 bYp
-pKi
+viX
 bZL
 caz
 cbs
@@ -97267,20 +97279,20 @@ bJP
 aaa
 aaa
 aaa
-jcM
-pWS
-cVO
-imN
-cVO
-cVO
-imN
-cVO
-cVO
-lED
+mqu
+fZq
+owX
+kha
+owX
+owX
+kha
+owX
+owX
+kea
 aaa
 aaa
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -97515,7 +97527,7 @@ bVW
 bWL
 bXu
 bLW
-moW
+qNP
 bMi
 caA
 cbt
@@ -97524,20 +97536,20 @@ bJP
 aaa
 aaa
 aaa
-evB
-ozc
-lED
-evB
-lED
-evB
-lED
-evB
-lED
+lsu
+xEz
+kea
+lsu
+kea
+lsu
+kea
+lsu
+kea
 cdm
 aht
 aht
 fon
-lgk
+isM
 fon
 aaa
 aaa
@@ -97772,7 +97784,7 @@ bVX
 bWM
 bXv
 bWc
-cVw
+opK
 bZL
 caB
 cbs
@@ -98024,12 +98036,12 @@ bQI
 bQI
 bTM
 bUs
-gTV
-iNn
-ugS
+sAU
+jkZ
+oqc
 bXw
-myZ
-feL
+pSH
+oEy
 bJP
 bJP
 bJP
@@ -98281,7 +98293,7 @@ bMf
 bMf
 bTN
 bUt
-dZs
+jHd
 bOk
 bWK
 bXt
@@ -98537,8 +98549,8 @@ bRx
 bQJ
 bPQ
 bTO
-gTV
-rrX
+sAU
+sHl
 bOk
 bWL
 bXx
@@ -98552,21 +98564,21 @@ bJP
 aaa
 aaa
 fon
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
-lgk
+isM
+isM
+isM
+isM
+isM
+isM
+isM
+isM
+isM
+isM
 fon
 aaa
 aht
-lgk
-lgk
+isM
+isM
 fon
 aaa
 aaa
@@ -98794,7 +98806,7 @@ bPQ
 bPQ
 bPQ
 bTP
-dZs
+jHd
 bVh
 bVY
 bWM
@@ -98822,7 +98834,7 @@ fon
 fon
 aaa
 aht
-lgk
+isM
 fon
 fon
 aaa
@@ -99051,7 +99063,7 @@ bQK
 bQK
 bPQ
 bTQ
-dZs
+jHd
 bKX
 bOk
 bWN
@@ -99308,7 +99320,7 @@ bRy
 bSf
 bSR
 bTM
-dZs
+jHd
 bKX
 bVZ
 bWO
@@ -99565,7 +99577,7 @@ bRz
 bMf
 bSS
 bTR
-nom
+hpJ
 bKX
 bWa
 bMf
@@ -100022,7 +100034,7 @@ aHn
 aIi
 aJi
 aKe
-jzw
+uaY
 aMi
 aNJ
 fwl
@@ -101060,7 +101072,7 @@ lAs
 eeQ
 aUs
 aLf
-dWF
+dwM
 aLf
 aLf
 aUl
@@ -101584,7 +101596,7 @@ bcA
 bdF
 beJ
 bfB
-kQj
+wuo
 aZv
 aUC
 biz
@@ -102321,7 +102333,7 @@ apX
 apX
 avl
 fIu
-fXn
+lwj
 aIh
 azA
 dbi
@@ -102855,7 +102867,7 @@ aNP
 aPb
 aNO
 aNP
-ora
+ucV
 aTq
 aSk
 aTm
@@ -107991,7 +108003,7 @@ aaa
 aLm
 aLm
 aNU
-lAC
+gJy
 dqY
 aRv
 sZh
@@ -108248,7 +108260,7 @@ aaa
 aLm
 aME
 aNV
-lAC
+gJy
 dqY
 aRw
 sqQ
@@ -108505,7 +108517,7 @@ aaa
 aLo
 aMF
 aNW
-lAC
+gJy
 cvf
 aQn
 sqQ
@@ -108762,7 +108774,7 @@ aaa
 aLo
 aMG
 aNX
-lAC
+gJy
 rax
 aRy
 aSn

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -17,6 +17,13 @@
 /obj/structure/grille,
 /turf/open/space,
 /area/space/nearstation)
+"abD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "abI" = (
 /obj/structure/lattice,
 /turf/open/space,
@@ -14549,6 +14556,18 @@
 	},
 /turf/open/space,
 /area/solar/port)
+"aIA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "aIC" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -24179,6 +24198,17 @@
 /obj/item/caution,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"beT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "beU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -37478,6 +37508,7 @@
 	dir = 8;
 	layer = 2.9
 	},
+/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bHP" = (
@@ -44057,12 +44088,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"bWm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "bWn" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/structure/extinguisher_cabinet{
@@ -46221,10 +46246,6 @@
 	},
 /turf/open/floor/plating,
 /area/chapel/office)
-"cbH" = (
-/obj/machinery/jukebox,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
 "cbK" = (
 /obj/structure/chair/wood/normal{
 	dir = 1
@@ -46437,13 +46458,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"ccL" = (
-/obj/item/flashlight/lantern{
-	icon_state = "lantern-on"
-	},
-/obj/effect/turf_decal/sand,
-/turf/open/floor/plasteel,
-/area/chapel/asteroid/monastery)
 "ccM" = (
 /obj/structure/chair,
 /turf/open/floor/plating/asteroid,
@@ -46845,6 +46859,15 @@
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
+"cep" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ceq" = (
 /obj/machinery/power/emitter,
 /turf/open/floor/plating,
@@ -47389,6 +47412,13 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"cgt" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
@@ -48087,16 +48117,6 @@
 "cjx" = (
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
-"cjz" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cjB" = (
 /obj/docking_port/stationary{
 	dir = 8;
@@ -51542,15 +51562,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"cvM" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
 "cvR" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -51848,6 +51859,22 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"cxj" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/machinery/light,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cxk" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -52393,6 +52420,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"cAp" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cAr" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -52824,26 +52857,11 @@
 "cDa" = (
 /turf/closed/wall,
 /area/quartermaster/warehouse)
-"cDm" = (
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "cDB" = (
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"cEJ" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cFB" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
@@ -52883,6 +52901,13 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"cOA" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cPy" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2
@@ -52917,43 +52942,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"cQC" = (
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "cQZ" = (
 /obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"cRD" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cRR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/chair{
-	dir = 8;
-	name = "Defense"
-	},
-/obj/machinery/camera{
-	c_tag = "Atmospherics Starboard";
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+"cRJ" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/warehouse)
 "cSJ" = (
 /obj/item/reagent_containers/glass/beaker/cryoxadone{
 	pixel_x = -2;
@@ -53009,15 +53005,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
-"cUO" = (
-/obj/structure/sign/poster/official/random{
-	pixel_x = -32
+"cUT" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cXW" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53053,15 +53049,6 @@
 /obj/item/clothing/ears/earmuffs,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"dcp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dcL" = (
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
@@ -53100,6 +53087,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"dhu" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dhz" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -53119,29 +53113,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"diq" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"dkD" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Supermatter Engine";
-	req_access_txt = "10"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "dkR" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -53161,6 +53138,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"dlI" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dmP" = (
 /obj/structure/chair{
 	dir = 8
@@ -53307,10 +53290,6 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"dwM" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/office)
 "dxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53346,6 +53325,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/chapel/monastery)
+"dAa" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "dAF" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -53360,6 +53347,30 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/engine)
+"dFF" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"dGd" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dGp" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"dHF" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dJm" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -53380,13 +53391,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"dLA" = (
-/obj/structure/window/reinforced,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "dLY" = (
 /obj/structure/table,
 /obj/item/assembly/igniter,
@@ -53426,6 +53430,13 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dPZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "dRs" = (
 /obj/structure/lattice,
 /obj/structure/grille,
@@ -53441,6 +53452,25 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"dUk" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"dVt" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "dVI" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 4;
@@ -53471,13 +53501,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"dYd" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "dZj" = (
 /obj/machinery/atmospherics/pipe/manifold/green/visible,
 /obj/machinery/airalarm/engine{
@@ -53488,19 +53511,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"dZk" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 4
-	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"eav" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "eaw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -53527,22 +53537,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"eeB" = (
-/obj/structure/table,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/item/pipe_dispenser,
-/obj/machinery/light,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "eeQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -53553,21 +53547,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"eeY" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 1;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "efu" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/scientist,
@@ -53593,18 +53572,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"eiG" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"ejC" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -53630,6 +53597,20 @@
 	icon_state = "wood-broken"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"eqM" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"erV" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "eta" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -53648,6 +53629,40 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"eue" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"eux" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"euN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "euQ" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
@@ -53657,6 +53672,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"eyT" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
+"ezo" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "ezF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -53672,13 +53701,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"eAj" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "eAp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -53695,13 +53717,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"eCn" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "eCw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -53734,29 +53749,12 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"eFg" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "eFj" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"eFK" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "eHI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -53781,6 +53779,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"eMz" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "eMC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -53800,6 +53809,15 @@
 /obj/structure/lattice,
 /turf/closed/wall,
 /area/space/nearstation)
+"eOA" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "eOZ" = (
 /obj/structure/closet,
 /obj/item/clothing/suit/judgerobe,
@@ -53807,6 +53825,19 @@
 /obj/item/gavelhammer,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ePS" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ePU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53888,6 +53919,12 @@
 /obj/item/stack/cable_coil/cut/random,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"fbu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "fdQ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53959,13 +53996,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
-"fin" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "fjs" = (
 /obj/machinery/light{
 	dir = 8
@@ -53979,14 +54009,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"fjE" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "fkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -53999,9 +54021,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"flP" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"fml" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "fmU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -54033,16 +54067,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
-"fpe" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "fpT" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -54193,6 +54217,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"fGt" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -54261,39 +54293,13 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"fVS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fWv" = (
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"fWQ" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
+"fWE" = (
 /turf/open/floor/engine,
-/area/engine/engineering)
-"fYL" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"fZq" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/area/engine/supermatter)
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -54306,6 +54312,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
+"gaJ" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall,
+/area/quartermaster/qm)
+"gaQ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gcj" = (
 /obj/machinery/vending/kink,
 /obj/effect/turf_decal/tile/blue{
@@ -54353,6 +54371,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"gfh" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gfi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -54362,6 +54387,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gih" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "giI" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -54405,6 +54443,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gkN" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gkR" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/structure/extinguisher_cabinet{
@@ -54452,12 +54496,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"glJ" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "gmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -54481,19 +54519,6 @@
 "gna" = (
 /turf/open/floor/plasteel/stairs/medium,
 /area/maintenance/department/crew_quarters/dorms)
-"gnb" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "gnq" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -54530,16 +54555,6 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
-"gqH" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gsW" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "gue" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -54555,17 +54570,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"guh" = (
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/hallway/secondary/entry)
-"guq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "gvf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -54696,6 +54700,29 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/medical/chemistry)
+"gHp" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"gHy" = (
+/obj/machinery/computer/cryopod{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "gHZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -54728,13 +54755,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"gJy" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
 "gKz" = (
 /obj/structure/table/wood,
 /obj/item/twohanded/required/kirbyplants{
@@ -54753,6 +54773,13 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gLn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "gLF" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/tile/neutral{
@@ -54798,12 +54825,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"gOZ" = (
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space,
-/area/space/nearstation)
 "gPV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -54827,6 +54848,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gUS" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gVc" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken4"
@@ -54839,15 +54875,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"gYh" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/turf/open/floor/plasteel,
-/area/science/lab)
 "gYo" = (
 /obj/structure/grille,
 /turf/open/space/basic,
@@ -54863,16 +54890,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
-"heL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hfZ" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/machinery/requests_console{
@@ -54884,26 +54901,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"hgf" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "hgD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/maintenance/department/science)
-"hhA" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 4;
-	name = "Mix to Gas"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hiw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -54924,15 +54925,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"hko" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "hkQ" = (
 /obj/machinery/light{
 	dir = 4
@@ -54942,13 +54934,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"hlX" = (
-/obj/structure/chair/office/dark{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "hnu" = (
 /obj/machinery/button/door{
 	id = "lawyer_shutters";
@@ -54962,13 +54947,6 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"hpJ" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Mix to Engine"
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "hqo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -54984,10 +54962,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"hrj" = (
-/obj/effect/decal/cleanable/dirt,
+"hrx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
 /turf/open/floor/engine,
-/area/engine/supermatter)
+/area/engine/engineering)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -55023,6 +55004,13 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"hxh" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hxn" = (
 /obj/structure/chair,
 /obj/item/clothing/glasses/regular,
@@ -55057,12 +55045,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
-"hAX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"hCg" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
 	},
 /turf/open/floor/plating,
+/area/maintenance/disposal)
+"hDy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "hDG" = (
 /obj/machinery/door/airlock/engineering{
@@ -55102,10 +55098,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"hLv" = (
-/obj/structure/sign/warning/fire,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
+"hJO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "hOx" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -55154,6 +55154,14 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/engine/engineering)
+"hRQ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -55178,6 +55186,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hUf" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"hUi" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -55205,6 +55224,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"hXm" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hXt" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -55259,12 +55287,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
-"ifO" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "igE" = (
 /obj/structure/table/reinforced,
 /obj/machinery/button/door{
@@ -55313,13 +55335,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
-"ijY" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
+"ikm" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Gas"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ikB" = (
 /obj/structure/closet/secure_closet/medical2,
 /turf/open/floor/plating,
@@ -55328,17 +55353,6 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"imS" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "ioj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -55362,17 +55376,6 @@
 /obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
-"isM" = (
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
-"ite" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "itl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -55388,16 +55391,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"itZ" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/door/airlock/engineering/glass/critical{
-	heat_proof = 1;
-	name = "Supermatter Chamber";
-	req_access_txt = "10"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "iuM" = (
 /obj/machinery/door/window/southleft{
 	dir = 8;
@@ -55415,13 +55408,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ivD" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "iyg" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55520,6 +55506,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
+"iHe" = (
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Escape";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "iHI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
@@ -55544,18 +55540,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"iOJ" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/clothing/glasses/welding,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "iPj" = (
 /obj/machinery/igniter{
 	id = "xenoigniter";
@@ -55610,19 +55594,7 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iSz" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/security/brig)
-"iVa" = (
+"iSi" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "Cooling Loop Bypass"
@@ -55638,6 +55610,27 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"iSz" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/security/brig)
+"iSL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
+"iTE" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "iVJ" = (
 /obj/effect/spawner/lootdrop/organ_spawner,
 /turf/open/floor/plating{
@@ -55650,15 +55643,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"jcG" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -55712,6 +55696,16 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/crew_quarters/dorms)
+"jjA" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jjC" = (
 /obj/structure/rack,
 /obj/item/storage/briefcase{
@@ -55731,17 +55725,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"jkZ" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
+"jrb" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
-/area/engine/atmos)
-"jmk" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/area/hallway/primary/aft)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -55797,6 +55785,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jtv" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -55824,13 +55823,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"jwU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "jxl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -55911,12 +55903,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library/lounge)
-"jHd" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "jHP" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka{
@@ -55929,34 +55915,43 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"jLw" = (
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/cable_coil,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "jLW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"jOw" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jOB" = (
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
+"jOX" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "jPf" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/kitchen/knife,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"jPC" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -55966,6 +55961,15 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/science)
+"jQn" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jRG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -55976,6 +55980,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"jTc" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Filter"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -56041,43 +56052,17 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
-"kaL" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"kbw" = (
-/obj/machinery/atmospherics/pipe/manifold/green/visible{
-	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+"kec" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kcR" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kea" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 9
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "kfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -56100,31 +56085,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"kha" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "khk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"kjJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "kjK" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "MiniSat Maintenance";
@@ -56165,15 +56131,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"klM" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_construction,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "klV" = (
 /obj/item/clothing/under/rank/clown/sexy,
 /turf/open/floor/plasteel/dark,
@@ -56182,15 +56139,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"knc" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -56210,6 +56158,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ksC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "kvj" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -56223,6 +56177,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"kvu" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"kvx" = (
+/obj/machinery/light,
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "kwm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -56250,11 +56218,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"kxV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "kyv" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/stripes/line{
@@ -56272,13 +56235,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"kyF" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Filter"
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
@@ -56295,12 +56251,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"kBe" = (
+/obj/structure/reflector/double/anchored{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "kDf" = (
 /obj/machinery/light/small{
 	dir = 2
 	},
 /turf/open/floor/carpet/black,
 /area/chapel/office)
+"kDI" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "kDJ" = (
 /obj/machinery/light{
 	dir = 8
@@ -56416,12 +56382,6 @@
 /obj/structure/closet,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"kKN" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
 "kNf" = (
 /obj/machinery/door/window/northleft{
 	base_state = "right";
@@ -56439,6 +56399,11 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kNK" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "kPi" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -56489,12 +56454,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"kSl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/hor)
 "kSF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -56518,6 +56477,10 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
+"kVA" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/sorting)
 "kWQ" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/structure/cable/yellow{
@@ -56531,20 +56494,11 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"kXK" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 8;
-	name = "Gas to Mix"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "kYR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/light,
 /turf/open/floor/plasteel/white{
 	heat_capacity = 1e+006
 	},
@@ -56576,13 +56530,10 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"leM" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+"lfZ" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/office)
 "lhA" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
@@ -56601,21 +56552,30 @@
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"llg" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
+"llS" = (
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hallway/secondary/entry)
 "lms" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"lmv" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lnn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral,
@@ -56629,6 +56589,12 @@
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"lqo" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "lqy" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -56638,26 +56604,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"lsu" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
+"lxh" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
+/turf/open/space,
 /area/space/nearstation)
-"lva" = (
-/obj/machinery/computer/cryopod{
-	dir = 1;
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"lwj" = (
-/obj/machinery/cryopod{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -56691,6 +56644,24 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"lCR" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"lCY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lDW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "lEn" = (
 /obj/structure/window/reinforced{
 	dir = 1
@@ -56774,13 +56745,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"lLm" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "lMU" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -56802,6 +56766,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"lQy" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "lQQ" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgespace";
@@ -56827,10 +56798,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lRD" = (
-/obj/machinery/light/small,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -56867,19 +56834,6 @@
 /obj/item/clothing/head/beret,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"lXn" = (
-/obj/structure/table,
-/obj/item/clothing/suit/hooded/wintercoat/engineering,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/item/clothing/glasses/meson,
-/obj/effect/turf_decal/delivery,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "mal" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -56920,6 +56874,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"mbD" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "mcf" = (
 /obj/structure/table/glass,
 /obj/machinery/reagentgrinder,
@@ -56932,6 +56892,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
+"mdi" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/camera{
+	c_tag = "Engineering Starboard Aft";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mdL" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -56948,22 +56916,19 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"meU" = (
-/obj/structure/cable{
-	icon_state = "1-8"
+"mfg" = (
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"mgb" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Gas to Cooling Loop"
+/turf/open/space,
+/area/space/nearstation)
+"mfx" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mhl" = (
 /obj/machinery/power/emitter,
 /obj/machinery/light{
@@ -56971,11 +56936,14 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"mjv" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/engine,
+"mlb" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "mlr" = (
 /obj/structure/lattice,
@@ -56984,6 +56952,26 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"mlx" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"mlS" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "mmv" = (
 /obj/machinery/door/airlock/engineering{
 	name = "Engineering Supplies";
@@ -57013,26 +57001,12 @@
 /obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"mpi" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen/blue,
 /turf/open/floor/wood,
 /area/lawoffice)
-"mpD" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "mql" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -57045,13 +57019,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"mqu" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -57090,6 +57057,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"mvA" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"mvY" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "Gas to Filter"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "mwg" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -57115,12 +57097,6 @@
 /obj/structure/cable/yellow,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
-"mxM" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
 "myu" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -57163,6 +57139,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"mAi" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "mCe" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -57171,6 +57153,27 @@
 	},
 /turf/open/floor/plating,
 /area/security/checkpoint/engineering)
+"mCP" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"mCU" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mDW" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -57197,24 +57200,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"mIg" = (
-/obj/machinery/camera{
-	c_tag = "Central Primary Hallway Escape";
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mIV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -57225,6 +57210,10 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"mLc" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "mLB" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -57264,12 +57253,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"mVp" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
-	dir = 1
+"mVj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "mVM" = (
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
@@ -57279,16 +57272,23 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/lawoffice)
-"mZq" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 10
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "mZE" = (
 /turf/open/space/basic,
 /area/space/nearstation)
+"mZK" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"mZV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "naq" = (
 /obj/structure/disposaloutlet{
 	dir = 4
@@ -57298,6 +57298,16 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"ndf" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Mix"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ndI" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /turf/open/floor/plating{
@@ -57328,13 +57338,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"nfj" = (
-/obj/structure/table/glass,
-/obj/item/book/manual/wiki/research_and_development,
-/obj/item/disk/tech_disk,
-/obj/item/disk/design_disk,
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
 "nfz" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57347,10 +57350,37 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"ngg" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ngp" = (
 /obj/item/chair/stool,
 /turf/open/floor/carpet,
 /area/maintenance/department/crew_quarters/dorms)
+"nhW" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nif" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nih" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/costume,
@@ -57374,17 +57404,30 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"njv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+"nkk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
 	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "engsm";
-	name = "Radiation Chamber Shutters"
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/item/tank/internals/plasma,
-/turf/open/floor/plating,
-/area/engine/supermatter)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Starboard";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nku" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Crematorium";
@@ -57426,40 +57469,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"npo" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/machinery/meter,
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "npE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nqb" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"nqs" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nqV" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -57470,6 +57483,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"nqW" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nsy" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -57493,11 +57519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"nsA" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nsD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -57540,6 +57561,10 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/central)
+"nyN" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "nyO" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -57638,6 +57663,15 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"nIq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "nIU" = (
 /obj/structure/disposalpipe/segment{
 	dir = 9
@@ -57661,13 +57695,10 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"nJT" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"nKS" = (
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
+"nKF" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
@@ -57682,13 +57713,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nLC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/obj/machinery/meter,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "nMG" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -57717,6 +57741,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"nNn" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57751,6 +57786,13 @@
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"nPW" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "nQc" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -57761,6 +57803,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"nQf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "nSj" = (
 /obj/structure/grille/broken,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -57773,13 +57819,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
-"nTC" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "nVU" = (
 /obj/item/twohanded/spear,
 /turf/open/floor/plating,
@@ -57788,19 +57827,17 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"nXI" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 9
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "nYb" = (
 /obj/structure/table_frame/wood,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"nYe" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "nYn" = (
 /obj/structure/sign/warning/docking,
 /obj/effect/spawner/structure/window/reinforced,
@@ -57827,6 +57864,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"obl" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"obG" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "10"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "obP" = (
 /obj/structure/table,
 /obj/item/paper_bin,
@@ -57836,6 +57890,11 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
+"ocy" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "oep" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
@@ -57848,14 +57907,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"ofc" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/blue,
@@ -57876,9 +57927,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"ohg" = (
-/turf/open/floor/engine,
-/area/engine/supermatter)
+"oge" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
@@ -57893,16 +57945,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"omJ" = (
-/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+"ona" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
 	dir = 8
 	},
 /obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
+	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -57955,21 +58003,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"opK" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
-"oqc" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -58009,6 +58042,14 @@
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"ovE" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "ovM" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -58034,14 +58075,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"owX" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 4
+"oxt" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/disk/tech_disk,
+/obj/item/disk/design_disk,
+/turf/open/floor/plasteel/dark,
+/area/science/lab)
+"oyE" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -58067,6 +58113,19 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"oBY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oCn" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -58094,24 +58153,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"oEt" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Starboard";
-	dir = 8;
-	network = list("ss13","engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"oEy" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "oEA" = (
 /turf/closed/wall,
 /area/construction/mining/aux_base)
@@ -58155,6 +58196,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"oFi" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oFo" = (
 /obj/structure/closet/emcloset/anchored,
 /obj/structure/sign/warning/vacuum/external{
@@ -58165,24 +58215,12 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"oFB" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space/nearstation)
 "oFI" = (
 /obj/structure/closet,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plasteel,
 /area/maintenance/department/engine)
-"oHg" = (
-/obj/structure/sign/warning/radiation,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "oKa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -58304,6 +58342,12 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"oTD" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "oUa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58318,23 +58362,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"oVG" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 8;
-	name = "Cooling Loop to Gas"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"oVI" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "oWw" = (
 /obj/item/flashlight,
@@ -58360,22 +58387,6 @@
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"oYI" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "External Gas to Loop"
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/engine,
-/area/engine/engineering)
-"oZU" = (
-/obj/structure/chair/stool,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "oZW" = (
@@ -58419,6 +58430,19 @@
 	},
 /turf/open/floor/plating,
 /area/science/explab)
+"peb" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "pfz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -58474,6 +58498,16 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"ppi" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pps" = (
 /turf/closed/wall,
 /area/engine/break_room)
@@ -58486,25 +58520,26 @@
 	},
 /turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
-"ppX" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "prQ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"pvn" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/obj/machinery/camera{
-	c_tag = "Engineering Starboard Aft";
-	dir = 8
+"ptk" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
+"puO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -58539,6 +58574,13 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pBs" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pBD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58605,6 +58647,29 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"pIk" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"pJx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -58664,24 +58729,18 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"pPC" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 5
+"pPu" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 1
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "pQw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"pSH" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/open/floor/plating,
-/area/engine/atmos)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -58770,6 +58829,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qbm" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qbp" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -58874,21 +58942,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
-"qvJ" = (
-/obj/effect/landmark/carpspawn,
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
-"qxm" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/engine,
 /area/engine/engineering)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -59020,13 +59073,6 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"qNP" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/space,
-/area/space/nearstation)
 "qOE" = (
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
@@ -59045,6 +59091,11 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"qPh" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qPB" = (
 /obj/structure/chair/stool,
 /obj/machinery/light/small{
@@ -59052,6 +59103,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"qUe" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qUw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -59077,15 +59134,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"qWb" = (
-/obj/structure/reflector/single/anchored{
-	dir = 6
+"qWB" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qWG" = (
 /obj/structure/closet/emcloset/anchored,
 /turf/open/floor/plating,
@@ -59261,12 +59315,6 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
-"rqS" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "rrb" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59314,15 +59362,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"rvl" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "rvH" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=2";
@@ -59339,6 +59378,23 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
+"rwf" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"rwt" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rxa" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -59364,19 +59420,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"rzd" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/machinery/button/door{
-	id = "engsm";
-	name = "Radiation Shutters Control";
-	pixel_y = 24;
-	req_access_txt = "10"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "rzp" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -59387,15 +59430,12 @@
 	},
 /area/maintenance/department/engine)
 "rAZ" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
 	},
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
-/area/maintenance/department/chapel/monastery)
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "rBh" = (
 /obj/structure/mopbucket,
 /obj/item/mop,
@@ -59410,6 +59450,19 @@
 /obj/item/reagent_containers/blood/random,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rEt" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rFq" = (
 /obj/structure/chair,
 /obj/item/reagent_containers/food/snacks/donkpocket,
@@ -59417,6 +59470,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"rGz" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rHv" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
@@ -59431,17 +59491,6 @@
 "rHA" = (
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"rIZ" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/poster/random{
-	pixel_x = 32
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "rJg" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/light/small{
@@ -59497,6 +59546,16 @@
 /obj/item/ammo_casing/shotgun/improvised,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"rMt" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rMV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -59508,6 +59567,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rPd" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "rPg" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
@@ -59522,11 +59591,12 @@
 /obj/item/trash/can,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
-"rUC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/corner,
+"rTZ" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/crew_quarters/dorms)
 "rWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -59595,16 +59665,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"scR" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = -27
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "sdk" = (
 /obj/structure/lattice,
 /obj/machinery/camera/motion{
@@ -59613,6 +59673,17 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"sdZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"sfr" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "sgc" = (
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/tile/neutral{
@@ -59627,6 +59698,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"sho" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/hallway/secondary/entry)
 "sij" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
@@ -59722,16 +59801,16 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"sAF" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sAK" = (
 /obj/item/clothing/mask/gas/plaguedoctor,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"sAU" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 6
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "sBA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -59748,15 +59827,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"sEu" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/disposalpipe/segment,
@@ -59774,19 +59844,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"sHl" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "sHX" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Cooling Loop to Gas"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sJp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -59808,6 +59876,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"sKw" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "sNz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59815,12 +59898,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
-"sOv" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "sOC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -59833,17 +59910,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"sQp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "sQt" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -59854,6 +59920,37 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"sQG" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"sQV" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"sRH" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/turf/open/space,
+/area/space/nearstation)
+"sTg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "sUP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -59931,6 +60028,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"tcC" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tcY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -59966,13 +60073,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"tdt" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tdB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
@@ -60030,13 +60130,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"tjv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "tlc" = (
 /obj/machinery/recharger,
 /obj/structure/table,
@@ -60055,6 +60148,14 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"tmi" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "tnY" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -60076,6 +60177,13 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"tpX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/hallway/secondary/entry)
 "tqX" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -60087,6 +60195,13 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"ttX" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "tue" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -60118,12 +60233,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"twk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main/monastery)
 "twv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
@@ -60133,19 +60242,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"twG" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
@@ -60162,27 +60258,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"tzC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tzI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"tzh" = (
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/engineering)
+"tAv" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "tAK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -60196,24 +60284,10 @@
 /obj/docking_port/stationary/public_mining_dock,
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"tCY" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "tDn" = (
 /obj/item/wrench,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"tDR" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
 "tHk" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -60229,17 +60303,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"tMA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tRc" = (
 /obj/structure/ore_box,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"tRS" = (
-/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/obj/machinery/meter,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "tSL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -60249,13 +60325,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"tVM" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
-	dir = 6
-	},
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -60273,11 +60342,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tYR" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "uaa" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -60304,18 +60368,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"uaY" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/sorting)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"ucV" = (
-/obj/machinery/status_display/supply,
-/turf/closed/wall,
-/area/quartermaster/warehouse)
 "uek" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -60350,6 +60406,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ufr" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ufx" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/lab)
 "ugC" = (
 /obj/structure/chair/office/light{
 	icon_state = "officechair_white";
@@ -60444,18 +60515,11 @@
 "uoS" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
-"uqd" = (
-/obj/machinery/atmospherics/pipe/simple/green/visible{
-	dir = 4
+"upg" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
 	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "uqJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -60525,6 +60589,13 @@
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"uwT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -60580,19 +60651,16 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uGJ" = (
-/obj/structure/chair/office/light{
+"uDr" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/effect/landmark/start/chemist,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/turf/open/floor/plating,
+/area/engine/engineering)
+"uER" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "uHG" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60605,12 +60673,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"uLD" = (
-/obj/structure/reflector/double/anchored{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "uLF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -60647,6 +60709,12 @@
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uQa" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
@@ -60659,10 +60727,6 @@
 	dir = 8
 	},
 /turf/open/floor/engine,
-/area/engine/engineering)
-"uTl" = (
-/obj/machinery/atmospherics/pipe/simple/orange/visible,
-/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -60690,6 +60754,14 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"uWe" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "External Gas to Loop"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -60712,6 +60784,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
+"uZs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vay" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -60722,6 +60801,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"vdb" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "veM" = (
 /obj/machinery/suit_storage_unit/rd,
 /obj/machinery/light{
@@ -60739,6 +60823,15 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"vfn" = (
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
 "vgp" = (
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -60756,18 +60849,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"vhk" = (
-/obj/structure/chair,
-/turf/open/floor/carpet,
-/area/lawoffice)
-"viX" = (
+"vgX" = (
 /obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 4
 	},
 /turf/open/space,
 /area/space/nearstation)
+"vhk" = (
+/obj/structure/chair,
+/turf/open/floor/carpet,
+/area/lawoffice)
 "vjd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -60818,12 +60911,6 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
-"vrd" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 6
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "vsk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -60867,6 +60954,13 @@
 /obj/item/clothing/mask/gas,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"vvr" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "vxp" = (
 /obj/machinery/door/window/eastright{
 	base_state = "left";
@@ -60880,6 +60974,12 @@
 /obj/item/assembly/mousetrap,
 /turf/open/floor/engine,
 /area/science/explab)
+"vyN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hor)
 "vzz" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -60930,10 +61030,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"vEk" = (
-/obj/machinery/power/supermatter_crystal/engine,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "vGg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -60949,6 +61045,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"vIn" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "vIU" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/sign/departments/holy{
@@ -60956,6 +61058,23 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"vJS" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vMv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -60965,6 +61084,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"vMH" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vMQ" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "vOw" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Library"
@@ -60979,6 +61111,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"vPU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "vRi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -61047,24 +61186,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"vVo" = (
+"vYi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/holopad,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"vVq" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall,
-/area/engine/supermatter)
-"vWA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8;
@@ -61092,20 +61227,6 @@
 	dir = 6
 	},
 /obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
-"wdJ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "7;29"
-	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "weL" = (
@@ -61151,6 +61272,16 @@
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wjm" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wkZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -61178,12 +61309,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
+"wlZ" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "wmA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
+"wnw" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "wnJ" = (
 /obj/structure/sign/warning,
 /turf/closed/wall,
@@ -61217,10 +61363,8 @@
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
-"wtF" = (
-/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
-	dir = 4
-	},
+"wsx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -61228,7 +61372,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/engine,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "wun" = (
 /obj/structure/cable{
@@ -61242,19 +61386,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wuo" = (
-/obj/machinery/status_display/ai,
-/turf/closed/wall,
-/area/quartermaster/qm)
-"wuB" = (
-/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "wwr" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -61302,14 +61433,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"wAX" = (
-/obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
-	name = "Gas to Filter"
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/engine,
-/area/engine/supermatter)
 "wBb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -61332,14 +61455,17 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"wDp" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+"wDH" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "wDZ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -61361,15 +61487,6 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
-"wEY" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/camera{
-	c_tag = "Engineering Supermatter Fore";
-	dir = 4;
-	network = list("ss13","engine")
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "wFT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -61388,16 +61505,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"wJu" = (
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wJP" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -61420,14 +61527,6 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/heads/cmo)
-"wMo" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "research_shutters_2";
-	name = "research shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/science/lab)
 "wMF" = (
 /obj/effect/spawner/lootdrop/three_course_meal,
 /obj/effect/spawner/lootdrop/three_course_meal,
@@ -61514,9 +61613,8 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "wSU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light/small{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
@@ -61562,6 +61660,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wXe" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -61621,20 +61729,6 @@
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"xcC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"xdH" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "xee" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -61645,6 +61739,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/wood,
 /area/lawoffice)
+"xgB" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "xgG" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -61669,6 +61767,11 @@
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"xiY" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -61716,23 +61819,28 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"xkf" = (
+/obj/effect/landmark/carpspawn,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"xkL" = (
+/obj/structure/table,
+/obj/item/clothing/suit/hooded/wintercoat/engineering,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "xlA" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"xlV" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xlY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
@@ -61789,17 +61897,24 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
-"xua" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xuv" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
+"xuW" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"xvK" = (
+/obj/structure/reflector/single/anchored{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "xvO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -61846,14 +61961,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"xxW" = (
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "xyl" = (
 /obj/structure/table,
 /obj/item/assembly/timer,
@@ -61865,6 +61972,10 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/security/brig)
+"xyT" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "xzp" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -61895,22 +62006,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"xEz" = (
-/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"xEW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
-	},
-/turf/open/floor/plasteel/white{
-	heat_capacity = 1e+006
-	},
-/area/chapel/dock)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
@@ -61944,31 +62039,10 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
-"xJG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#d8b1b1"
-	},
-/turf/open/floor/plasteel/white,
-/area/hallway/secondary/entry)
 "xKc" = (
 /obj/structure/sign/warning/biohazard,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"xKS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/engine,
-/area/engine/engineering)
-"xKU" = (
-/obj/effect/spawner/structure/window/plasma/reinforced,
-/obj/machinery/atmospherics/pipe/simple/orange/visible{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "xLi" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -61993,24 +62067,6 @@
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/space/basic,
 /area/space/nearstation)
-"xOi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
-"xOs" = (
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "xOC" = (
 /obj/machinery/door/airlock/external{
 	name = "Construction Zone";
@@ -62053,6 +62109,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"xVT" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "xWl" = (
 /obj/item/pen,
 /obj/item/paper_bin{
@@ -62064,19 +62126,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
-"xXd" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible{
-	dir = 6
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/engine,
-/area/engine/engineering)
 "xXh" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -62110,13 +62159,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"ygN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ygZ" = (
 /obj/structure/closet/crate,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -62125,19 +62167,21 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"ylD" = (
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = -28
-	},
+"yjy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
-	dir = 8
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"ykV" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
 /turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/engine/atmos)
 "ymb" = (
 /obj/machinery/camera{
 	c_tag = "Engineering Telecomms Access";
@@ -79022,7 +79066,7 @@ bQf
 bQf
 bQf
 bWW
-twk
+vMv
 bZn
 bZn
 bZn
@@ -80288,8 +80332,8 @@ aaa
 aaa
 aaa
 aaa
-aaa
-bGI
+irs
+aqG
 bGE
 bKf
 gvO
@@ -80544,9 +80588,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-bGI
+irs
+irs
+aqG
 bGE
 bKf
 gvO
@@ -80800,13 +80844,13 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-bGI
+irs
+irs
+irs
+aqG
 bGE
-xxW
-xEW
+jOX
+beT
 bHM
 bNA
 bHM
@@ -80843,8 +80887,8 @@ cvc
 cho
 cvk
 cdx
-cvc
-cvM
+euN
+csS
 cfm
 cwe
 fWv
@@ -81056,17 +81100,17 @@ bVp
 bVp
 bVp
 bVp
-bVp
-bVp
-bVp
-bVp
-dLA
+gLn
+sTg
+gLn
+gLn
+eOA
 aZx
-guh
+llS
 kYR
 aZx
 bNB
-ofc
+hRQ
 abI
 aby
 abI
@@ -81319,8 +81363,8 @@ aZx
 aZx
 aZx
 aZx
-guh
-kYR
+llS
+sho
 aZx
 amC
 aaa
@@ -81328,8 +81372,8 @@ aht
 aby
 aby
 abI
-gOZ
-oFB
+mfg
+sRH
 cqS
 bNs
 bQe
@@ -81340,8 +81384,8 @@ bQg
 bQg
 bQg
 bOw
-bOw
-ccL
+bQe
+bQg
 bWV
 csT
 cen
@@ -81567,16 +81611,16 @@ aaa
 bGI
 aZx
 jkm
-xJG
+tpX
 iHI
 iHI
 iHI
-iHI
+tpX
 iHI
 hWa
 wwK
-wwK
-guh
+wSU
+llS
 wmA
 aZx
 amB
@@ -81587,7 +81631,7 @@ aaa
 abI
 abI
 abI
-oFB
+sRH
 bNs
 bNs
 bNs
@@ -81615,7 +81659,7 @@ chr
 chL
 cfm
 cfN
-lRD
+xyT
 cfN
 cfN
 cfN
@@ -81833,7 +81877,7 @@ vbQ
 vbQ
 vbQ
 vbQ
-wSU
+vbQ
 pga
 aZx
 amC
@@ -82335,7 +82379,7 @@ aZx
 aaa
 aaa
 aaa
-bGI
+aqG
 aZx
 oto
 wwK
@@ -82591,8 +82635,8 @@ bon
 aZx
 aaa
 aaa
-aaa
-bGI
+irs
+aqG
 aZx
 oto
 wwK
@@ -82852,7 +82896,7 @@ aZx
 aZx
 aZx
 oto
-wwK
+kvx
 bAI
 qbV
 abI
@@ -82900,7 +82944,7 @@ cfN
 cfN
 cfN
 cfN
-uaa
+wlZ
 cjm
 cfN
 cfN
@@ -83034,7 +83078,7 @@ aeU
 afo
 afG
 aeU
-lva
+gHy
 agy
 agL
 agZ
@@ -83548,7 +83592,7 @@ lGp
 aeU
 afI
 aeU
-ifO
+dUk
 agy
 agN
 agY
@@ -83662,17 +83706,17 @@ cwA
 cwA
 cwA
 cwA
-kKN
+lqo
 cwA
 cwA
 cwA
 cwA
 uaa
-uaa
+ovE
 uaa
 uBu
 xlY
-rAZ
+ezo
 cjm
 aht
 aaa
@@ -84173,7 +84217,7 @@ bNK
 bva
 bva
 irs
-qvJ
+xkf
 dRs
 dRs
 aht
@@ -84445,7 +84489,7 @@ dRs
 dRs
 irs
 irs
-ejC
+xiY
 aaa
 aaa
 aaa
@@ -89309,7 +89353,7 @@ bpL
 fQf
 cbW
 cbd
-wDp
+gaQ
 cri
 cbX
 cbX
@@ -90847,9 +90891,9 @@ bXh
 bXZ
 bYK
 bZz
-cRD
+sAF
 cbd
-oZU
+fGt
 cam
 cdM
 bXq
@@ -90859,8 +90903,8 @@ cfQ
 bXk
 qWG
 bXk
-vrd
-mVp
+tAv
+pPu
 cdm
 aaa
 aht
@@ -91112,22 +91156,22 @@ qtO
 bXk
 bXk
 bXk
-bWm
-nJT
-nJT
-nJT
-ivD
-cEJ
-cEJ
+fbu
+nQf
+nQf
+nQf
+cgt
+oge
+oge
 bXk
-isM
-isM
-isM
-isM
-isM
-isM
-isM
-isM
+uER
+uER
+uER
+uER
+uER
+uER
+uER
+uER
 fon
 fon
 mau
@@ -91366,16 +91410,16 @@ cbf
 ccb
 cah
 cdO
-fYL
+jOw
 ceX
-tYR
+ocy
 cfS
 fFv
-mIV
-wEY
-sOv
-dZk
-dZk
+yjy
+nIq
+mAi
+abD
+abD
 bXk
 aaa
 aht
@@ -91628,10 +91672,10 @@ mwG
 nAs
 cfT
 wcs
-fVS
+upg
 qbp
 qbp
-tRS
+hUi
 dMG
 bXk
 aaa
@@ -91875,14 +91919,14 @@ bXk
 bYc
 bYO
 bZA
-guq
+dlI
 cbh
 cbh
 cbh
 cbh
 cbh
-sQp
-xdH
+nNn
+mvA
 cfU
 tIS
 iCs
@@ -92132,21 +92176,21 @@ bXk
 bYd
 bYP
 bZF
-tjv
-rUC
-kjJ
-xcC
-xcC
+uZs
+lDW
+wsx
+uwT
+uwT
 qFu
 cet
 ulY
 cfV
 cgu
 cgU
-ppX
+kNK
 chw
-cEJ
-dkD
+oge
+eMz
 bXk
 bXk
 bXk
@@ -92392,26 +92436,26 @@ bZA
 can
 cbi
 ccc
-cEJ
+oge
 cdR
-hAX
+vvr
 bXk
 bXk
-npo
+oBY
 cgv
-kXK
+ndf
 cgv
 uaP
 cgv
-hhA
+ikm
 cgV
 cgv
 cgv
-mpD
+gkN
 bXk
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -92648,27 +92692,27 @@ bYR
 bZA
 can
 cbj
-cEJ
+oge
 cbX
 wcs
 iyJ
 cfa
-cEJ
+oge
 twv
-xXd
+pJx
 sWj
 dnS
-twG
-fpe
-wtF
-xua
-xua
+rEt
+mZK
+nqW
+pBs
+pBs
 uRk
 ciG
 bXk
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -92904,7 +92948,7 @@ bYf
 bYS
 bZA
 can
-tdt
+eue
 ccd
 ccX
 ccX
@@ -92912,20 +92956,20 @@ ceu
 cbX
 cfu
 tlN
-qxm
+pIk
 cCI
 uoq
-njv
+wDH
 chA
 meF
-mjv
-oYI
-eiG
+oTD
+uWe
+dHF
 hQC
 bXk
 aht
 fon
-isM
+uER
 fon
 aht
 aaa
@@ -93162,27 +93206,27 @@ bYT
 bZB
 caq
 cbk
-cEJ
+oge
 ccY
 cdT
 ccY
 cbX
-cEJ
-knc
-fjE
-cQC
+oge
+jQn
+sQV
+dFF
 fyO
 fyO
 fyO
-cQC
-mjv
-oYI
-mpi
+dFF
+oTD
+uWe
+dGd
 hQC
 bXk
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -93418,28 +93462,28 @@ bYh
 bYU
 bZE
 car
-kaL
-cEJ
+sdZ
+oge
 cbX
 wcs
 wcs
 cfd
 bXk
 tlN
-qxm
-oHg
+pIk
+obl
 mpd
-gnb
-gnb
+peb
+peb
 cit
-cQC
-hLv
-xlV
+dFF
+vMQ
+gih
 hQC
 bXk
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -93640,7 +93684,7 @@ bkh
 bkh
 boN
 bpW
-uGJ
+dVt
 bsM
 bum
 bvt
@@ -93681,22 +93725,22 @@ cda
 wcs
 wcs
 wcs
-cEJ
-wuB
-tCY
-cQC
-diq
-diq
-diq
+oge
+oFi
+wjm
+dFF
+uQa
+uQa
+uQa
 cgY
 ciI
-tDR
-rzd
+mZV
+obG
 hQC
 bXk
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -93877,7 +93921,7 @@ aSS
 aUg
 aVf
 aWi
-cbH
+eyT
 aYe
 aZb
 bag
@@ -93930,30 +93974,30 @@ bWz
 bVN
 bYf
 bYW
-vVo
+hDy
 cam
-eeB
+cxj
 ckJ
 cey
 cdW
 wcs
 cdW
-cEJ
-xOi
-eFK
-jmk
-ohg
-vEk
-ohg
-itZ
-hrj
-cDm
-kyF
+oge
+vPU
+eux
+kDI
+fWE
+nyN
+fWE
+wXe
+iTE
+mlS
+jTc
 hQC
 bXk
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -94162,7 +94206,7 @@ bwW
 bpY
 bpY
 bpY
-wdJ
+vYi
 bva
 bva
 bva
@@ -94189,28 +94233,28 @@ bUT
 bYX
 bZA
 cam
-lXn
+xkL
 bXk
-qWb
+xvK
 wcs
 wcs
-uLD
-cEJ
-jcG
-eeY
-cQC
+kBe
+oge
+mlx
+gUS
+dFF
 prQ
 prQ
 prQ
-nLC
-wAX
-gsW
+nPW
+mvY
+sfr
 dZj
 hQC
 bXk
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -94410,17 +94454,17 @@ bls
 aBI
 aBI
 bmB
-cjz
-gqH
-mIg
-dcp
+tcC
+qWB
+iHe
+qbm
 bvu
-tzC
-cUO
-ylD
-kcR
-lLm
-scR
+wnw
+cep
+ePS
+nhW
+rGz
+rPd
 xDj
 blt
 jCv
@@ -94446,28 +94490,28 @@ bYj
 bYM
 bZA
 cam
-kaL
-cEJ
+sdZ
+oge
 cbX
 wcs
 wcs
-eCn
+hxh
 bXk
 tlN
-qxm
-hLv
+pIk
+vMQ
 fyF
 cZt
 cZt
-glJ
-cQC
-vVq
-uqd
+hUf
+dFF
+mLc
+lmv
 hQC
 bXk
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -94675,11 +94719,11 @@ gkS
 tTl
 tTl
 tTl
-rqS
+qUe
 dgg
 phJ
 phJ
-eav
+lCY
 bAk
 bIt
 bJB
@@ -94703,28 +94747,28 @@ bYk
 bYQ
 bZF
 cbm
-kaL
-cEJ
-wJu
-wJu
+sdZ
+oge
+rwf
+rwf
 eWi
 cbX
-cEJ
-knc
+oge
+jQn
 cgx
-cQC
+dFF
 fyO
 fyO
 fyO
-cQC
+dFF
 cBS
 cjt
-hko
+mCP
 hQC
 bXk
 aaa
 fon
-isM
+uER
 fon
 aht
 aaa
@@ -94924,19 +94968,19 @@ blu
 aDZ
 aDZ
 bjm
-rIZ
+nKF
 cqi
 cqi
 cqi
 cqi
 cqi
-ijY
-nKS
-vWA
+erV
+rMt
+ksC
 fdQ
 bmD
 bmD
-kxV
+jrb
 bAl
 bIu
 bJC
@@ -94960,28 +95004,28 @@ bYl
 bYO
 bZA
 cam
-nTC
+lCR
 ccd
-rvl
-rvl
-meU
+mlb
+mlb
+mbD
 cbX
 cfu
 jBn
-dYd
+ptk
 meF
 chA
 chA
 woh
 cCI
 cBS
-fin
+rwt
 liR
 hQC
 bXk
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -95184,18 +95228,18 @@ bKM
 cCl
 cCl
 cCl
-gYh
-wMo
-wMo
+vfn
+ufx
+ufx
 byD
 bAm
 dhz
-cRR
+nkk
 bDA
 bEQ
 bGa
 bHg
-heL
+mVj
 bJD
 bBo
 bBo
@@ -95218,27 +95262,27 @@ bYY
 bZA
 cam
 cbn
-cEJ
+oge
 cbX
 wcs
 cfP
 cff
-cEJ
+oge
 cfX
-nqs
-omJ
+kvu
+gHp
 kWQ
-iVa
-kbw
-imS
-eFg
-eFg
-nXI
+iSi
+ona
+kec
+ngg
+ngg
+cUT
 hQC
 bXk
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -95443,10 +95487,10 @@ brp
 gFo
 cSK
 duF
-nfj
+oxt
 byE
 bBp
-kSl
+vyN
 bBp
 bBp
 bBp
@@ -95476,22 +95520,22 @@ bZG
 cax
 cbo
 ccc
-cEJ
+oge
 cdR
-leM
+uDr
 bXq
 bXq
 cfY
-jwU
-oVG
-jwU
-sEu
-mgb
+hrx
+sHX
+hrx
+hXm
+jjA
 civ
 civ
-oEt
-fWQ
-xKS
+jtv
+ppi
+oyE
 bXk
 aht
 fon
@@ -95733,19 +95777,19 @@ bZF
 cal
 cbp
 cci
-ygN
-ygN
-llg
-xOs
-oVI
-eAj
-cEJ
-hgf
-cEJ
-cEJ
-hgf
-cEJ
-cEJ
+dPZ
+dPZ
+vMH
+vJS
+vIn
+ttX
+oge
+dGp
+oge
+oge
+dGp
+oge
+oge
 bXk
 bXk
 bXk
@@ -95985,24 +96029,24 @@ bVU
 bWG
 bXq
 bYo
-hlX
+tzh
 bZI
-hlX
+tzh
 cbq
 cbd
 cam
 cam
 cam
-iOJ
-xKU
-tVM
-fZq
-kea
-tVM
-pPC
-lsu
-fZq
-pPC
+mCU
+cOA
+gfh
+vdb
+rAZ
+gfh
+tMA
+puO
+vdb
+tMA
 cdm
 aaa
 aaa
@@ -96243,23 +96287,23 @@ bWH
 bXk
 bTE
 bZc
-klM
+nif
 cCU
 bZJ
-pvn
+mdi
 cCV
 ceb
-nsA
-jLw
-xKU
-sHX
-tVM
-nqb
-sHX
-sHX
-mqu
-pPC
-sHX
+qPh
+sKw
+cOA
+sQG
+gfh
+eqM
+sQG
+sQG
+dhu
+tMA
+sQG
 cdm
 aaa
 aaa
@@ -96499,29 +96543,29 @@ bJN
 bJN
 bJN
 bJN
-oVI
-uTl
-uTl
-uTl
-uTl
-uTl
-uTl
-uTl
-uTl
-mxM
-mZq
-owX
-kha
-owX
-owX
-kha
-owX
-owX
-nqb
+vIn
+xgB
+xgB
+xgB
+xgB
+xgB
+xgB
+xgB
+xgB
+fml
+mfx
+hJO
+dAa
+hJO
+hJO
+dAa
+hJO
+hJO
+eqM
 aht
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -96756,7 +96800,7 @@ bVV
 bWI
 bXr
 bKQ
-ite
+vgX
 bZK
 abI
 abI
@@ -96765,20 +96809,20 @@ abI
 aaa
 aaa
 aaa
-mqu
-fZq
-owX
-kha
-owX
-owX
-kha
-owX
-owX
-kea
+dhu
+vdb
+hJO
+dAa
+hJO
+hJO
+dAa
+hJO
+hJO
+rAZ
 aaa
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -97013,7 +97057,7 @@ bQI
 bWJ
 bXs
 bJN
-qNP
+lxh
 bJP
 bJP
 bJP
@@ -97022,20 +97066,20 @@ bJP
 abI
 abI
 aht
-lsu
-fZq
-owX
-kha
-owX
-owX
-kha
-owX
-owX
-nqb
+puO
+vdb
+hJO
+dAa
+hJO
+hJO
+dAa
+hJO
+hJO
+eqM
 aht
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -97250,7 +97294,7 @@ bCK
 bDG
 bEW
 bAt
-tzI
+aIA
 cqw
 cqD
 bKO
@@ -97270,7 +97314,7 @@ bMf
 fuR
 bXt
 bYp
-viX
+jPC
 bZL
 caz
 cbs
@@ -97279,20 +97323,20 @@ bJP
 aaa
 aaa
 aaa
-mqu
-fZq
-owX
-kha
-owX
-owX
-kha
-owX
-owX
-kea
+dhu
+vdb
+hJO
+dAa
+hJO
+hJO
+dAa
+hJO
+hJO
+rAZ
 aaa
 aaa
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -97527,7 +97571,7 @@ bVW
 bWL
 bXu
 bLW
-qNP
+lxh
 bMi
 caA
 cbt
@@ -97536,20 +97580,20 @@ bJP
 aaa
 aaa
 aaa
-lsu
-xEz
-kea
-lsu
-kea
-lsu
-kea
-lsu
-kea
+puO
+xuW
+rAZ
+puO
+rAZ
+puO
+rAZ
+puO
+rAZ
 cdm
 aht
 aht
 fon
-isM
+uER
 fon
 aaa
 aaa
@@ -97784,7 +97828,7 @@ bVX
 bWM
 bXv
 bWc
-opK
+tmi
 bZL
 caB
 cbs
@@ -98036,12 +98080,12 @@ bQI
 bQI
 bTM
 bUs
-sAU
-jkZ
-oqc
+cAp
+ykV
+ufr
 bXw
-pSH
-oEy
+iSL
+lQy
 bJP
 bJP
 bJP
@@ -98293,7 +98337,7 @@ bMf
 bMf
 bTN
 bUt
-jHd
+flP
 bOk
 bWK
 bXt
@@ -98549,8 +98593,8 @@ bRx
 bQJ
 bPQ
 bTO
-sAU
-sHl
+cAp
+xVT
 bOk
 bWL
 bXx
@@ -98564,21 +98608,21 @@ bJP
 aaa
 aaa
 fon
-isM
-isM
-isM
-isM
-isM
-isM
-isM
-isM
-isM
-isM
+uER
+uER
+uER
+uER
+uER
+uER
+uER
+uER
+uER
+uER
 fon
 aaa
 aht
-isM
-isM
+uER
+uER
 fon
 aaa
 aaa
@@ -98806,7 +98850,7 @@ bPQ
 bPQ
 bPQ
 bTP
-jHd
+flP
 bVh
 bVY
 bWM
@@ -98834,7 +98878,7 @@ fon
 fon
 aaa
 aht
-isM
+uER
 fon
 fon
 aaa
@@ -99063,7 +99107,7 @@ bQK
 bQK
 bPQ
 bTQ
-jHd
+flP
 bKX
 bOk
 bWN
@@ -99320,7 +99364,7 @@ bRy
 bSf
 bSR
 bTM
-jHd
+flP
 bKX
 bVZ
 bWO
@@ -99577,7 +99621,7 @@ bRz
 bMf
 bSS
 bTR
-hpJ
+nYe
 bKX
 bWa
 bMf
@@ -100034,7 +100078,7 @@ aHn
 aIi
 aJi
 aKe
-uaY
+kVA
 aMi
 aNJ
 fwl
@@ -101072,7 +101116,7 @@ lAs
 eeQ
 aUs
 aLf
-dwM
+lfZ
 aLf
 aLf
 aUl
@@ -101596,7 +101640,7 @@ bcA
 bdF
 beJ
 bfB
-wuo
+gaJ
 aZv
 aUC
 biz
@@ -102333,7 +102377,7 @@ apX
 apX
 avl
 fIu
-lwj
+rTZ
 aIh
 azA
 dbi
@@ -102867,7 +102911,7 @@ aNP
 aPb
 aNO
 aNP
-ucV
+cRJ
 aTq
 aSk
 aTm
@@ -108003,7 +108047,7 @@ aaa
 aLm
 aLm
 aNU
-gJy
+hCg
 dqY
 aRv
 sZh
@@ -108260,7 +108304,7 @@ aaa
 aLm
 aME
 aNV
-gJy
+hCg
 dqY
 aRw
 sqQ
@@ -108517,7 +108561,7 @@ aaa
 aLo
 aMF
 aNW
-gJy
+hCg
 cvf
 aQn
 sqQ
@@ -108774,7 +108818,7 @@ aaa
 aLo
 aMG
 aNX
-gJy
+hCg
 rax
 aRy
 aSn

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -139,7 +139,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/circuit,
@@ -350,7 +350,7 @@
 	id = "AI";
 	pixel_y = 20
 	},
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 37
 	},
 /turf/open/floor/circuit,
@@ -502,9 +502,17 @@
 	name = "AI Core";
 	req_access_txt = "65"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "adc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -1024,9 +1032,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aev" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1116,9 +1128,13 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aeJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -1205,11 +1221,23 @@
 /obj/structure/sink{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aeX" = (
 /obj/machinery/washing_machine,
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aeY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -1288,9 +1316,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "aff" = (
 /obj/structure/cable/yellow{
@@ -1299,9 +1331,13 @@
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afg" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
@@ -1315,9 +1351,11 @@
 	dir = 2;
 	network = list("minisat")
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afh" = (
 /obj/structure/cable/yellow{
@@ -1413,12 +1451,24 @@
 /area/security/prison)
 "afr" = (
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "afs" = (
 /obj/structure/table,
 /obj/structure/bedsheetbin,
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aft" = (
 /obj/machinery/light/small{
@@ -1451,9 +1501,13 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afx" = (
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afy" = (
 /obj/effect/landmark/start/cyborg,
@@ -1461,9 +1515,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afz" = (
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "afA" = (
 /obj/machinery/light/small{
@@ -1629,8 +1685,11 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/window/reinforced{
-	dir = 8
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 8;
+	icon_state = "right";
+	name = "Unisex Showers"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1656,9 +1715,11 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "agh" = (
 /obj/structure/transit_tube/station/reverse/flipped{
@@ -1699,12 +1760,9 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "ago" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
+/obj/structure/window/reinforced{
 	dir = 8;
-	icon_state = "right";
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	layer = 2.9
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1776,7 +1834,17 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agA" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
@@ -1795,7 +1863,17 @@
 	name = "Cell 1"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/prison)
 "agC" = (
 /obj/machinery/door/airlock{
@@ -1849,13 +1927,7 @@
 	dir = 1
 	},
 /obj/item/toy/plush/slimeplushie,
-/turf/open/floor/plasteel/floorgrime,
-/area/security/prison)
-"agJ" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agK" = (
 /obj/machinery/light/small{
@@ -1873,7 +1945,7 @@
 	dir = 8
 	},
 /obj/structure/chair,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agL" = (
 /obj/structure/bed,
@@ -1892,7 +1964,7 @@
 	dir = 1
 	},
 /obj/item/toy/plush/lizardplushie,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agM" = (
 /obj/structure/cable{
@@ -1901,7 +1973,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agN" = (
 /obj/machinery/light/small{
@@ -1919,7 +1991,7 @@
 	dir = 8
 	},
 /obj/structure/chair,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agO" = (
 /obj/structure/sink{
@@ -1982,17 +2054,13 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/floorgrime,
-/area/security/prison)
-"agX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agY" = (
 /obj/structure/table,
 /obj/item/paper,
 /obj/item/pen,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "agZ" = (
 /obj/machinery/flasher{
@@ -2000,14 +2068,14 @@
 	pixel_x = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aha" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ahb" = (
 /obj/structure/toilet{
@@ -2038,9 +2106,13 @@
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/tank/internals/anesthetic,
 /obj/item/clothing/mask/breath/medical,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahk" = (
 /obj/machinery/button/flasher{
@@ -2061,9 +2133,13 @@
 	pixel_x = 6;
 	pixel_y = 36
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahl" = (
 /obj/item/radio/intercom{
@@ -2073,9 +2149,13 @@
 	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahm" = (
 /obj/machinery/door/airlock/security/glass{
@@ -2086,7 +2166,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ahn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -2112,7 +2192,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ahq" = (
 /turf/open/floor/plasteel/showroomfloor,
@@ -2141,9 +2221,16 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahv" = (
 /obj/structure/cable{
@@ -2152,9 +2239,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -2202,9 +2293,11 @@
 	pixel_x = 24;
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ahA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -2369,9 +2462,13 @@
 /area/space/nearstation)
 "ahS" = (
 /obj/structure/table/optable,
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "ahT" = (
 /turf/open/floor/plasteel/white,
@@ -2586,7 +2683,11 @@
 /obj/item/storage/backpack/duffelbag/sec/surgery{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/whitered/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "aiw" = (
 /obj/machinery/power/emitter/anchored{
@@ -2603,9 +2704,13 @@
 /turf/open/floor/plating,
 /area/security/execution/transfer)
 "aix" = (
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiy" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -2617,31 +2722,49 @@
 /turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiz" = (
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aiA" = (
 /turf/closed/wall/r_wall,
 /area/security/execution/transfer)
 "aiB" = (
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aiC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aiD" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aiE" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aiF" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -2667,13 +2790,21 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aiK" = (
 /obj/structure/table,
 /obj/item/assembly/signaler,
 /obj/item/electropack,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aiL" = (
 /obj/structure/table,
@@ -2783,7 +2914,11 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "aja" = (
 /obj/structure/cable{
@@ -2792,7 +2927,11 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ajb" = (
 /obj/structure/closet/secure_closet/injection,
@@ -2804,9 +2943,11 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/execution/transfer)
 "ajc" = (
 /obj/structure/closet/secure_closet/brig,
@@ -2819,7 +2960,17 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aje" = (
 /obj/structure/cable{
@@ -2836,7 +2987,17 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
 "ajg" = (
 /obj/structure/rack,
@@ -2859,23 +3020,14 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/clothing/suit/armor/riot,
 /obj/item/clothing/suit/armor/riot{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/riot{
-	pixel_x = -3;
-	pixel_y = 3
 	},
 /obj/item/clothing/head/helmet/riot,
 /obj/item/clothing/head/helmet/riot{
 	pixel_x = 3;
 	pixel_y = -3
-	},
-/obj/item/shield/riot{
-	pixel_x = -3;
-	pixel_y = 3
 	},
 /obj/item/shield/riot,
 /obj/item/shield/riot{
@@ -2906,10 +3058,6 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/item/storage/box/rubbershot{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -2922,7 +3070,17 @@
 "ajk" = (
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajl" = (
 /obj/structure/filingcabinet,
@@ -2931,9 +3089,13 @@
 	departmentType = 5;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajm" = (
 /obj/structure/table,
@@ -2943,9 +3105,13 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajn" = (
 /obj/structure/table,
@@ -2959,27 +3125,39 @@
 	pixel_x = 1;
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajo" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajp" = (
 /obj/machinery/photocopier,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajq" = (
 /obj/effect/landmark/start/security_officer,
@@ -2987,7 +3165,17 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajr" = (
 /obj/item/reagent_containers/food/snacks/donut/chaos,
@@ -3133,9 +3321,16 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ajO" = (
 /obj/structure/closet{
@@ -3144,9 +3339,14 @@
 /obj/structure/sign/poster/official/safety_report{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "ajP" = (
 /obj/structure/rack,
@@ -3155,10 +3355,6 @@
 	pixel_y = 3
 	},
 /obj/item/gun/energy/e_gun,
-/obj/item/gun/energy/e_gun{
-	pixel_x = 3;
-	pixel_y = -3
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/machinery/firealarm{
 	dir = 8;
@@ -3177,15 +3373,6 @@
 	pixel_y = 3
 	},
 /obj/item/clothing/suit/armor/bulletproof,
-/obj/item/clothing/suit/armor/bulletproof{
-	pixel_x = 3;
-	pixel_y = -3
-	},
-/obj/item/clothing/head/helmet/alt{
-	layer = 3.00001;
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/clothing/head/helmet/alt{
 	layer = 3.00001
 	},
@@ -3209,7 +3396,6 @@
 	pixel_x = -3;
 	pixel_y = 3
 	},
-/obj/item/gun/energy/laser,
 /obj/item/gun/energy/laser{
 	pixel_x = 3;
 	pixel_y = -3
@@ -3226,9 +3412,13 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ajV" = (
 /obj/effect/landmark/start/security_officer,
@@ -3260,9 +3450,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "aka" = (
 /obj/machinery/suit_storage_unit/hos,
@@ -3274,9 +3466,8 @@
 "akb" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/structure/sign/plaques/atmos{
+/obj/structure/sign/plaques/kiddie{
 	desc = "An embossed piece of paper from the University of Nanotrasen at Portpoint.";
-	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},
@@ -3530,9 +3721,16 @@
 /obj/item/clothing/mask/surgical,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/whitered/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akC" = (
 /obj/item/storage/firstaid/regular{
@@ -3544,9 +3742,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akD" = (
 /obj/item/radio/intercom{
@@ -3557,26 +3759,39 @@
 	},
 /obj/structure/table/glass,
 /obj/machinery/computer/med_data/laptop,
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akE" = (
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/whitered/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "akF" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "akG" = (
 /obj/structure/cable{
@@ -3602,7 +3817,17 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "akJ" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -3618,9 +3843,11 @@
 	c_tag = "Brig Evidence Room";
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "akL" = (
 /obj/structure/rack,
@@ -3633,6 +3860,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
+/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "akM" = (
@@ -3661,10 +3889,6 @@
 /area/security/armory)
 "akP" = (
 /obj/structure/rack,
-/obj/item/gun/ballistic/shotgun/riot{
-	pixel_x = -3;
-	pixel_y = 3
-	},
 /obj/item/gun/ballistic/shotgun/riot,
 /obj/item/gun/ballistic/shotgun/riot{
 	pixel_x = 3;
@@ -3680,15 +3904,27 @@
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/red/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "akR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3702,21 +3938,34 @@
 	icon_state = "2-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/darkred/corner,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akV" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akW" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akX" = (
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "akZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -3854,17 +4103,23 @@
 	},
 /obj/item/reagent_containers/glass/bottle/charcoal,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
-/turf/open/floor/plasteel/whitered/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "alr" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitered/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "als" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -3882,9 +4137,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "alu" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
@@ -3902,9 +4159,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "alx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -3917,23 +4176,41 @@
 	dir = 8
 	},
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "alz" = (
 /obj/structure/closet{
 	name = "Evidence Closet"
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "alA" = (
 /obj/machinery/flasher/portable,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/armory)
 "alB" = (
 /obj/structure/cable{
@@ -3944,9 +4221,13 @@
 	dir = 8;
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "alC" = (
 /obj/structure/table/wood,
@@ -3974,9 +4255,11 @@
 /area/security/main)
 "alG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "alH" = (
 /turf/open/floor/plasteel/dark,
@@ -4102,9 +4385,13 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amb" = (
 /obj/structure/cable{
@@ -4125,9 +4412,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/whitered/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amd" = (
 /obj/structure/cable{
@@ -4163,9 +4452,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amg" = (
 /turf/closed/wall/r_wall,
@@ -4189,7 +4480,17 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "amj" = (
 /obj/structure/cable{
@@ -4216,7 +4517,17 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aml" = (
 /obj/structure/cable{
@@ -4243,9 +4554,13 @@
 	name = "Station Intercom (General)";
 	pixel_x = -31
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "amn" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -4294,9 +4609,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ams" = (
 /obj/structure/cable{
@@ -4383,7 +4700,6 @@
 /area/crew_quarters/heads/hos)
 "amA" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 4
 	},
 /obj/structure/lattice/catwalk,
@@ -4401,7 +4717,6 @@
 /area/space/nearstation)
 "amD" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
@@ -4461,9 +4776,17 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "amL" = (
 /obj/structure/cable{
@@ -4479,15 +4802,24 @@
 	icon_state = "1-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/whitered/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitered/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amO" = (
 /obj/structure/closet/crate/freezer,
@@ -4500,18 +4832,27 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitered/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/brig)
 "amP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amQ" = (
 /obj/structure/cable{
@@ -4526,9 +4867,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "amS" = (
 /obj/structure/closet/secure_closet/warden,
@@ -4611,9 +4954,13 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "anc" = (
 /obj/structure/table/wood,
@@ -4635,9 +4982,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ang" = (
 /obj/structure/cable{
@@ -4743,9 +5092,17 @@
 /area/security/processing/cremation)
 "anw" = (
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/security/processing/cremation)
 "anx" = (
 /obj/machinery/door/airlock/maintenance{
@@ -4767,9 +5124,13 @@
 	icon_state = "map-pubby";
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "anz" = (
 /obj/structure/cable{
@@ -4782,9 +5143,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "anB" = (
 /obj/structure/cable{
@@ -4865,9 +5228,14 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "anM" = (
 /obj/structure/chair/office/dark{
@@ -4891,9 +5259,14 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "anP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -4924,9 +5297,10 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/darkred/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anS" = (
 /obj/structure/cable{
@@ -4935,17 +5309,25 @@
 /obj/machinery/keycard_auth{
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anT" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anU" = (
 /obj/structure/cable{
@@ -4960,9 +5342,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = -27
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anV" = (
 /obj/structure/cable{
@@ -4976,9 +5362,13 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "anW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -5079,18 +5469,24 @@
 /area/security/brig)
 "aom" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aon" = (
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aoo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aop" = (
 /obj/structure/bed/dogbed,
@@ -5137,9 +5533,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "aou" = (
 /obj/structure/cable{
@@ -5192,9 +5592,11 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "aoz" = (
 /turf/closed/wall,
@@ -5204,9 +5606,17 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoB" = (
 /obj/machinery/gateway{
@@ -5216,18 +5626,34 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoC" = (
 /obj/machinery/gateway{
 	dir = 5
 	},
 /obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "aoH" = (
 /obj/structure/lattice,
@@ -5369,13 +5795,27 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "apb" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "apc" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -5391,7 +5831,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "ape" = (
 /obj/machinery/airalarm{
@@ -5401,7 +5845,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "apf" = (
 /obj/structure/cable{
@@ -5417,7 +5865,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/main)
 "apg" = (
 /obj/structure/cable{
@@ -5522,9 +5980,17 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apr" = (
 /obj/machinery/gateway/centerstation,
@@ -5535,9 +6001,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apt" = (
 /obj/structure/chair{
@@ -5724,25 +6198,49 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/bot_white/left,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apV" = (
 /obj/machinery/gateway,
 /obj/effect/turf_decal/bot_white,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apW" = (
 /obj/machinery/gateway{
 	dir = 6
 	},
 /obj/effect/turf_decal/bot_white/right,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/gateway)
 "apX" = (
 /turf/closed/wall,
@@ -5815,9 +6313,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqo" = (
 /obj/structure/cable{
@@ -5829,17 +6328,25 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqq" = (
 /obj/machinery/camera{
@@ -5849,9 +6356,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -5861,17 +6372,25 @@
 /area/security/brig)
 "aqs" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqt" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5892,9 +6411,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5903,9 +6426,13 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -5914,9 +6441,13 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqy" = (
 /obj/structure/disposalpipe/segment,
@@ -5926,18 +6457,27 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aqz" = (
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqA" = (
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 8;
 	pixel_x = 30
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aqB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -5947,7 +6487,7 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aqD" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -6001,9 +6541,17 @@
 /area/bridge)
 "aqL" = (
 /obj/machinery/computer/bank_machine,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aqM" = (
 /obj/machinery/light_switch{
@@ -6040,9 +6588,17 @@
 "aqP" = (
 /obj/structure/filingcabinet,
 /obj/item/folder/documents,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aqQ" = (
 /obj/structure/window/reinforced,
@@ -6082,7 +6638,13 @@
 /area/gateway)
 "aqT" = (
 /obj/machinery/computer/arcade,
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aqU" = (
 /obj/machinery/washing_machine,
@@ -6090,14 +6652,26 @@
 	department = "Crew Quarters";
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aqV" = (
 /obj/machinery/washing_machine,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aqY" = (
 /obj/docking_port/stationary{
@@ -6228,9 +6802,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "aru" = (
 /obj/machinery/door/airlock/security{
@@ -6321,7 +6897,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -6341,21 +6916,36 @@
 /area/bridge)
 "arH" = (
 /obj/machinery/modular_computer/console/preset/command,
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arI" = (
 /obj/machinery/computer/med_data,
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arJ" = (
 /obj/machinery/computer/crew,
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arK" = (
 /obj/machinery/status_display{
@@ -6370,9 +6960,13 @@
 	light_color = "#e8eaff"
 	},
 /obj/item/pen,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arL" = (
 /obj/machinery/computer/card,
@@ -6380,24 +6974,36 @@
 	c_tag = "Bridge - Central";
 	dir = 2
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arM" = (
 /obj/machinery/computer/communications,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arN" = (
 /obj/machinery/computer/station_alert,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arO" = (
-/obj/machinery/ai_status_display{
+/obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
@@ -6406,35 +7012,60 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/recharger,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arP" = (
 /obj/machinery/computer/security,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arQ" = (
 /obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arR" = (
 /obj/machinery/computer/prisoner,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "arS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -6446,9 +7077,17 @@
 /area/ai_monitored/nuke_storage)
 "arU" = (
 /obj/machinery/nuclearbomb/selfdestruct,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6465,9 +7104,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/machinery/ore_silo,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "arX" = (
 /obj/machinery/camera{
@@ -6564,14 +7212,26 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ase" = (
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "asf" = (
 /obj/effect/landmark/start/assistant,
@@ -6579,7 +7239,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "asg" = (
 /obj/structure/bedsheetbin,
@@ -6589,7 +7255,13 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ash" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -6655,9 +7327,14 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -6670,7 +7347,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asx" = (
 /obj/structure/cable{
@@ -6685,13 +7366,21 @@
 	name = "Cell 1";
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -6702,7 +7391,11 @@
 	name = "Cell 2";
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asA" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
@@ -6718,33 +7411,54 @@
 	name = "Cell 3";
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asC" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asD" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asE" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "asG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -6830,9 +7544,13 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "asR" = (
 /obj/structure/chair/office/dark{
@@ -6857,9 +7575,11 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "asU" = (
 /obj/structure/cable{
@@ -6872,9 +7592,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "asW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -6906,9 +7634,17 @@
 /area/ai_monitored/nuke_storage)
 "asZ" = (
 /obj/structure/closet/crate/silvercrate,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "ata" = (
 /obj/machinery/light_switch{
@@ -6960,7 +7696,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ath" = (
 /obj/machinery/light,
@@ -6968,21 +7710,39 @@
 	c_tag = "Laundry Room";
 	dir = 1
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "ati" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "atj" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "atk" = (
 /turf/open/floor/plating,
@@ -7042,7 +7802,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "atx" = (
 /obj/structure/cable{
@@ -7083,7 +7847,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "atB" = (
 /obj/structure/cable{
@@ -7099,7 +7867,11 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "atD" = (
 /obj/structure/cable{
@@ -7124,9 +7896,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "atF" = (
 /obj/structure/cable{
@@ -7147,9 +7923,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "atH" = (
 /obj/machinery/door/airlock/security/glass{
@@ -7198,7 +7976,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "atN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -7219,54 +7997,100 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/darkpurple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atQ" = (
 /obj/machinery/computer/atmos_alert,
-/turf/open/floor/plasteel/darkpurple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atR" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	dir = 8
-	},
-/area/bridge)
-"atS" = (
-/turf/open/floor/plasteel/darkblue/corner{
-	dir = 4
-	},
-/area/bridge)
-"atT" = (
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"atS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
+"atT" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atU" = (
 /obj/item/beacon,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atV" = (
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atX" = (
 /obj/machinery/computer/shuttle/labor{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkyellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "atY" = (
 /turf/closed/wall,
@@ -7278,7 +8102,7 @@
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "aua" = (
 /obj/structure/closet/secure_closet/freezer/money,
 /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka,
@@ -7287,9 +8111,17 @@
 /obj/item/clothing/head/bearpelt,
 /obj/item/skub,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "aub" = (
 /obj/machinery/light,
@@ -7327,9 +8159,17 @@
 /obj/item/disk/nuclear/fake,
 /obj/item/stack/ore/diamond,
 /obj/item/gun/energy/disabler,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auf" = (
 /obj/structure/cable{
@@ -7389,7 +8229,13 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "aul" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
@@ -7473,10 +8319,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/security/brig)
-"auy" = (
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "auz" = (
 /obj/machinery/light/small{
@@ -7485,11 +8328,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "auA" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/security/brig)
 "auB" = (
 /obj/machinery/light{
@@ -7500,15 +8343,21 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "auC" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "auD" = (
 /obj/structure/table/reinforced,
@@ -7604,17 +8453,25 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auO" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auP" = (
 /obj/structure/cable{
@@ -7623,29 +8480,46 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/darkpurple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auQ" = (
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auR" = (
 /obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "auS" = (
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auT" = (
 /obj/machinery/computer/cargo/request{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkyellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "auU" = (
 /obj/structure/closet/emcloset/anchored,
@@ -7682,7 +8556,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
 "auZ" = (
 /obj/structure/sign/warning/securearea,
@@ -7723,22 +8607,19 @@
 /area/crew_quarters/dorms)
 "ave" = (
 /obj/structure/bed,
-/obj/item/bedsheet/nanotrasen,
 /obj/machinery/button/door{
 	id = "Dorm3Shutters";
 	name = "Privacy Shutters Control";
 	pixel_y = 26
 	},
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "avf" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -7766,9 +8647,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avi" = (
 /obj/structure/disposalpipe/segment{
@@ -7781,9 +8666,13 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/blue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -7802,9 +8691,10 @@
 	network = list("monastery");
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avk" = (
 /turf/open/floor/plasteel,
@@ -7817,7 +8707,9 @@
 /obj/machinery/computer/cryopod{
 	pixel_y = 30
 	},
-/obj/machinery/cryopod,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "avm" = (
@@ -7872,17 +8764,29 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/blue,
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avt" = (
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avu" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 1";
 	name = "Cell 1 Locker"
 	},
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avv" = (
 /obj/structure/bed,
@@ -7891,17 +8795,29 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/green,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avw" = (
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avx" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 2";
 	name = "Cell 2 Locker"
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avy" = (
 /obj/structure/bed,
@@ -7910,23 +8826,39 @@
 	pixel_x = -28
 	},
 /obj/item/bedsheet/orange,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avz" = (
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avA" = (
 /obj/structure/closet/secure_closet/brig{
 	id = "Cell 3";
 	name = "Cell 3 Locker"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "avC" = (
 /obj/structure/table/reinforced,
@@ -8017,7 +8949,17 @@
 /area/maintenance/fore)
 "avN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avO" = (
 /obj/effect/landmark/event_spawn,
@@ -8027,7 +8969,17 @@
 	dir = 1
 	},
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -8037,7 +8989,17 @@
 	name = "Station Intercom (General)";
 	pixel_y = -28
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avQ" = (
 /obj/machinery/door/airlock/command{
@@ -8049,25 +9011,39 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/area/bridge)
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "avR" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avT" = (
 /obj/structure/cable{
@@ -8080,9 +9056,11 @@
 /area/bridge)
 "avU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "avV" = (
 /obj/structure/table/glass,
@@ -8117,15 +9095,29 @@
 /area/bridge)
 "awa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "awb" = (
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkyellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "awc" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -8136,7 +9128,7 @@
 	req_access_txt = "10;13"
 	},
 /turf/open/floor/plating,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "awd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -8255,9 +9247,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "awr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -8307,7 +9307,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -8319,7 +9322,10 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -8338,13 +9344,19 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
 "awB" = (
 /obj/machinery/vending/clothing,
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -8443,9 +9455,13 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "awM" = (
 /obj/structure/cable{
@@ -8470,9 +9486,11 @@
 	req_access_txt = "63"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "awO" = (
 /obj/structure/table/reinforced,
@@ -8587,9 +9605,13 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "awZ" = (
 /obj/structure/cable{
@@ -8604,9 +9626,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axb" = (
 /obj/structure/chair/comfy/black{
@@ -8616,9 +9640,13 @@
 /area/bridge)
 "axc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axd" = (
 /obj/structure/cable{
@@ -8638,9 +9666,11 @@
 /obj/machinery/computer/rdconsole{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axg" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -8822,9 +9852,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axM" = (
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "axN" = (
 /obj/structure/dresser,
@@ -8858,9 +9890,13 @@
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "axS" = (
 /obj/machinery/power/apc{
@@ -8911,9 +9947,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "axY" = (
 /obj/structure/cable{
@@ -8929,7 +9969,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aya" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -8941,21 +9982,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aye" = (
 /obj/machinery/door/airlock/command{
@@ -8967,7 +10015,7 @@
 	},
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
-/area/bridge)
+/area/ai_monitored/turret_protected/aisat_interior)
 "ayf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -8977,9 +10025,17 @@
 	name = "bridge external shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -9004,23 +10060,20 @@
 /area/crew_quarters/dorms)
 "ayj" = (
 /obj/structure/bed,
-/obj/item/bedsheet/nanotrasen,
 /obj/machinery/button/door{
 	id = "Dorm2Shutters";
 	name = "Privacy Shutters Control";
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "ayk" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -9102,7 +10155,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/obj/structure/stacklifter,
+/obj/structure/weightmachine/stacklifter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "ayw" = (
@@ -9173,9 +10226,13 @@
 	pixel_x = -25;
 	req_access_txt = "2"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayF" = (
 /obj/structure/sign/warning/vacuum/external{
@@ -9263,9 +10320,11 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "ayS" = (
 /obj/structure/bed,
@@ -9352,9 +10411,13 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aze" = (
 /obj/structure/cable{
@@ -9501,9 +10564,11 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "azp" = (
 /obj/machinery/light,
@@ -9547,9 +10612,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "azv" = (
 /obj/structure/chair/comfy{
@@ -9605,7 +10678,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/obj/structure/weightlifter,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "azE" = (
@@ -9732,9 +10805,13 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAc" = (
 /obj/structure/cable{
@@ -9833,9 +10910,11 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-14"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aAp" = (
 /obj/structure/table/wood,
@@ -9866,6 +10945,7 @@
 "aAs" = (
 /obj/structure/table/wood,
 /obj/item/kitchen/fork,
+/obj/item/card/id/captains_spare,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/captain)
 "aAt" = (
@@ -9917,9 +10997,13 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aAA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9938,7 +11022,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aAD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -9964,9 +11058,11 @@
 	pixel_y = -2;
 	req_access_txt = "19"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aAF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10123,13 +11219,15 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/red/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/red/corner,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aBi" = (
 /turf/closed/wall,
@@ -10207,37 +11305,66 @@
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBt" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 9
-	},
-/area/ai_monitored/turret_protected/ai_upload)
-"aBu" = (
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/ai_upload)
+"aBu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBw" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBx" = (
 /obj/machinery/power/apc/highcap/five_k{
@@ -10249,9 +11376,14 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aBy" = (
 /obj/machinery/door/firedoor,
@@ -10386,23 +11518,20 @@
 /area/crew_quarters/dorms)
 "aBM" = (
 /obj/structure/bed,
-/obj/item/bedsheet/nanotrasen,
 /obj/machinery/button/door{
 	id = "Dorm1Shutters";
 	name = "Privacy Shutters Control";
 	pixel_y = 26;
 	req_access_txt = "0"
 	},
+/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/dorms)
 "aBN" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -10451,26 +11580,41 @@
 /area/crew_quarters/dorms)
 "aBT" = (
 /obj/structure/closet/wardrobe/white,
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
 "aBU" = (
 /obj/structure/closet/wardrobe/mixed,
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
 "aBV" = (
 /obj/structure/closet/wardrobe/green,
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
 "aBW" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/machinery/light,
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
 "aBX" = (
 /obj/structure/closet/wardrobe/black,
 /obj/item/clothing/shoes/jackboots,
 /obj/item/storage/backpack,
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/crew_quarters/fitness/recreation)
 "aBY" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -10596,9 +11740,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aCq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -10611,18 +11756,29 @@
 /obj/structure/sign/poster/official/pda_ad{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCs" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCt" = (
 /obj/structure/table,
@@ -10633,9 +11789,13 @@
 	departmentType = 0;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCu" = (
 /obj/structure/table,
@@ -10648,9 +11808,13 @@
 /obj/item/screwdriver{
 	pixel_y = 16
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCv" = (
 /obj/structure/table,
@@ -10666,9 +11830,13 @@
 /obj/structure/noticeboard{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCw" = (
 /obj/structure/table,
@@ -10681,9 +11849,13 @@
 	},
 /obj/item/flashlight,
 /obj/item/electronics/airlock,
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCx" = (
 /obj/structure/sign/poster/official/obey{
@@ -10704,9 +11876,13 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aCy" = (
 /obj/structure/displaycase/captain,
@@ -10774,9 +11950,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aCG" = (
 /obj/structure/table,
@@ -10791,17 +11968,25 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -10822,9 +12007,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCM" = (
 /obj/structure/table,
@@ -10841,9 +12027,14 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aCN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11008,9 +12199,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/dorms)
 "aDf" = (
 /obj/structure/disposalpipe/segment,
@@ -11056,7 +12255,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/white/corner{
-	icon_state = "whitecorner";
 	dir = 8
 	},
 /area/crew_quarters/dorms)
@@ -11116,16 +12314,18 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/red/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/corner,
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aDw" = (
 /obj/structure/cable{
@@ -11136,8 +12336,13 @@
 	name = "Tool Storage APC";
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/storage/primary)
@@ -11163,9 +12368,11 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aDC" = (
 /obj/structure/table/wood,
@@ -11242,23 +12449,29 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDK" = (
 /obj/machinery/porta_turret/ai{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDL" = (
 /turf/open/floor/circuit,
@@ -11286,13 +12499,16 @@
 /obj/structure/sign/plaques/kiddie{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aDO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDP" = (
 /obj/structure/cable{
@@ -11304,9 +12520,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aDQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -11555,9 +12772,10 @@
 /area/security/detectives_office)
 "aEs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aEt" = (
 /obj/structure/table,
@@ -11575,8 +12793,13 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/storage/primary)
@@ -11603,9 +12826,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aEx" = (
 /obj/structure/table/wood,
@@ -11639,9 +12864,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aEC" = (
 /obj/machinery/light{
@@ -11652,9 +12878,10 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aED" = (
 /obj/structure/table,
@@ -11678,13 +12905,22 @@
 	id = "brigentry";
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEE" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEF" = (
 /obj/machinery/computer/upload/ai{
@@ -11727,9 +12963,14 @@
 	id = "brigentry";
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 6
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "aEJ" = (
 /obj/machinery/light{
@@ -11740,14 +12981,16 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aEK" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aEL" = (
 /obj/machinery/disposal/bin,
@@ -11993,9 +13236,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aFs" = (
 /obj/structure/table,
@@ -12005,8 +13249,13 @@
 	},
 /obj/item/electronics/apc,
 /obj/item/t_scanner,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/storage/primary)
@@ -12027,9 +13276,11 @@
 /obj/item/crowbar,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aFw" = (
 /obj/structure/table/wood,
@@ -12044,10 +13295,18 @@
 /area/crew_quarters/heads/captain)
 "aFy" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aFz" = (
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aFA" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12316,13 +13575,22 @@
 /obj/item/wirecutters,
 /obj/item/flashlight,
 /obj/item/gps,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 10
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGf" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGg" = (
 /obj/structure/table,
@@ -12335,43 +13603,83 @@
 /obj/item/clothing/gloves/color/fyellow,
 /obj/item/assembly/timer,
 /obj/item/radio,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGh" = (
 /obj/structure/table,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
 /obj/item/storage/belt/utility,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGi" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGj" = (
 /obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "aGk" = (
 /obj/machinery/vending/boozeomat/pubby_captain,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGl" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGm" = (
 /obj/machinery/computer/arcade,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "aGn" = (
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
@@ -12603,16 +13911,32 @@
 /area/storage/primary)
 "aHb" = (
 /obj/machinery/computer/arcade,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHc" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aHd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -12633,7 +13957,17 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aHe" = (
 /obj/machinery/door/poddoor/preopen{
@@ -12650,7 +13984,17 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aHf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -12675,7 +14019,17 @@
 	req_access_txt = "19"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "aHh" = (
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -12838,9 +14192,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHI" = (
 /obj/structure/cable{
@@ -12850,9 +14205,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12861,9 +14217,10 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHK" = (
 /obj/machinery/light{
@@ -12876,9 +14233,10 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -12887,15 +14245,17 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12928,9 +14288,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHR" = (
 /obj/machinery/door/firedoor,
@@ -12940,9 +14301,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHS" = (
 /obj/structure/disposalpipe/segment{
@@ -12954,9 +14316,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHT" = (
 /obj/structure/cable{
@@ -12967,23 +14330,26 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHU" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHV" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -12993,9 +14359,10 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHX" = (
 /obj/structure/cable{
@@ -13004,9 +14371,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHY" = (
 /obj/structure/cable{
@@ -13018,9 +14386,10 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aHZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13029,9 +14398,10 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIa" = (
 /obj/structure/disposalpipe/segment,
@@ -13039,9 +14409,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIb" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -13050,9 +14421,10 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIc" = (
 /obj/machinery/door/firedoor,
@@ -13063,9 +14435,10 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aId" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -13074,9 +14447,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aIe" = (
 /obj/structure/cable{
@@ -13587,9 +14961,17 @@
 	c_tag = "Departure Lounge Fore";
 	dir = 2
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aJE" = (
 /turf/open/floor/plasteel,
@@ -13607,9 +14989,17 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aJG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -13691,33 +15081,37 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJP" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJS" = (
 /obj/structure/cable{
@@ -13727,18 +15121,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJT" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJU" = (
 /obj/structure/disposalpipe/segment,
@@ -13746,17 +15142,19 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJV" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJW" = (
 /obj/machinery/camera{
@@ -13766,9 +15164,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aJX" = (
 /obj/structure/sign/directions/security{
@@ -13841,7 +15240,6 @@
 	icon_state = "plant-04"
 	},
 /turf/open/floor/plasteel/white/corner{
-	icon_state = "whitecorner";
 	dir = 4
 	},
 /area/hallway/primary/central)
@@ -13921,7 +15319,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -13944,7 +15345,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -13952,7 +15356,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -13960,19 +15367,31 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aKH" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aKI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aKJ" = (
 /turf/closed/wall,
@@ -14152,15 +15571,24 @@
 /area/maintenance/disposal)
 "aLu" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aLv" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aLw" = (
 /obj/effect/spawner/structure/window,
@@ -14175,7 +15603,17 @@
 	},
 /obj/structure/easel,
 /obj/item/canvas/twentythreeXnineteen,
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aLy" = (
 /obj/structure/cable{
@@ -14184,7 +15622,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aLz" = (
 /obj/machinery/photocopier,
@@ -14192,7 +15640,17 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aLA" = (
 /obj/structure/table,
@@ -14384,19 +15842,22 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/teleporter)
 "aMb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMd" = (
 /obj/machinery/requests_console{
@@ -14408,9 +15869,16 @@
 	pixel_y = 30
 	},
 /obj/machinery/computer/security,
-/turf/open/floor/plasteel/red/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMe" = (
 /obj/machinery/computer/security/mining,
@@ -14424,9 +15892,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMf" = (
 /obj/machinery/computer/secure_data,
@@ -14434,9 +15906,14 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aMg" = (
 /obj/machinery/conveyor{
@@ -14466,10 +15943,6 @@
 	id = "packageSort2"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/obj/machinery/status_display{
-	pixel_y = 30;
-	supply_display = 1
-	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aMj" = (
@@ -14540,7 +16013,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMq" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -14550,7 +16023,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMr" = (
 /obj/structure/closet/crate,
@@ -14560,7 +16033,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMs" = (
 /obj/structure/disposalpipe/segment{
@@ -14572,7 +16045,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMt" = (
 /obj/structure/closet/cardboard,
@@ -14589,7 +16062,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMu" = (
 /obj/item/cigbutt/cigarbutt,
@@ -14599,7 +16072,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMv" = (
 /obj/structure/disposalpipe/segment{
@@ -14615,7 +16088,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aMw" = (
 /obj/structure/disposalpipe/segment{
@@ -14726,7 +16199,10 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aML" = (
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -14750,7 +16226,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -14774,7 +16251,17 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aMW" = (
 /obj/structure/cable{
@@ -14783,7 +16270,17 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aMX" = (
 /obj/structure/table,
@@ -14796,7 +16293,17 @@
 	name = "Art Storage APC";
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aMY" = (
 /obj/structure/chair{
@@ -14950,8 +16457,8 @@
 /area/storage/eva)
 "aNt" = (
 /obj/structure/rack,
-/obj/item/tank/jetpack/carbondioxide,
-/obj/item/tank/jetpack/carbondioxide{
+/obj/item/tank/jetpack/carbondioxide/eva,
+/obj/item/tank/jetpack/carbondioxide/eva{
 	pixel_x = -4;
 	pixel_y = 1
 	},
@@ -14992,7 +16499,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/teleporter)
 "aNz" = (
 /obj/machinery/door/firedoor,
@@ -15007,18 +16515,20 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15033,9 +16543,13 @@
 	dir = 4
 	},
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNE" = (
 /obj/structure/chair/office/dark{
@@ -15051,9 +16565,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aNH" = (
 /obj/structure/disposalpipe/segment,
@@ -15125,20 +16641,20 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aNO" = (
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aNP" = (
 /obj/structure/closet/crate,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aNQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aNR" = (
 /obj/structure/cable{
@@ -15165,15 +16681,15 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aNV" = (
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "garbagestacked"
-	},
 /obj/machinery/mineral/stacking_unit_console{
 	dir = 2;
 	machinedir = 8;
 	pixel_x = -32;
 	pixel_y = 32
+	},
+/obj/machinery/conveyor{
+	dir = 4;
+	id = "garbagestacked"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -15204,16 +16720,26 @@
 /area/maintenance/disposal)
 "aOf" = (
 /obj/structure/chair,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aOg" = (
 /obj/structure/chair,
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -15223,15 +16749,21 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aOk" = (
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aOm" = (
 /obj/structure/cable{
@@ -15251,7 +16783,17 @@
 /obj/item/instrument/glockenspiel{
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aOu" = (
 /obj/structure/table,
@@ -15263,7 +16805,17 @@
 	dir = 1
 	},
 /obj/item/hand_labeler,
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aOv" = (
 /obj/structure/table,
@@ -15281,7 +16833,17 @@
 	},
 /obj/item/canvas/twentythreeXtwentythree,
 /obj/item/canvas/nineteenXnineteen,
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/art)
 "aOw" = (
 /obj/structure/grille/broken,
@@ -15374,9 +16936,13 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aOF" = (
 /obj/structure/chair/stool,
@@ -15422,7 +16988,8 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/teleporter)
 "aOJ" = (
 /obj/machinery/door/firedoor,
@@ -15447,9 +17014,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aOL" = (
 /obj/structure/cable{
@@ -15471,9 +17039,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aON" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15490,26 +17059,36 @@
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOP" = (
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOQ" = (
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aOR" = (
 /obj/machinery/door/airlock/security/glass{
 	name = "Cargo Security Post";
 	req_access_txt = "63"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aOS" = (
 /obj/structure/disposalpipe/segment{
@@ -15569,33 +17148,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aOZ" = (
 /obj/item/stack/sheet/cardboard,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aPa" = (
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aPb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aPc" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aPd" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15609,7 +17188,7 @@
 /area/maintenance/department/cargo)
 "aPg" = (
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "garbage"
 	},
 /obj/structure/disposaloutlet{
@@ -15620,16 +17199,6 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/disposal)
-"aPh" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "garbage"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
@@ -15644,14 +17213,21 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "aPn" = (
-/turf/open/floor/plasteel/escape{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "aPo" = (
-/turf/open/floor/plasteel/escape{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
 "aPq" = (
 /obj/machinery/light{
@@ -15665,7 +17241,8 @@
 	c_tag = "Departure Lounge Starboard";
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aPt" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15684,7 +17261,8 @@
 	dir = 1;
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPx" = (
 /obj/machinery/light/small{
@@ -15722,7 +17300,7 @@
 	lootcount = 2;
 	name = "2maintenance loot spawner"
 	},
-/obj/item/clothing/gloves/color/random,
+/obj/effect/spawner/lootdrop/gloves,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aPD" = (
@@ -15792,33 +17370,54 @@
 /obj/structure/table,
 /obj/item/beacon,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkblue/side{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPN" = (
 /obj/machinery/computer/teleporter{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPO" = (
 /obj/machinery/teleport/station,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPP" = (
 /obj/machinery/teleport/hub,
 /obj/machinery/light,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPQ" = (
 /obj/structure/closet/crate,
 /obj/item/crowbar,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/teleporter)
 "aPR" = (
 /obj/structure/disposalpipe/segment,
@@ -15829,9 +17428,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aPT" = (
 /obj/structure/cable,
@@ -15841,19 +17441,33 @@
 	pixel_x = -24
 	},
 /obj/structure/closet/secure_closet/security/cargo,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPV" = (
 /obj/structure/filingcabinet/security,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aPW" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -15907,27 +17521,27 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQd" = (
 /obj/item/flashlight,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQe" = (
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQf" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQg" = (
 /obj/structure/closet/crate/medical,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aQj" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -15958,7 +17572,7 @@
 	dir = 8
 	},
 /obj/machinery/conveyor{
-	dir = 2;
+	dir = 1;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -15974,9 +17588,10 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aQs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16023,21 +17638,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"aQA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aQB" = (
-/obj/structure/disposalpipe/junction/flip{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -16046,16 +17652,25 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aQD" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aQE" = (
 /obj/structure/grille/broken,
@@ -16327,18 +17942,20 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/sign/departments/cargo{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aRf" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -16351,9 +17968,13 @@
 	req_access_txt = "63"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "aRh" = (
 /obj/structure/chair/stool,
@@ -16431,7 +18052,7 @@
 /area/quartermaster/warehouse)
 "aRq" = (
 /obj/structure/closet/crate/internals,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aRs" = (
 /obj/structure/disposalpipe/segment,
@@ -16497,13 +18118,31 @@
 /area/maintenance/disposal)
 "aRB" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aRC" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aRD" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -16583,9 +18222,17 @@
 	dir = 4
 	},
 /obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "aRJ" = (
 /obj/structure/cable{
@@ -16745,15 +18392,17 @@
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
 "aSc" = (
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aSd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aSe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -16908,7 +18557,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSB" = (
 /obj/structure/cable{
@@ -16916,17 +18565,17 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSC" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSD" = (
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSE" = (
 /obj/machinery/airalarm{
@@ -16936,14 +18585,14 @@
 	c_tag = "Hydroponics Storage"
 	},
 /obj/structure/closet/secure_closet/hydroponics,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSF" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSG" = (
 /obj/structure/table,
@@ -16952,7 +18601,7 @@
 /obj/item/reagent_containers/glass/bottle/mutagen,
 /obj/item/reagent_containers/dropper,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aSH" = (
 /obj/machinery/door/airlock/maintenance{
@@ -16993,14 +18642,30 @@
 	name = "Kitchen Delivery";
 	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aSM" = (
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aSN" = (
 /obj/item/assembly/mousetrap,
@@ -17077,9 +18742,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aSY" = (
 /obj/machinery/door/firedoor,
@@ -17109,23 +18775,26 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTc" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aTe" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -17206,17 +18875,6 @@
 	},
 /obj/machinery/airalarm{
 	pixel_y = 22
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aTo" = (
-/obj/machinery/status_display{
-	pixel_y = 30;
-	supply_display = 1
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "QMLoad"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -17397,9 +19055,10 @@
 /area/space)
 "aTJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aTK" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -17449,13 +19108,14 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTQ" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aTR" = (
 /obj/structure/cable{
@@ -17467,13 +19127,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aTS" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aTT" = (
 /obj/structure/disposalpipe/segment{
@@ -17482,7 +19142,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aTU" = (
 /obj/structure/disposalpipe/segment{
@@ -17491,10 +19151,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/hydroponics)
-"aTV" = (
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aTW" = (
 /obj/structure/table,
@@ -17510,7 +19167,7 @@
 	pixel_y = 5
 	},
 /obj/item/watertank,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aTX" = (
 /obj/structure/kitchenspike,
@@ -17552,9 +19209,17 @@
 /area/crew_quarters/kitchen)
 "aUb" = (
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/bar)
 "aUc" = (
 /obj/structure/reagent_dispensers/beerkeg,
@@ -17592,9 +19257,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUj" = (
 /obj/structure/disposalpipe/segment{
@@ -17769,7 +19435,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -17784,7 +19453,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -17799,7 +19471,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -17811,7 +19486,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/primary/central)
@@ -17845,7 +19523,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aUN" = (
 /obj/structure/cable{
@@ -17880,9 +19559,17 @@
 /area/maintenance/department/crew_quarters/bar)
 "aUQ" = (
 /obj/structure/plasticflaps/opaque,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aUR" = (
 /obj/machinery/door/window/eastright{
@@ -17905,14 +19592,14 @@
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/reagent_containers/glass/bucket,
 /obj/item/wirecutters,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aUT" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aUU" = (
 /obj/machinery/power/apc{
@@ -17922,17 +19609,12 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/hydrofloor,
-/area/hydroponics)
-"aUV" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aUW" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aUX" = (
 /obj/machinery/icecream_vat,
@@ -18129,9 +19811,10 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -18166,9 +19849,13 @@
 /area/quartermaster/office)
 "aVt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18186,9 +19873,11 @@
 /obj/machinery/conveyor_switch{
 	id = "cargodeliver"
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aVw" = (
 /obj/machinery/navbeacon{
@@ -18295,7 +19984,17 @@
 /area/hallway/secondary/exit/departure_lounge)
 "aVN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aVO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -18327,7 +20026,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aVS" = (
 /turf/closed/wall,
@@ -18348,9 +20048,17 @@
 	freq = 1400;
 	location = "Janitor"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aVV" = (
 /obj/machinery/door/firedoor,
@@ -18493,7 +20201,17 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWo" = (
 /obj/structure/cable{
@@ -18503,7 +20221,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWp" = (
 /obj/structure/cable{
@@ -18512,7 +20240,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWq" = (
 /obj/machinery/light/small{
@@ -18528,7 +20266,17 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWr" = (
 /obj/structure/cable{
@@ -18546,20 +20294,33 @@
 	pixel_x = 28;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aWs" = (
 /obj/machinery/computer/cargo/request{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aWt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/brown/corner,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aWu" = (
-/turf/open/floor/plasteel/brown/corner,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aWv" = (
 /obj/machinery/door/firedoor,
@@ -18570,15 +20331,11 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "aWw" = (
-/obj/machinery/status_display{
-	dir = 8;
-	layer = 4;
-	pixel_x = 32;
-	supply_display = 1
-	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aWx" = (
 /obj/machinery/navbeacon{
@@ -18620,15 +20377,19 @@
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aWE" = (
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aWF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aWI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18642,24 +20403,40 @@
 	c_tag = "Departure Lounge Hallway";
 	dir = 1
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aWJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aWK" = (
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "aWM" = (
 /obj/machinery/washing_machine,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWN" = (
 /obj/machinery/camera{
@@ -18678,7 +20455,17 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWO" = (
 /obj/structure/bed,
@@ -18687,19 +20474,37 @@
 /obj/machinery/light_switch{
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aWP" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aWQ" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aWR" = (
 /obj/machinery/disposal/bin,
@@ -18729,9 +20534,10 @@
 	name = "utility sink";
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aWU" = (
 /obj/structure/closet/secure_closet/freezer/meat,
@@ -18809,7 +20615,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aXl" = (
 /obj/structure/disposalpipe/segment{
@@ -18822,7 +20638,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aXm" = (
 /obj/structure/disposalpipe/sorting/mail{
@@ -18836,14 +20662,34 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aXn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/effect/landmark/start/clown,
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aXo" = (
 /obj/structure/disposalpipe/segment{
@@ -18857,7 +20703,17 @@
 	pixel_x = 28;
 	pixel_y = -2
 	},
-/turf/open/floor/plasteel/redblue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aXp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -18870,9 +20726,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXr" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -18881,9 +20738,10 @@
 /obj/structure/sign/departments/cargo{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXs" = (
 /obj/structure/table/reinforced,
@@ -18919,9 +20777,11 @@
 	c_tag = "Cargo Foyer";
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aXw" = (
 /obj/machinery/navbeacon{
@@ -18984,18 +20844,34 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aXG" = (
 /obj/structure/table,
 /obj/effect/holodeck_effect/cards{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "aXH" = (
 /turf/closed/wall/r_wall,
@@ -19036,7 +20912,8 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aXM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -19049,14 +20926,34 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aXO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aXP" = (
 /obj/structure/table,
@@ -19065,7 +20962,17 @@
 /obj/item/grenade/clusterbuster/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
 /obj/item/grenade/chem_grenade/cleaner,
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aXQ" = (
 /obj/structure/sink{
@@ -19073,22 +20980,38 @@
 	pixel_x = -12;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXR" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/neutral/side{
-	dir = 9
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXS" = (
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXT" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hydroponics)
@@ -19098,18 +21021,24 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXV" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXW" = (
 /obj/machinery/plantgenes{
 	pixel_y = 6
 	},
 /obj/structure/table,
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXX" = (
 /obj/machinery/hydroponics/constructable,
@@ -19117,9 +21046,13 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXY" = (
 /obj/machinery/hydroponics/constructable,
@@ -19130,15 +21063,23 @@
 	dir = 1;
 	light_color = "#e8eaff"
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aXZ" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYa" = (
 /obj/machinery/door/airlock{
@@ -19172,31 +21113,47 @@
 	icon_state = "plant-18";
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYf" = (
 /obj/structure/table/reinforced,
-/obj/item/book/manual/barman_recipes,
-/obj/item/reagent_containers/glass/rag,
-/turf/open/floor/plasteel/darkred/side{
+/obj/item/book/manual/wiki/barman_recipes,
+/obj/item/reagent_containers/rag,
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYg" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYh" = (
 /obj/structure/table/reinforced,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/instrument/guitar,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYi" = (
 /obj/structure/table/reinforced,
@@ -19205,9 +21162,13 @@
 	icon_state = "plant-18";
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aYj" = (
 /obj/machinery/door/airlock{
@@ -19215,18 +21176,34 @@
 	req_access_txt = "46"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYk" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYl" = (
 /obj/structure/table/wood,
@@ -19234,17 +21211,33 @@
 /obj/structure/table/wood,
 /obj/item/bikehorn,
 /obj/item/toy/cattoy,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYm" = (
 /obj/structure/closet/crate/wooden/toy,
 /obj/item/lipstick/random,
 /obj/item/clothing/gloves/color/rainbow/clown,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/theatre)
 "aYn" = (
 /obj/machinery/requests_console{
@@ -19255,27 +21248,39 @@
 /obj/machinery/computer/cargo{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYo" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYp" = (
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
 /obj/effect/landmark/start/cargo_technician,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYq" = (
 /obj/item/stamp{
@@ -19287,21 +21292,33 @@
 	pixel_y = -2
 	},
 /obj/structure/table,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYr" = (
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYs" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYu" = (
 /obj/machinery/light{
@@ -19311,9 +21328,11 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aYv" = (
 /obj/machinery/navbeacon{
@@ -19418,20 +21437,35 @@
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 9
-	},
-/area/security/checkpoint/customs)
-"aYI" = (
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/checkpoint/customs)
+"aYI" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYJ" = (
 /obj/machinery/vending/wardrobe/sec_wardrobe,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYK" = (
 /obj/structure/closet/secure_closet/security,
@@ -19439,16 +21473,22 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aYL" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aYM" = (
 /obj/machinery/door/firedoor,
@@ -19456,25 +21496,41 @@
 	name = "Custodial Quarters";
 	req_access_txt = "26"
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/janitor)
 "aYN" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYO" = (
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYP" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aYQ" = (
 /obj/structure/sink{
@@ -19531,9 +21587,13 @@
 	pixel_y = -2
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "aYY" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -19560,9 +21620,17 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZb" = (
 /obj/structure/disposalpipe/segment{
@@ -19581,9 +21649,17 @@
 	dir = 4
 	},
 /obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZd" = (
 /obj/structure/disposalpipe/segment{
@@ -19594,17 +21670,33 @@
 	dir = 1
 	},
 /obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZe" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZf" = (
 /obj/structure/disposalpipe/segment{
@@ -19613,9 +21705,17 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aZg" = (
 /obj/structure/disposalpipe/junction/flip{
@@ -19633,25 +21733,24 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZj" = (
-/obj/machinery/status_display{
-	dir = 4;
-	layer = 4;
-	pixel_x = -32;
-	supply_display = 1
+/obj/machinery/status_display/supply{
+	pixel_x = -32
 	},
 /obj/machinery/computer/bounty{
 	dir = 4
@@ -19766,7 +21865,10 @@
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "aZy" = (
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -19774,7 +21876,10 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -19782,7 +21887,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -19794,7 +21902,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -19805,7 +21916,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -19813,7 +21927,10 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -19832,9 +21949,13 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -19861,9 +21982,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZK" = (
 /obj/machinery/door/airlock/security{
@@ -19876,7 +21999,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "aZL" = (
 /obj/structure/cable{
@@ -19909,7 +22042,8 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZO" = (
 /obj/machinery/disposal/bin,
@@ -19917,10 +22051,10 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aZP" = (
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aZQ" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -19932,7 +22066,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "aZR" = (
 /obj/machinery/hydroponics/constructable,
@@ -19943,35 +22077,58 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aZS" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 8;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hydroponics)
 "aZT" = (
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aZU" = (
 /obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aZV" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "aZW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20013,20 +22170,40 @@
 	},
 /obj/item/storage/fancy/donut_box,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bae" = (
 /obj/structure/chair/stool/bar,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bag" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bah" = (
 /turf/open/floor/plasteel/dark,
@@ -20038,9 +22215,17 @@
 	pixel_y = 1
 	},
 /obj/structure/chair/wood/normal,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bao" = (
 /obj/machinery/computer/slot_machine,
@@ -20075,9 +22260,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bas" = (
 /obj/structure/table,
@@ -20268,9 +22454,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "baQ" = (
 /obj/machinery/computer/secure_data{
@@ -20289,9 +22476,14 @@
 	pixel_x = -26;
 	pixel_y = -4
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baR" = (
 /obj/item/pen,
@@ -20299,20 +22491,32 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baS" = (
 /obj/structure/chair/office/dark,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baT" = (
 /obj/machinery/recharger{
 	pixel_y = 4
 	},
 /obj/structure/table,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baU" = (
 /obj/machinery/power/apc{
@@ -20322,9 +22526,14 @@
 	pixel_y = -24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "baV" = (
 /obj/structure/cable{
@@ -20347,7 +22556,8 @@
 	pixel_x = 25;
 	req_access_txt = "26"
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baX" = (
 /obj/vehicle/ridden/janicart,
@@ -20368,7 +22578,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "baY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -20377,7 +22587,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "baZ" = (
 /obj/structure/closet/l3closet/janitor,
@@ -20389,7 +22599,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bba" = (
 /obj/machinery/holopad,
@@ -20399,26 +22609,43 @@
 /obj/machinery/vending/hydroseeds{
 	slogan_delay = 700
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bbc" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bbd" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/plasteel/green/corner,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bbe" = (
 /obj/structure/chair/stool,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bbg" = (
 /obj/effect/landmark/start/cook,
@@ -20446,9 +22673,13 @@
 	name = "kitchen shutters"
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/kitchen)
 "bbm" = (
 /obj/structure/chair/stool/bar,
@@ -20472,9 +22703,17 @@
 /area/crew_quarters/bar)
 "bbq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bbr" = (
 /obj/structure/chair/wood/normal{
@@ -20537,9 +22776,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bbA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -20592,7 +22832,11 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/brown,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bbH" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -20608,12 +22852,20 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/brown,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bbK" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/brown,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bbL" = (
 /obj/machinery/power/smes,
@@ -20677,9 +22929,10 @@
 /area/hallway/secondary/entry)
 "bbU" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bbV" = (
 /obj/machinery/door/firedoor,
@@ -20713,7 +22966,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bbY" = (
 /obj/machinery/camera{
@@ -20721,13 +22974,21 @@
 	dir = 8
 	},
 /obj/machinery/vending/wardrobe/jani_wardrobe,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bbZ" = (
 /obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bca" = (
 /obj/machinery/light{
@@ -20737,9 +22998,11 @@
 	c_tag = "Hydroponics South";
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bcb" = (
 /obj/structure/table/reinforced,
@@ -20832,9 +23095,17 @@
 /obj/structure/chair/wood/normal{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcs" = (
 /obj/item/clothing/shoes/sandal,
@@ -20844,9 +23115,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -20858,9 +23137,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bcw" = (
 /obj/machinery/door/firedoor,
@@ -20906,9 +23193,16 @@
 	pixel_x = -23
 	},
 /obj/item/storage/belt/fannypack/yellow,
-/turf/open/floor/plasteel/brown{
-	dir = 9
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcB" = (
 /obj/structure/cable{
@@ -20920,18 +23214,27 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcC" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown{
-	dir = 5
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bcD" = (
 /obj/structure/closet/wardrobe/miner,
@@ -20939,9 +23242,16 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/brown{
-	dir = 9
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcE" = (
 /obj/structure/cable{
@@ -20949,15 +23259,23 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcG" = (
 /obj/structure/closet/emcloset,
@@ -20965,9 +23283,14 @@
 	dir = 8;
 	pixel_x = 23
 	},
-/turf/open/floor/plasteel/brown{
-	dir = 5
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bcH" = (
 /obj/structure/cable{
@@ -21092,7 +23415,10 @@
 /area/hallway/secondary/entry)
 "bdc" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
@@ -21125,13 +23451,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bdh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bdi" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -21144,36 +23470,41 @@
 	dir = 9;
 	pixel_x = 22
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bdj" = (
-/turf/open/floor/plasteel/green/corner,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bdk" = (
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bdl" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bdm" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/hydroponics)
 "bdn" = (
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdo" = (
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bdp" = (
 /obj/structure/table,
@@ -21202,17 +23533,33 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bdx" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bdy" = (
 /obj/machinery/door/firedoor,
@@ -21282,9 +23629,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bdG" = (
 /obj/structure/cable{
@@ -21296,9 +23647,11 @@
 /obj/machinery/computer/bounty{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bdI" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -21308,9 +23661,10 @@
 /obj/structure/table,
 /obj/item/folder/yellow,
 /obj/item/pen,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdK" = (
 /obj/structure/chair/office/dark{
@@ -21339,7 +23693,8 @@
 /obj/machinery/computer/security/mining{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown/corner,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bdQ" = (
 /obj/structure/cable{
@@ -21424,7 +23779,8 @@
 /obj/structure/sign/departments/custodian{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bec" = (
 /obj/structure/cable{
@@ -21432,14 +23788,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bed" = (
 /obj/structure/table,
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/restraints/legcuffs/beartrap,
 /obj/item/reagent_containers/spray/cleaner,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bee" = (
 /obj/structure/table,
@@ -21452,12 +23808,17 @@
 	pixel_x = 24
 	},
 /obj/item/clothing/head/crown,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bef" = (
-/turf/open/floor/plasteel/neutral/side{
-	dir = 10
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "beg" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -21469,7 +23830,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bei" = (
 /obj/structure/disposalpipe/segment{
@@ -21514,9 +23879,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bem" = (
 /obj/structure/disposalpipe/segment{
@@ -21535,9 +23901,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "beo" = (
 /obj/machinery/door/firedoor,
@@ -21624,9 +23991,17 @@
 "bez" = (
 /obj/structure/table/wood,
 /obj/item/instrument/trombone,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beA" = (
 /obj/structure/chair/wood/normal{
@@ -21666,9 +24041,17 @@
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/snacks/chocolatebar,
 /obj/item/kitchen/fork,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beE" = (
 /obj/structure/chair/wood/normal{
@@ -21680,9 +24063,17 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beG" = (
 /obj/structure/disposalpipe/segment{
@@ -21702,24 +24093,34 @@
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "beI" = (
 /turf/closed/wall,
 /area/science/robotics/mechbay)
 "beJ" = (
-/obj/machinery/status_display{
-	dir = 4;
-	layer = 4;
-	pixel_x = -32;
-	supply_display = 1
-	},
 /obj/structure/filingcabinet,
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/machinery/keycard_auth{
+	pixel_x = -23;
+	pixel_y = 0
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beK" = (
 /obj/structure/chair/office/dark{
@@ -21732,15 +24133,18 @@
 /obj/machinery/computer/cargo{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown{
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "beM" = (
 /obj/machinery/mineral/equipment_vendor,
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "beN" = (
 /obj/structure/cable{
@@ -21759,7 +24163,8 @@
 /obj/machinery/computer/shuttle/mining{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown/corner,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "beR" = (
 /obj/structure/cable{
@@ -21809,7 +24214,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bfb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -21894,21 +24302,31 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/janitor)
 "bfj" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/side{
-	dir = 10
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bfk" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bfl" = (
 /obj/machinery/hydroponics/constructable,
-/turf/open/floor/plasteel/green/corner,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bfm" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -21917,13 +24335,15 @@
 /area/hydroponics)
 "bfn" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/green/corner,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bfo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bfp" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -21957,9 +24377,17 @@
 	name = "bar shutters"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bfu" = (
 /obj/machinery/door/airlock/maintenance{
@@ -22029,9 +24457,14 @@
 	layer = 2.9
 	},
 /obj/item/pen,
-/turf/open/floor/plasteel/brown{
-	dir = 10
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfC" = (
 /obj/structure/table,
@@ -22055,9 +24488,11 @@
 	},
 /obj/item/coin/silver,
 /obj/item/stamp/qm,
-/turf/open/floor/plasteel/brown{
-	dir = 2
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfD" = (
 /obj/item/radio/intercom{
@@ -22067,9 +24502,14 @@
 /obj/machinery/computer/security/qm{
 	dir = 8
 	},
-/turf/open/floor/plasteel/brown{
-	dir = 6
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "bfE" = (
 /obj/structure/rack,
@@ -22087,9 +24527,10 @@
 	c_tag = "Cargo Mining Dock";
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfF" = (
 /obj/structure/cable{
@@ -22109,7 +24550,8 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfH" = (
-/turf/open/floor/plasteel/brown/corner,
+/obj/effect/turf_decal/tile/brown,
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bfI" = (
 /obj/machinery/door/airlock/external{
@@ -22157,7 +24599,8 @@
 /area/maintenance/department/cargo)
 "bfY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bfZ" = (
 /turf/closed/wall/r_wall,
@@ -22213,9 +24656,10 @@
 "bgf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgg" = (
 /obj/structure/cable{
@@ -22223,9 +24667,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgh" = (
 /obj/structure/chair{
@@ -22235,9 +24680,10 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgi" = (
 /obj/machinery/vending/cola,
@@ -22245,9 +24691,10 @@
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgj" = (
 /obj/effect/spawner/structure/window,
@@ -22278,48 +24725,54 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgo" = (
 /obj/structure/table,
 /obj/item/trash/plate,
 /obj/item/storage/fancy/rollingpapers,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgp" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgq" = (
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgr" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgs" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/snacks/donut,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgt" = (
 /obj/machinery/door/firedoor,
@@ -22340,16 +24793,18 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-14"
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgw" = (
 /obj/structure/chair,
 /obj/item/clothing/head/bowler,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgx" = (
 /obj/machinery/firealarm{
@@ -22358,9 +24813,10 @@
 	},
 /obj/structure/chair,
 /obj/item/clothing/mask/cigarette,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgy" = (
 /obj/machinery/light{
@@ -22369,17 +24825,19 @@
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgz" = (
 /obj/structure/sign/poster/official/cohiba_robusto_ad{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -22406,7 +24864,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgC" = (
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bgD" = (
 /obj/machinery/door/firedoor,
@@ -22422,7 +24881,7 @@
 /obj/effect/decal/cleanable/robot_debris{
 	icon_state = "gib3"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bgF" = (
 /obj/structure/cable{
@@ -22470,9 +24929,10 @@
 	name = "Mining Dock APC";
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/brown/corner{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bgL" = (
 /obj/structure/cable{
@@ -22635,7 +25095,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhj" = (
 /obj/machinery/door/firedoor,
@@ -22763,9 +25224,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/brown{
-	dir = 10
+/obj/effect/turf_decal/tile/brown{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bht" = (
 /obj/structure/closet/secure_closet/miner,
@@ -22778,21 +25244,34 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/brown,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhu" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/machinery/light,
-/turf/open/floor/plasteel/brown,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhv" = (
 /obj/structure/closet/secure_closet/miner,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/brown{
-	dir = 6
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
 "bhz" = (
 /obj/structure/cable{
@@ -22820,7 +25299,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bhF" = (
 /obj/structure/chair/comfy/beige{
@@ -22913,7 +25393,8 @@
 	pixel_x = 25;
 	req_access_txt = "29"
 	},
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bhR" = (
 /obj/machinery/light{
@@ -23028,13 +25509,15 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bik" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bil" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23044,13 +25527,15 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bim" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bin" = (
 /obj/machinery/light,
@@ -23059,7 +25544,8 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bio" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -23072,14 +25558,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biq" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bir" = (
 /obj/machinery/camera{
@@ -23089,11 +25577,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bis" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bit" = (
 /obj/machinery/door/firedoor,
@@ -23177,7 +25667,7 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
 	},
-/turf/open/floor/circuit/killroom,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "biF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23192,7 +25682,8 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "biJ" = (
 /obj/effect/spawner/structure/window,
@@ -23258,7 +25749,11 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biP" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -23276,7 +25771,11 @@
 /obj/structure/sign/departments/examroom{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biR" = (
 /obj/machinery/light,
@@ -23284,22 +25783,28 @@
 	c_tag = "Central Primary Hallway Genetics";
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biS" = (
 /obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biT" = (
 /obj/structure/closet/firecloset,
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "biW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23349,22 +25854,38 @@
 "bjf" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bjg" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bjh" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bji" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjj" = (
 /obj/structure/disposalpipe/segment{
@@ -23376,7 +25897,11 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjk" = (
 /obj/machinery/camera{
@@ -23384,32 +25909,50 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjl" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjm" = (
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjn" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bjp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bjr" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/corner,
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bju" = (
 /turf/open/floor/plasteel,
@@ -23437,7 +25980,7 @@
 /area/maintenance/department/cargo)
 "bjB" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/circuit/killroom,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bjD" = (
 /obj/structure/cable{
@@ -23551,9 +26094,16 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjY" = (
 /obj/structure/table,
@@ -23565,24 +26115,37 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjZ" = (
 /obj/machinery/computer/secure_data,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bka" = (
 /obj/machinery/computer/security,
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bkb" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -23594,31 +26157,50 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkd" = (
 /obj/structure/chair,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bke" = (
 /obj/structure/chair,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkf" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -23632,9 +26214,13 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bkm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -23642,9 +26228,13 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bkn" = (
 /obj/machinery/navbeacon{
@@ -23655,16 +26245,26 @@
 /area/hallway/primary/aft)
 "bko" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bkp" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bkq" = (
 /obj/structure/table,
@@ -23818,7 +26418,8 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bkW" = (
 /obj/item/hemostat,
@@ -23915,9 +26516,13 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bli" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -23938,17 +26543,20 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bll" = (
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "blm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -23984,57 +26592,82 @@
 	pixel_x = 3;
 	pixel_y = 2
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "blr" = (
 /obj/structure/table,
 /obj/item/folder/white,
 /obj/item/healthanalyzer,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bls" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "blt" = (
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blu" = (
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "blv" = (
 /obj/structure/table,
 /obj/item/paicard,
 /obj/item/clothing/glasses/science,
-/turf/open/floor/plasteel/green/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blw" = (
 /obj/structure/table,
 /obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blx" = (
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bly" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -24043,73 +26676,108 @@
 	pixel_x = -26;
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blz" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blA" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/chair/stool,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blC" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blD" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/green/side{
-	dir = 5
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "blE" = (
 /obj/structure/filingcabinet/chestdrawer,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "blF" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/roboticist,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blG" = (
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blH" = (
 /obj/machinery/camera{
@@ -24121,9 +26789,13 @@
 	name = "utility sink";
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blI" = (
 /obj/machinery/requests_console{
@@ -24133,9 +26805,13 @@
 	pixel_y = 30;
 	receive_ore_updates = 1
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blJ" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -24149,9 +26825,13 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blK" = (
 /obj/structure/disposalpipe/segment{
@@ -24165,18 +26845,30 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "blL" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "blM" = (
 /obj/machinery/rnd/server,
@@ -24193,7 +26885,7 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/dark/telecomms/server/walkway,
+/turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "blP" = (
 /obj/effect/landmark/event_spawn,
@@ -24217,7 +26909,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/book/manual/experimentor,
+/obj/item/book/manual/wiki/experimentor,
 /turf/open/floor/engine,
 /area/science/explab)
 "blT" = (
@@ -24227,9 +26919,17 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blU" = (
 /obj/structure/table/reinforced,
@@ -24240,18 +26940,34 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blV" = (
 /obj/structure/table/reinforced,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
 /obj/item/stack/sheet/metal/ten,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blW" = (
 /obj/structure/table/reinforced,
@@ -24262,18 +26978,30 @@
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "blX" = (
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "blZ" = (
 /obj/machinery/computer/camera_advanced/xenobio,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bmc" = (
 /obj/structure/table,
@@ -24411,9 +27139,14 @@
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/security/med,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmt" = (
 /obj/structure/cable{
@@ -24422,28 +27155,42 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmv" = (
 /obj/structure/table,
 /obj/item/book/manual/wiki/security_space_law,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bmw" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-05"
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bmx" = (
 /obj/structure/disposalpipe/segment,
@@ -24462,28 +27209,27 @@
 /area/medical/medbay/central)
 "bmz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bmA" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/blue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "bmB" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21";
-	pixel_y = 3
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmC" = (
 /turf/open/floor/plasteel,
@@ -24528,9 +27274,17 @@
 	pixel_y = 5
 	},
 /obj/item/clothing/glasses/welding,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bmM" = (
 /turf/open/floor/plasteel,
@@ -24592,7 +27346,7 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark/telecomms/server/walkway,
+/turf/open/floor/plasteel/dark/telecomms,
 /area/science/server)
 "bmU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -24631,18 +27385,34 @@
 	pixel_x = -28;
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bna" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/box/red,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bnb" = (
 /obj/structure/table/reinforced,
@@ -24653,9 +27423,17 @@
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
 /obj/item/stock_parts/cell/high,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bnc" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/heater{
@@ -24725,7 +27503,8 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bnt" = (
 /obj/structure/chair/comfy{
@@ -24770,9 +27549,13 @@
 /obj/item/clothing/gloves/color/latex/nitrile,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/mask/surgical,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
 "bny" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -24787,9 +27570,11 @@
 	dir = 1;
 	light_color = "#ffc1c1"
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/storage/emergency/port)
 "bnz" = (
 /obj/structure/table,
@@ -24815,23 +27600,38 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bnC" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/britcup{
 	desc = "Kingston's personal cup."
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnD" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin{
 	pixel_x = 1
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnE" = (
 /obj/structure/disposalpipe/segment,
@@ -24848,9 +27648,14 @@
 /area/medical/medbay/central)
 "bnG" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bnH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -24862,7 +27667,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bnL" = (
 /obj/structure/disposalpipe/segment{
@@ -24871,7 +27680,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bnM" = (
 /obj/structure/disposalpipe/segment{
@@ -24880,9 +27693,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bnN" = (
 /obj/structure/disposalpipe/segment{
@@ -24899,9 +27713,17 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bnP" = (
 /obj/effect/turf_decal/stripes/line{
@@ -24994,9 +27816,17 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "boa" = (
 /obj/structure/disposalpipe/segment,
@@ -25055,14 +27885,20 @@
 	},
 /area/maintenance/department/cargo)
 "bon" = (
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "boo" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Port Aft";
 	dir = 1
 	},
-/turf/open/floor/plasteel/arrival,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/entry)
 "bop" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -25097,17 +27933,25 @@
 /area/medical/genetics)
 "bov" = (
 /obj/structure/closet/secure_closet/personal/patient,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bow" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "box" = (
 /obj/structure/cable{
@@ -25117,15 +27961,23 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boy" = (
 /obj/structure/closet/wardrobe/mixed,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boz" = (
 /obj/machinery/vending/clothing,
@@ -25133,24 +27985,34 @@
 	dir = 1;
 	pixel_y = 27
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "boA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "boB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "boC" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -25164,9 +28026,16 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boF" = (
 /obj/structure/cable{
@@ -25175,17 +28044,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boH" = (
 /obj/machinery/requests_console{
@@ -25203,26 +28081,39 @@
 	name = "Station Intercom (Medbay)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boI" = (
 /obj/structure/chair/office/light{
 	dir = 4
 	},
 /obj/effect/landmark/start/medical_doctor,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 5
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boJ" = (
 /obj/structure/table/reinforced,
 /obj/item/folder/white,
 /obj/item/pen,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boK" = (
 /obj/structure/disposalpipe/segment,
@@ -25231,7 +28122,11 @@
 /area/medical/medbay/central)
 "boL" = (
 /obj/structure/bed/roller,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boM" = (
 /obj/structure/bed/roller,
@@ -25240,16 +28135,28 @@
 	network = list("ss13","medbay");
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boN" = (
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boO" = (
 /obj/structure/table/glass,
 /obj/item/stack/medical/gauze,
 /obj/item/reagent_containers/glass/bottle/epinephrine,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boP" = (
 /obj/structure/closet/emcloset,
@@ -25274,18 +28181,34 @@
 "boS" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boT" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
 	},
 /obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boU" = (
 /obj/machinery/firealarm{
@@ -25301,9 +28224,17 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "boX" = (
 /obj/machinery/computer/rdconsole/robotics{
@@ -25382,9 +28313,17 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/general/visible,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpe" = (
 /obj/machinery/computer/rdconsole/experiment,
@@ -25392,9 +28331,17 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -25407,9 +28354,17 @@
 	},
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bph" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25433,9 +28388,17 @@
 	dir = 2;
 	network = list("ss13","rd")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpi" = (
 /obj/structure/closet/crate,
@@ -25449,9 +28412,17 @@
 /obj/item/gun/energy/laser/practice,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/clothing/ears/earmuffs,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bpn" = (
 /turf/open/floor/plasteel/white,
@@ -25526,7 +28497,17 @@
 	name = "Station Intercom (Medbay)";
 	pixel_x = -30
 	},
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "bpz" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25562,9 +28543,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bpE" = (
 /obj/structure/cable{
@@ -25580,9 +28565,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bpG" = (
 /obj/machinery/door/firedoor,
@@ -25672,9 +28659,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpO" = (
 /obj/structure/cable{
@@ -25687,9 +28678,11 @@
 /area/medical/medbay/central)
 "bpP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpQ" = (
 /obj/machinery/door/firedoor,
@@ -25703,26 +28696,34 @@
 /obj/structure/chair/office/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpS" = (
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpU" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -25746,9 +28747,17 @@
 	},
 /obj/item/folder/white,
 /obj/item/pen,
-/turf/open/floor/plasteel/whiteyellow{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bpX" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
@@ -25790,9 +28799,13 @@
 	name = "Research Division"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bqe" = (
 /obj/machinery/door/firedoor,
@@ -25810,13 +28823,15 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bqg" = (
 /obj/structure/table,
-/obj/item/book/manual/robotics_cyborgs{
+/obj/item/book/manual/wiki/robotics_cyborgs{
 	pixel_x = 2;
 	pixel_y = 5
 	},
@@ -25829,9 +28844,17 @@
 /obj/item/radio/headset/headset_sci{
 	pixel_x = -3
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bqh" = (
 /obj/structure/disposalpipe/segment{
@@ -25862,9 +28885,17 @@
 /area/science/robotics/lab)
 "bqk" = (
 /obj/machinery/aug_manipulator,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bql" = (
 /obj/machinery/power/apc{
@@ -25897,18 +28928,29 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
 /obj/structure/chair/stool,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqq" = (
 /obj/effect/landmark/start/scientist,
@@ -25916,17 +28958,25 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqr" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqs" = (
 /turf/open/floor/plasteel/white,
@@ -25944,9 +28994,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqw" = (
 /obj/effect/turf_decal/stripes/line{
@@ -25956,9 +29010,13 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqx" = (
 /obj/item/stack/sheet/glass/fifty{
@@ -25976,9 +29034,13 @@
 /obj/item/stack/sheet/mineral/plasma{
 	pixel_y = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bqA" = (
 /obj/machinery/door/airlock/maintenance{
@@ -26001,14 +29063,22 @@
 /obj/structure/window/reinforced,
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/science,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqF" = (
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 1
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bqG" = (
 /obj/machinery/door/poddoor/preopen{
@@ -26119,7 +29189,8 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bqT" = (
 /obj/structure/flora/grass/jungle/b,
@@ -26154,7 +29225,17 @@
 /obj/machinery/computer/cloning{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "bqX" = (
 /obj/machinery/holopad,
@@ -26213,9 +29294,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "brc" = (
 /obj/structure/cable{
@@ -26247,9 +29332,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bre" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26261,9 +29347,10 @@
 	name = "Medbay APC";
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brf" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -26278,53 +29365,52 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brh" = (
 /obj/machinery/computer/med_data{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bri" = (
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 6
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brj" = (
 /obj/machinery/chem_master,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brk" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /obj/effect/landmark/start/chemist,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 1
-	},
-/area/medical/chemistry)
-"brl" = (
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 1
-	},
-/area/medical/chemistry)
-"brm" = (
-/obj/machinery/chem_master,
 /obj/machinery/button/door{
 	id = "chemistry_shutters";
 	name = "Shutters Control";
@@ -26332,20 +29418,55 @@
 	pixel_y = 4;
 	req_access_txt = "5; 33"
 	},
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 5
-	},
-/area/medical/chemistry)
-"bro" = (
-/obj/structure/plasticflaps/opaque,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/maintenance/department/engine)
-"brp" = (
-/obj/item/storage/toolbox/mechanical,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"brl" = (
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/obj/structure/table,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"brm" = (
+/obj/machinery/chem_master,
+/obj/machinery/requests_console{
+	department = "Chemistry";
+	departmentType = 2;
+	pixel_x = 32;
+	receive_ore_updates = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"brp" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-03"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/lab)
 "brq" = (
 /obj/structure/sink/kitchen{
@@ -26354,9 +29475,14 @@
 	pixel_y = 28
 	},
 /obj/item/stack/cable_coil/orange,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/item/storage/toolbox/mechanical,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brr" = (
 /obj/machinery/disposal/bin,
@@ -26369,26 +29495,38 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brs" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brt" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "bru" = (
 /obj/machinery/holopad,
@@ -26396,9 +29534,13 @@
 	pixel_x = 25
 	},
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "brv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -26406,15 +29548,27 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "brw" = (
 /obj/machinery/vending/wardrobe/robo_wardrobe,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "brx" = (
 /obj/structure/cable{
@@ -26525,9 +29679,13 @@
 	pixel_x = -25
 	},
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "brH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26571,9 +29729,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "brU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -26583,9 +29745,13 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "brV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -26597,15 +29763,23 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "brX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bsa" = (
 /obj/machinery/disposal/bin,
@@ -26694,9 +29868,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bsl" = (
 /obj/structure/sign/warning/vacuum/external,
@@ -26715,7 +29893,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bsn" = (
 /obj/structure/girder,
@@ -26747,7 +29926,17 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/genetics)
 "bss" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -26793,9 +29982,10 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bsy" = (
 /obj/structure/cable{
@@ -26808,9 +29998,10 @@
 /obj/machinery/shower{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bsA" = (
 /turf/closed/wall,
@@ -26825,12 +30016,32 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsC" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -26842,7 +30053,17 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsE" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -26859,15 +30080,26 @@
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bsF" = (
 /obj/machinery/shower{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsG" = (
 /obj/structure/extinguisher_cabinet{
@@ -26876,9 +30108,10 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -26887,9 +30120,10 @@
 	id_tag = "medbaybolts";
 	name = "Medbay"
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsI" = (
 /obj/structure/disposalpipe/segment,
@@ -26899,7 +30133,8 @@
 	id_tag = "medbaybolts";
 	name = "Medbay"
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsJ" = (
 /obj/machinery/chem_dispenser{
@@ -26908,16 +30143,20 @@
 /obj/structure/sign/poster/official/safety_eye_protection{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/whiteyellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsK" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsL" = (
 /obj/item/storage/box/beakers,
-/obj/structure/table/glass,
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsM" = (
@@ -26932,9 +30171,11 @@
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
-/turf/open/floor/plasteel/whiteyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsR" = (
 /obj/effect/turf_decal/stripes/line,
@@ -26959,9 +30200,13 @@
 /area/science/lab)
 "bsU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsV" = (
 /obj/structure/chair{
@@ -26972,15 +30217,25 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsW" = (
 /obj/item/twohanded/required/kirbyplants,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "bsX" = (
 /obj/structure/cable{
@@ -26988,10 +30243,18 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bsY" = (
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bsZ" = (
 /obj/item/storage/firstaid/regular{
@@ -27012,7 +30275,11 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/structure/table,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "bta" = (
 /obj/item/retractor,
@@ -27081,9 +30348,13 @@
 	},
 /obj/item/multitool,
 /obj/item/multitool,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "bth" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -27126,9 +30397,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "btt" = (
 /obj/machinery/door/firedoor,
@@ -27166,9 +30439,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btx" = (
 /obj/structure/cable{
@@ -27177,9 +30454,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "btA" = (
 /obj/structure/chair{
@@ -27195,7 +30476,7 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "btB" = (
 /obj/structure/cable{
@@ -27204,7 +30485,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "btE" = (
 /obj/structure/disposalpipe/segment{
@@ -27242,7 +30523,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "btK" = (
 /obj/docking_port/stationary{
@@ -27282,7 +30563,8 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "btO" = (
 /obj/structure/cable{
@@ -27336,29 +30618,45 @@
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btX" = (
 /obj/structure/table,
-/obj/item/book/manual/medical_cloning{
+/obj/item/book/manual/wiki/medical_cloning{
 	pixel_y = 6
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btY" = (
 /obj/structure/table,
@@ -27376,13 +30674,18 @@
 	pixel_x = 24;
 	pixel_y = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bua" = (
 /obj/machinery/door/firedoor,
@@ -27434,9 +30737,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "buh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27450,10 +30754,10 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "buj" = (
-/obj/machinery/chem_heater,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -27464,21 +30768,23 @@
 	c_tag = "Chemistry";
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteyellow/corner{
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "buk" = (
 /obj/structure/disposalpipe/segment{
-	dir = 6
+	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bul" = (
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/obj/machinery/disposal/bin,
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bum" = (
@@ -27486,9 +30792,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bun" = (
-/turf/open/floor/plasteel/whiteyellow/corner{
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = 28
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bup" = (
 /obj/machinery/rnd/destructive_analyzer,
@@ -27529,9 +30844,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "buu" = (
 /obj/structure/chair{
@@ -27539,9 +30858,11 @@
 	},
 /obj/item/clothing/mask/cigarette,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "buv" = (
 /obj/structure/disposalpipe/segment,
@@ -27563,9 +30884,13 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bux" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -27578,10 +30903,11 @@
 /obj/item/twohanded/required/kirbyplants/photosynthetic{
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "buz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27591,7 +30917,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buB" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27615,25 +30945,46 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buE" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buG" = (
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buH" = (
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 6
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "buI" = (
 /obj/structure/disposalpipe/segment{
@@ -27651,7 +31002,11 @@
 "buK" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "buL" = (
 /obj/structure/disposalpipe/segment{
@@ -27721,7 +31076,11 @@
 	dir = 1;
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "buW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -27730,7 +31089,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bva" = (
 /turf/closed/wall,
@@ -27754,7 +31117,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bve" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -27864,7 +31237,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bvq" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -27894,11 +31268,14 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
 	},
-/turf/closed/wall,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bvw" = (
 /obj/machinery/computer/rdconsole/core{
 	dir = 4
@@ -27938,9 +31315,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27949,9 +31327,13 @@
 /obj/machinery/newscaster{
 	pixel_y = 34
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -27960,9 +31342,13 @@
 /obj/structure/sign/poster/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvE" = (
 /obj/structure/disposalpipe/segment{
@@ -27975,9 +31361,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvF" = (
 /obj/effect/turf_decal/stripes/line{
@@ -27989,9 +31379,14 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/green/side{
-	dir = 5
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bvG" = (
 /obj/machinery/door/poddoor/preopen{
@@ -28060,15 +31455,20 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvM" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/darkpurple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvN" = (
 /obj/structure/cable{
@@ -28084,10 +31484,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkpurple/corner{
-	icon_state = "darkpurplecorners";
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -28097,33 +31497,49 @@
 	pixel_y = 30
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvR" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvT" = (
 /obj/structure/window/reinforced{
@@ -28132,17 +31548,29 @@
 	},
 /obj/structure/closet/emcloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvU" = (
 /obj/machinery/recharger,
 /obj/structure/table,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvV" = (
 /turf/open/floor/plasteel,
@@ -28152,9 +31580,17 @@
 /obj/effect/landmark/blobstart,
 /obj/structure/target_stake,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bvY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -28190,7 +31626,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwf" = (
 /obj/structure/cable{
@@ -28199,11 +31639,19 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwh" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bwm" = (
 /turf/closed/wall,
@@ -28237,7 +31685,8 @@
 	name = "Monastery Transit"
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bws" = (
 /obj/structure/closet,
@@ -28268,30 +31717,49 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bww" = (
 /obj/machinery/computer/scan_consolenew,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwx" = (
 /obj/machinery/dna_scannernew,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwy" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwz" = (
 /obj/machinery/disposal/bin,
@@ -28299,9 +31767,13 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwA" = (
 /obj/structure/table,
@@ -28310,9 +31782,14 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/bodybags,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwB" = (
 /obj/machinery/requests_console{
@@ -28363,7 +31840,11 @@
 	icon_state = "plant-21";
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwG" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
@@ -28382,7 +31863,11 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bwK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -28409,14 +31894,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwO" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/bed/roller,
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -28424,13 +31911,15 @@
 	},
 /obj/structure/bed/roller,
 /obj/machinery/iv_drip,
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwS" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -28440,9 +31929,10 @@
 	dir = 8;
 	pixel_x = -12
 	},
-/turf/open/floor/plasteel/whiteyellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwT" = (
 /obj/structure/disposalpipe/segment,
@@ -28456,31 +31946,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwV" = (
-/turf/open/floor/plasteel/whiteyellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwW" = (
-/obj/structure/rack,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/machinery/light_switch{
-	pixel_x = 25
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
 	},
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 6
-	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/chemistry)
-"bxa" = (
-/obj/structure/table/glass,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -24
-	},
-/obj/item/book/manual/research_and_development,
-/obj/item/disk/tech_disk,
-/obj/item/disk/design_disk,
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
 "bxc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -28579,9 +32055,13 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxj" = (
 /obj/structure/cable{
@@ -28658,9 +32138,11 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bxp" = (
 /obj/machinery/door/poddoor/preopen{
@@ -28805,16 +32287,25 @@
 	},
 /obj/structure/closet/firecloset,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxD" = (
 /obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxF" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -28828,9 +32319,17 @@
 /area/science/explab)
 "bxH" = (
 /obj/effect/turf_decal/box/corners,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bxJ" = (
 /obj/structure/window/reinforced{
@@ -29027,9 +32526,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "byg" = (
 /obj/structure/chair/stool,
@@ -29070,9 +32573,11 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "byl" = (
 /obj/structure/extinguisher_cabinet{
@@ -29088,9 +32593,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bym" = (
 /obj/structure/cable{
@@ -29111,7 +32617,8 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "byo" = (
 /obj/effect/spawner/structure/window,
@@ -29124,9 +32631,10 @@
 /area/medical/sleeper)
 "byr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bys" = (
 /obj/structure/disposalpipe/segment,
@@ -29137,7 +32645,8 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "byu" = (
 /turf/closed/wall,
@@ -29165,9 +32674,13 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/radio/headset/headset_med,
-/turf/open/floor/plasteel/whiteyellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "byx" = (
 /obj/structure/cable{
@@ -29175,14 +32688,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/medical/chemistry)
-"byy" = (
-/obj/structure/chair/office/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 4
-	},
 /area/medical/chemistry)
 "byz" = (
 /obj/structure/window/reinforced{
@@ -29217,28 +32722,34 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byD" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/machinery/door/airlock/research{
+	name = "R&D Lab";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29;30"
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/science/lab)
 "byE" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/lab)
 "byF" = (
 /obj/structure/chair/office/light{
@@ -29255,14 +32766,22 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "byH" = (
 /obj/structure/table,
 /obj/item/multitool,
 /obj/item/clothing/glasses/science,
 /obj/item/clothing/glasses/science,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "byI" = (
 /obj/structure/table,
@@ -29270,30 +32789,43 @@
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "byJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/purple/side{
-	icon_state = "purple";
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byL" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -29320,9 +32852,11 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "byO" = (
 /obj/machinery/door/poddoor/preopen{
@@ -29388,14 +32922,22 @@
 	pixel_y = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byU" = (
 /obj/structure/chair/comfy{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byV" = (
 /obj/structure/table,
@@ -29403,7 +32945,11 @@
 /obj/item/pen,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/light,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byW" = (
 /obj/structure/chair/comfy{
@@ -29412,7 +32958,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byX" = (
 /obj/machinery/camera{
@@ -29423,16 +32973,20 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byY" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/corner{
-	icon_state = "darkpurplecorners";
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "byZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -29448,7 +33002,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkpurple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzb" = (
 /obj/structure/closet/radiation,
@@ -29459,16 +33014,28 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 6
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzc" = (
 /obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bzd" = (
 /obj/effect/turf_decal/stripes/line,
@@ -29481,7 +33048,11 @@
 /area/science/explab)
 "bzg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bzh" = (
 /obj/structure/table,
@@ -29692,9 +33263,13 @@
 /turf/open/floor/grass,
 /area/medical/genetics)
 "bzG" = (
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzH" = (
 /turf/open/floor/plasteel/white,
@@ -29728,27 +33303,41 @@
 /obj/structure/mirror{
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bzM" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-10"
 	},
-/turf/open/floor/plasteel/whitegreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzN" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/whitegreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzO" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitegreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzP" = (
 /obj/machinery/sleeper{
@@ -29760,7 +33349,17 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bzQ" = (
 /obj/effect/turf_decal/stripes/line{
@@ -29774,9 +33373,13 @@
 /area/medical/sleeper)
 "bzS" = (
 /obj/structure/chair,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzT" = (
 /obj/structure/table/glass,
@@ -29786,9 +33389,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bzU" = (
 /obj/effect/spawner/structure/window,
@@ -29802,9 +33409,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzW" = (
 /obj/structure/disposalpipe/segment,
@@ -29817,7 +33425,8 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bzY" = (
 /obj/structure/sign/departments/medbay/alt,
@@ -29828,7 +33437,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bAa" = (
 /obj/machinery/computer/crew,
@@ -29842,21 +33457,39 @@
 	name = "Chief Medical Officer RC";
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bAb" = (
 /obj/machinery/computer/med_data,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bAc" = (
 /obj/machinery/computer/card/minor/cmo,
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bAd" = (
 /obj/machinery/disposal/bin,
@@ -29874,16 +33507,27 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bAe" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
 /obj/machinery/vending/wardrobe/chem_wardrobe,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAf" = (
 /obj/structure/cable{
@@ -29893,7 +33537,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/whiteyellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAg" = (
 /obj/structure/table/glass,
@@ -29904,21 +33552,18 @@
 	},
 /obj/item/stack/cable_coil/random,
 /obj/item/book/manual/wiki/chemistry,
-/turf/open/floor/plasteel/whiteyellow/side,
-/area/medical/chemistry)
-"bAh" = (
-/obj/structure/table/glass,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
 /obj/item/stack/sheet/mineral/plasma{
 	amount = 2;
 	layer = 2.9
 	},
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
-/obj/item/grenade/chem_grenade,
 /obj/item/screwdriver,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bAi" = (
 /obj/machinery/smoke_machine,
@@ -29934,24 +33579,16 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAm" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_access_txt = "0";
-	req_one_access_txt = "7;29"
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/closed/wall/r_wall,
+/area/hallway/primary/aft)
 "bAo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -29981,9 +33618,13 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bAq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -30024,9 +33665,13 @@
 "bAv" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAw" = (
 /obj/structure/disposalpipe/segment,
@@ -30045,9 +33690,11 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bAy" = (
 /turf/closed/wall/r_wall,
@@ -30061,9 +33708,13 @@
 /area/science/storage)
 "bAC" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bAD" = (
 /obj/machinery/door/firedoor,
@@ -30076,10 +33727,11 @@
 "bAE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bAF" = (
 /turf/closed/wall,
@@ -30097,16 +33749,15 @@
 /area/science/xenobiology)
 "bAI" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 4
 	},
-/obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAJ" = (
 /obj/structure/transit_tube/horizontal,
 /obj/structure/window/reinforced/fulltile,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "bAK" = (
 /obj/structure/transit_tube/horizontal,
@@ -30159,9 +33810,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bAR" = (
 /obj/structure/chair/stool,
@@ -30202,9 +33857,11 @@
 	name = "Genetics Requests Console";
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bAW" = (
 /turf/closed/wall,
@@ -30263,14 +33920,23 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBf" = (
-/obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
+	},
+/obj/structure/disposalpipe/junction/flip{
+	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -30284,14 +33950,26 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
 /mob/living/simple_animal/pet/cat/Runtime,
-/turf/open/floor/plasteel/cmo,
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBi" = (
 /obj/effect/landmark/start/chief_medical_officer,
@@ -30307,7 +33985,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -30316,7 +34000,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBk" = (
 /obj/structure/disposalpipe/segment,
@@ -30337,7 +34027,13 @@
 	dir = 8;
 	pixel_x = 30
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bBl" = (
 /obj/machinery/door/airlock/maintenance{
@@ -30353,9 +34049,10 @@
 /area/maintenance/department/engine)
 "bBm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bBo" = (
 /turf/closed/wall,
@@ -30373,9 +34070,16 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBr" = (
 /obj/structure/cable{
@@ -30384,7 +34088,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBs" = (
@@ -30431,23 +34137,32 @@
 	pixel_y = 5;
 	req_access_txt = "47"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bBw" = (
 /obj/machinery/computer/security,
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBx" = (
 /obj/machinery/computer/security/mining,
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBy" = (
 /obj/machinery/computer/secure_data,
@@ -30462,9 +34177,14 @@
 	pixel_x = 28;
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bBz" = (
 /obj/structure/disposalpipe/segment,
@@ -30477,18 +34197,28 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bBB" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-20";
 	pixel_y = 3
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bBC" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -30529,9 +34259,13 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBI" = (
 /obj/structure/cable{
@@ -30542,10 +34276,11 @@
 /area/science/explab)
 "bBJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bBK" = (
 /obj/structure/closet/bombcloset,
@@ -30560,8 +34295,8 @@
 /area/science/mixing)
 "bBL" = (
 /obj/structure/closet/bombcloset,
-/obj/machinery/airalarm{
-	pixel_y = 22
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
@@ -30569,9 +34304,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bBN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -30581,16 +34320,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bBP" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/obj/machinery/portable_atmospherics/canister,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBQ" = (
@@ -30616,9 +34357,18 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBS" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -30630,9 +34380,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBT" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -30645,9 +34403,18 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/machinery/portable_atmospherics/pump,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bBU" = (
 /mob/living/simple_animal/slime,
@@ -30655,7 +34422,6 @@
 /area/science/xenobiology)
 "bBV" = (
 /obj/structure/transit_tube/curved,
-/obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "bBW" = (
@@ -30680,15 +34446,24 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCa" = (
 /obj/machinery/computer/scan_consolenew{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCb" = (
 /obj/machinery/dna_scannernew,
@@ -30697,15 +34472,20 @@
 	dir = 1;
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCc" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/whitepurple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCd" = (
 /obj/structure/cable{
@@ -30722,9 +34502,11 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bCf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -30768,13 +34550,33 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCj" = (
 /obj/machinery/sleeper{
 	dir = 4
 	},
-/turf/open/floor/plasteel/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCl" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -30785,20 +34587,32 @@
 	pixel_x = -2;
 	pixel_y = -27
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCm" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCo" = (
 /obj/structure/disposalpipe/segment{
@@ -30813,9 +34627,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bCq" = (
 /obj/structure/disposalpipe/segment{
@@ -30829,7 +34645,13 @@
 	name = "Chief Medical Office";
 	req_access_txt = "40"
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/cmo)
 "bCr" = (
 /obj/structure/disposalpipe/segment{
@@ -30841,7 +34663,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCs" = (
 /obj/structure/table/glass,
@@ -30855,7 +34683,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCt" = (
 /obj/structure/table/glass,
@@ -30864,7 +34698,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCu" = (
 /obj/structure/table/glass,
@@ -30873,7 +34713,13 @@
 	},
 /obj/item/stack/medical/gauze,
 /obj/item/clothing/neck/stethoscope,
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCv" = (
 /obj/structure/cable{
@@ -30889,7 +34735,13 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bCw" = (
 /obj/machinery/door/airlock/maintenance{
@@ -30980,7 +34832,8 @@
 /area/maintenance/department/engine)
 "bCC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bCD" = (
 /obj/structure/disposalpipe/segment{
@@ -31002,9 +34855,13 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bCF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -31029,10 +34886,11 @@
 	dir = 4;
 	light_color = "#c1caff"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bCJ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31056,9 +34914,14 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCL" = (
 /obj/effect/landmark/start/depsec/science,
@@ -31071,15 +34934,25 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCM" = (
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bCN" = (
 /obj/structure/chair/comfy,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bCO" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -31105,9 +34978,13 @@
 /turf/closed/wall,
 /area/science/storage)
 "bCT" = (
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bCU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -31153,17 +35030,33 @@
 /obj/machinery/atmospherics/components/trinary/mixer/flipped{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDc" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDd" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -31178,9 +35071,17 @@
 	dir = 4
 	},
 /obj/item/wrench,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDe" = (
 /obj/machinery/light{
@@ -31221,9 +35122,14 @@
 /area/maintenance/department/engine)
 "bDl" = (
 /obj/structure/closet/secure_closet/medical1,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bDm" = (
 /obj/structure/closet/secure_closet/personal/patient,
@@ -31232,13 +35138,22 @@
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bDn" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 6
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bDo" = (
 /obj/machinery/shower{
@@ -31274,9 +35189,13 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bDt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -31285,13 +35204,25 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bDu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bDv" = (
 /obj/structure/chair/office/light{
@@ -31300,13 +35231,25 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bDw" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bDx" = (
 /obj/machinery/power/apc{
@@ -31316,7 +35259,13 @@
 	pixel_x = 26
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bDy" = (
 /turf/closed/wall,
@@ -31334,8 +35283,12 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bDB" = (
 /obj/machinery/airalarm/unlocked{
 	dir = 4;
@@ -31344,9 +35297,13 @@
 /obj/machinery/computer/rdconsole{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDC" = (
 /obj/structure/chair/office/light{
@@ -31369,10 +35326,11 @@
 /obj/machinery/computer/card/minor/rd{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bDG" = (
 /obj/structure/table,
@@ -31382,9 +35340,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bDH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -31399,9 +35361,11 @@
 "bDI" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bDK" = (
 /obj/structure/table,
@@ -31413,9 +35377,17 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bDL" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
@@ -31475,9 +35447,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDS" = (
 /obj/structure/cable{
@@ -31496,10 +35472,11 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bDU" = (
 /obj/machinery/door/firedoor/heavy,
@@ -31516,9 +35493,17 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bDV" = (
 /obj/structure/cable{
@@ -31567,17 +35552,33 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEc" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEd" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -31593,9 +35594,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEf" = (
 /obj/machinery/airalarm{
@@ -31605,9 +35614,17 @@
 /obj/item/pickaxe,
 /obj/structure/closet/crate,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bEj" = (
 /obj/machinery/atmospherics/pipe/manifold/general/hidden{
@@ -31710,10 +35727,14 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/machinery/rnd/production/protolathe/department/medical,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/rnd/production/techfab/department/medical,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEw" = (
 /obj/structure/table,
@@ -31730,9 +35751,13 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEx" = (
 /obj/structure/table,
@@ -31749,9 +35774,13 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEy" = (
 /obj/structure/table,
@@ -31768,9 +35797,13 @@
 	name = "First-Aid Supplies";
 	req_access_txt = "5"
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEz" = (
 /obj/structure/table,
@@ -31784,16 +35817,21 @@
 	pixel_y = -3
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEA" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bEB" = (
 /obj/machinery/door/firedoor,
@@ -31802,20 +35840,33 @@
 "bEC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bED" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/item/valentine,
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEE" = (
 /obj/machinery/modular_computer/console/preset/civilian{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEF" = (
 /obj/item/cartridge/medical{
@@ -31833,7 +35884,13 @@
 /obj/structure/table,
 /obj/machinery/light,
 /obj/item/wrench/medical,
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEG" = (
 /obj/item/folder/blue,
@@ -31843,7 +35900,13 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEH" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -31852,7 +35915,13 @@
 /obj/machinery/light_switch{
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel/cmo,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
 "bEI" = (
 /obj/structure/cable{
@@ -31937,9 +36006,10 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bEQ" = (
 /obj/structure/closet/crate{
@@ -31947,8 +36017,12 @@
 	},
 /obj/item/stock_parts/matter_bin,
 /obj/item/stock_parts/matter_bin,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bER" = (
 /obj/machinery/computer/mecha{
 	dir = 4
@@ -31961,10 +36035,14 @@
 	dir = 9;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bES" = (
 /obj/item/aicard,
@@ -31979,7 +36057,11 @@
 	},
 /obj/machinery/light,
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bET" = (
 /obj/item/paper_bin{
@@ -31990,9 +36072,8 @@
 /obj/item/folder/white,
 /obj/item/pen,
 /obj/item/stamp/rd,
-/obj/machinery/status_display{
-	pixel_y = -30;
-	supply_display = 0
+/obj/machinery/status_display/ai{
+	pixel_y = -32
 	},
 /obj/machinery/camera{
 	c_tag = "Research Director's Office";
@@ -32000,7 +36081,11 @@
 	network = list("ss13","rd")
 	},
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEU" = (
 /obj/item/cartridge/signal/toxins,
@@ -32017,7 +36102,11 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEV" = (
 /obj/machinery/newscaster{
@@ -32026,19 +36115,28 @@
 /obj/machinery/modular_computer/console/preset/research{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
-	dir = 6
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hor)
 "bEW" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = -32
 	},
 /obj/structure/filingcabinet/security,
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -32048,7 +36146,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEY" = (
 /obj/machinery/power/apc{
@@ -32061,17 +36163,30 @@
 	icon_state = "0-8"
 	},
 /obj/structure/closet/secure_closet/security/science,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bEZ" = (
 /obj/structure/chair/comfy{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bFa" = (
 /obj/effect/turf_decal/bot,
@@ -32099,10 +36214,11 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bFf" = (
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bFh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -32161,39 +36277,67 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bFp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/mixing)
-"bFr" = (
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
+"bFr" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFu" = (
 /obj/machinery/button/massdriver{
@@ -32204,9 +36348,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bFx" = (
 /obj/structure/chair{
@@ -32373,15 +36521,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bFU" = (
 /turf/closed/wall,
@@ -32447,7 +36597,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/science)
 "bGc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -32459,9 +36619,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bGe" = (
 /obj/machinery/portable_atmospherics/scrubber,
@@ -32469,9 +36633,17 @@
 	dir = 4;
 	pixel_x = 28
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bGf" = (
 /obj/effect/turf_decal/bot,
@@ -32511,9 +36683,13 @@
 /area/science/storage)
 "bGj" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bGk" = (
 /obj/machinery/light,
@@ -32522,10 +36698,11 @@
 /area/science/explab)
 "bGl" = (
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/darkpurple/side{
-	icon_state = "darkpurple";
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "bGm" = (
 /obj/structure/closet/emcloset,
@@ -32534,14 +36711,22 @@
 	pixel_x = -24;
 	pixel_y = 8
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGn" = (
 /obj/machinery/vending/wardrobe/science_wardrobe,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGo" = (
 /obj/item/assembly/signaler{
@@ -32563,7 +36748,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGp" = (
 /obj/item/transfer_valve{
@@ -32590,7 +36779,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGq" = (
 /obj/item/assembly/timer{
@@ -32610,14 +36803,22 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGr" = (
 /obj/structure/tank_dispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGs" = (
 /obj/effect/turf_decal/stripes/line{
@@ -32626,7 +36827,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGt" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
@@ -32634,14 +36839,30 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGu" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGv" = (
 /obj/machinery/meter,
@@ -32651,9 +36872,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bGw" = (
 /obj/machinery/door/firedoor/heavy,
@@ -32788,9 +37017,16 @@
 	pixel_x = -4;
 	pixel_y = 24
 	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGT" = (
 /obj/structure/cable{
@@ -32812,13 +37048,17 @@
 /obj/machinery/light_switch{
 	pixel_x = 22
 	},
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 5
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bGV" = (
 /obj/machinery/shower{
-	icon_state = "shower";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -32856,9 +37096,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHa" = (
 /obj/machinery/light{
@@ -32871,9 +37115,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHb" = (
 /obj/structure/closet/crate/freezer/surplus_limbs,
@@ -32909,17 +37155,23 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHg" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHh" = (
 /obj/machinery/light{
@@ -32928,18 +37180,26 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHi" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHj" = (
 /obj/item/storage/belt/utility,
@@ -32948,9 +37208,13 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHk" = (
 /obj/item/gps{
@@ -32965,9 +37229,13 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHl" = (
 /obj/structure/chair,
@@ -32975,17 +37243,25 @@
 	dir = 4
 	},
 /obj/item/clothing/mask/gas,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHm" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -32995,33 +37271,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHo" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/area/hallway/primary/aft)
-"bHp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/purple/side{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHq" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHr" = (
 /obj/structure/disposalpipe/segment{
@@ -33042,18 +37318,28 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bHt" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bHu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -33084,9 +37370,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHA" = (
 /obj/machinery/atmospherics/components/binary/valve,
@@ -33105,9 +37399,17 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "bHC" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -33123,7 +37425,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bHE" = (
 /obj/structure/window/reinforced,
@@ -33136,7 +37442,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bHI" = (
 /obj/structure/grille/broken,
@@ -33168,7 +37478,6 @@
 	dir = 8;
 	layer = 2.9
 	},
-/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space/nearstation)
 "bHP" = (
@@ -33196,25 +37505,40 @@
 /area/maintenance/department/engine)
 "bHU" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHV" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitegreen/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHX" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whitegreen/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHY" = (
 /obj/machinery/camera{
@@ -33228,17 +37552,22 @@
 /obj/machinery/airalarm/unlocked{
 	pixel_y = 23
 	},
-/turf/open/floor/plasteel/whitegreen/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bHZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitegreen/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33261,17 +37590,26 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/open/floor/plasteel/whitegreen/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bIc" = (
 /obj/machinery/vending/medical,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bId" = (
 /obj/structure/closet/secure_closet/medical3,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIe" = (
 /obj/structure/closet/secure_closet/medical3,
@@ -33281,11 +37619,19 @@
 	network = list("ss13","medbay");
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIf" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIg" = (
 /obj/structure/table,
@@ -33310,7 +37656,11 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -33322,9 +37672,11 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIj" = (
 /obj/effect/spawner/structure/window,
@@ -33372,7 +37724,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33381,9 +37743,13 @@
 /obj/structure/sink{
 	pixel_y = 28
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIq" = (
 /obj/machinery/light{
@@ -33400,9 +37766,13 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33413,16 +37783,30 @@
 	pixel_y = 28;
 	products = list(/obj/item/reagent_containers/syringe = 3, /obj/item/reagent_containers/pill/patch/styptic = 1, /obj/item/reagent_containers/pill/patch/silver_sulf = 1, /obj/item/reagent_containers/medspray/sterilizine = 1)
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIs" = (
 /obj/structure/closet/secure_closet/medical2,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bIt" = (
 /obj/structure/disposalpipe/segment{
@@ -33518,9 +37902,17 @@
 /area/hallway/primary/aft)
 "bIE" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bIF" = (
 /obj/machinery/power/apc{
@@ -33577,9 +37969,7 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "bIL" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/engine,
 /area/science/mixing)
 "bIM" = (
@@ -33595,7 +37985,11 @@
 	network = list("toxins");
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "bIP" = (
 /obj/structure/grille,
@@ -33637,17 +38031,33 @@
 /area/chapel/dock)
 "bIW" = (
 /obj/machinery/computer/shuttle/monastery_shuttle,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bIX" = (
 /obj/machinery/atmospherics/components/unary/tank/air{
 	dir = 2
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bIZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -33658,42 +38068,90 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJb" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJc" = (
 /obj/structure/chair/comfy/black,
 /obj/item/trash/pistachios,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJd" = (
 /obj/structure/chair/comfy/black,
 /obj/item/stack/spacecash/c100,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJe" = (
 /obj/structure/chair/comfy/black,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJf" = (
 /obj/structure/chair/comfy/black,
 /obj/item/cigbutt,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJg" = (
 /obj/item/trash/popcorn,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bJh" = (
 /obj/structure/sign/poster/contraband/random{
@@ -33729,9 +38187,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitegreen/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bJl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -33765,17 +38227,23 @@
 	pixel_x = -30
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJq" = (
 /obj/machinery/door/airlock/medical/glass{
@@ -33820,9 +38288,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bJv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33845,9 +38317,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bJz" = (
 /obj/machinery/door/airlock/maintenance{
@@ -33894,7 +38368,12 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33903,14 +38382,22 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJG" = (
 /obj/structure/disposalpipe/segment,
@@ -33919,7 +38406,11 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
@@ -33934,18 +38425,30 @@
 /obj/machinery/light{
 	dir = 2
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -33955,14 +38458,22 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
 /obj/machinery/portable_atmospherics/canister/air,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -33975,9 +38486,14 @@
 /obj/structure/sign/poster/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/green/side{
-	dir = 6
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bJN" = (
 /turf/closed/wall/r_wall,
@@ -34098,11 +38614,11 @@
 /area/chapel/dock)
 "bKe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/structure/closet/emcloset,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bKf" = (
-/turf/open/floor/plasteel/white,
+/obj/structure/closet/emcloset,
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bKh" = (
 /obj/machinery/door/window/eastright{
@@ -34143,13 +38659,20 @@
 /area/maintenance/department/engine)
 "bKl" = (
 /obj/item/stack/medical/gauze,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bKm" = (
 /obj/structure/light_construct{
-	icon_state = "tube-construct-stage1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -34196,9 +38719,11 @@
 /area/medical/virology)
 "bKu" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
-/turf/open/floor/plasteel/whitegreen/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bKv" = (
 /obj/item/bedsheet/medical,
@@ -34261,9 +38786,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bKB" = (
 /obj/structure/bed/roller,
@@ -34286,9 +38813,13 @@
 	dir = 8;
 	pixel_x = -26
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKF" = (
 /obj/structure/table/optable,
@@ -34304,9 +38835,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bKH" = (
 /obj/structure/cable{
@@ -34318,9 +38851,10 @@
 "bKI" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bKJ" = (
 /obj/machinery/door/firedoor,
@@ -34335,7 +38869,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bKM" = (
 /obj/effect/spawner/structure/window,
@@ -34381,9 +38916,13 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -34396,9 +38935,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKU" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -34414,9 +38957,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKV" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -34432,9 +38979,13 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKW" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -34446,9 +38997,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKX" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -34461,9 +39016,14 @@
 	dir = 8;
 	name = "Mix Outlet Pump"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bKZ" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
@@ -34506,11 +39066,7 @@
 /turf/open/floor/engine/vacuum,
 /area/engine/atmos)
 "bLf" = (
-/obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_exterior,
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
 /turf/open/floor/engine,
 /area/science/mixing)
 "bLh" = (
@@ -34537,9 +39093,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -34555,22 +39119,22 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bLr" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
-"bLs" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/turf/open/space,
-/area/space/nearstation)
 "bLt" = (
 /obj/effect/decal/cleanable/oil{
 	icon_state = "floor6"
@@ -34639,9 +39203,11 @@
 	layer = 2.9
 	},
 /obj/item/pen/red,
-/turf/open/floor/plasteel/whitegreen/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bLF" = (
 /obj/structure/table,
@@ -34688,17 +39254,23 @@
 /area/medical/medbay/central)
 "bLJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLK" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bLL" = (
 /obj/machinery/light,
@@ -34715,9 +39287,13 @@
 /obj/machinery/light_switch{
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -34741,21 +39317,25 @@
 "bLQ" = (
 /obj/structure/table,
 /obj/item/surgical_drapes,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLR" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bLS" = (
 /obj/machinery/vending/cola,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bLT" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -34764,17 +39344,24 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bLU" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/escape{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
 	},
 /area/hallway/primary/aft)
 "bLV" = (
@@ -34811,18 +39398,26 @@
 	pixel_x = -3;
 	pixel_y = -3
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bLZ" = (
 /obj/machinery/meter/atmos/atmos_waste_loop,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMa" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -34832,33 +39427,49 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMb" = (
 /obj/machinery/meter/atmos/distro_loop,
 /obj/machinery/atmospherics/pipe/manifold/supply/visible,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMc" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMd" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 8;
 	name = "Mix to Distro"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMe" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
@@ -34884,9 +39495,11 @@
 	output_tag = "mix_in";
 	sensors = list("mix_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMi" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -34966,17 +39579,33 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -34996,7 +39625,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMx" = (
 /obj/effect/turf_decal/stripes/line,
@@ -35009,7 +39638,7 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bMA" = (
 /obj/effect/landmark/event_spawn,
@@ -35021,9 +39650,17 @@
 /area/maintenance/department/engine)
 "bMC" = (
 /obj/item/stack/spacecash/c10,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bMD" = (
 /obj/effect/decal/cleanable/oil,
@@ -35071,35 +39708,70 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/whitegreen/side{
-	dir = 6
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bMK" = (
 /obj/item/soap/nanotrasen,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/gun/syringe,
 /obj/structure/table/glass,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMM" = (
 /obj/structure/closet/l3closet,
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 6
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMN" = (
 /obj/structure/table,
 /obj/item/hemostat,
 /obj/item/stack/medical/gauze,
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMO" = (
 /obj/structure/table,
 /obj/item/surgicaldrill,
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMP" = (
 /obj/structure/table,
@@ -35108,7 +39780,17 @@
 	},
 /obj/item/circular_saw,
 /obj/machinery/light,
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMQ" = (
 /obj/structure/table,
@@ -35118,12 +39800,32 @@
 /obj/item/razor{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMR" = (
 /obj/structure/table,
 /obj/item/retractor,
-/turf/open/floor/plasteel/whiteblue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bMS" = (
 /obj/structure/cable{
@@ -35169,9 +39871,10 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plasteel/escape{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 8
 	},
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/aft)
 "bMX" = (
 /obj/machinery/meter,
@@ -35183,9 +39886,13 @@
 	dir = 4;
 	name = "External to Filter"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bMZ" = (
 /obj/structure/disposalpipe/segment,
@@ -35199,9 +39906,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -35280,9 +39989,11 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bNm" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -35316,7 +40027,7 @@
 	dir = 6
 	},
 /turf/open/space,
-/area/space/nearstation)
+/area/science/mixing)
 "bNr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35342,9 +40053,17 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bNu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -35364,16 +40083,23 @@
 	pixel_x = 27
 	},
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bNw" = (
 /turf/closed/wall,
 /area/chapel/dock)
 "bNx" = (
 /obj/structure/transit_tube/station/reverse{
-	icon_state = "closed_terminus0";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -35479,19 +40205,31 @@
 /obj/structure/table,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/whitegreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNQ" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /obj/machinery/vending/wardrobe/viro_wardrobe,
-/turf/open/floor/plasteel/whitegreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNR" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
 	},
-/turf/open/floor/plasteel/whitegreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bNS" = (
 /obj/structure/closet/emcloset,
@@ -35557,9 +40295,10 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bOb" = (
 /obj/structure/cable{
@@ -35590,8 +40329,14 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/arrival{
-	dir = 9
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
 	},
 /area/hallway/primary/aft)
 "bOf" = (
@@ -35606,9 +40351,13 @@
 	dir = 8;
 	name = "Air to External"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOh" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -35622,9 +40371,11 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOj" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -35713,7 +40464,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/airless,
-/area/space/nearstation)
+/area/science/mixing)
 "bOv" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -35728,18 +40479,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault,
-/area/chapel/dock)
-"bOy" = (
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bOz" = (
 /obj/structure/chair/comfy/black{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "bOA" = (
 /obj/structure/chair/stool,
@@ -35826,9 +40592,10 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bOL" = (
 /obj/structure/chair/stool,
@@ -35839,9 +40606,10 @@
 	dir = 4
 	},
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/arrival{
-	dir = 10
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/primary/aft)
 "bON" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
@@ -35856,9 +40624,13 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOP" = (
 /obj/structure/disposalpipe/segment,
@@ -35869,9 +40641,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -35888,7 +40662,11 @@
 	dir = 1
 	},
 /obj/machinery/space_heater,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -35916,7 +40694,11 @@
 /obj/item/multitool{
 	layer = 4
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOW" = (
 /obj/structure/table,
@@ -35925,7 +40707,11 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/item/t_scanner,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOX" = (
 /obj/structure/table,
@@ -35937,7 +40723,11 @@
 /obj/item/stack/sheet/glass,
 /obj/item/stack/rods/fifty,
 /obj/item/pipe_dispenser,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bOY" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -35984,9 +40774,11 @@
 	dir = 8;
 	name = "N2O Outlet Pump"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPf" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -36023,18 +40815,34 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPo" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Chapel";
 	opacity = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "bPp" = (
 /obj/structure/sign/poster/contraband/random{
@@ -36147,9 +40955,10 @@
 	dir = 8;
 	pixel_x = -24
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bPH" = (
 /obj/structure/cable{
@@ -36183,15 +40992,20 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bPN" = (
 /obj/machinery/conveyor_switch{
 	id = "atmosdeliver"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPO" = (
 /obj/structure/disposalpipe/segment,
@@ -36199,9 +41013,11 @@
 /area/engine/atmos)
 "bPP" = (
 /obj/structure/tank_dispenser,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPQ" = (
 /turf/closed/wall,
@@ -36254,9 +41070,11 @@
 	output_tag = "n2o_out";
 	sensors = list("n2o_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bPY" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -36295,8 +41113,7 @@
 /area/chapel/asteroid/monastery)
 "bQe" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
 /turf/open/floor/plating/asteroid,
 /area/chapel/asteroid/monastery)
@@ -36304,14 +41121,12 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/asteroid{
-	icon_plating = "asteroid"
-	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/asteroid/monastery)
 "bQg" = (
-/turf/open/floor/plasteel/asteroid{
-	icon_plating = "asteroid"
-	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/asteroid/monastery)
 "bQh" = (
 /obj/machinery/camera{
@@ -36393,7 +41208,17 @@
 /obj/item/aicard,
 /obj/item/aiModule/reset,
 /obj/item/assembly/flash/handheld,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQu" = (
 /obj/structure/table,
@@ -36405,7 +41230,17 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQv" = (
 /obj/structure/rack,
@@ -36413,7 +41248,17 @@
 	pixel_y = 32
 	},
 /obj/effect/spawner/lootdrop/techstorage/engineering,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQw" = (
 /obj/structure/rack,
@@ -36431,12 +41276,32 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQx" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/rnd,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQy" = (
 /obj/structure/rack,
@@ -36449,15 +41314,45 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQz" = (
 /obj/machinery/computer/arcade,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQA" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bQB" = (
 /obj/machinery/power/apc{
@@ -36470,9 +41365,10 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bQC" = (
 /obj/structure/cable{
@@ -36488,7 +41384,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bQD" = (
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bQE" = (
 /obj/structure/table/reinforced,
@@ -36511,17 +41408,23 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQG" = (
 /obj/machinery/computer/atmos_control{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bQH" = (
 /obj/machinery/pipedispenser,
@@ -36603,7 +41506,6 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
 "bQS" = (
@@ -36845,7 +41747,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRr" = (
 /obj/structure/table/reinforced,
@@ -36874,9 +41777,13 @@
 	dir = 8
 	},
 /obj/effect/landmark/start/atmospheric_technician,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRt" = (
 /obj/structure/disposalpipe/segment,
@@ -36898,9 +41805,11 @@
 /obj/machinery/computer/atmos_alert{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRv" = (
 /obj/machinery/pipedispenser/disposal,
@@ -36948,9 +41857,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bRC" = (
 /obj/structure/lattice,
@@ -37055,17 +41966,47 @@
 "bRO" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/medical,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRP" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/tcomms,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRQ" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/security,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bRR" = (
 /obj/machinery/holopad,
@@ -37111,9 +42052,10 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRW" = (
 /obj/structure/cable{
@@ -37165,7 +42107,11 @@
 	freq = 1400;
 	location = "Atmospherics"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSc" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -37175,14 +42121,22 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSd" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSe" = (
 /obj/machinery/pipedispenser/disposal/transit_tube,
@@ -37213,9 +42167,11 @@
 	dir = 8;
 	name = "Plasma Outlet Pump"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSi" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
@@ -37434,13 +42390,15 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSN" = (
 /obj/machinery/camera{
@@ -37454,7 +42412,8 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSO" = (
 /obj/structure/cable{
@@ -37463,7 +42422,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSP" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -37473,7 +42433,8 @@
 /obj/structure/sign/departments/engineering{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bSQ" = (
 /obj/machinery/door/firedoor/heavy,
@@ -37522,9 +42483,11 @@
 	output_tag = "tox_out";
 	sensors = list("tox_sensor" = "Tank")
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bSW" = (
 /obj/machinery/air_sensor{
@@ -37732,7 +42695,17 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTx" = (
 /obj/structure/rack,
@@ -37743,7 +42716,17 @@
 /obj/machinery/light{
 	light_color = "#cee5d2"
 	},
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTy" = (
 /obj/structure/rack,
@@ -37751,7 +42734,17 @@
 /obj/item/stock_parts/subspace/amplifier,
 /obj/item/stock_parts/subspace/analyzer,
 /obj/item/stock_parts/subspace/analyzer,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTz" = (
 /obj/structure/rack,
@@ -37761,7 +42754,17 @@
 	},
 /obj/item/clothing/gloves/color/yellow,
 /obj/item/t_scanner,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTA" = (
 /obj/structure/rack,
@@ -37775,7 +42778,17 @@
 	pixel_y = -32
 	},
 /obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTB" = (
 /obj/machinery/power/apc{
@@ -37786,7 +42799,17 @@
 	},
 /obj/structure/cable,
 /obj/structure/closet/crate/solarpanel_small,
-/turf/open/floor/plasteel/darkgreen,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bTC" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -37815,26 +42838,38 @@
 /turf/closed/wall,
 /area/engine/break_room)
 "bTH" = (
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTI" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTK" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37850,9 +42885,13 @@
 	c_tag = "Atmospherics Entrance";
 	dir = 2
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37862,9 +42901,13 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTM" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible,
@@ -37886,9 +42929,13 @@
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37898,9 +42945,13 @@
 /obj/structure/fireaxecabinet{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -37911,9 +42962,13 @@
 	c_tag = "Atmospherics Mixing";
 	dir = 2
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTR" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -38015,21 +43070,37 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUj" = (
 /obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUk" = (
 /obj/machinery/computer/secure_data,
-/turf/open/floor/plasteel/red/side{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUl" = (
 /obj/machinery/light{
@@ -38090,6 +43161,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/firecloset,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUp" = (
@@ -38124,9 +43196,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUu" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUv" = (
@@ -38157,9 +43227,11 @@
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUz" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38228,9 +43300,16 @@
 	name = "Chief Engineer RC";
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUJ" = (
 /obj/structure/filingcabinet/chestdrawer,
@@ -38244,9 +43323,13 @@
 /obj/machinery/computer/security/telescreen/ce{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUK" = (
 /obj/machinery/airalarm{
@@ -38254,24 +43337,37 @@
 	pixel_y = 22
 	},
 /obj/machinery/computer/apc_control,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUL" = (
 /obj/machinery/computer/station_alert,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUM" = (
 /obj/machinery/computer/card/minor/ce,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bUN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -38295,9 +43391,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/smes/engineering,
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUR" = (
 /obj/structure/cable{
@@ -38311,18 +43411,26 @@
 	c_tag = "Engineering Power Storage";
 	dir = 2
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUS" = (
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/power/smes/engineering,
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bUT" = (
 /turf/closed/wall,
@@ -38344,9 +43452,13 @@
 /obj/item/paper_bin{
 	layer = 2.9
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUW" = (
 /obj/structure/chair/office/dark{
@@ -38368,9 +43480,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUY" = (
 /obj/machinery/door/airlock/security/glass{
@@ -38383,7 +43497,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bUZ" = (
 /obj/structure/cable{
@@ -38504,9 +43628,11 @@
 	dir = 8;
 	name = "CO2 Outlet Pump"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bVl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38616,10 +43742,14 @@
 /obj/item/folder/yellow,
 /obj/item/paper/monitorkey,
 /obj/item/pen,
-/mob/living/simple_animal/parrot/Poly,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/mob/living/simple_animal/parrot/Poly,
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bVE" = (
 /turf/open/floor/plasteel,
@@ -38649,9 +43779,11 @@
 	icon_state = "0-8"
 	},
 /obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bVI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -38696,10 +43828,13 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bVM" = (
 /obj/machinery/power/terminal{
@@ -38715,9 +43850,11 @@
 /area/engine/engine_smes)
 "bVN" = (
 /obj/machinery/suit_storage_unit/engine,
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bVO" = (
 /obj/structure/table,
@@ -38733,9 +43870,13 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bVP" = (
 /obj/structure/cable{
@@ -38751,9 +43892,11 @@
 	dir = 4
 	},
 /obj/structure/closet/wardrobe/red,
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bVR" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38839,9 +43982,11 @@
 /obj/machinery/computer/atmos_control/tank/carbon_tank{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bWc" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -38868,7 +44013,8 @@
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
 "bWh" = (
-/turf/open/floor/plating/asteroid,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/office)
 "bWi" = (
 /obj/structure/flora/ausbushes/leafybush,
@@ -38907,9 +44053,13 @@
 	pixel_x = -27
 	},
 /obj/item/clothing/glasses/meson/gar,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bWo" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -38938,14 +44088,26 @@
 	dir = 2;
 	pixel_x = 22
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bWs" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/RnD_secure,
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bWt" = (
 /obj/structure/rack,
@@ -38954,12 +44116,32 @@
 	dir = 1
 	},
 /obj/effect/spawner/lootdrop/techstorage/command,
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bWu" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/techstorage/AI,
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/storage/tech)
 "bWv" = (
 /obj/structure/table,
@@ -38992,10 +44174,13 @@
 	network = list("engine");
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWw" = (
 /obj/structure/cable/yellow{
@@ -39037,9 +44222,11 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bWA" = (
 /obj/structure/filingcabinet,
@@ -39050,24 +44237,38 @@
 	network = list("engine");
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/red/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/red/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWC" = (
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_x = 32
 	},
 /obj/structure/closet/secure_closet/security/engine,
-/turf/open/floor/plasteel/red/side{
-	dir = 6
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bWD" = (
 /turf/closed/wall/r_wall,
@@ -39083,8 +44284,11 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/machinery/shower{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "bWF" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -39098,7 +44302,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "bWG" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "Engineering";
@@ -39109,14 +44313,18 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/shower{
+	dir = 8;
+	pixel_y = -4
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "bWH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
 /turf/closed/wall,
-/area/engine/engineering)
+/area/engine/break_room)
 "bWI" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
@@ -39231,7 +44439,7 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "bXe" = (
 /obj/structure/cable{
@@ -39241,16 +44449,29 @@
 /area/maintenance/department/engine)
 "bXf" = (
 /obj/machinery/suit_storage_unit/ce,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXg" = (
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXi" = (
 /obj/structure/cable{
@@ -39260,7 +44481,11 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXj" = (
 /obj/machinery/disposal/bin,
@@ -39277,9 +44502,14 @@
 	pixel_x = 24;
 	req_access_txt = "11"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "bXk" = (
 /turf/closed/wall/r_wall,
@@ -39299,10 +44529,13 @@
 /obj/structure/cable,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "bXm" = (
 /obj/structure/cable{
@@ -39343,58 +44576,103 @@
 "bXr" = (
 /obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXs" = (
 /obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXt" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXu" = (
 /obj/machinery/computer/atmos_control/tank/nitrogen_tank{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXv" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXw" = (
 /obj/machinery/light,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXx" = (
 /obj/machinery/computer/atmos_control/tank/oxygen_tank{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXy" = (
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXz" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXA" = (
 /obj/machinery/atmospherics/components/trinary/mixer/airmix,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXB" = (
 /obj/machinery/computer/atmos_control/tank/air_tank{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXC" = (
 /obj/machinery/light,
@@ -39402,7 +44680,11 @@
 	dir = 4;
 	name = "Air Outlet Pump"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXD" = (
 /obj/structure/cable{
@@ -39411,7 +44693,11 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXE" = (
 /obj/machinery/atmospherics/pipe/simple/green/visible,
@@ -39421,15 +44707,24 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXF" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "bXG" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
@@ -39595,6 +44890,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYn" = (
@@ -39613,6 +44909,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYp" = (
@@ -39675,13 +44978,6 @@
 /obj/structure/chair/wood/normal,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main/monastery)
-"bYC" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bYF" = (
 /obj/item/trash/pistachios,
 /obj/structure/rack,
@@ -39695,9 +44991,13 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYJ" = (
 /obj/structure/disposalpipe/segment{
@@ -39709,9 +45009,13 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYK" = (
 /obj/structure/cable{
@@ -39724,9 +45028,13 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYL" = (
 /obj/structure/cable{
@@ -39740,16 +45048,17 @@
 	sortType = 5
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYM" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -39757,9 +45066,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYN" = (
 /obj/structure/cable{
@@ -39772,16 +45085,20 @@
 	c_tag = "Engineering Port Fore";
 	dir = 2
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/sign/map{
 	icon_state = "map-pubby";
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYO" = (
 /obj/structure/cable{
@@ -39790,12 +45107,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 1
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYP" = (
 /obj/structure/cable{
@@ -39807,12 +45128,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYQ" = (
 /obj/structure/cable{
@@ -39821,12 +45146,16 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYR" = (
 /obj/structure/cable{
@@ -39845,9 +45174,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYS" = (
 /obj/structure/cable{
@@ -39862,9 +45195,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYT" = (
 /obj/structure/cable{
@@ -39882,9 +45219,16 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYU" = (
 /obj/structure/cable{
@@ -39903,9 +45247,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYV" = (
 /obj/structure/cable{
@@ -39927,15 +45275,19 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYX" = (
 /obj/structure/cable{
@@ -39954,9 +45306,13 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYY" = (
 /obj/structure/cable{
@@ -39976,16 +45332,17 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bYZ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 8;
@@ -40003,22 +45360,22 @@
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZc" = (
-/obj/structure/rack,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/suit/hazardvest,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/head/hardhat/orange,
-/obj/item/clothing/glasses/meson/engine,
-/obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel/yellow/side{
+/obj/structure/table/glass,
+/obj/item/paper_bin,
+/obj/item/pen,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZd" = (
 /obj/structure/lattice,
@@ -40046,10 +45403,13 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZg" = (
 /obj/structure/cable{
@@ -40077,9 +45437,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZi" = (
 /obj/machinery/meter,
@@ -40151,9 +45513,13 @@
 /obj/item/flashlight,
 /obj/item/flashlight,
 /obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -40183,13 +45549,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"bZC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "bZD" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
@@ -40197,7 +45556,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZE" = (
-/obj/machinery/holopad,
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
@@ -40212,33 +45570,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"bZH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZI" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/chair/office/dark{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "bZJ" = (
@@ -40281,10 +45626,13 @@
 	pixel_x = -27
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZP" = (
 /obj/structure/cable/yellow{
@@ -40305,9 +45653,11 @@
 	pixel_x = 24;
 	pixel_y = -6
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "bZR" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible{
@@ -40359,11 +45709,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/department/engine)
-"cad" = (
-/obj/structure/window/reinforced,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "cae" = (
 /obj/effect/spawner/structure/window,
@@ -40380,24 +45726,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cai" = (
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/station_engineer,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "caj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/table,
+/obj/item/electronics/airlock,
+/obj/item/electronics/airlock,
+/obj/item/electronics/apc,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stock_parts/cell/high/plus,
+/obj/item/stack/cable_coil,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/chair/office/dark,
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cak" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -40409,73 +45751,26 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "can" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 2
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cao" = (
-/obj/structure/rack,
-/obj/item/storage/belt/utility,
-/obj/item/clothing/head/welding{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/item/airlock_painter,
-/obj/item/clothing/glasses/meson/engine,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cap" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "caq" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "car" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-8"
-	},
-/obj/machinery/camera{
-	c_tag = "Engineering Central";
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cat" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cau" = (
-/obj/structure/rack,
-/obj/item/clothing/mask/gas{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/mask/gas,
-/obj/item/clothing/mask/gas{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cav" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -40485,16 +45780,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cax" = (
-/obj/structure/table,
-/obj/item/electronics/airlock,
-/obj/item/electronics/airlock,
-/obj/item/electronics/apc,
-/obj/item/stock_parts/cell/high/plus,
-/obj/item/stock_parts/cell/high/plus,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/item/stack/cable_coil,
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "caz" = (
@@ -40563,10 +45849,13 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caJ" = (
 /obj/structure/cable/yellow{
@@ -40584,9 +45873,11 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "caL" = (
 /obj/structure/cable/yellow{
@@ -40720,82 +46011,60 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbe" = (
-/obj/item/pen,
-/obj/item/paper_bin{
-	layer = 2.9
-	},
-/obj/structure/table/glass,
+/obj/structure/table,
+/obj/item/storage/belt/utility,
+/obj/item/storage/belt/utility,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbf" = (
-/obj/item/book/manual/wiki/engineering_hacking{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
+/obj/structure/table,
+/obj/machinery/cell_charger,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbg" = (
-/obj/item/book/manual/engineering_singularity_safety{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/engineering_particle_accelerator{
-	pixel_x = -3;
-	pixel_y = -3
-	},
-/obj/structure/table/glass,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cbh" = (
+/obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/obj/effect/landmark/event_spawn,
+/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cbi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/closet/radiation,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cbj" = (
-/obj/structure/sign/warning/radiation/rad_area,
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"cbk" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
+"cbh" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cbl" = (
-/obj/machinery/light{
-	dir = 8
+"cbi" = (
+/obj/structure/rack,
+/obj/item/clothing/mask/gas{
+	pixel_x = 3;
+	pixel_y = 3
 	},
-/obj/structure/closet/secure_closet/engineering_welding,
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/item/clothing/mask/gas,
+/obj/item/clothing/mask/gas{
+	pixel_x = -3;
+	pixel_y = -3
 	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cbj" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cbk" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbm" = (
@@ -40805,29 +46074,43 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbn" = (
-/obj/structure/table,
-/obj/item/storage/belt/utility,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbo" = (
-/obj/structure/table,
-/obj/machinery/cell_charger,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/rack,
+/obj/item/storage/belt/utility,
+/obj/item/wrench,
+/obj/item/weldingtool,
+/obj/item/clothing/head/welding{
+	pixel_x = -3;
+	pixel_y = 5
 	},
+/obj/structure/disposalpipe/segment{
+	dir = 5
+	},
+/obj/item/airlock_painter,
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbp" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbs" = (
@@ -40864,10 +46147,13 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbB" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -40886,9 +46172,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cbD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
@@ -40974,6 +46262,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
+/obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cbX" = (
@@ -41002,9 +46291,13 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cca" = (
-/obj/effect/landmark/start/station_engineer,
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/structure/table,
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = 1;
+	pixel_y = 5
+	},
+/obj/item/storage/toolbox/mechanical{
+	pixel_x = -2
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -41012,100 +46305,38 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/table,
+/obj/item/storage/toolbox/electrical{
+	pixel_x = 1;
+	pixel_y = 5
 	},
-/obj/structure/chair/office/dark{
-	dir = 1
+/obj/item/storage/toolbox/electrical{
+	pixel_x = -2
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/effect/landmark/start/station_engineer,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccc" = (
-/obj/structure/closet/radiation,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 27
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/obj/structure/sign/warning/nosmoking,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ccd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cce" = (
-/obj/structure/cable/yellow{
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"ccf" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Center";
-	dir = 2;
-	network = list("ss13","engine");
-	pixel_x = 23
-	},
+"cci" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ccg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cch" = (
-/obj/structure/closet/secure_closet/engineering_electrical,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -27
+	dir = 8;
+	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cci" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ccj" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/mechanical{
-	pixel_x = -2
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cck" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/electrical{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/toolbox/electrical{
-	pixel_x = -2
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -41125,10 +46356,13 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccq" = (
 /obj/structure/chair/office/dark,
@@ -41140,9 +46374,11 @@
 	dir = 2;
 	name = "Incinerator Output Pump"
 	},
-/turf/open/floor/plasteel/darkyellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "ccs" = (
 /obj/machinery/door/poddoor/incinerator_atmos_aux,
@@ -41183,12 +46419,10 @@
 /area/chapel/main/monastery)
 "ccL" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
-/turf/open/floor/plasteel/asteroid{
-	icon_plating = "asteroid"
-	},
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/asteroid/monastery)
 "ccM" = (
 /obj/structure/chair,
@@ -41224,54 +46458,41 @@
 /obj/item/gps/engineering,
 /turf/open/floor/plating,
 /area/engine/engineering)
-"ccS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ccV" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ccW" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/item/clothing/suit/hazardvest,
+/obj/item/clothing/suit/hazardvest,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/structure/table,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/bot{
-	dir = 2
-	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ccX" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ccY" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ccZ" = (
-/obj/structure/particle_accelerator/end_cap,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cda" = (
-/obj/effect/landmark/event_spawn,
+/obj/structure/reflector/single/anchored{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdc" = (
@@ -41280,20 +46501,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cdf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cdg" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
 /obj/item/pen,
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdh" = (
 /obj/structure/table/glass,
@@ -41301,14 +46520,22 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
 	},
-/turf/open/floor/plasteel/darkyellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdi" = (
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
-/turf/open/floor/plasteel/darkyellow/side{
-	icon_state = "darkyellow";
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/disposal/incinerator)
 "cdj" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -41425,156 +46652,77 @@
 /area/maintenance/department/engine)
 "cdI" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/machinery/power/port_gen/pacman,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdK" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/structure/disposaloutlet{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdM" = (
-/obj/effect/turf_decal/stripes/corner,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/camera{
+	c_tag = "Engineering Port Aft";
+	dir = 1;
+	pixel_x = 23
 	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"cdN" = (
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"cdP" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"cdQ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/camera{
-	c_tag = "Engineering Port Aft";
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cdR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Laser Room";
+	req_access_txt = "10"
 	},
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 25;
-	req_access_txt = "11"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"cdS" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	req_access_txt = "11"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cdT" = (
-/obj/machinery/particle_accelerator/control_box,
-/obj/structure/cable/yellow,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cdU" = (
-/obj/structure/particle_accelerator/fuel_chamber,
+/obj/machinery/power/emitter/anchored{
+	dir = 4;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cdW" = (
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 25;
-	req_access_txt = "11"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cdX" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = -25;
-	req_access_txt = "11"
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"cdY" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"cdZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/structure/reflector/box/anchored,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceb" = (
 /obj/machinery/computer/rdconsole/production{
@@ -41598,13 +46746,15 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/asteroid,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/office)
 "cef" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/asteroid,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/office)
 "ceg" = (
 /obj/machinery/door/airlock/centcom{
@@ -41689,56 +46839,39 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/engine/engineering)
-"cet" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ceu" = (
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
-/obj/item/stack/cable_coil{
-	pixel_x = 3;
-	pixel_y = -7
-	},
-/obj/item/crowbar,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
-"cev" = (
-/obj/structure/chair/stool,
-/turf/open/floor/plating,
+"cet" = (
+/obj/structure/closet/radiation,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cew" = (
-/obj/structure/particle_accelerator/power_box,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cex" = (
-/obj/item/screwdriver,
+"ceu" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cey" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/obj/structure/girder,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceA" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -41770,9 +46903,17 @@
 /area/chapel/office)
 "ceF" = (
 /obj/structure/filingcabinet,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ceH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -41833,9 +46974,6 @@
 "ceT" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/structure/closet/emcloset,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ceU" = (
@@ -41850,9 +46988,6 @@
 	network = list("tcomms");
 	pixel_y = 28
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceV" = (
@@ -41862,77 +46997,44 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "ceX" = (
-/obj/machinery/light/small{
-	dir = 8;
-	light_color = "#fff4bc"
-	},
-/obj/structure/closet/emcloset/anchored,
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"ceY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfa" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfb" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/structure/closet/secure_closet/engineering_welding,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"cfc" = (
-/obj/structure/particle_accelerator/particle_emitter/left,
-/turf/open/floor/plating,
+"cfa" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfd" = (
-/obj/structure/particle_accelerator/particle_emitter/center,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfe" = (
-/obj/structure/particle_accelerator/particle_emitter/right,
-/turf/open/floor/plating,
+/obj/machinery/firealarm{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cff" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = -32
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfg" = (
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 4;
-	light_color = "#fff4bc"
+	light_color = "#e8eaff"
 	},
-/obj/structure/closet/emcloset/anchored,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -41957,23 +47059,31 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfo" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/area/chapel/main/monastery)
-"cfp" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfr" = (
 /obj/structure/transit_tube_pod,
@@ -41992,42 +47102,16 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine Room";
+	req_access_txt = "10"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfv" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfw" = (
-/obj/item/wirecutters,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfx" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/engine/engineering)
-"cfy" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cfC" = (
 /obj/machinery/biogenerator,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cfD" = (
 /obj/structure/cable{
@@ -42038,9 +47122,17 @@
 /area/chapel/main/monastery)
 "cfE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -42054,17 +47146,33 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfG" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cfH" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -42083,16 +47191,14 @@
 /obj/machinery/door/airlock/external,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
-"cfK" = (
-/turf/open/floor/plasteel/asteroid,
-/area/chapel/asteroid/monastery)
 "cfL" = (
 /obj/machinery/camera{
 	c_tag = "Monastery Asteroid Starboard Aft";
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/asteroid,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/asteroid/monastery)
 "cfN" = (
 /turf/closed/mineral,
@@ -42120,89 +47226,78 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cfS" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/structure/table/reinforced,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/tank/internals/emergency_oxygen/engi,
+/obj/item/clothing/mask/breath{
+	pixel_x = 4
 	},
-/obj/structure/disposaloutlet,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cfT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cfU" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine Containment Port Fore";
-	dir = 2;
-	network = list("engine")
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cfV" = (
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cfW" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"cfT" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"cfU" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/structure/closet/firecloset,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"cfV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cfX" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 1
+	},
+/obj/machinery/meter,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cfY" = (
-/obj/machinery/disposal/deliveryChute,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cgb" = (
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
 /obj/item/storage/firstaid/regular,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cgd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cgf" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42214,17 +47309,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 8
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/area/chapel/main/monastery)
-"cgi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cgj" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -42278,31 +47373,26 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cgu" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cgv" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"cgx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 9
+	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cgw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cgx" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cgG" = (
 /obj/structure/window/reinforced/fulltile,
@@ -42340,10 +47430,7 @@
 /area/chapel/main/monastery)
 "cgM" = (
 /obj/structure/dresser,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel/grimy,
@@ -42385,51 +47472,50 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"cgT" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cgU" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cgV" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 4
-	},
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cgY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "chb" = (
 /obj/machinery/camera{
 	c_tag = "Monastery Kitchen";
 	dir = 4;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chc" = (
 /obj/machinery/vending/dinnerware,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chd" = (
 /obj/item/clothing/suit/apron/chef,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chf" = (
 /obj/machinery/light/small{
@@ -42466,9 +47552,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cho" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -42527,31 +47621,27 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "chw" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "chA" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "chB" = (
 /obj/item/seeds/banana,
 /obj/item/seeds/grass,
 /obj/item/seeds/grape,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chC" = (
 /obj/structure/table,
@@ -42564,16 +47654,16 @@
 	name = "Station Intercom (General)";
 	pixel_y = 26
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chD" = (
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chE" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -42633,12 +47723,12 @@
 	dir = 4;
 	pixel_x = 11
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chV" = (
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chW" = (
 /obj/structure/table,
@@ -42650,7 +47740,7 @@
 /obj/item/storage/box/ingredients/wildcard{
 	layer = 3.1
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chX" = (
 /obj/structure/table,
@@ -42658,21 +47748,15 @@
 /obj/item/kitchen/rollingpin,
 /obj/item/kitchen/knife,
 /obj/machinery/light/small,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chY" = (
 /obj/structure/closet/crate/bin,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "chZ" = (
 /obj/structure/reagent_dispensers/watertank/high,
-/turf/open/floor/plasteel/hydrofloor,
-/area/chapel/main/monastery)
-"cia" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 8
-	},
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cib" = (
 /obj/structure/flora/ausbushes/ppflowers,
@@ -42726,27 +47810,17 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/chapel/main/monastery)
-"cir" = (
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cit" = (
-/obj/machinery/the_singularitygen/tesla,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "civ" = (
-/obj/effect/turf_decal/stripes/end{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ciy" = (
 /obj/item/reagent_containers/glass/bucket,
@@ -42754,7 +47828,7 @@
 	dir = 9
 	},
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "ciz" = (
 /obj/structure/closet/crate/coffin,
@@ -42771,9 +47845,17 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ciE" = (
 /obj/structure/flora/ausbushes/genericbush,
@@ -42793,23 +47875,22 @@
 /turf/open/floor/plasteel/grimy,
 /area/chapel/main/monastery)
 "ciG" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Aft";
+	dir = 1;
+	network = list("ss13","engine")
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"ciH" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ciI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Gas to Chamber"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "ciJ" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/cobweb,
@@ -42959,17 +48040,12 @@
 /obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/hydroponics/garden/monastery)
-"cjs" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "cjt" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cju" = (
 /turf/closed/mineral,
@@ -43163,22 +48239,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
-"ckr" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine Containment Port Aft";
-	dir = 1;
-	network = list("engine")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"cks" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine Containment Starboard Aft";
-	dir = 1;
-	network = list("engine")
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "ckt" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating/asteroid/airless,
@@ -43257,9 +48317,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ckF" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -43412,8 +48480,7 @@
 /area/library)
 "clj" = (
 /obj/item/flashlight/lantern{
-	icon_state = "lantern-on";
-	on = 1
+	icon_state = "lantern-on"
 	},
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation/bomb_site)
@@ -43676,9 +48743,16 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 9
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmg" = (
 /obj/machinery/requests_console{
@@ -43691,9 +48765,13 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmh" = (
 /obj/machinery/door/airlock/engineering{
@@ -43717,9 +48795,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmk" = (
 /obj/machinery/power/apc{
@@ -43734,15 +48816,24 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cml" = (
 /obj/machinery/announcement_system,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 5
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmm" = (
 /obj/machinery/light/small{
@@ -43752,29 +48843,42 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/chair/office/dark,
-/turf/open/floor/plasteel/yellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmq" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -43788,9 +48892,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cms" = (
 /obj/machinery/light/small{
@@ -43799,9 +48904,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmt" = (
 /obj/structure/lattice,
@@ -43822,18 +48929,28 @@
 	pixel_y = 5
 	},
 /obj/item/pen,
-/turf/open/floor/plasteel/yellow/side{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmv" = (
 /obj/machinery/computer/telecomms/monitor{
 	dir = 1;
 	network = "tcommsat"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
@@ -43844,26 +48961,44 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cmx" = (
 /obj/machinery/computer/telecomms/server{
 	dir = 1;
 	network = "tcommsat"
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 10
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmy" = (
 /obj/machinery/computer/message_monitor{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side{
-	dir = 6
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "cmz" = (
 /obj/structure/lattice,
@@ -43881,9 +49016,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
 "cmG" = (
 /obj/machinery/blackbox_recorder,
@@ -44090,9 +49233,13 @@
 	pixel_x = -5;
 	pixel_y = -24
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cnD" = (
 /turf/open/space/basic,
@@ -44139,7 +49286,7 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnT" = (
-/obj/structure/weightlifter,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "cnV" = (
@@ -44165,7 +49312,13 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/barber,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/dorms)
 "coe" = (
 /obj/machinery/power/apc{
@@ -44266,7 +49419,11 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "coy" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -44282,9 +49439,10 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "coB" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -44297,9 +49455,10 @@
 	c_tag = "Central Primary Hallway Bridge";
 	dir = 1
 	},
-/turf/open/floor/plasteel/blue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "coF" = (
 /obj/structure/cable{
@@ -44351,13 +49510,22 @@
 /turf/open/floor/plating,
 /area/quartermaster/warehouse)
 "coN" = (
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "coV" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "coW" = (
 /obj/structure/cable{
@@ -44419,9 +49587,17 @@
 	pixel_y = 26;
 	req_access_txt = "28"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cph" = (
 /obj/structure/disposalpipe/segment{
@@ -44451,9 +49627,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpk" = (
 /obj/structure/disposalpipe/sorting/mail/flip{
@@ -44505,9 +49689,17 @@
 /area/crew_quarters/kitchen)
 "cpt" = (
 /obj/item/beacon,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpu" = (
 /obj/machinery/deepfryer,
@@ -44584,6 +49776,19 @@
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
 /area/crew_quarters/bar)
+"cpE" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "cpH" = (
 /obj/effect/turf_decal/plaque{
 	icon_state = "L1"
@@ -44678,45 +49883,70 @@
 /area/hallway/primary/central)
 "cpT" = (
 /obj/item/twohanded/required/kirbyplants,
-/turf/open/floor/plasteel/blue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cpU" = (
 /obj/item/twohanded/required/kirbyplants,
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cpX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cpY" = (
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cpZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whiteblue/side{
-	dir = 6
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/area/medical/medbay/central)
-"cqa" = (
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"cqa" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqc" = (
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqd" = (
-/turf/open/floor/plasteel/whiteblue/side{
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqe" = (
 /obj/effect/turf_decal/plaque,
@@ -44730,24 +49960,34 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqh" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/purple/corner,
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqi" = (
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqk" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/purple/side{
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cql" = (
 /obj/structure/disposalpipe/segment,
@@ -44760,23 +50000,29 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqp" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/green/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteblue/corner,
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cqt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -44789,7 +50035,11 @@
 /obj/machinery/light{
 	dir = 2
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqv" = (
 /obj/structure/disposalpipe/segment,
@@ -44823,12 +50073,20 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqD" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqE" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -44838,15 +50096,23 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cqG" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/atmos)
 "cqH" = (
 /obj/machinery/light/small{
@@ -44855,9 +50121,17 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "cqI" = (
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
 "cqS" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -45125,21 +50399,25 @@
 /area/chapel/office)
 "csf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkyellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/darkyellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/darkyellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csi" = (
-/turf/open/floor/plasteel/darkyellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csk" = (
 /obj/structure/table/wood,
@@ -45163,9 +50441,17 @@
 /obj/item/clothing/head/nun_hood,
 /obj/item/clothing/suit/nun,
 /obj/item/clothing/suit/holidaypriest,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cso" = (
 /obj/structure/table/wood,
@@ -45182,26 +50468,41 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "css" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csu" = (
 /obj/structure/disposalpipe/segment{
@@ -45243,19 +50544,49 @@
 /turf/open/floor/carpet/black,
 /area/chapel/office)
 "csE" = (
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csF" = (
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "csM" = (
 /obj/structure/cable{
@@ -45266,7 +50597,8 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/asteroid,
+/obj/effect/turf_decal/sand,
+/turf/open/floor/plasteel,
 /area/chapel/office)
 "csN" = (
 /obj/structure/cable{
@@ -45323,25 +50655,47 @@
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cta" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctb" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cte" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45362,25 +50716,28 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctr" = (
-/turf/open/floor/plasteel/darkyellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkyellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctu" = (
 /obj/machinery/light/small{
 	dir = 2
 	},
-/turf/open/floor/plasteel/darkyellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "ctx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -45416,9 +50773,17 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctM" = (
 /obj/machinery/light/small{
@@ -45427,9 +50792,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctN" = (
 /obj/machinery/light/small{
@@ -45443,9 +50816,17 @@
 	dir = 2;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45454,9 +50835,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "ctP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -45489,9 +50878,17 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuc" = (
 /obj/machinery/light,
@@ -45507,7 +50904,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkpurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cuk" = (
 /obj/structure/closet{
@@ -45522,18 +50923,18 @@
 /obj/item/melee/flyswatter,
 /obj/item/melee/flyswatter,
 /obj/item/melee/flyswatter,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cul" = (
 /obj/machinery/chem_master/condimaster,
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cum" = (
 /obj/machinery/seed_extractor,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cun" = (
 /obj/structure/flora/ausbushes/ywflowers,
@@ -45567,11 +50968,11 @@
 /obj/item/honey_frame,
 /obj/item/honey_frame,
 /obj/item/honey_frame,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cut" = (
 /obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuu" = (
 /obj/item/storage/bag/plants,
@@ -45583,7 +50984,7 @@
 	},
 /obj/item/storage/bag/plants/portaseeder,
 /obj/item/storage/bag/plants/portaseeder,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuv" = (
 /obj/structure/chair/wood/normal{
@@ -45657,19 +51058,19 @@
 /obj/machinery/light/small{
 	dir = 2
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuH" = (
 /obj/item/hatchet,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuI" = (
 /obj/machinery/vending/hydronutrients,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuJ" = (
 /obj/item/shovel/spade,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuK" = (
 /obj/machinery/light/small{
@@ -45709,9 +51110,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45723,7 +51132,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cuS" = (
 /obj/machinery/door/airlock{
@@ -45769,21 +51178,37 @@
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuY" = (
 /obj/machinery/door/airlock{
 	name = "Garden"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cuZ" = (
 /obj/item/wrench,
-/turf/open/floor/plasteel/hydrofloor,
+/turf/open/floor/plasteel,
 /area/chapel/main/monastery)
 "cvb" = (
 /obj/machinery/hydroponics/soil,
@@ -45795,9 +51220,17 @@
 /area/hydroponics/garden/monastery)
 "cvc" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvd" = (
 /obj/structure/chair/wood/normal{
@@ -45812,11 +51245,11 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvf" = (
+/obj/machinery/recycler,
 /obj/machinery/conveyor{
-	dir = 8;
+	dir = 4;
 	id = "garbage"
 	},
-/obj/machinery/recycler,
 /turf/open/floor/plating,
 /area/maintenance/disposal)
 "cvg" = (
@@ -45907,31 +51340,49 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/area/chapel/main/monastery)
-"cvv" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvw" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvA" = (
 /obj/machinery/door/airlock/external{
@@ -45974,9 +51425,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvH" = (
 /obj/structure/cable{
@@ -45988,9 +51447,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvI" = (
 /obj/machinery/light/small,
@@ -46006,9 +51473,17 @@
 	dir = 1;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvJ" = (
 /obj/machinery/light/small,
@@ -46018,9 +51493,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46030,17 +51513,17 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/area/chapel/main/monastery)
-"cvL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
 "cvM" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -46297,13 +51780,6 @@
 /obj/item/flashlight/lantern,
 /turf/open/floor/plasteel/dark,
 /area/chapel/main/monastery)
-"cwP" = (
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = 28
-	},
-/turf/closed/wall,
-/area/medical/chemistry)
 "cwR" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -46322,7 +51798,11 @@
 /area/library/lounge)
 "cxb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/science/mixing)
 "cxe" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
@@ -46374,9 +51854,17 @@
 /obj/effect/turf_decal/box/corners{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "cxz" = (
 /obj/machinery/door/airlock/grunge{
@@ -46403,9 +51891,17 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxD" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -46417,9 +51913,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxE" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46439,9 +51943,17 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxL" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46450,15 +51962,36 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxM" = (
 /obj/structure/window/reinforced/fulltile,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/library/lounge)
+"cxN" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 6
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cxX" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -46468,9 +52001,17 @@
 	dir = 4;
 	network = list("ss13","monastery")
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cxY" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46482,17 +52023,33 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cym" = (
 /obj/effect/turf_decal/stripes/line{
@@ -46502,9 +52059,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyy" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -46519,9 +52084,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyA" = (
 /obj/effect/turf_decal/stripes/corner{
@@ -46533,9 +52106,17 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library/lounge)
 "cyB" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -46674,7 +52255,6 @@
 "czC" = (
 /obj/structure/table/wood/fancy,
 /obj/item/flashlight/lantern{
-	on = 1;
 	icon_state = "lantern-on";
 	pixel_y = 8
 	},
@@ -46769,24 +52349,45 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "cAg" = (
-/turf/open/floor/plasteel/vault,
-/area/library)
-"cAh" = (
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAr" = (
 /obj/machinery/light/small{
@@ -46799,7 +52400,11 @@
 	name = "Curator Desk Door";
 	req_access_txt = "37"
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAs" = (
 /obj/structure/table/wood,
@@ -46807,34 +52412,66 @@
 	icon_state = "plant-05";
 	pixel_y = 10
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lantern{
 	pixel_y = 8
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAu" = (
 /obj/structure/table/wood,
 /obj/item/clothing/head/pharaoh,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAv" = (
 /obj/structure/table/wood,
 /obj/item/camera,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAy" = (
 /obj/machinery/light/small{
@@ -46847,12 +52484,20 @@
 	name = "Curator Desk Door";
 	req_access_txt = "37"
 	},
-/turf/open/floor/plasteel/darkred/side,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAB" = (
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/library)
 "cAC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47056,27 +52701,18 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/chapel/office)
-"cBQ" = (
-/obj/machinery/power/rad_collector,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "cBR" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cBS" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "cBT" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
@@ -47106,11 +52742,9 @@
 /turf/open/floor/plasteel/white,
 /area/engine/gravity_generator)
 "cCI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/status_display/ai,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "cCO" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -47139,7 +52773,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "cCU" = (
-/obj/machinery/rnd/production/circuit_imprinter,
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/tcomms{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_guide,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cCV" = (
@@ -47190,6 +52829,15 @@
 /obj/effect/landmark/carpspawn,
 /turf/open/space/basic,
 /area/space)
+"cHb" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "cHS" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Firing Range"
@@ -47202,9 +52850,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cKA" = (
 /obj/effect/turf_decal/stripes/line{
@@ -47215,6 +52864,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"cLh" = (
+/obj/machinery/atmospherics/pipe/manifold/green/visible{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "cOp" = (
 /obj/item/clothing/mask/gas,
 /obj/item/clothing/mask/gas,
@@ -47232,9 +52893,10 @@
 	pixel_x = -32;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/darkgreen/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "cPO" = (
 /obj/item/chair/stool,
@@ -47251,12 +52913,14 @@
 /obj/structure/window/reinforced,
 /obj/item/storage/box/monkeycubes,
 /obj/item/storage/box/monkeycubes,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cQZ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cSJ" = (
@@ -47291,7 +52955,11 @@
 	pixel_x = 24
 	},
 /obj/structure/cable,
-/turf/open/floor/plasteel/whiteblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "cSK" = (
 /obj/effect/turf_decal/delivery,
@@ -47310,6 +52978,22 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
+"cVw" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"cVO" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cXW" = (
 /obj/structure/grille,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -47319,14 +53003,15 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 4
+	},
 /obj/structure/window/plasma/reinforced{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "daY" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
@@ -47338,6 +53023,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
+"dbw" = (
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/hallway/secondary/entry)
 "dci" = (
 /obj/structure/rack,
 /obj/item/gun/energy/laser/practice,
@@ -47348,6 +53038,13 @@
 /obj/structure/barricade/wooden,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"ddh" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "dgg" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -47359,8 +53056,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dgz" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -47388,8 +53085,19 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "dir" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -47403,9 +53111,17 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "dmP" = (
 /obj/structure/chair{
@@ -47424,14 +53140,24 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "dnS" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "Mix Bypass"
 	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"dnW" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "doo" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47458,7 +53184,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -47539,7 +53268,10 @@
 	c_tag = "Departure Lounge Aft";
 	dir = 1
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "dxc" = (
 /obj/structure/disposalpipe/segment{
@@ -47567,14 +53299,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "dzA" = (
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
+/obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/rack,
 /obj/machinery/light/small{
-	dir = 4;
-	light_color = "#fff4bc"
+	dir = 4
 	},
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -47604,6 +53332,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dJO" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dKs" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -47623,11 +53359,12 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "dMG" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -26
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dMI" = (
 /obj/item/clothing/suit/apron/surgical,
@@ -47635,6 +53372,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"dML" = (
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
 "dMO" = (
 /obj/structure/urinal{
 	pixel_y = 32
@@ -47652,11 +53396,28 @@
 /obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"dNR" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "dRs" = (
 /obj/structure/lattice,
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space)
+"dSc" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "dSr" = (
 /obj/item/chair,
 /turf/open/floor/wood,
@@ -47697,27 +53458,31 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
+"dWF" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/office)
 "dZj" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/machinery/atmospherics/pipe/manifold/green/visible,
+/obj/machinery/airalarm/engine{
+	pixel_y = 22
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"dZy" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/area/maintenance/department/chapel/monastery)
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"dZs" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "eaw" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
-"eaQ" = (
-/turf/closed/wall,
-/area/hallway/secondary/entry)
 "ebD" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -47730,25 +53495,15 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "edJ" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"eeF" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/random{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/yellow/corner{
-	dir = 4
-	},
-/area/hallway/primary/central)
 "eeQ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -47784,13 +53539,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"ekQ" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space)
+"eiw" = (
+/obj/machinery/jukebox,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "ekU" = (
 /obj/effect/decal/cleanable/cobweb{
 	icon_state = "cobweb2"
@@ -47801,9 +53553,6 @@
 /obj/structure/chair/office/dark,
 /turf/open/floor/wood,
 /area/lawoffice)
-"emV" = (
-/turf/open/space,
-/area/space/nearstation)
 "epJ" = (
 /obj/structure/sign/poster/contraband/random{
 	pixel_y = 32
@@ -47846,6 +53595,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"evB" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"ewH" = (
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ezF" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -47865,8 +53627,18 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral,
-/area/maintenance/department/security/brig)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "eCw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47910,15 +53682,24 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "eIL" = (
-/turf/open/floor/plasteel/darkgreen/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "eLt" = (
 /obj/structure/closet/firecloset,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "eMC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -47928,6 +53709,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"eML" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"eNo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "eNq" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -47976,9 +53770,17 @@
 "eSL" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/item/beacon,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "eVy" = (
 /obj/effect/turf_decal/arrows{
@@ -47987,14 +53789,14 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "eVW" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "eWi" = (
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plasteel/dark,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
 /area/engine/engineering)
 "eXo" = (
 /obj/structure/disposalpipe/segment,
@@ -48007,18 +53809,14 @@
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/area/science/explab)
-"eYM" = (
-/obj/machinery/disposal/deliveryChute{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/structure/disposalpipe/trunk,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel/white,
+/area/science/explab)
 "eZA" = (
 /obj/item/stack/cable_coil/cut/random,
 /turf/open/floor/plating,
@@ -48033,8 +53831,8 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "fdS" = (
 /obj/machinery/door/window/southleft{
 	base_state = "left";
@@ -48049,10 +53847,17 @@
 	location = "Engineering"
 	},
 /obj/effect/turf_decal/delivery,
-/obj/structure/window/reinforced,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/department/engine)
 "fef" = (
 /obj/machinery/door/airlock/maintenance{
@@ -48064,12 +53869,29 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"feL" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/space,
+/area/space/nearstation)
 "ffJ" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"fhf" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "fhM" = (
 /obj/item/storage/secure/safe{
 	pixel_x = -22
@@ -48083,14 +53905,37 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/grimy,
 /area/security/detectives_office)
+"fjr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Research Lab Maintenance";
+	req_access_txt = "0";
+	req_one_access_txt = "7;29"
+	},
+/turf/open/floor/plating,
+/area/maintenance/department/engine)
 "fjs" = (
 /obj/machinery/light{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 10
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
+"fjT" = (
+/obj/structure/sign/warning/radiation,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "fkH" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -48103,6 +53948,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/explab)
+"flN" = (
+/obj/machinery/atmospherics/pipe/manifold4w/general/visible,
+/obj/machinery/meter,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "fmh" = (
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
@@ -48113,7 +53963,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -48126,9 +53979,13 @@
 /obj/structure/chair/office/dark{
 	dir = 1
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/checkpoint/customs)
 "fpT" = (
 /obj/structure/cable{
@@ -48144,9 +54001,10 @@
 	},
 /area/maintenance/department/engine)
 "ftW" = (
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fuP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48177,7 +54035,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "fwl" = (
 /obj/structure/disposalpipe/segment{
@@ -48186,9 +54045,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "fwo" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
+/obj/machinery/door/airlock/maintenance,
 /turf/open/floor/plating,
 /area/chapel/main/monastery)
 "fwr" = (
@@ -48204,19 +54061,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
-"fwR" = (
-/obj/structure/reagent_dispensers/watertank,
-/turf/open/floor/plasteel/dark,
-/area/engine/engineering)
 "fyF" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 8
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "fyO" = (
-/turf/open/space/basic,
-/area/engine/engineering)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "fzu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -48225,7 +54088,7 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "fAx" = (
 /obj/structure/cable{
@@ -48245,25 +54108,47 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "fBz" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"fEM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "fFv" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -24
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "fIu" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/cryopod,
+/obj/machinery/cryopod{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "fIN" = (
@@ -48318,7 +54203,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "fUA" = (
 /obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -48326,6 +54214,12 @@
 /obj/structure/bookcase/random/religion,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"fXn" = (
+/obj/machinery/cryopod{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "gam" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Service Door";
@@ -48340,7 +54234,10 @@
 /area/crew_quarters/kitchen)
 "gcj" = (
 /obj/machinery/vending/kink,
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/crew_quarters/fitness/recreation)
@@ -48352,7 +54249,11 @@
 	dir = 8
 	},
 /obj/structure/window/reinforced,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "gdL" = (
 /obj/structure/disposalpipe/segment,
@@ -48360,9 +54261,16 @@
 	dir = 8;
 	pixel_x = -28
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 9
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "geU" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -48428,16 +54336,21 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "gkS" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gkX" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Storage";
@@ -48453,9 +54366,17 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "gmp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48471,7 +54392,11 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "gna" = (
 /turf/open/floor/plasteel/stairs/medium,
@@ -48484,18 +54409,25 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "gpC" = (
 /obj/structure/chair,
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 1;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -48505,6 +54437,38 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"gqg" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 1;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"gqo" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"gsu" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "gue" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -48520,9 +54484,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"gus" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "gvf" = (
-/turf/open/floor/plasteel/neutral/corner{
-	dir = 8;
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel{
 	heat_capacity = 1e+006
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -48530,8 +54503,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/dark,
 /area/chapel/dock)
+"gvX" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "gwn" = (
 /obj/structure/sign/warning{
 	pixel_y = 32
@@ -48557,9 +54536,17 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gxK" = (
 /obj/machinery/light/small{
@@ -48576,6 +54563,23 @@
 /obj/item/flashlight/lamp/green,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"gBq" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"gDN" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = -27
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "gDZ" = (
 /obj/effect/turf_decal/box/corners{
 	dir = 1
@@ -48583,10 +54587,28 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
+"gEs" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Cooling Loop"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gFo" = (
 /obj/structure/window/reinforced,
 /obj/structure/table/glass,
@@ -48620,20 +54642,15 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "gGA" = (
-/obj/machinery/requests_console{
-	department = "Chemistry";
-	departmentType = 2;
-	pixel_x = 32;
-	receive_ore_updates = 1
-	},
-/obj/structure/table/glass,
-/obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "chemistry_shutters";
+	name = "chemistry shutters"
 	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/medical/chemistry)
 "gHZ" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -48656,12 +54673,16 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "gIG" = (
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "gKz" = (
 /obj/structure/table/wood,
@@ -48683,9 +54704,17 @@
 /area/maintenance/department/security/brig)
 "gLF" = (
 /obj/machinery/vending/snack/random,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "gMm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -48693,9 +54722,12 @@
 	},
 /turf/closed/wall,
 /area/science/mixing)
+"gMu" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "gMO" = (
 /obj/structure/plasticflaps/opaque,
-/obj/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "gNv" = (
@@ -48719,12 +54751,29 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"gPc" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"gPR" = (
+/obj/structure/sign/warning/electricshock,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "gPV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/lawoffice)
+"gQN" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "gSH" = (
 /turf/closed/wall,
 /area/lawoffice)
@@ -48736,6 +54785,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"gTV" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "gUb" = (
 /obj/structure/chair/office/dark{
 	dir = 4
@@ -48747,6 +54802,16 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/department/engine)
+"gVZ" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "gXg" = (
 /obj/item/extinguisher,
 /obj/structure/closet/crate{
@@ -48758,6 +54823,12 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
+"hdG" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "heC" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 8;
@@ -48780,6 +54851,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"hgs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hgD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -48798,15 +54876,36 @@
 	codes_txt = "patrol;next_patrol=Sci4";
 	location = "Sci3"
 	},
-/turf/open/floor/plasteel/purple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
+"hkC" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 1;
+	name = "Cooling Loop Bypass"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hkQ" = (
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "hnu" = (
 /obj/machinery/button/door{
@@ -48831,10 +54930,19 @@
 	pixel_y = 24;
 	req_access_txt = "10"
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"hrX" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/holopad,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "hvW" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio4";
@@ -48854,9 +54962,13 @@
 	c_tag = "Departure Lounge Port";
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "hwj" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -48982,9 +55094,16 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"hQA" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "hQC" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "hSM" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -49010,12 +55129,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"hTr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"hTu" = (
+/obj/structure/lattice,
+/obj/structure/window/reinforced{
+	dir = 8
 	},
-/turf/open/space/basic,
-/area/maintenance/department/engine)
+/obj/structure/window/reinforced,
+/turf/open/space,
+/area/space/nearstation)
 "hUt" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -49047,15 +55168,36 @@
 /obj/structure/girder,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hXK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "hYe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkred,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
-"hYm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/chair/stool,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+"hZx" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "hZB" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49068,12 +55210,27 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"hZL" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "iab" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "iaZ" = (
 /turf/open/space/basic,
@@ -49104,15 +55261,28 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"igO" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "ihj" = (
 /obj/item/clothing/suit/toggle/labcoat/science,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "ihk" = (
 /obj/structure/chair/office/light,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "ijF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -49136,6 +55306,14 @@
 /obj/machinery/processor/slime,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"imN" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ioj" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -49152,6 +55330,16 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
+"ioV" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "iqc" = (
 /turf/open/floor/plasteel/stairs/right,
 /area/maintenance/department/crew_quarters/dorms)
@@ -49166,9 +55354,13 @@
 /obj/structure/sign/departments/xenobio{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iuM" = (
 /obj/machinery/door/window/southleft{
@@ -49179,9 +55371,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iyg" = (
 /obj/structure/cable{
@@ -49194,8 +55390,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "iyJ" = (
-/obj/structure/disposalpipe/segment,
-/turf/closed/wall/r_wall,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "izB" = (
 /obj/machinery/door/airlock/external{
@@ -49245,13 +55443,10 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "iCs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
 	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "iCV" = (
 /obj/effect/turf_decal/stripes/line{
@@ -49260,10 +55455,6 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
-"iEa" = (
-/obj/structure/window/reinforced,
-/turf/open/space/basic,
-/area/space)
 "iEQ" = (
 /obj/structure/table,
 /obj/item/storage/box/lights/mixed,
@@ -49310,6 +55501,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
+"iLA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
+"iNn" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "iPj" = (
 /obj/machinery/igniter{
 	id = "xenoigniter";
@@ -49331,9 +55533,14 @@
 	dir = 4;
 	network = list("xeno","rd")
 	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 10
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "iPO" = (
 /obj/machinery/door/poddoor/shutters{
@@ -49383,17 +55590,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"jcM" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "jcT" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jep" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space)
 "jeq" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49401,7 +55610,10 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -49416,6 +55628,13 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"jgQ" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jhk" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49457,17 +55676,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"jlb" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engineering)
-"jmz" = (
-/obj/structure/flora/ausbushes/reedbush,
-/obj/structure/flora/ausbushes/leafybush,
-/turf/open/floor/plating/asteroid,
-/area/chapel/asteroid/monastery)
+"jlc" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "jrG" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -49486,6 +55698,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"jrW" = (
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/obj/structure/rack,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/department/chapel/monastery)
 "jsf" = (
 /obj/item/toy/katana,
 /turf/open/floor/plating,
@@ -49501,10 +55723,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "jsD" = (
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /obj/item/twohanded/required/kirbyplants{
@@ -49517,10 +55736,37 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/xenobiology)
+"jtu" = (
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty{
+	layer = 4
+	},
+/obj/item/stack/cable_coil,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/area/science/xenobiology)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"jue" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jvi" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -49529,10 +55775,23 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
+"jvq" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Fore";
+	dir = 4;
+	network = list("ss13","engine")
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "jwe" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49551,8 +55810,26 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"jyr" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"jzb" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"jzw" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/sorting)
 "jzz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
@@ -49564,6 +55841,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"jAQ" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 4
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "jBh" = (
 /obj/structure/rack,
 /obj/item/stack/sheet/glass/fifty{
@@ -49574,38 +55862,25 @@
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "jBn" = (
-/obj/machinery/camera/emp_proof{
-	c_tag = "Engine Containment Starboard Fore";
-	dir = 2;
-	network = list("engine")
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "jCv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/obj/structure/sign/poster/random{
-	pixel_y = 32
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17"
-	},
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/yellow/corner{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "jDA" = (
 /obj/item/chair,
@@ -49645,6 +55920,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/dorms)
+"jKh" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"jKs" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/junction{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "jLW" = (
 /obj/machinery/atmospherics/pipe/simple/purple/visible,
 /turf/closed/wall/r_wall,
@@ -49656,12 +55943,8 @@
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/item/kitchen/knife,
-/turf/open/floor/plasteel/floorgrime,
-/area/maintenance/department/engine)
-"jPo" = (
-/obj/structure/chair,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/maintenance/department/engine)
 "jQh" = (
 /obj/item/stack/sheet/animalhide/xeno,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -49681,10 +55964,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"jSA" = (
-/obj/structure/sign/departments/science,
-/turf/closed/wall,
-/area/maintenance/department/engine)
+"jRO" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 8;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "jTh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -49750,12 +56039,38 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/engine)
+"kdu" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/lab)
 "kfh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"kfp" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/random{
+	pixel_x = 32
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kfr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "kfM" = (
 /obj/structure/closet,
 /obj/machinery/light/small{
@@ -49812,9 +56127,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "klB" = (
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "klV" = (
 /obj/item/clothing/under/rank/clown/sexy,
@@ -49824,18 +56141,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"knw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "kpK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -49846,7 +56151,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "ksf" = (
 /obj/item/stack/tile/carpet,
@@ -49856,15 +56161,32 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "kvj" = (
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "kwm" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/darkred/side{
-	dir = 9
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "kxj" = (
 /obj/structure/chair/office/dark{
@@ -49887,26 +56209,30 @@
 	dir = 2;
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "kAa" = (
 /obj/structure/chair{
 	dir = 8
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
-"kCc" = (
-/obj/structure/plasticflaps/opaque,
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "EngLoad"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "kDf" = (
 /obj/machinery/light/small{
 	dir = 2
@@ -49919,9 +56245,6 @@
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -27
-	},
-/obj/machinery/conveyor_switch/oneway{
-	id = "EngLoad"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -49936,9 +56259,10 @@
 	dir = 1;
 	pixel_x = -32
 	},
-/turf/open/floor/plasteel/green/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kEW" = (
 /obj/machinery/smartfridge/disks{
@@ -49985,9 +56309,16 @@
 	dir = 8;
 	pixel_x = -27
 	},
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "kIo" = (
 /obj/structure/table,
@@ -50003,6 +56334,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"kJn" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kJo" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -50040,6 +56384,14 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
+"kNu" = (
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
+	},
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "kPi" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -50054,6 +56406,10 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"kQj" = (
+/obj/machinery/status_display/ai,
+/turf/closed/wall,
+/area/quartermaster/qm)
 "kQy" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -50074,14 +56430,21 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "kRq" = (
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
 "kRK" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/canister/bz,
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 9
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "kSF" = (
 /obj/structure/cable{
@@ -50106,24 +56469,35 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/port)
+"kVV" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "kWQ" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/obj/machinery/power/emitter/anchored{
-	dir = 8;
-	state = 2
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "kYR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/public/glass{
-	name = "Monastery Transit"
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
 	},
-/turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
 "lcU" = (
 /obj/effect/turf_decal/stripes/line{
@@ -50152,18 +56526,27 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"lgk" = (
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "lhA" = (
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "liR" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/green/visible{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"liY" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "lje" = (
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
@@ -50177,15 +56560,12 @@
 /area/maintenance/department/engine)
 "lnn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/side,
-/area/storage/primary)
-"lnD" = (
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/structure/rack,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/area/maintenance/department/chapel/monastery)
+/turf/open/floor/plasteel,
+/area/storage/primary)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -50200,6 +56580,32 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library/lounge)
+"lun" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"lva" = (
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
+	dir = 1
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"lxy" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "lzJ" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/carpet,
@@ -50208,18 +56614,30 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkyellow/corner,
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "lAs" = (
 /turf/closed/wall,
 /area/quartermaster/sorting)
+"lAC" = (
+/obj/machinery/conveyor{
+	dir = 8;
+	id = "garbage"
+	},
+/turf/open/floor/plating,
+/area/maintenance/disposal)
 "lAR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "lBP" = (
 /obj/machinery/disposal/bin,
@@ -50236,6 +56654,13 @@
 /obj/structure/window/reinforced,
 /turf/open/space/basic,
 /area/space/nearstation)
+"lED" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 9
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "lFh" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -50247,7 +56672,7 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "lGp" = (
-/obj/structure/weightlifter,
+/obj/structure/weightmachine/weightlifter,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "lGv" = (
@@ -50264,9 +56689,13 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "lHc" = (
 /obj/structure/girder,
@@ -50334,9 +56763,17 @@
 	name = "bridge external shutters"
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
 "lQX" = (
 /obj/effect/spawner/lootdrop/maintenance,
@@ -50345,12 +56782,16 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"lRY" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
+"lTB" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/effect/mapping_helpers/airlock/cyclelink_helper,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "lTC" = (
 /obj/item/shard,
 /obj/effect/turf_decal/stripes/line{
@@ -50382,11 +56823,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"lWR" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced,
-/turf/open/space,
-/area/space/nearstation)
 "lXc" = (
 /obj/structure/table,
 /obj/item/clothing/head/beret,
@@ -50399,7 +56835,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -50421,41 +56860,47 @@
 	dir = 1
 	},
 /obj/machinery/vending/wardrobe/engi_wardrobe,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
-"mbW" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space)
 "mcf" = (
+/obj/structure/table/glass,
+/obj/machinery/reagentgrinder,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"mci" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
 "mdL" = (
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen{
 	layer = 3.1
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "meF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/status_display/evac,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
+"mgo" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "mhl" = (
 /obj/machinery/power/emitter,
@@ -50464,6 +56909,10 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
+"mlj" = (
+/obj/machinery/light/small,
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
 "mlr" = (
 /obj/structure/lattice,
 /obj/structure/disposalpipe/junction{
@@ -50487,10 +56936,43 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/wood,
 /area/maintenance/department/crew_quarters/dorms)
-"mpd" = (
-/obj/structure/lattice,
-/turf/open/space,
+"mnW" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/turf/open/floor/engine,
 /area/engine/engineering)
+"moQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"moW" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
+"mpd" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/structure/window/plasma/reinforced{
+	dir = 4
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "mpy" = (
 /obj/structure/table/wood,
 /obj/item/paper_bin,
@@ -50501,9 +56983,13 @@
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "msX" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -50541,7 +57027,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "mwg" = (
 /obj/structure/closet/crate{
@@ -50554,13 +57040,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "mwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/obj/structure/sign/warning/vacuum/external{
-	pixel_x = 32
-	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "mxy" = (
 /obj/machinery/power/terminal{
@@ -50588,8 +57073,23 @@
 	dir = 1;
 	pixel_x = 32
 	},
-/turf/open/floor/plasteel/vault,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/bridge)
+"myZ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plating,
+/area/engine/atmos)
 "mzl" = (
 /obj/structure/chair,
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -50597,6 +57097,26 @@
 	},
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"mzy" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"mzP" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 4
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mzU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall,
@@ -50616,12 +57136,38 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"mEs" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/engine/engineering)
+"mEG" = (
+/obj/structure/table,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/clothing/glasses/meson/engine,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/item/pipe_dispenser,
+/obj/machinery/light,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mES" = (
 /obj/machinery/door/airlock/maintenance/abandoned{
 	name = "Surgical Room"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"mFn" = (
+/obj/structure/lattice,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "mHy" = (
 /obj/item/storage/fancy/cigarettes/cigpack_shadyjims,
 /turf/open/floor/wood,
@@ -50635,6 +57181,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"mJv" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/item/tank/internals/plasma,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "mKc" = (
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/plasteel/dark,
@@ -50656,12 +57213,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/security/brig)
-"mMc" = (
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/space/basic,
-/area/maintenance/department/engine)
 "mMz" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable,
@@ -50671,6 +57222,17 @@
 	},
 /turf/open/floor/plating,
 /area/science/xenobiology)
+"mNz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "mQm" = (
 /obj/structure/chair/office/light{
 	dir = 1
@@ -50717,6 +57279,13 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/science)
+"nei" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 6
+	},
+/obj/machinery/meter,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "nev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -50729,12 +57298,39 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"ney" = (
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/chair{
+	dir = 8;
+	name = "Defense"
+	},
+/obj/machinery/camera{
+	c_tag = "Atmospherics Starboard";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "nfi" = (
 /obj/structure/sign/directions/evac{
 	dir = 1;
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -50765,9 +57361,17 @@
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "nku" = (
 /obj/machinery/door/airlock/centcom{
@@ -50779,7 +57383,19 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "nnf" = (
-/turf/open/floor/plasteel/whiteyellow/side,
+/obj/structure/rack,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "nnh" = (
 /obj/structure/chair{
@@ -50788,6 +57404,26 @@
 /obj/item/stack/spacecash/c10,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"nnU" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"nom" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Mix to Engine"
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "noC" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/wood,
@@ -50812,6 +57448,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"nrl" = (
+/obj/structure/chair/stool,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/station_engineer,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "nsy" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal/fifty,
@@ -50857,7 +57501,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nxT" = (
 /obj/machinery/smartfridge/extract/preloaded,
@@ -50868,7 +57516,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/primary/central)
 "nyO" = (
 /obj/item/twohanded/required/kirbyplants{
@@ -50889,17 +57540,12 @@
 	},
 /area/maintenance/department/science)
 "nAs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Supermatter Engine";
+	req_access_txt = "10"
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
-	},
-/turf/open/floor/plating,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "nBw" = (
 /obj/machinery/computer/crew{
@@ -50914,20 +57560,43 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/corner{
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
+"nCb" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "nDo" = (
 /obj/structure/bed,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "nDx" = (
 /obj/machinery/vending/coffee,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
+"nDW" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "nEb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -50947,8 +57616,11 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
 "nIm" = (
@@ -50971,7 +57643,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/lab)
 "nJI" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -51007,9 +57683,13 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "nNJ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51033,9 +57713,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkblue/side{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "nPA" = (
 /obj/item/chair,
@@ -51110,16 +57794,40 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
+"ocB" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "oep" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin,
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 10
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"ofE" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "ofN" = (
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ofX" = (
 /obj/structure/cable{
@@ -51133,19 +57841,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"ogX" = (
-/obj/machinery/camera{
-	c_tag = "Engineering Starboard Aft";
-	dir = 1
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
 "ohR" = (
 /obj/item/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"oix" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "Gas to Filter"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/engine,
+/area/engine/supermatter)
+"ojx" = (
+/obj/structure/chair/office/dark{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "olc" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Bedroom";
@@ -51156,16 +57870,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"omI" = (
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1"
-	},
-/turf/open/floor/plating{
-	luminosity = 2;
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
-/area/maintenance/department/chapel/monastery)
 "onX" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -51189,6 +57893,9 @@
 /obj/item/wrench/medical,
 /turf/open/floor/engine,
 /area/medical/chemistry)
+"opv" = (
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "opz" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -51200,28 +57907,28 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"ory" = (
-/obj/machinery/light{
-	dir = 4
+"oqJ" = (
+/obj/machinery/light/small{
+	dir = 8
 	},
-/obj/structure/table,
-/obj/item/stack/sheet/glass/fifty{
-	layer = 4
-	},
-/obj/item/stack/cable_coil,
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
-"orZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel/yellow/side,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/maintenance/department/chapel/monastery)
+"ora" = (
+/obj/machinery/status_display/supply,
+/turf/closed/wall,
+/area/quartermaster/warehouse)
 "ost" = (
 /obj/structure/table/glass,
 /obj/item/paper_bin{
@@ -51241,9 +57948,6 @@
 /area/hallway/secondary/entry)
 "ous" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
 /obj/machinery/button/door{
 	desc = "A remote control-switch for secure storage.";
 	id = "Secure Storage";
@@ -51251,7 +57955,12 @@
 	pixel_y = -24;
 	req_access_txt = "11"
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/watertank,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "ouv" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
@@ -51267,19 +57976,42 @@
 	c_tag = "Arrivals Port Fore";
 	dir = 2
 	},
-/turf/open/floor/plasteel/arrival{
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/entry)
-"owS" = (
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+"owI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"owS" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "oyF" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/storage/primary)
+"ozc" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
 "oAw" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -51301,6 +58033,21 @@
 	},
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
+"oBw" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"oBx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/main/monastery)
 "oCn" = (
 /obj/structure/chair/office/dark{
 	dir = 1
@@ -51308,6 +58055,12 @@
 /obj/effect/landmark/start/lawyer,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"oCs" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "oCX" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51322,9 +58075,11 @@
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard)
 "oDP" = (
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "oEA" = (
 /turf/closed/wall,
@@ -51383,14 +58138,8 @@
 /obj/structure/closet,
 /obj/effect/decal/cleanable/blood/old,
 /obj/item/stack/sheet/mineral/wood,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
-"oGm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "oKa" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -51407,9 +58156,10 @@
 	},
 /area/maintenance/department/science)
 "oLR" = (
-/turf/open/floor/plasteel/escape{
-	dir = 5
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/turf/open/floor/plasteel/cafeteria,
 /area/hallway/secondary/exit/departure_lounge)
 "oMN" = (
 /turf/open/floor/plasteel/stairs/left,
@@ -51420,9 +58170,10 @@
 	pixel_x = -32;
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/darkgreen/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "oPx" = (
 /obj/structure/cable{
@@ -51536,9 +58287,14 @@
 /obj/structure/table/glass,
 /obj/item/mmi,
 /obj/item/clothing/mask/balaclava,
-/turf/open/floor/plasteel/whitered/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/security/execution/transfer)
 "oYj" = (
 /obj/effect/turf_decal/loading_area{
@@ -51552,6 +58308,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"pae" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/turf/open/space,
+/area/space/nearstation)
 "pbm" = (
 /obj/machinery/door/airlock/external{
 	name = "Pod Docking Bay"
@@ -51613,23 +58375,27 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/secondary/entry)
-"phg" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "phJ" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "pjH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/space/nearstation)
+"pjV" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pkM" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "22"
@@ -51640,22 +58406,21 @@
 /obj/structure/piano,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
+"pmW" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pnU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
 	dir = 4;
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
-/turf/open/floor/circuit/killroom,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
-"poK" = (
-/obj/structure/window/reinforced,
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "pps" = (
 /turf/closed/wall,
 /area/engine/break_room)
@@ -51663,27 +58428,34 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = -32
 	},
-/turf/open/floor/plasteel/escape,
-/area/hallway/secondary/exit/departure_lounge)
-"prQ" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
-	},
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/floor/plasteel/white/corner,
+/area/hallway/secondary/exit/departure_lounge)
+"prQ" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "pvK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "pwj" = (
 /obj/structure/cable{
@@ -51701,6 +58473,17 @@
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
+"pBj" = (
+/obj/structure/closet/radiation,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pBD" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -51713,9 +58496,17 @@
 /area/maintenance/department/engine)
 "pDP" = (
 /obj/machinery/vending/assist,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -51725,9 +58516,14 @@
 /area/lawoffice)
 "pFe" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/darkred/side{
-	dir = 10
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "pFy" = (
 /obj/structure/cable{
@@ -51738,11 +58534,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
+"pFH" = (
+/obj/machinery/atmospherics/pipe/manifold/orange/visible{
+	dir = 8
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "pGe" = (
 /obj/structure/chair{
 	dir = 1
 	},
-/turf/open/floor/plasteel/neutral/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "pHo" = (
 /obj/machinery/computer/bounty{
@@ -51750,6 +58566,12 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
+"pJV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/hor)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -51758,6 +58580,14 @@
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"pKi" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
+	dir = 4
+	},
+/turf/open/space,
+/area/space/nearstation)
 "pMG" = (
 /obj/structure/sink{
 	dir = 8;
@@ -51767,9 +58597,10 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/darkgreen/corner{
+/obj/effect/turf_decal/tile/green{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "pNy" = (
 /obj/structure/closet/firecloset,
@@ -51781,9 +58612,17 @@
 /obj/structure/sign/poster/official/random{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "pOr" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -51793,7 +58632,10 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -51803,12 +58645,6 @@
 	},
 /turf/closed/wall/r_wall,
 /area/medical/virology)
-"pSc" = (
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/whiteyellow/side{
-	dir = 5
-	},
-/area/medical/chemistry)
 "pVD" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -51841,10 +58677,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"pWS" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "pWT" = (
 /obj/structure/chair/stool,
 /obj/effect/landmark/start/botanist,
-/turf/open/floor/plasteel/green/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "pXc" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -51862,7 +58707,11 @@
 	},
 /obj/item/extinguisher,
 /obj/machinery/light,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "pXT" = (
 /obj/item/twohanded/required/kirbyplants,
@@ -51875,19 +58724,32 @@
 /obj/structure/cable,
 /turf/open/floor/wood,
 /area/lawoffice)
-"pYw" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-03"
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
 "pYC" = (
 /obj/structure/sign/warning{
 	pixel_y = -32
 	},
 /obj/structure/barricade/wooden,
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/maintenance/department/engine)
+"pZu" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/rods/fifty,
+/obj/item/clothing/glasses/welding,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qan" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/disk/tech_disk,
+/obj/item/disk/design_disk,
+/turf/open/floor/plasteel/dark,
+/area/science/lab)
 "qar" = (
 /obj/structure/chair/office/light{
 	icon_state = "officechair_white";
@@ -51895,15 +58757,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
+"qbh" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = -32
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qbp" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+/obj/machinery/atmospherics/pipe/manifold/general/visible{
+	dir = 8
 	},
-/obj/machinery/power/emitter/anchored{
-	dir = 4;
-	state = 2
-	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "qbV" = (
 /obj/structure/lattice,
@@ -51916,15 +58783,23 @@
 /area/storage/emergency/starboard)
 "qcD" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/turf/open/floor/plasteel/darkgreen/side{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qcH" = (
 /obj/structure/table/glass,
 /obj/item/folder/blue,
 /obj/item/pen,
-/turf/open/floor/plasteel/darkgreen/side,
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qdi" = (
 /obj/structure/disposalpipe/segment{
@@ -51948,29 +58823,51 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "qdj" = (
 /obj/structure/disposalpipe/segment,
 /obj/item/stack/sheet/mineral/wood,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
-"qfj" = (
-/obj/structure/lattice,
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "qjx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
+"qky" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qnw" = (
+/obj/structure/sign/warning/fire,
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "qnT" = (
 /obj/machinery/iv_drip,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"qpc" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 4;
+	name = "Mix to Gas"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"qqt" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "qtA" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -51989,14 +58886,15 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qtO" = (
-/obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "qxq" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
@@ -52007,6 +58905,19 @@
 	},
 /turf/open/floor/plating,
 /area/tcommsat/computer)
+"qyx" = (
+/obj/structure/table,
+/obj/item/clothing/suit/hooded/wintercoat/engineering,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/item/clothing/glasses/meson,
+/obj/effect/turf_decal/delivery,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "qyF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52030,9 +58941,17 @@
 /obj/structure/sign/warning/securearea{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "qEN" = (
 /obj/machinery/rnd/production/techfab/department/service,
@@ -52042,8 +58961,13 @@
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "qFu" = (
-/obj/machinery/power/port_gen/pacman,
-/turf/open/floor/plasteel/dark,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "qGu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -52140,19 +59064,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/department/crew_quarters/dorms)
-"qQr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "qUw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "qVP" = (
 /obj/machinery/door/firedoor,
@@ -52177,7 +59101,11 @@
 /obj/item/storage/toolbox/electrical{
 	pixel_x = -2
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "qXq" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
@@ -52193,9 +59121,10 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "qYi" = (
 /obj/structure/disposalpipe/segment{
@@ -52211,9 +59140,14 @@
 	icon_state = "2-4"
 	},
 /obj/item/wrench,
-/turf/open/floor/plasteel/darkgreen/side{
-	dir = 5
+/obj/effect/turf_decal/tile/green{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "qYS" = (
 /obj/structure/cable{
@@ -52233,11 +59167,17 @@
 /area/medical/sleeper)
 "rax" = (
 /obj/machinery/conveyor{
-	dir = 2;
+	dir = 1;
 	id = "garbage"
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
+"rbd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "reH" = (
 /obj/item/reagent_containers/food/drinks/bottle/vodka,
 /obj/structure/disposalpipe/segment{
@@ -52245,6 +59185,12 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"reU" = (
+/obj/structure/reflector/double/anchored{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "reV" = (
 /obj/structure/table,
 /obj/item/storage/toolbox/mechanical,
@@ -52261,9 +59207,17 @@
 "rgs" = (
 /obj/structure/table,
 /obj/item/instrument/eguitar,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "rhr" = (
 /obj/machinery/light/small{
@@ -52275,9 +59229,17 @@
 /area/maintenance/department/engine)
 "riF" = (
 /obj/machinery/computer/arcade,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "riW" = (
 /obj/structure/cable{
@@ -52324,10 +59286,23 @@
 	},
 /area/maintenance/department/security/brig)
 "rrU" = (
-/turf/open/floor/plasteel/darkred/side{
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
+"rrX" = (
+/obj/machinery/atmospherics/pipe/simple/orange/visible{
 	dir = 9
 	},
-/area/chapel/office)
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "rse" = (
 /obj/machinery/power/smes/engineering,
 /obj/structure/cable{
@@ -52432,7 +59407,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
 "rHA" = (
 /turf/open/floor/plasteel,
@@ -52503,26 +59480,55 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"rNC" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
+	name = "External Gas to Loop"
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/engine,
+/area/engine/engineering)
 "rPg" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "rPW" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
+"rSl" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "rSH" = (
 /obj/item/trash/can,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"rTj" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"rVh" = (
+/obj/machinery/door/airlock/engineering/glass/critical{
+	heat_proof = 1;
+	name = "Supermatter Chamber";
+	req_access_txt = "10"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "rWE" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -52549,23 +59555,35 @@
 	},
 /turf/open/floor/plating,
 /area/storage/emergency/starboard)
-"rYY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+"rZw" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
 	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper,
-/obj/machinery/door/airlock/external{
-	name = "Engineering External Access";
-	req_access_txt = "10;13"
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "saW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Monastery Transit"
 	},
-/turf/open/floor/plasteel/white,
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
 /area/hallway/secondary/entry)
+"sbf" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 8;
+	name = "Cooling Loop to Gas"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sbk" = (
 /obj/structure/girder,
 /turf/open/floor/plating,
@@ -52608,21 +59626,69 @@
 	},
 /turf/open/space,
 /area/space/nearstation)
+"sen" = (
+/obj/machinery/camera{
+	c_tag = "Engineering Supermatter Starboard";
+	dir = 8;
+	network = list("ss13","engine")
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sgc" = (
 /obj/machinery/vending/cigarette,
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "sij" = (
 /obj/structure/closet,
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"siE" = (
+/obj/structure/table/glass,
+/obj/item/book/manual/wiki/engineering_hacking{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/book/manual/wiki/engineering_construction,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "skw" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
 /turf/closed/wall,
 /area/maintenance/department/security/brig)
+"smo" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"spr" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "spz" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
@@ -52642,12 +59708,12 @@
 "sqQ" = (
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"srv" = (
-/obj/structure/window/reinforced{
-	dir = 4
+"sqY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
 	},
-/turf/open/space/basic,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/engine/engineering)
 "srZ" = (
 /obj/structure/closet/crate{
 	icon_state = "crateopen"
@@ -52686,6 +59752,14 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/monkey,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"sxO" = (
+/obj/structure/closet/secure_closet/engineering_electrical,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "syn" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -52699,10 +59773,7 @@
 /area/maintenance/department/security/brig)
 "syQ" = (
 /obj/machinery/vending/games,
-/obj/structure/sign/warning/securearea{
-	desc = "Under the painting a plaque reads: 'While the meat grinder may not have spared you, fear not. Not one part of you has gone to waste... You were delicious.'";
-	icon_state = "monkey_painting";
-	name = "Mr. Deempisi portrait";
+/obj/structure/sign/plaques/deempisi{
 	pixel_y = 28
 	},
 /turf/open/floor/plating{
@@ -52730,9 +59801,13 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/red/side{
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/security/brig)
 "sEB" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -52751,6 +59826,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"sGB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "sJp" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line,
@@ -52759,14 +59841,30 @@
 "sJr" = (
 /turf/open/floor/wood,
 /area/lawoffice)
+"sJv" = (
+/turf/closed/wall/r_wall,
+/area/engine/supermatter)
 "sKa" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/structure/closet/secure_closet/engineering_personal,
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"sMb" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "sNz" = (
 /obj/structure/cable{
@@ -52785,7 +59883,6 @@
 /obj/structure/window/reinforced{
 	dir = 8
 	},
-/obj/structure/lattice,
 /turf/open/space/basic,
 /area/space)
 "sQt" = (
@@ -52798,6 +59895,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"sUe" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "sUP" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -52807,11 +59910,31 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"sWj" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
+"sVF" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4
 	},
-/turf/open/floor/plating/airless,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"sWj" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/machinery/meter,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "sXi" = (
 /obj/machinery/disposal/bin,
@@ -52827,13 +59950,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
-"sYp" = (
-/obj/structure/lattice,
-/obj/machinery/light{
-	dir = 2
-	},
-/turf/open/space,
-/area/engine/engineering)
 "sZh" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating,
@@ -52883,6 +59999,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"tdf" = (
+/obj/machinery/atmospherics/components/binary/pump{
+	dir = 8;
+	name = "Gas to Mix"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tdp" = (
 /obj/structure/rack,
 /obj/item/stack/packageWrap,
@@ -52897,17 +60023,26 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "tdB" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
 /obj/item/reagent_containers/dropper,
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "tfw" = (
 /obj/structure/cable{
@@ -52964,18 +60099,13 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "tlN" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "tnY" = (
 /obj/machinery/button/door{
@@ -52986,7 +60116,11 @@
 	req_one_access_txt = "32;47;48"
 	},
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "tpb" = (
 /obj/item/reagent_containers/food/snacks/donut,
@@ -53022,13 +60156,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"tuL" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/the_singularitygen,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "tvj" = (
 /obj/structure/festivus{
 	anchored = 1;
@@ -53044,18 +60171,16 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "twv" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Singularity";
-	name = "radiation shutters"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/disposalpipe/segment{
-	dir = 5
-	},
-/turf/open/floor/plating,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "typ" = (
 /obj/structure/table/glass,
@@ -53064,12 +60189,53 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/science)
+"tyu" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "tyL" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
+"tzc" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/machinery/button/door{
+	id = "engsm";
+	name = "Radiation Shutters Control";
+	pixel_y = 24;
+	req_access_txt = "10"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tzR" = (
+/obj/machinery/atmospherics/pipe/manifold/cyan/visible,
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/engine,
+/area/engine/engineering)
+"tAJ" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 5
+	},
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "tAK" = (
 /obj/structure/table,
 /obj/structure/window/reinforced{
@@ -53097,16 +60263,24 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "tIS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"tPm" = (
-/obj/structure/disposalpipe/segment{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/turf/closed/wall,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
+"tMG" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"tOw" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/engine,
 /area/engine/engineering)
 "tRc" = (
 /obj/structure/ore_box,
@@ -53114,12 +60288,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/department/engine)
-"tRK" = (
-/turf/open/floor/plating{
-	luminosity = 2;
-	initial_gas_mix = "o2=0.01;n2=0.01"
-	},
-/area/maintenance/department/chapel/monastery)
 "tSL" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -53127,8 +60295,8 @@
 /area/maintenance/department/science)
 "tTl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "tXn" = (
 /obj/structure/sink{
 	dir = 4;
@@ -53137,21 +60305,15 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/turf/open/floor/plasteel/whitepurple/side{
-	dir = 5
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
-"tYx" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/ash,
-/obj/effect/decal/cleanable/robot_debris/old,
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
 "uaa" = (
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
@@ -53170,16 +60332,13 @@
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "uaP" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/structure/window/plasma/reinforced{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "ubW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -53224,16 +60383,36 @@
 	icon_state = "officechair_white";
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"ugS" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/orange/visible,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "uiP" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"uje" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "ujI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/cable{
@@ -53247,23 +60426,39 @@
 	},
 /turf/closed/wall,
 /area/maintenance/department/engine)
+"ukC" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ulg" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ulu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/plasteel/neutral/side{
-	dir = 6
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "ulY" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/power/grounding_rod{
-	anchored = 1
-	},
-/turf/open/floor/plating/airless,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
 /area/engine/engineering)
 "ume" = (
 /obj/machinery/door/firedoor,
@@ -53279,6 +60474,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
+"umf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "uoj" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
@@ -53289,8 +60491,16 @@
 	},
 /area/maintenance/department/science)
 "uoq" = (
-/turf/open/space,
-/area/engine/engineering)
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
+	},
+/obj/effect/decal/cleanable/dirt,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "uos" = (
 /obj/machinery/computer/camera_advanced/base_construction,
 /obj/effect/turf_decal/stripes/line{
@@ -53298,12 +60508,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"uot" = (
-/obj/effect/decal/cleanable/oil{
-	icon_state = "floor6"
-	},
-/turf/closed/wall,
-/area/maintenance/department/chapel/monastery)
 "uoS" = (
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
@@ -53312,6 +60516,11 @@
 /obj/structure/cable,
 /turf/open/floor/plating,
 /area/security/execution/transfer)
+"uqL" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "urP" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -53373,8 +60582,15 @@
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 1
 	},
-/turf/open/floor/circuit/killroom,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
+"uwJ" = (
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "uwX" = (
 /obj/machinery/field/generator,
 /turf/open/floor/plating,
@@ -53384,10 +60600,21 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/tcommsat/computer)
+"uzu" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Gas to Filter"
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "uAL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
@@ -53446,7 +60673,10 @@
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
@@ -53460,28 +60690,37 @@
 /area/maintenance/department/engine)
 "uMo" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/turf/open/floor/plasteel/yellow/side,
+/obj/structure/closet/crate/solarpanel_small,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "uMt" = (
 /obj/effect/turf_decal/plaque,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"uPS" = (
+/obj/machinery/rnd/production/circuit_imprinter,
+/obj/machinery/camera{
+	c_tag = "Engineering Starboard Aft";
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "uQR" = (
 /obj/item/ammo_casing/shotgun/beanbag,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
 "uRk" = (
-/obj/machinery/field/generator{
-	anchored = 1;
-	state = 2
+/obj/machinery/atmospherics/pipe/simple/cyan/visible{
+	dir = 5
 	},
 /obj/effect/turf_decal/stripes/corner{
-	dir = 1
+	dir = 8
 	},
-/turf/open/floor/plating/airless,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "uUQ" = (
 /obj/machinery/door/airlock/maintenance{
@@ -53509,15 +60748,17 @@
 /obj/item/stamp/law,
 /turf/open/floor/carpet,
 /area/lawoffice)
-"uVW" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
+"uWI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/machinery/door/airlock/public/glass{
+	name = "Monastery Transit"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/floor/plasteel/white{
+	heat_capacity = 1e+006
+	},
+/area/chapel/dock)
 "uXG" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -53529,7 +60770,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "uXH" = (
 /obj/structure/cable{
@@ -53546,6 +60787,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"vaH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vbQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -53555,9 +60803,17 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "vgp" = (
 /obj/machinery/door/firedoor,
@@ -53574,12 +60830,25 @@
 	name = "Containment Pen";
 	req_access_txt = "55"
 	},
-/turf/open/floor/plasteel/floorgrime,
+/turf/open/floor/plasteel,
 /area/science/xenobiology)
 "vhk" = (
 /obj/structure/chair,
 /turf/open/floor/carpet,
 /area/lawoffice)
+"vhF" = (
+/obj/effect/landmark/carpspawn,
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"vil" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vjd" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -53602,9 +60871,17 @@
 "vmG" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
-/turf/open/floor/plasteel/vault{
-	dir = 5
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/explab)
 "vmY" = (
 /obj/structure/sign/warning/deathsposal{
@@ -53615,6 +60892,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"voA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "vpz" = (
 /obj/structure/girder,
 /turf/open/floor/plating{
@@ -53634,9 +60918,10 @@
 /area/maintenance/department/cargo)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "vtl" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -53749,6 +61034,13 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
+"vKO" = (
+/obj/machinery/computer/cryopod{
+	dir = 1;
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "vMx" = (
 /obj/structure/disposalpipe/segment{
 	dir = 6
@@ -53772,6 +61064,10 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/library)
+"vPL" = (
+/obj/machinery/power/supermatter_crystal/engine,
+/turf/open/floor/engine,
+/area/engine/supermatter)
 "vRi" = (
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -53803,15 +61099,23 @@
 	c_tag = "Engineering Port Storage";
 	dir = 2
 	},
-/turf/open/floor/plasteel/yellow/side{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "vTL" = (
 /obj/machinery/vending/tool,
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
 /area/storage/primary)
 "vTN" = (
 /obj/machinery/door/firedoor/heavy,
@@ -53820,19 +61124,24 @@
 	req_access_txt = "8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/vault{
-	dir = 5
-	},
-/area/science/mixing)
-"vXt" = (
-/obj/effect/turf_decal/stripes/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/rods/fifty,
-/obj/item/clothing/glasses/welding,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/mixing)
+"vTZ" = (
+/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+	dir = 4
+	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "vYN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -53841,7 +61150,7 @@
 	name = "server vent";
 	pressure_checks = 0
 	},
-/turf/open/floor/circuit/killroom,
+/turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "waN" = (
 /obj/effect/spawner/lootdrop/maintenance{
@@ -53854,10 +61163,7 @@
 	},
 /area/maintenance/department/chapel/monastery)
 "wcs" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
+/turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "wdx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53909,6 +61215,13 @@
 /obj/item/stack/cable_coil/red,
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"wko" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wkZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -53920,13 +61233,21 @@
 	dir = 4;
 	name = "emergency shower"
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "wlK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "wmA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -53939,30 +61260,27 @@
 /turf/closed/wall,
 /area/science/mixing)
 "woh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "engsm";
+	name = "Radiation Chamber Shutters"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/effect/decal/cleanable/oil,
+/turf/open/floor/plating,
+/area/engine/supermatter)
 "woq" = (
 /obj/structure/chair,
 /turf/open/floor/plating,
 /area/maintenance/department/security/brig)
-"wpI" = (
-/obj/structure/window/plasma/reinforced{
-	dir = 8
+"wqq" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "wqu" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 8
@@ -53990,9 +61308,13 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "wwr" = (
-/turf/open/floor/plasteel/neutral/side{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wwG" = (
 /obj/effect/turf_decal/stripes/line{
@@ -54026,6 +61348,14 @@
 /obj/structure/chair,
 /turf/open/floor/wood,
 /area/maintenance/department/engine)
+"wzA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/engineering)
 "wAI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -54037,7 +61367,11 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/whitepurple/side,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
 /area/science/explab)
 "wBg" = (
 /obj/machinery/door/airlock/maintenance{
@@ -54046,6 +61380,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/crew_quarters/bar)
+"wBQ" = (
+/obj/structure/reflector/single/anchored{
+	dir = 6
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "wDm" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -54064,10 +61407,20 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Departure Lounge"
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"wFy" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible,
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wFT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -54097,10 +61450,6 @@
 /obj/machinery/light/small,
 /turf/open/floor/plating,
 /area/hallway/secondary/exit/departure_lounge)
-"wKK" = (
-/obj/machinery/power/tesla_coil,
-/turf/open/floor/plating,
-/area/engine/engineering)
 "wLo" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -54141,7 +61490,8 @@
 /area/maintenance/department/engine)
 "wOa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner,
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "wOf" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
@@ -54245,6 +61595,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"wVS" = (
+/obj/machinery/atmospherics/pipe/simple/green/visible{
+	dir = 9
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "wXu" = (
 /obj/machinery/disposal/bin,
 /obj/structure/window/reinforced{
@@ -54289,9 +61648,17 @@
 	dir = 1;
 	pixel_y = 29
 	},
-/turf/open/floor/plasteel/vault{
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "xbJ" = (
 /turf/open/floor/plasteel/dark,
@@ -54323,10 +61690,19 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 27
 	},
-/turf/open/floor/plasteel/escape{
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
 	dir = 1
 	},
 /area/hallway/secondary/exit/departure_lounge)
+"xif" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 6
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "xja" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -54346,12 +61722,10 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "xje" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xjK" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
@@ -54368,9 +61742,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/darkpurple/side{
+/obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xlA" = (
 /obj/machinery/door/airlock/maintenance/abandoned,
@@ -54379,15 +61757,27 @@
 "xlY" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plating{
-	icon_state = "panelscorched"
+	icon_state = "platingdmg1"
 	},
 /area/maintenance/department/chapel/monastery)
+"xmm" = (
+/obj/structure/plasticflaps/opaque,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "research_shutters_2";
+	name = "research shutters"
+	},
+/turf/open/floor/plasteel,
+/area/science/lab)
 "xmp" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel/escape,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "xmE" = (
 /obj/structure/chair{
@@ -54397,9 +61787,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "xnm" = (
@@ -54411,15 +61798,15 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"xpf" = (
-/obj/item/trash/tray,
-/turf/open/floor/plating,
-/area/maintenance/department/chapel/monastery)
 "xpr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xpD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -54432,6 +61819,16 @@
 	initial_gas_mix = "o2=0.01;n2=0.01"
 	},
 /area/maintenance/department/science)
+"xtN" = (
+/obj/machinery/camera{
+	c_tag = "Central Primary Hallway Escape";
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xuv" = (
 /obj/item/broken_bottle,
 /turf/open/floor/plating,
@@ -54446,6 +61843,19 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"xwf" = (
+/obj/structure/chair/office/light{
+	dir = 1
+	},
+/obj/effect/landmark/start/chemist,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
 "xxw" = (
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 2
@@ -54494,7 +61904,11 @@
 	},
 /area/maintenance/department/security/brig)
 "xzp" = (
-/turf/open/floor/plasteel/darkblue/side,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "xCV" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -54511,11 +61925,14 @@
 /obj/structure/sign/poster/official/random{
 	pixel_x = -32
 	},
-/obj/structure/chair{
-	dir = 4
+/obj/machinery/light{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xFl" = (
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
@@ -54529,6 +61946,19 @@
 	},
 /turf/open/floor/plasteel/dark/telecomms,
 /area/tcommsat/server)
+"xGO" = (
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = -28
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "xIx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -54537,9 +61967,8 @@
 /area/science/mixing)
 "xJy" = (
 /obj/structure/chair/comfy/black,
-/obj/structure/sign/plaques/atmos{
+/obj/structure/sign/plaques/kiddie{
 	desc = "An embossed piece of paper from the Third University of Harvard.";
-	icon_state = "kiddieplaque";
 	name = "\improper 'Diploma' frame";
 	pixel_y = 32
 	},
@@ -54547,6 +61976,7 @@
 	dir = 1;
 	light_color = "#ffc1c1"
 	},
+/obj/effect/landmark/start/lawyer,
 /turf/open/floor/wood,
 /area/lawoffice)
 "xJG" = (
@@ -54562,9 +61992,13 @@
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "xLi" = (
-/turf/open/floor/plasteel/escape{
-	dir = 6
+/obj/effect/turf_decal/tile/red{
+	dir = 4
 	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white/corner,
 /area/hallway/secondary/exit/departure_lounge)
 "xLC" = (
 /obj/machinery/door/firedoor,
@@ -54618,22 +62052,18 @@
 /area/chapel/office)
 "xSZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/neutral/corner{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"xTi" = (
-/obj/machinery/conveyor{
-	dir = 8;
-	id = "EngLoad"
+"xVA" = (
+/obj/machinery/atmospherics/pipe/heat_exchanging/simple{
+	dir = 6
 	},
-/obj/structure/sign/warning/deathsposal{
-	desc = "A warning sign which reads 'DISPOSAL: LEADS TO ENGINE'.";
-	name = "\improper DISPOSAL: LEADS TO ENGINE";
-	pixel_y = -32
-	},
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
 "xWl" = (
 /obj/item/pen,
 /obj/item/paper_bin{
@@ -54649,6 +62079,16 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/department/chapel/monastery)
+"ybc" = (
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 27
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "ybX" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -54672,7 +62112,11 @@
 /area/maintenance/department/engine)
 "yfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/yellow/side,
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ygZ" = (
 /obj/structure/closet/crate,
@@ -69259,7 +76703,7 @@ bQg
 bQg
 bQg
 bOw
-jmz
+bOw
 cbG
 cee
 ceB
@@ -69508,8 +76952,8 @@ bQQ
 bNs
 bNs
 bQe
-bOw
 bQg
+bOw
 bOw
 bOw
 bOw
@@ -69765,8 +77209,8 @@ bNs
 bNs
 bOw
 bOw
-bOw
 bQg
+bOw
 bOw
 bOw
 bOw
@@ -70022,8 +77466,8 @@ bOw
 bOw
 bOw
 bOw
-bOw
 bQg
+bOw
 bOw
 bOw
 bWV
@@ -70278,9 +77722,9 @@ bSm
 bOw
 bOw
 bOw
+bOw
 bQg
-bQg
-bQg
+bOw
 bOw
 bUC
 bWV
@@ -70296,14 +77740,14 @@ ctL
 cgg
 cfE
 cfE
-cfp
-cia
+cua
+cfE
 cuW
-cia
 cfE
 cfE
 cfE
-cvv
+cfE
+cfo
 cvF
 cvZ
 cwm
@@ -70536,7 +77980,7 @@ bOw
 bOw
 bOw
 bQg
-bOw
+bQg
 bOw
 bWV
 bWV
@@ -70807,7 +78251,7 @@ csN
 bWV
 cfm
 cfF
-cgi
+cfn
 cgG
 chi
 cid
@@ -70817,7 +78261,7 @@ cvb
 ciT
 cvh
 cgG
-cgi
+cfn
 cvF
 cwa
 cwo
@@ -71321,7 +78765,7 @@ csQ
 ceL
 cfm
 ctM
-cgi
+cfn
 bWV
 cun
 cuB
@@ -71566,7 +79010,7 @@ bQf
 bQf
 bQf
 bWW
-bZn
+oBx
 bZn
 bZn
 bZn
@@ -71811,7 +79255,7 @@ bKc
 cqI
 bMt
 bLn
-bOy
+cqI
 bPo
 bQg
 bQg
@@ -71823,7 +79267,7 @@ bQg
 bQg
 bQg
 bWX
-bZo
+bXJ
 bZo
 bZo
 bZo
@@ -72092,7 +79536,7 @@ ceP
 cth
 cfm
 ctN
-cgi
+cfn
 bWV
 cup
 cuE
@@ -72102,7 +79546,7 @@ cgH
 cgj
 cvj
 bWV
-cgi
+cfn
 cvJ
 cwe
 cjP
@@ -72128,7 +79572,7 @@ ckH
 ckH
 ckH
 czW
-cAh
+cAg
 cAt
 ckH
 czW
@@ -72606,7 +80050,7 @@ csS
 bWV
 cfm
 ctO
-cgi
+cfn
 cgG
 cgm
 cuE
@@ -72832,10 +80276,10 @@ aaa
 aaa
 aaa
 aaa
-irs
-aqG
+aaa
+bGI
 bGE
-bKf
+bLn
 gvO
 bMw
 bNy
@@ -72899,7 +80343,7 @@ ckH
 ckH
 ckH
 cAa
-cAh
+cAg
 cAt
 ckH
 cAa
@@ -73088,9 +80532,9 @@ aaa
 aaa
 aaa
 aaa
-irs
-irs
-aqG
+aaa
+aaa
+bGI
 bGE
 bKf
 gvO
@@ -73124,14 +80568,14 @@ cua
 cfE
 cfE
 chn
-cia
+cfE
 cdw
-cia
+cfE
 chn
 cfE
 cfE
 cvy
-cvL
+cfG
 cwe
 cwe
 fWv
@@ -73330,7 +80774,7 @@ aaa
 aaa
 jzz
 aZx
-aZx
+jzz
 bsl
 btM
 aZx
@@ -73338,23 +80782,23 @@ aaa
 aaa
 aaa
 aaa
-srv
-srv
-srv
-srv
-srv
-srv
-ekQ
-ekQ
-ekQ
-poK
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+aaa
+bGI
 bGE
-bKf
-gvO
-bGE
+kNu
+uWI
+bHM
 bNA
 bHM
-bLs
+bSZ
 bQi
 bQR
 bNs
@@ -73594,23 +81038,23 @@ aZx
 aaa
 aaa
 aaa
-iEa
+mZE
+bVp
+bVp
+bVp
+bVp
+bVp
+bVp
+bVp
+bVp
+bVp
+dML
 aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-saW
+dbw
 kYR
 aZx
 bNB
-abI
+tMG
 abI
 aby
 abI
@@ -73851,20 +81295,20 @@ aZx
 aaa
 aaa
 aaa
-iEa
+bGI
 aZx
-jkm
-iHI
-iHI
-xJG
-iHI
-iHI
-iHI
-hWa
-wwK
-wwK
-wwK
-wmA
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+dbw
+kYR
 aZx
 amC
 aaa
@@ -73872,8 +81316,8 @@ aht
 aby
 aby
 abI
-bQi
-bSZ
+pae
+hTu
 cqS
 bNs
 bQe
@@ -73901,9 +81345,9 @@ cio
 chq
 ciX
 cfm
-cjm
+cfN
 cwA
-cjm
+cfN
 cwe
 cwe
 cwe
@@ -74108,20 +81552,20 @@ aZx
 aaa
 aaa
 aaa
-iEa
+bGI
 aZx
-oto
+jkm
+xJG
+iHI
+iHI
+iHI
+iHI
+iHI
+hWa
 wwK
 wwK
-wwK
-wwK
-uAL
-vbQ
-vbQ
-vbQ
-wSU
-vbQ
-pga
+dbw
+wmA
 aZx
 amB
 aht
@@ -74131,7 +81575,7 @@ aaa
 abI
 abI
 abI
-lWR
+hTu
 bNs
 bNs
 bNs
@@ -74141,7 +81585,7 @@ crl
 bXL
 bNs
 bOw
-bSm
+bOw
 bQg
 bWV
 csU
@@ -74158,9 +81602,9 @@ cgM
 chr
 chL
 cfm
-cjm
-cwA
-cjm
+cfN
+mlj
+cfN
 cfN
 cfN
 cfN
@@ -74365,30 +81809,30 @@ aZx
 aaa
 aaa
 aaa
-iEa
+bGI
 aZx
 oto
 wwK
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
-aZx
+wwK
+wwK
+uAL
+vbQ
+vbQ
+vbQ
+vbQ
+vbQ
+wSU
+pga
 aZx
 amC
 aaa
 aht
 aaa
 aaa
-mbW
-mbW
+aaa
+aaa
 abI
-irs
+aaa
 sOQ
 bQR
 bNs
@@ -74405,7 +81849,7 @@ ccM
 cdD
 ceo
 bOw
-cfK
+bQg
 cfm
 cgN
 chs
@@ -74415,9 +81859,9 @@ cip
 chs
 ciY
 cfm
-cjm
-omI
-cjm
+cfN
+cwA
+cfN
 cfN
 cfN
 cfN
@@ -74622,21 +82066,21 @@ aZx
 aaa
 aaa
 aaa
-iEa
+bGI
 aZx
 oto
 wwK
 aZx
-irs
-irs
-aaa
-irs
-irs
-aaa
-irs
-irs
-aaa
-irs
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
+aZx
 amB
 aht
 aht
@@ -74659,7 +82103,7 @@ bOw
 bQg
 bQg
 bQg
-ccL
+bQg
 bQg
 bQg
 cfL
@@ -74672,9 +82116,9 @@ cfm
 cht
 cfm
 cfm
-cjm
-tRK
-cjm
+cfN
+cwA
+cfN
 cfN
 cfN
 cfN
@@ -74809,8 +82253,8 @@ afD
 aga
 aga
 agz
-agJ
-agX
+aie
+aiH
 ahm
 ahD
 aib
@@ -74879,21 +82323,21 @@ aZx
 aaa
 aaa
 aaa
-iEa
+bGI
 aZx
 oto
 wwK
 aZx
 irs
-aaa
-aaa
-aaa
 irs
-aaa
 irs
-aaa
-aaa
-aaa
+irs
+irs
+irs
+irs
+irs
+irs
+irs
 amD
 aaa
 aht
@@ -74904,8 +82348,8 @@ aaa
 aaa
 aaa
 aht
-mbW
-mbW
+aaa
+aaa
 abI
 aaa
 bSZ
@@ -74916,10 +82360,10 @@ bOw
 bUC
 bOw
 bOw
+bQe
 bOw
 bUC
-bUC
-cfK
+bQg
 cfm
 cgO
 chu
@@ -74929,9 +82373,9 @@ ciq
 chu
 ciZ
 cfm
-cjm
+cfN
 cwA
-cjm
+cfN
 cfN
 cfN
 cfN
@@ -75136,7 +82580,7 @@ aZx
 aaa
 aaa
 aaa
-iEa
+bGI
 aZx
 oto
 wwK
@@ -75186,7 +82630,7 @@ cfm
 cfm
 cfm
 cfm
-cjm
+cfN
 cwA
 cjm
 cfN
@@ -75400,7 +82844,7 @@ wwK
 bAI
 qbV
 abI
-aaa
+irs
 abI
 aaa
 bva
@@ -75426,16 +82870,16 @@ abI
 ahi
 bSZ
 crO
-qfj
-qfj
-qfj
-qfj
-qfj
+arF
+arF
+arF
+arF
+arF
 crO
 crO
 crO
-mZE
-aht
+crO
+crO
 cfN
 cfN
 cfN
@@ -75443,7 +82887,7 @@ cfN
 cfN
 cfN
 cfN
-cjm
+cfN
 uaa
 cjm
 cfN
@@ -75578,7 +83022,7 @@ aeU
 afo
 afG
 aeU
-aeU
+vKO
 agy
 agL
 agZ
@@ -75600,7 +83044,7 @@ aqm
 aon
 asv
 atw
-auy
+aon
 avt
 awJ
 axG
@@ -75651,7 +83095,7 @@ bbR
 bbR
 bbR
 bbR
-eaQ
+aZx
 rHv
 saW
 bAJ
@@ -75692,7 +83136,7 @@ aaa
 aaa
 aaa
 aaa
-irs
+aaa
 aaa
 cfN
 cfN
@@ -75700,7 +83144,7 @@ cfN
 cfN
 cfN
 cfN
-cjm
+cfN
 uaa
 cjm
 irs
@@ -75908,7 +83352,7 @@ baK
 baK
 baK
 baK
-eaQ
+aZx
 bxY
 bzz
 vIU
@@ -75954,10 +83398,10 @@ cjm
 cjm
 cjm
 cjm
-cjm
-cjm
-cjm
-cjm
+cfN
+cfN
+cfN
+cfN
 uBu
 cjm
 cjm
@@ -76092,7 +83536,7 @@ lGp
 aeU
 afI
 aeU
-aeU
+sUe
 agy
 agN
 agY
@@ -76203,22 +83647,22 @@ cbT
 bDi
 cQZ
 cwA
-xpf
 cwA
 cwA
 cwA
-cwA
-tYx
+oqJ
 cwA
 cwA
 cwA
 cwA
 uaa
-dZy
+uaa
+uaa
+uBu
 xlY
-waN
+jrW
 cjm
-irs
+aht
 aaa
 aaa
 aaa
@@ -76461,21 +83905,21 @@ ccO
 bIZ
 cjm
 cjm
-cjm
-xXh
-xXh
-cjm
-uot
 xXh
 xXh
 cjm
 cjm
+cjm
+xXh
 xXh
 cjm
-lnD
+cjm
+cjm
+cjm
+waN
 dzA
 cjm
-jep
+aht
 aaa
 aaa
 aaa
@@ -76716,23 +84160,23 @@ bva
 bNK
 bva
 bva
-aaa
-cFB
-aaa
 irs
-jep
-dRs
-irs
+vhF
 dRs
 dRs
-irs
-irs
-aaa
+aht
+aht
+mau
+fon
+fon
+aht
+aht
+aht
 cjm
 cjm
 cjm
 cjm
-jep
+aht
 aaa
 aaa
 aaa
@@ -76967,7 +84411,7 @@ aaa
 bva
 crB
 bva
-irs
+aaa
 aaa
 bIZ
 csy
@@ -76984,12 +84428,12 @@ aaa
 aaa
 aaa
 aaa
-irs
-irs
-mbW
+aaa
 dRs
 dRs
 irs
+irs
+mFn
 aaa
 aaa
 aaa
@@ -78448,7 +85892,7 @@ aAL
 aMR
 aAL
 aAL
-aQA
+aHE
 aAL
 aAL
 aTO
@@ -80567,11 +88011,11 @@ bOB
 bSw
 bDi
 bDi
-cad
-eYM
-bQl
-mMc
+bDi
+bIZ
 mZE
+aaa
+aaa
 aaa
 aaa
 eNF
@@ -80825,10 +88269,10 @@ fpT
 wNq
 bva
 gMO
-kCc
-bva
-hTr
+bBX
 mZE
+mZE
+aaa
 aaa
 aaa
 eNF
@@ -81082,17 +88526,17 @@ bBX
 uUQ
 bBX
 fdS
-xTi
-bXk
-jlb
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
+bBX
+bBX
+mZE
+aaa
+aaa
+aaa
+eNF
+aaa
+aaa
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81279,7 +88723,7 @@ aQJ
 aRL
 aSD
 aTT
-aTV
+aXS
 aRL
 aWR
 aXT
@@ -81341,15 +88785,15 @@ kDJ
 oYj
 uMo
 bXk
-mci
-cbX
-ceq
-ceq
-ceq
-mhl
-ceq
-ceq
 bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+bXk
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81536,7 +88980,7 @@ aQK
 aRL
 aSE
 aTU
-aUV
+aXU
 aVV
 aWS
 aXU
@@ -81597,16 +89041,16 @@ tcY
 cam
 cam
 cdI
-cri
+bXk
 eVW
 cbX
-wKK
-wKK
-wKK
-wKK
-wKK
-wKK
+ceq
+mhl
+ceq
+ceq
 bXk
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -81792,8 +89236,8 @@ aLL
 aQL
 aRL
 aSF
-aTV
-aTV
+aXS
+aXS
 aRL
 aWT
 aXV
@@ -81853,17 +89297,17 @@ bpL
 fQf
 cbW
 cbd
-cdI
+vil
 cri
-eVW
 cbX
-cBQ
-cBQ
-cBQ
-cBQ
-cBQ
-cBQ
+cbX
+cbV
+cbV
+ceq
+ceq
 bXk
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82112,15 +89556,15 @@ bZA
 cam
 ous
 bXk
-tuL
 ccR
-cbV
-cbV
+cbX
 ccQ
 ccQ
 ccQ
 ccQ
 bXk
+aaa
+aaa
 aaa
 aaa
 aaa
@@ -82369,7 +89813,6 @@ vjd
 oAw
 cdK
 bXk
-jlb
 bXk
 bXk
 bXk
@@ -82377,7 +89820,8 @@ bXk
 bXk
 bXk
 bXk
-bXk
+aht
+aht
 aht
 abI
 abI
@@ -82624,7 +90068,7 @@ cae
 eta
 mmv
 cae
-tPm
+bTE
 bXk
 ceT
 cfr
@@ -83147,16 +90591,16 @@ cgs
 cgQ
 chv
 mKk
+cdm
+cdm
+aaa
 aht
 aaa
 aht
-aht
-aaa
 aaa
 aht
+aaa
 aht
-aaa
-aaa
 aaa
 aaa
 aaa
@@ -83391,9 +90835,9 @@ bXh
 bXZ
 bYK
 bZz
-cah
+gsu
 cbd
-bZA
+nrl
 cam
 cdM
 bXq
@@ -83403,15 +90847,17 @@ cfQ
 bXk
 qWG
 bXk
-mVM
+xif
+lva
+cdm
+aaa
+aht
+aaa
 aht
 aaa
 aht
-aht
-aaa
 aaa
 aht
-aht
 aaa
 aaa
 aaa
@@ -83424,8 +90870,6 @@ aaa
 aaa
 aaa
 aaa
-aaa
-emV
 iBJ
 clB
 hQz
@@ -83648,41 +91092,41 @@ bXi
 bYa
 bYL
 bZA
-cai
+caw
 cbe
 cca
 cam
 qtO
 bXk
-jlb
 bXk
 bXk
+sqY
+iLA
+iLA
+iLA
+ddh
+dNR
+dNR
 bXk
-bXk
-bXk
-bXk
-cbj
-bXk
-cbj
-bXk
-bXk
-bXk
-bXk
-ckJ
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+fon
+fon
+mau
+fon
+aht
+aht
+mau
+fon
+fon
+aht
+aht
 ouv
 clw
 clw
@@ -83904,31 +91348,31 @@ bWr
 bXj
 qGZ
 bYM
-bZB
+bZD
 caj
 cbf
 ccb
-ccS
+cah
 cdO
-bXk
+sxO
 ceX
-iyJ
+mEs
 cfS
 fFv
-fFv
-fFv
-fFv
-fFv
-cir
-fFv
-fFv
-fFv
-fFv
-fFv
-bTE
+wzA
+jvq
+fhf
+vTZ
+vTZ
+bXk
 aaa
+aht
 aaa
+aht
 aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
@@ -84161,31 +91605,31 @@ bUH
 bUH
 bYb
 bYN
-bZA
+bZF
 cak
 cbg
-bYC
 cam
-cdP
-rYY
+cam
+cam
+cam
 mwG
 nAs
 cfT
-fFv
-fFv
+wcs
+jKh
 qbp
-fFv
-fFv
+qbp
+flN
 dMG
-fFv
-fFv
-qbp
-fFv
-fFv
-bTE
+bXk
 aaa
+aht
 aaa
+aht
 aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
@@ -84418,31 +91862,31 @@ bWs
 bXk
 bYc
 bYO
-bZC
-cal
+bZA
+ewH
 cbh
-cam
-cam
-cdQ
-bXk
-bTE
-bXk
+cbh
+cbh
+cbh
+cbh
+gqo
+gQN
 cfU
 tIS
 iCs
 rPg
+rPg
 cBR
-cBR
-knw
-cBR
-cBR
-uVW
-lRY
-ckr
-bTE
+iCs
+bXk
 aaa
+aht
 aaa
+aht
 aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
@@ -84675,31 +92119,31 @@ bWt
 bXk
 bYd
 bYP
-bZA
-cam
-cam
-cam
-cam
-orZ
+bZF
+hgs
+fEM
+mNz
+vaH
+vaH
 qFu
 cet
 ulY
 cfV
 cgu
 cgU
-cgU
+liY
 chw
-chw
-chw
-chw
-cjs
-cfV
-cfV
-cfV
-bTE
-abI
+dNR
+jAQ
+bXk
+bXk
+bXk
+bXk
+bXk
 aaa
-aaa
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -84931,32 +92375,32 @@ bVK
 bWu
 bXk
 bYe
-bYQ
+bYM
 bZA
 can
 cbi
 ccc
-ccV
+dNR
 cdR
-qFu
-cet
-ulY
-cfV
+hZL
+bXk
+bXk
+mzy
 cgv
-cfV
-sWj
+tdf
+cgv
 uaP
+cgv
+qpc
 cgV
-uaP
-cgV
-uaP
-ciG
-cfV
-cfV
-bTE
-abI
-abI
-aaa
+cgv
+cgv
+tOw
+bXk
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -85190,30 +92634,30 @@ bXk
 bTE
 bYR
 bZA
-cao
+can
 cbj
-bXk
-ccW
+dNR
+cbX
 wcs
 iyJ
 cfa
-cfa
+dNR
 twv
-cgv
+cxN
 sWj
 dnS
-uoq
-fyO
-mpd
-fyO
-uoq
+dSc
+rTj
+kJn
+hQA
+hQA
 uRk
 ciG
-cfV
-bTE
-abI
+bXk
 aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -85446,32 +92890,32 @@ bWv
 bXl
 bYf
 bYS
-bZD
-cap
-bXk
+bZA
+can
+jue
 ccd
 ccX
-cdS
+ccX
 ceu
-cfb
+cbX
 cfu
 tlN
-cgv
+lun
 cCI
 uoq
-fyO
-fyO
-mpd
-fyO
-fyO
-uoq
+mJv
+chA
+meF
+mnW
+rNC
+nDW
 hQC
-mpd
-bTE
-abI
-aaa
-aaa
-aaa
+bXk
+aht
+fon
+lgk
+fon
+aht
 aaa
 aaa
 aaa
@@ -85703,31 +93147,31 @@ bWw
 bXm
 bYg
 bYT
-bZA
+bZB
 caq
 cbk
-cce
+dNR
 ccY
 cdT
-cev
-cfc
-cfv
-tlN
-cgv
-cCI
+ccY
+cbX
+dNR
+sVF
+tzR
+sJv
 fyO
 fyO
-sWj
-cgT
-ciG
 fyO
-fyO
+sJv
+mnW
+rNC
+dJO
 hQC
-mpd
-bTE
-abI
+bXk
 aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -85962,29 +93406,29 @@ bYh
 bYU
 bZE
 car
-bXk
-ccf
-ccZ
-cdU
-cew
+voA
+dNR
+cbX
+wcs
+wcs
 cfd
-cfw
-cfW
-cgw
-cCI
+bXk
+tlN
+lun
+fjT
 mpd
-mpd
-cCI
+cpE
+cpE
 cit
-ciH
-mpd
-mpd
+sJv
+qnw
+tyu
 hQC
-sYp
-bTE
-abI
-aaa
-aaa
+bXk
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -86184,13 +93628,13 @@ bkh
 bkh
 boN
 bpW
-brk
+xwf
 bsM
 bum
 bvt
 bwV
-byy
-bAh
+byz
+ooh
 bpY
 bCA
 bDy
@@ -86218,30 +93662,30 @@ bXo
 bYi
 bYV
 bZA
-cdN
+cam
 ccW
-ceY
+bXk
 cda
-cbX
-cex
-cfe
-cfx
-tlN
-cgv
-cCI
-fyO
-fyO
-fyF
+wcs
+wcs
+wcs
+dNR
+kVV
+ioV
+sJv
+rSl
+rSl
+rSl
 cgY
 ciI
-fyO
-fyO
+hZx
+tzc
 hQC
-mpd
-bTE
+bXk
 aaa
-aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -86421,7 +93865,7 @@ aSS
 aUg
 aVf
 aWi
-bah
+eiw
 aYe
 aZb
 bag
@@ -86446,8 +93890,8 @@ bsN
 bun
 mcf
 nnf
-byz
-ooh
+byA
+bAi
 bpY
 bCB
 bDz
@@ -86474,31 +93918,31 @@ bWz
 bVN
 bYf
 bYW
-bZF
-cat
-bXk
-ccg
+hrX
+cam
+mEG
+ckJ
 cey
 cdW
-cey
-cey
-cfy
-tlN
-cgv
-cCI
-uoq
-fyO
-fyO
-mpd
-fyO
-fyO
-uoq
+wcs
+cdW
+dNR
+umf
+rZw
+gMu
+opv
+vPL
+opv
+lTB
+jlc
+rVh
+uzu
 hQC
-mpd
-bTE
-aaa
-aaa
-aaa
+bXk
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -86699,14 +94143,14 @@ bmA
 bjd
 bpY
 bpY
-cwP
-pSc
+bpY
+bpY
 gGA
 bwW
-byA
-bAi
 bpY
-pwj
+bpY
+bpY
+fjr
 bva
 bva
 bva
@@ -86732,30 +94176,30 @@ bUU
 bUT
 bYX
 bZA
-cau
-cbj
+cam
+qyx
 bXk
-ccW
-bXk
-bXk
-cet
-cet
-tlN
-cgv
-fyF
+wBQ
+wcs
+wcs
+reU
+dNR
+smo
+gqg
+sJv
 prQ
-fyO
-fyO
-mpd
-fyO
-fyO
+prQ
+prQ
+nei
+oix
+jzb
 dZj
-ciI
-cfV
-bTE
+hQC
+bXk
 aaa
-aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -86954,19 +94398,19 @@ bls
 aBI
 aBI
 bmB
-bva
-bsn
-bva
-bva
+lxy
+qqt
+xtN
+cHb
 bvu
-bva
-bva
-bva
-bva
-pwj
-hVx
+ukC
+qbh
+xGO
+moQ
+ulg
+gDN
 xDj
-bva
+blt
 jCv
 bOK
 bEN
@@ -86987,32 +94431,32 @@ bVO
 bWA
 mCe
 bYj
-bYQ
+bYM
 bZA
-cav
-cbl
-cch
-cdc
-cdX
-fwR
-cet
-ulY
-oGm
-cgv
-cfV
+cam
+voA
+dNR
+cbX
+wcs
+wcs
+gus
+bXk
+tlN
+lun
+qnw
 fyF
 cZt
-wpI
 cZt
-wpI
-cZt
-ciI
-cfV
-cfV
-bTE
-abI
-aaa
-aaa
+hdG
+sJv
+gPR
+nnU
+hQC
+bXk
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -87219,11 +94663,11 @@ gkS
 tTl
 tTl
 tTl
-tTl
+oCs
 dgg
 phJ
 phJ
-xje
+eNo
 bAk
 bIt
 bJB
@@ -87245,32 +94689,32 @@ bWB
 mCe
 bYk
 bYQ
-bZA
-cam
-cam
-cam
-cam
-cdI
+bZF
+cbm
+voA
+dNR
+jRO
+jRO
 eWi
-cet
-ulY
-oGm
+cbX
+dNR
+sVF
 cgx
-cgU
-cgU
-cBS
-cBS
-cBS
+sJv
+fyO
+fyO
+fyO
+sJv
 cBS
 cjt
-cfV
-cfV
-cfV
-bTE
-abI
-abI
-abI
-abI
+igO
+hQC
+bXk
+aaa
+fon
+lgk
+fon
+aht
 aaa
 aaa
 aaa
@@ -87467,20 +94911,20 @@ aGV
 blu
 aDZ
 aDZ
-eeF
-bBX
-bBX
-bBX
-bro
-bBX
-bBX
-bBX
-bBX
-bva
+bjm
+kfp
+cqi
+cqi
+cqi
+cqi
+cqi
+uwJ
+ybc
+rbd
 fdQ
-npE
-npE
-bFZ
+bmD
+bmD
+qky
 bAl
 bIu
 bJC
@@ -87502,31 +94946,31 @@ bWC
 mCe
 bYl
 bYO
-bZC
-hYm
-cbm
-cci
+bZA
 cam
-ogX
-bXk
-bXk
-bXk
+gBq
+ccd
+oBw
+oBw
+gPc
+cbX
+cfu
 jBn
-tIS
+pmW
 meF
 chA
+chA
 woh
-woh
-qQr
-woh
-woh
+cCI
+cBS
+eML
 liR
-phg
-cks
-bTE
-abI
-aaa
-abI
+hQC
+bXk
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -87726,20 +95170,20 @@ blt
 cqh
 bKM
 cCl
-pYw
-gFo
-cSK
-duF
-bxa
+cCl
+cCl
+xmm
+kdu
+kdu
 byD
 bAm
 dhz
-bCD
+ney
 bDA
 bEQ
-jSA
+bGa
 bHg
-bIv
+owI
 bJD
 bBo
 bBo
@@ -87760,30 +95204,30 @@ bWD
 bTE
 bYY
 bZA
-caw
-cbn
-ccj
 cam
-cdY
-rYY
+cbn
+dNR
+cbX
+wcs
+cfP
 cff
-nAs
+dNR
 cfX
-fFv
-fFv
+gVZ
+pFH
 kWQ
-fFv
-fFv
-dMG
-fFv
-fFv
-kWQ
-fFv
-fFv
-bTE
-abI
+hkC
+cLh
+spr
+wFy
+wFy
+wVS
+hQC
+bXk
 aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -87984,13 +95428,13 @@ cqi
 boP
 bqb
 brp
-byF
-cCt
-byF
-cCt
+gFo
+cSK
+duF
+qan
 byE
 bBp
-bBp
+pJV
 bBp
 bBp
 bBp
@@ -88019,28 +95463,28 @@ bYZ
 bZG
 cax
 cbo
-cck
-cdf
-cdZ
-bXk
-cfg
-bXk
+ccc
+dNR
+cdR
+wko
+bXq
+bXq
 cfY
-fFv
-fFv
-fFv
-fFv
-fFv
+sGB
+sbf
+sGB
+sMb
+gEs
 civ
-fFv
-fFv
-fFv
-fFv
-fFv
-bTE
-abI
-abI
-abI
+civ
+sen
+pjV
+jyr
+bXk
+aht
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -88241,9 +95685,9 @@ cqi
 boQ
 cCl
 brq
+byF
 cCt
-cCt
-cCt
+byF
 bxc
 nIU
 bAo
@@ -88273,30 +95717,30 @@ bWF
 bXp
 bYn
 bZa
-bZH
-cam
+bZF
+cal
 cbp
 cci
-cam
-cdI
+kfr
+kfr
+uje
+pBj
+gvX
+nCb
+dNR
+jKs
+dNR
+dNR
+jKs
+dNR
+dNR
 bXk
 bXk
 bXk
 bXk
-bXk
-bXk
-bXk
-bXk
-cbj
-bXk
-cbj
-bXk
-bXk
-bXk
-bXk
-ckJ
-abI
-aaa
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -88529,30 +95973,30 @@ bVU
 bWG
 bXq
 bYo
-cah
+ojx
 bZI
-cah
+ojx
 cbq
+cbd
 cam
 cam
-vXt
-bXk
+cam
+pZu
+jgQ
+xVA
+pWS
+lED
+xVA
+tAJ
+evB
+pWS
+tAJ
+cdm
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -88787,29 +96231,29 @@ bWH
 bXk
 bTE
 bZc
-bZJ
+siE
 cCU
+bZJ
+uPS
 cCV
 ceb
-jPo
-ory
-bXk
+uqL
+jtu
+jgQ
+mzP
+xVA
+ofE
+mzP
+mzP
+jcM
+tAJ
+mzP
+cdm
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-abI
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -89043,30 +96487,30 @@ bJN
 bJN
 bJN
 bJN
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-bXk
-abI
-adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+gvX
+dnW
+dnW
+dnW
+dnW
+dnW
+dnW
+dnW
+dnW
+mgo
+wqq
+cVO
+imN
+cVO
+cVO
+imN
+cVO
+cVO
+ofE
+aht
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -89300,7 +96744,7 @@ bVV
 bWI
 bXr
 bKQ
-acN
+ocB
 bZK
 abI
 abI
@@ -89309,21 +96753,21 @@ abI
 aaa
 aaa
 aaa
-adR
+jcM
+pWS
+cVO
+imN
+cVO
+cVO
+imN
+cVO
+cVO
+lED
 aaa
 aaa
-acO
-adR
-adR
-adR
-adR
-adR
-adR
-adR
-aaa
-aaa
-aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -89557,7 +97001,7 @@ bQI
 bWJ
 bXs
 bJN
-abI
+moW
 bJP
 bJP
 bJP
@@ -89565,22 +97009,22 @@ bJP
 bJP
 abI
 abI
-abI
-adR
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+evB
+pWS
+cVO
+imN
+cVO
+cVO
+imN
+cVO
+cVO
+ofE
+aht
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -89794,7 +97238,7 @@ bCK
 bDG
 bEW
 bAt
-bHg
+hXK
 cqw
 cqD
 bKO
@@ -89814,7 +97258,7 @@ bMf
 fuR
 bXt
 bYp
-bZd
+pKi
 bZL
 caz
 cbs
@@ -89823,21 +97267,21 @@ bJP
 aaa
 aaa
 aaa
-adR
+jcM
+pWS
+cVO
+imN
+cVO
+cVO
+imN
+cVO
+cVO
+lED
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -90071,7 +97515,7 @@ bVW
 bWL
 bXu
 bLW
-abI
+moW
 bMi
 caA
 cbt
@@ -90080,21 +97524,21 @@ bJP
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+evB
+ozc
+lED
+evB
+lED
+evB
+lED
+evB
+lED
+cdm
+aht
+aht
+fon
+lgk
+fon
 aaa
 aaa
 aaa
@@ -90328,7 +97772,7 @@ bVX
 bWM
 bXv
 bWc
-bZe
+cVw
 bZL
 caB
 cbs
@@ -90337,21 +97781,21 @@ bJP
 aaa
 aaa
 aaa
+aht
+aaa
+aht
+aaa
+aht
+aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+fon
+fon
+fon
 aaa
 aaa
 aaa
@@ -90565,7 +98009,7 @@ bAt
 bAt
 bAu
 bAu
-bHp
+bHg
 cqx
 bJJ
 bKQ
@@ -90580,33 +98024,33 @@ bQI
 bQI
 bTM
 bUs
-bMf
-bOk
-bWL
+gTV
+iNn
+ugS
 bXw
-bLW
-abI
+myZ
+feL
 bJP
 bJP
 bJP
 bJP
 bJP
 aaa
-aby
+aaa
+aaa
+aht
+aaa
+aht
+aaa
+aht
+aaa
+aht
+aaa
+aht
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
 aaa
 aaa
 aaa
@@ -90837,7 +98281,7 @@ bMf
 bMf
 bTN
 bUt
-bMf
+dZs
 bOk
 bWK
 bXt
@@ -90848,24 +98292,24 @@ caC
 cbu
 cbu
 bJP
-abI
-aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+aht
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+aht
+aht
+aht
+aht
 aaa
 aaa
 aaa
@@ -91093,8 +98537,8 @@ bRx
 bQJ
 bPQ
 bTO
-bMf
-bMf
+gTV
+rrX
 bOk
 bWL
 bXx
@@ -91106,24 +98550,24 @@ cbv
 ccn
 bJP
 aaa
-aby
 aaa
+fon
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+lgk
+fon
 aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+lgk
+lgk
+fon
 aaa
 aaa
 aaa
@@ -91350,7 +98794,7 @@ bPQ
 bPQ
 bPQ
 bTP
-bMf
+dZs
 bVh
 bVY
 bWM
@@ -91362,25 +98806,25 @@ caE
 cbu
 cbu
 bJP
+aht
+aht
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
+fon
 aaa
-aby
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
-aaa
+aht
+lgk
+fon
+fon
 aaa
 aaa
 aaa
@@ -91607,7 +99051,7 @@ bQK
 bQK
 bPQ
 bTQ
-bMf
+dZs
 bKX
 bOk
 bWN
@@ -91619,8 +99063,6 @@ bJP
 bJP
 bJP
 bJP
-abI
-aby
 aaa
 aaa
 aaa
@@ -91637,6 +99079,8 @@ aaa
 aaa
 aaa
 aaa
+fon
+fon
 aaa
 aaa
 aaa
@@ -91864,7 +99308,7 @@ bRy
 bSf
 bSR
 bTM
-bMf
+dZs
 bKX
 bVZ
 bWO
@@ -91879,7 +99323,7 @@ bJP
 aaa
 aaa
 aaa
-aby
+fon
 aaa
 aaa
 aaa
@@ -92121,7 +99565,7 @@ bRz
 bMf
 bSS
 bTR
-bMf
+nom
 bKX
 bWa
 bMf
@@ -92133,10 +99577,10 @@ caG
 cbx
 cco
 bJP
-abI
-abI
-abI
-aby
+aht
+aht
+aht
+fon
 aaa
 aaa
 aaa
@@ -92393,7 +99837,7 @@ bJP
 aaa
 aaa
 aaa
-aby
+fon
 aaa
 aaa
 aaa
@@ -92578,7 +100022,7 @@ aHn
 aIi
 aJi
 aKe
-lAs
+jzw
 aMi
 aNJ
 fwl
@@ -92650,7 +100094,7 @@ bYw
 bYw
 aht
 aht
-aby
+fon
 aaa
 aaa
 aaa
@@ -92907,7 +100351,7 @@ cdg
 cbz
 aaa
 aaa
-aby
+mau
 aaa
 aaa
 aaa
@@ -93616,7 +101060,7 @@ lAs
 eeQ
 aUs
 aLf
-aLf
+dWF
 aLf
 aLf
 aUl
@@ -94140,7 +101584,7 @@ bcA
 bdF
 beJ
 bfB
-bbE
+kQj
 aZv
 aUC
 biz
@@ -94877,7 +102321,7 @@ apX
 apX
 avl
 fIu
-dbi
+fXn
 aIh
 azA
 dbi
@@ -95411,8 +102855,8 @@ aNP
 aPb
 aNO
 aNP
-cDa
-aTo
+ora
+aTq
 aSk
 aTm
 aTm
@@ -100547,8 +107991,8 @@ aaa
 aLm
 aLm
 aNU
+lAC
 dqY
-aPh
 aRv
 sZh
 aLm
@@ -100804,8 +108248,8 @@ aaa
 aLm
 aME
 aNV
+lAC
 dqY
-aPh
 aRw
 sqQ
 aLm
@@ -101061,7 +108505,7 @@ aaa
 aLo
 aMF
 aNW
-dqY
+lAC
 cvf
 aQn
 sqQ
@@ -101318,7 +108762,7 @@ aaa
 aLo
 aMG
 aNX
-dqY
+lAC
 rax
 aRy
 aSn


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Connects the monastery with 2 new paths, as well as some small edits to consistency with windows. This also relocates the aux dock for ships found in space to the end of one of the docking arms.
This probably works.
The new entries are a new bright main hallway, and a small maint access.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

The monastery on pubby can be annoying to get to, having to use the tube. The tube remains in place, but now you have other options.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: chef
add: Added main hallway approach to monastery
add: Added Maintenance hallway approach, with some maint loot
tweak: moved the docking arm for the white ship
tweak: changed placement of some grills and windows
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
