### PR TITLE
Adds the ability to construct and deconstruct locker locks

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -34,7 +34,8 @@
 	var/delivery_icon = "deliverycloset" //which icon to use when packagewrapped. null to be unwrappable.
 	var/anchorable = TRUE
 	var/icon_welded = "welded"
-
+	var/obj/item/electronics/airlock/lockerelectronics //Installed electronics
+	var/lock_in_use = FALSE //Someone is doing some stuff with the lock here, better not proceed further
 
 /obj/structure/closet/Initialize(mapload)
 	. = ..()
@@ -42,47 +43,56 @@
 	PopulateContents()
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
 		take_contents()
+	if(secure)
+		lockerelectronics = new(src)
+		lockerelectronics.accesses = req_access
 
 //USE THIS TO FILL IT, NOT INITIALIZE OR NEW
 /obj/structure/closet/proc/PopulateContents()
 	return
 
 /obj/structure/closet/Destroy()
-	dump_contents()
+	dump_contents(override = FALSE)
 	return ..()
 
 /obj/structure/closet/update_icon()
 	cut_overlays()
-	if(!opened)
+	if(opened & icon_door_override)
+		add_overlay("[icon_door]_open")
 		layer = OBJ_LAYER
-		if(icon_door)
-			add_overlay("[icon_door]_door")
-		else
-			add_overlay("[icon_state]_door")
-		if(welded)
-			add_overlay(icon_welded)
-		if(secure && !broken)
-			if(locked)
-				add_overlay("locked")
-			else
-				add_overlay("unlocked")
-
+		return
+	else if(opened)
+		add_overlay("[icon_state]_open")
+		return
+	if(icon_door)
+		add_overlay("[icon_door]_door")
 	else
 		layer = BELOW_OBJ_LAYER
-		if(icon_door_override)
-			add_overlay("[icon_door]_open")
-		else
-			add_overlay("[icon_state]_open")
+		add_overlay("[icon_state]_door")
+	if(welded)
+		add_overlay("welded")
+	if(!secure)
+		return
+	if(broken)
+		add_overlay("off")
+		add_overlay("sparking")
+	else if(locked)
+		add_overlay("locked")
+	else
+		add_overlay("unlocked")
 
 /obj/structure/closet/examine(mob/user)
 	..()
 	if(welded)
-		to_chat(user, "<span class='notice'>It's welded shut.</span>")
+		to_chat(user, "<span class='notice'>It's <b>welded</b> shut.</span>")
 	if(anchored)
 		to_chat(user, "<span class='notice'>It is <b>bolted</b> to the ground.</span>")
 	if(opened)
 		to_chat(user, "<span class='notice'>The parts are <b>welded</b> together.</span>")
 	else if(secure && !opened)
+	else if(broken)
+		to_chat(user, "<span class='notice'>The lock is <b>screwed</b> in.</span>")
+	else if(secure)
 		to_chat(user, "<span class='notice'>Alt-click to [locked ? "unlock" : "lock"].</span>")
 	if(isliving(user))
 		var/mob/living/L = user
@@ -117,9 +127,37 @@
 			return FALSE
 	return TRUE
 
-/obj/structure/closet/proc/dump_contents()
+/obj/structure/closet/proc/can_lock(mob/living/user, var/check_access = TRUE) //set check_access to FALSE if you only need to check if a locker has a functional lock rather than access
+	if(!secure)
+		return FALSE
+	if(broken)
+		to_chat(user, "<span class='notice'>[src] is broken!</span>")
+		return FALSE
+	if(QDELETED(lockerelectronics) && !locked) //We want to be able to unlock it regardless of electronics, but only lockable with electronics
+		to_chat(user, "<span class='notice'>[src] is missing locker electronics!</span>")
+		return FALSE
+	if(!check_access)
+		return TRUE
+	if(allowed(user))
+		return TRUE
+	to_chat(user, "<span class='notice'>Access denied.</span>")
+
+/obj/structure/closet/proc/togglelock(mob/living/user)
+	add_fingerprint(user)
+	if(opened)
+		return
+	if(!can_lock(user))
+		return
+	locked = !locked
+	user.visible_message("<span class='notice'>[user] [locked ? null : "un"]locks [src].</span>",
+	"<span class='notice'>You [locked ? null : "un"]lock [src].</span>")
+	update_icon()
+
+/obj/structure/closet/proc/dump_contents(var/override = TRUE) //Override is for not revealing the locker electronics when you open the locker, for example
 	var/atom/L = drop_location()
 	for(var/atom/movable/AM in src)
+		if(AM == lockerelectronics && override)
+			continue
 		AM.forceMove(L)
 		if(throwing) // you keep some momentum when getting out of a thrown closet
 			step(AM, dir)
@@ -207,6 +245,73 @@
 	else
 		return open(user)
 
+/obj/structure/closet/proc/bust_open()
+	welded = FALSE //applies to all lockers
+	locked = FALSE //applies to critter crates and secure lockers only
+	broken = TRUE //applies to secure lockers only
+	open()
+
+/obj/structure/closet/proc/handle_lock_addition(mob/user, obj/item/electronics/airlock/E)
+	add_fingerprint(user)
+	if(lock_in_use)
+		to_chat(user, "<span class='notice'>Wait for work on [src] to be done first!</span>")
+		return
+	if(secure)
+		to_chat(user, "<span class='notice'>This locker already has a lock!</span>")
+		return
+	if(broken)
+		to_chat(user, "<span class='notice'><b>Unscrew</b> the broken lock first!</span>")
+		return
+	if(!istype(E))
+		return
+	user.visible_message("<span class='notice'>[user] begins installing a lock on [src]...</span>","<span class='notice'>You begin installing a lock on [src]...</span>")
+	lock_in_use = TRUE
+	playsound(loc, 'sound/items/screwdriver.ogg', 50, 1)
+	if(!do_after(user, 60, target = src))
+		lock_in_use = FALSE
+		return
+	lock_in_use = FALSE
+	to_chat(user, "<span class='notice'>You finish the lock on [src]!</span>")
+	E.forceMove(src)
+	lockerelectronics = E
+	req_access = E.accesses
+	secure = TRUE
+	update_icon()
+	return TRUE
+
+/obj/structure/closet/proc/handle_lock_removal(mob/user, obj/item/screwdriver/S)
+	if(lock_in_use)
+		to_chat(user, "<span class='notice'>Wait for work on [src] to be done first!</span>")
+		return
+	if(locked)
+		to_chat(user, "<span class='notice'>Unlock it first!</span>")
+		return
+	if(!secure)
+		to_chat(user, "<span class='notice'>[src] doesn't have a lock that you can remove!</span>")
+		return
+	if(!istype(S))
+		return
+	var/brokenword = broken ? "broken " : null
+	user.visible_message("<span class='notice'>You begin removing the [brokenword]lock on [src]...</span>", "<span class='notice'>[user] begins removing the [brokenword]lock on [src]...</span>")
+	playsound(loc, S.usesound, 50, 1)
+	lock_in_use = TRUE
+	if(!do_after(user, 100 * S.toolspeed, target = src))
+		lock_in_use = FALSE
+		return
+	to_chat(user, "<span class='notice'>You remove the [brokenword]lock from [src]!</span>")
+	if(!QDELETED(lockerelectronics))
+		lockerelectronics.add_fingerprint(user)
+		lockerelectronics.forceMove(user.loc)
+	lockerelectronics = null
+	req_access = null
+	secure = FALSE
+	broken = FALSE
+	locked = FALSE
+	lock_in_use = FALSE
+	update_icon()
+	return TRUE
+
+
 /obj/structure/closet/deconstruct(disassembled = TRUE)
 	if(ispath(material_drop) && material_drop_amount && !(flags_1 & NODECONSTRUCT_1))
 		new material_drop(loc, material_drop_amount)
@@ -247,7 +352,11 @@
 				deconstruct(TRUE)
 				return
 		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
-			return
+			return TRUE
+	else if(istype(W, /obj/item/electronics/airlock))
+		handle_lock_addition(user, W)
+	else if(istype(W, /obj/item/screwdriver))
+		handle_lock_removal(user, W)
 	else if(istype(W, /obj/item/weldingtool) && can_weld_shut)
 		if(!W.tool_start_check(user, amount=0))
 			return
@@ -258,7 +367,7 @@
 				return
 			welded = !welded
 			after_weld(welded)
-			user.visible_message("<span class='notice'>[user] [welded ? "welds shut" : "unwelded"] \the [src].</span>",
+			user.visible_message("<span class='notice'>[user] [welded ? "welds shut" : "unwelds"] \the [src].</span>",
 							"<span class='notice'>You [welded ? "weld" : "unwelded"] \the [src] with \the [W].</span>",
 							"<span class='italics'>You hear welding.</span>")
 			update_icon()
@@ -401,20 +510,12 @@
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, "<span class='warning'>You fail to break out of [src]!</span>")
 
-/obj/structure/closet/proc/bust_open()
-	welded = FALSE //applies to all lockers
-	locked = FALSE //applies to critter crates and secure lockers only
-	broken = TRUE //applies to secure lockers only
-	open()
-
 /obj/structure/closet/AltClick(mob/user)
 	..()
-	if(!user.canUseTopic(src, BE_CLOSE) || !isturf(loc))
+	if(!user.canUseTopic(src, be_close=TRUE) || !isturf(loc))
+		to_chat(user, "<span class='warning'>You can't do that right now!</span>")
 		return
-	if(opened || !secure)
-		return
-	else
-		togglelock(user)
+	togglelock(user)
 
 /obj/structure/closet/CtrlShiftClick(mob/living/user)
 	if(!HAS_TRAIT(user, TRAIT_SKITTISH))
@@ -422,20 +523,6 @@
 	if(!user.canUseTopic(src) || !isturf(user.loc))
 		return
 	dive_into(user)
-
-/obj/structure/closet/proc/togglelock(mob/living/user, silent)
-	if(secure && !broken)
-		if(allowed(user))
-			if(iscarbon(user))
-				add_fingerprint(user)
-			locked = !locked
-			user.visible_message("<span class='notice'>[user] [locked ? null : "un"]locks [src].</span>",
-							"<span class='notice'>You [locked ? null : "un"]lock [src].</span>")
-			update_icon()
-		else if(!silent)
-			to_chat(user, "<span class='notice'>Access Denied</span>")
-	else if(secure && broken)
-		to_chat(user, "<span class='warning'>\The [src] is broken!</span>")
 
 /obj/structure/closet/emag_act(mob/user)
 	if(secure && !broken)
@@ -445,6 +532,9 @@
 		playsound(src, "sparks", 50, 1)
 		broken = TRUE
 		locked = FALSE
+		if(!QDELETED(lockerelectronics))
+			qdel(lockerelectronics)
+		lockerelectronics = null
 		update_icon()
 
 /obj/structure/closet/get_remote_view_fullscreens(mob/user)
@@ -458,16 +548,19 @@
 	if (!(. & EMP_PROTECT_CONTENTS))
 		for(var/obj/O in src)
 			O.emp_act(severity)
-	if(secure && !broken && !(. & EMP_PROTECT_SELF))
-		if(prob(50 / severity))
-			locked = !locked
-			update_icon()
-		if(prob(20 / severity) && !opened)
-			if(!locked)
-				open()
-			else
-				req_access = list()
-				req_access += pick(get_all_accesses())
+	if(!secure || broken)
+		return ..()
+	if(prob(50 / severity))
+		locked = !locked
+		update_icon()
+	if(prob(20 / severity) && !opened)
+		if(!locked)
+			open()
+		else
+			req_access = list()
+			req_access += pick(get_all_accesses())
+			if(!QDELETED(lockerelectronics))
+				lockerelectronics.accesses = req_access
 
 /obj/structure/closet/contents_explosion(severity, target)
 	for(var/atom/A in contents)

--- a/code/game/objects/structures/crates_lockers/closets/bodybag.dm
+++ b/code/game/objects/structures/crates_lockers/closets/bodybag.dm
@@ -49,6 +49,12 @@
 		return 1
 	return 0
 
+/obj/structure/closet/body_bag/handle_lock_addition()
+	return
+
+/obj/structure/closet/body_bag/handle_lock_removal()
+	return
+
 /obj/structure/closet/body_bag/MouseDrop(over_object, src_location, over_location)
 	. = ..()
 	if(over_object == usr && Adjacent(usr) && (in_range(src, usr) || usr.contents.Find(src)))

--- a/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
+++ b/code/game/objects/structures/crates_lockers/closets/cardboardbox.dm
@@ -57,6 +57,11 @@
 	I.alpha = 0
 	animate(I, pixel_z = 32, alpha = 255, time = 5, easing = ELASTIC_EASING)
 
+/obj/structure/closet/cardboard/handle_lock_addition() //Whoever heard of a lockable cardboard box anyway
+	return
+
+/obj/structure/closet/cardboard/handle_lock_removal()
+	return
 
 /obj/structure/closet/cardboard/metal
 	name = "large metal box"

--- a/code/game/objects/structures/crates_lockers/closets/job_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/job_closets.dm
@@ -358,3 +358,8 @@
 	new /obj/item/clothing/shoes/workboots/mining(src)
 	new /obj/item/storage/backpack/satchel/explorer(src)
 
+/obj/structure/closet/coffin/handle_lock_addition()
+	return
+
+/obj/structure/closet/coffin/handle_lock_removal()
+	return

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -4,6 +4,18 @@
 	req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
 	var/registered_name = null
 
+/obj/structure/closet/secure_closet/personal/examine(mob/user)
+	..()
+	if(registered_name)
+		to_chat(user, "<span class='notice'>The display reads, \"Owned by [registered_name]\".</span>")
+
+/obj/structure/closet/secure_closet/personal/check_access(obj/item/card/id/I)
+	. = ..()
+	if(!I || !istype(I))
+		return
+	if(registered_name == I.registered_name)
+		return TRUE
+
 /obj/structure/closet/secure_closet/personal/PopulateContents()
 	..()
 	if(prob(50))
@@ -33,21 +45,21 @@
 
 /obj/structure/closet/secure_closet/personal/attackby(obj/item/W, mob/user, params)
 	var/obj/item/card/id/I = W.GetID()
-	if(istype(I))
-		if(broken)
-			to_chat(user, "<span class='danger'>It appears to be broken.</span>")
-			return
-		if(!I || !I.registered_name)
-			return
-		if(allowed(user) || !registered_name || (istype(I) && (registered_name == I.registered_name)))
-			//they can open all lockers, or nobody owns this, or they own this locker
-			locked = !locked
-			update_icon()
-
-			if(!registered_name)
-				registered_name = I.registered_name
-				desc = "Owned by [I.registered_name]."
-		else
-			to_chat(user, "<span class='danger'>Access Denied.</span>")
-	else
+	if(!I || !istype(I))
 		return ..()
+	if(!can_lock(user, FALSE)) //Can't do anything if there isn't a lock!
+		return
+	if(I.registered_name && !registered_name)
+		to_chat(user, "<span class='notice'>You claim [src].</span>")
+		registered_name = I.registered_name
+	else
+		..()
+
+/obj/structure/closet/secure_closet/personal/handle_lock_addition() //If lock construction is successful we don't care what access the electronics had, so we override it
+	if(..())
+		req_access = list(ACCESS_ALL_PERSONAL_LOCKERS)
+		lockerelectronics.accesses = req_access
+
+/obj/structure/closet/secure_closet/personal/handle_lock_removal()
+	if(..())
+		registered_name = null

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -54,6 +54,12 @@
 		manifest = null
 		update_icon()
 
+/obj/structure/closet/crate/handle_lock_addition()
+	return
+
+/obj/structure/closet/crate/handle_lock_removal()
+	return
+
 /obj/structure/closet/crate/proc/tear_manifest(mob/user)
 	to_chat(user, "<span class='notice'>You tear the manifest off of [src].</span>")
 	playsound(src, 'sound/items/poster_ripped.ogg', 75, 1)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -747,6 +747,12 @@ Difficulty: Very Hard
 /obj/structure/closet/stasis/ex_act()
 	return
 
+/obj/structure/closet/stasis/handle_lock_addition()
+	return
+
+/obj/structure/closet/stasis/handle_lock_removal()
+	return
+
 /obj/effect/proc_holder/spell/targeted/exit_possession
 	name = "Exit Possession"
 	desc = "Exits the body you are possessing."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Port of https://github.com/OracleStation/OracleStation/pull/994
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
More options for both crew and antags is always a good thing.

Below from the Oraclestation PR:
This PR adds the ability to construct and deconstruct locker locks.

Use an airlock electronics on a locker without a lock to add one. The locker will inherit the access from the electronics. You can't lock certain lockers such as cardboard boxes.
Screwdriver a locker to remove its lock. This will give you back the electronics (emagging destroys the electronics). You can only do this to unlocked lockers.

To create a locker lock:

Make sure your locker doesn't have a lock and is closed.
Hit the locker with airlock electronics.
Wait for construction to complete (6 seconds). The locker's access will be updated with the airlock electronics access.

To deconstruct a locker lock:

The locker must be unlocked and closed, and must have either a functional or broken lock.
Use a screwdriver on the locker.
After 10 seconds (better screwdrivers will be faster), the lock will be removed and the airlock electronics (should they exist) will be dropped at your feet.
I had to tweak the locker icons slightly - broken lockers now spark instead of a black panel.

Why? So you can fix emagged / broken lockers, you can construct new lockable lockers, and IMO it makes sense to be able to have this ability.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Original by Citinited, port by Sishen1542
add: You can now use an airlock electronics on a locker to add a lock, and can screwdriver an unlocked locker to remove its lock.
add: You can now remove the locks on broken or emagged lockers.
tweak: Removing the lock from a personal locker now wipes that locker's ID details.
tweak: Broken lockers have had their appearance changed.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
