### PR TITLE
Fixes combatmode pushing not knocking people down against walls.

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/species.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/species.dm
@@ -80,21 +80,23 @@
 		else
 			target.Move(target_shove_turf, shove_dir)
 			if(get_turf(target) == target_oldturf)
-				var/thoushallnotpass = FALSE
-				for(var/obj/O in target_shove_turf)
-					if(O.density)
-						shove_blocked = TRUE
+				if(target_shove_turf.density)
+					shove_blocked = TRUE
+				else
+					var/thoushallnotpass = FALSE
+					for(var/obj/O in target_shove_turf)
 						if(istype(O, /obj/structure/table))
 							target_table = O
-						else
+						else if(!O.CanPass(src, target_shove_turf))
+							shove_blocked = TRUE
 							thoushallnotpass = TRUE
-				if(thoushallnotpass)
-					target_table = null
+					if(thoushallnotpass)
+						target_table = null
 
 		if(target.is_shove_knockdown_blocked())
 			return
 
-		if(shove_blocked)
+		if(shove_blocked || target_table)
 			var/directional_blocked = FALSE
 			if(shove_dir in GLOB.cardinals) //Directional checks to make sure that we're not shoving through a windoor or something like that
 				var/target_turf = get_turf(target)


### PR DESCRIPTION
## About The Pull Request
I forgot to add a target turf's density check (no CanPass() as it calls itself onto every contents' key). Also replaced object density checks with CanPass() for the special cases of objects that can or can not be walked through regardless of density.

## Why It's Good For The Game
Bugfixing.

## Changelog
:cl:
fix: fixes a few bad touchs on combat mode pushing.
/:cl:
