### PR TITLE
Officially ends the non-stop thrill ride of coating the station in your gender fluids for "fun"

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -40,7 +40,7 @@
 #define BALLS_SACK_SIZE_DEF	8
 #define BALLS_SACK_SIZE_MAX 40
 
-#define CUM_RATE			5
+#define CUM_RATE			0.015
 #define CUM_RATE_MULT		1
 #define CUM_EFFICIENCY		1//amount of nutrition required per life()
 

--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -40,7 +40,7 @@
 #define BALLS_SACK_SIZE_DEF	8
 #define BALLS_SACK_SIZE_MAX 40
 
-#define CUM_RATE			0.015
+#define CUM_RATE			0.035
 #define CUM_RATE_MULT		1
 #define CUM_EFFICIENCY		1//amount of nutrition required per life()
 

--- a/modular_citadel/code/modules/arousal/organs/breasts.dm
+++ b/modular_citadel/code/modules/arousal/organs/breasts.dm
@@ -15,10 +15,6 @@
 	can_climax				= TRUE
 	fluid_transfer_factor 	= 0.5
 
-/obj/item/organ/genital/breasts/Initialize()
-	. = ..()
-	reagents.add_reagent(fluid_id, fluid_max_volume)
-
 /obj/item/organ/genital/breasts/on_life()
 	if(QDELETED(src))
 		return

--- a/modular_citadel/code/modules/arousal/organs/breasts.dm
+++ b/modular_citadel/code/modules/arousal/organs/breasts.dm
@@ -26,6 +26,14 @@
 		return
 	reagents.maximum_volume = fluid_max_volume
 	if(fluid_id && producing)
+		if(reagents.total_volume == 0) // Apparently, 0.015 gets rounded down to zero and no reagents are created if we don't start it with 0.1 in the tank.
+			fluid_rate = 0.1
+		else
+			fluid_rate = CUM_RATE
+		if(reagents.total_volume >= 5)
+			fluid_mult = 0.5
+		else
+			fluid_mult = 1
 		generate_milk()
 
 /obj/item/organ/genital/breasts/proc/generate_milk()

--- a/modular_citadel/code/modules/arousal/organs/genitals.dm
+++ b/modular_citadel/code/modules/arousal/organs/genitals.dm
@@ -10,7 +10,7 @@
 	var/fluid_transfer_factor	= 0.0 //How much would a partner get in them if they climax using this?
 	var/size					= 2 //can vary between num or text, just used in icon_state strings
 	var/fluid_id				= null
-	var/fluid_max_volume		= 50
+	var/fluid_max_volume		= 15
 	var/fluid_efficiency		= 1
 	var/fluid_rate				= 1
 	var/fluid_mult				= 1

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -16,10 +16,6 @@
 	can_climax				= TRUE
 	var/sent_full_message	= TRUE //defaults to 1 since they're full to start
 
-/obj/item/organ/genital/testicles/Initialize()
-	. = ..()
-	reagents.add_reagent(fluid_id, fluid_max_volume)
-
 /obj/item/organ/genital/testicles/on_life()
 	if(QDELETED(src))
 		return

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -24,6 +24,14 @@
 	if(QDELETED(src))
 		return
 	if(reagents && producing)
+		if(reagents.total_volume == 0) // Apparently, 0.015 gets rounded down to zero and no reagents are created if we don't start it with 0.1 in the tank.
+			fluid_rate = 0.1
+		else
+			fluid_rate = CUM_RATE
+		if(reagents.total_volume >= 5)
+			fluid_mult = 0.5
+		else
+			fluid_mult = 1
 		generate_cum()
 
 /obj/item/organ/genital/testicles/proc/generate_cum()

--- a/modular_citadel/code/modules/arousal/organs/womb.dm
+++ b/modular_citadel/code/modules/arousal/organs/womb.dm
@@ -17,6 +17,14 @@
 	if(QDELETED(src))
 		return
 	if(reagents && producing)
+		if(reagents.total_volume == 0) // Apparently, 0.015 gets rounded down to zero and no reagents are created if we don't start it with 0.1 in the tank.
+			fluid_rate = 0.1
+		else
+			fluid_rate = CUM_RATE
+		if(reagents.total_volume >= 5)
+			fluid_mult = 0.5
+		else
+			fluid_mult = 1
 		generate_femcum()
 
 /obj/item/organ/genital/womb/proc/generate_femcum()

--- a/modular_citadel/code/modules/arousal/organs/womb.dm
+++ b/modular_citadel/code/modules/arousal/organs/womb.dm
@@ -9,10 +9,6 @@
 	fluid_id 		= "femcum"
 	producing		= TRUE
 
-/obj/item/organ/genital/womb/Initialize()
-	. = ..()
-	reagents.add_reagent(fluid_id, fluid_max_volume)
-
 /obj/item/organ/genital/womb/on_life()
 	if(QDELETED(src))
 		return

--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -8,6 +8,7 @@
 	data = list("donor"=null,"viruses"=null,"donor_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null)
 	reagent_state = LIQUID
 	color = "#FFFFFF" // rgb: 255, 255, 255
+	can_synth = FALSE
 	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 
 /datum/reagent/consumable/semen/reaction_turf(turf/T, reac_volume)
@@ -19,7 +20,6 @@
 	var/obj/effect/decal/cleanable/semen/S = locate() in T
 	if(!S)
 		S = new(T)
-	S.reagents.add_reagent("semen", reac_volume)
 	if(data["blood_DNA"])
 		S.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
 
@@ -50,6 +50,7 @@
 	data = list("donor"=null,"viruses"=null,"donor_DNA"=null,"blood_type"=null,"resistances"=null,"trace_chem"=null,"mind"=null,"ckey"=null,"gender"=null,"real_name"=null)
 	reagent_state = LIQUID
 	color = "#AAAAAA77"
+	can_synth = FALSE
 	nutriment_factor = 0.5 * REAGENTS_METABOLISM
 
 /obj/effect/decal/cleanable/femcum
@@ -82,7 +83,6 @@
 	var/obj/effect/decal/cleanable/femcum/S = locate() in T
 	if(!S)
 		S = new(T)
-	S.reagents.add_reagent("femcum", reac_volume)
 	if(data["blood_DNA"])
 		S.add_blood_DNA(list(data["blood_DNA"] = data["blood_type"]))
 


### PR DESCRIPTION
## About The Pull Request

Genitals that produce fluids (testicles, wombs, breasts) are now capped at a capacity of 15, rather than 50. They also produce at a rate of 0.035 units per life tick, down from 5.

## Why It's Good For The Game

The sex fluid decal spam has outstayed its welcome. It now takes approximately four-to-five minutes to "regenerate" enough fluid to create floor decals, instead of the two seconds it used to. You can climax as much as you want in the meantime, but if you want to make a mess anyone can see, you'll need to save up.

## Changelog
:cl:
tweak: Fluid-producing sexual organs no longer start full
tweak: Sexual organ fluid capacity decreased from 50 to 15
tweak: Sexual organ production rate decreased from 5u to 0.035u per two seconds.
tweak: Sexual fluid decals no longer contain reagents
tweak: Sexual fluids cannot by synthesized (e.g., by the Odysseus)
/:cl: