### PR TITLE
Hmm, today the Hierophant will go sicko mode on shaft miners.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -475,7 +475,7 @@ Difficulty: Normal
 	duration = 100
 	smooth = SMOOTH_TRUE
 
-/obj/effect/temp_visual/hierophant/wall/Initialize(mapload, new_caste r)
+/obj/effect/temp_visual/hierophant/wall/Initialize(mapload, new_caster)
 	. = ..()
 	queue_smooth_neighbors(src)
 	queue_smooth(src)

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -158,6 +158,7 @@ Difficulty: Normal
 				else
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
+				OpenFire()
 			else
 				devour(L)
 		else
@@ -426,6 +427,7 @@ Difficulty: Normal
 /mob/living/simple_animal/hostile/megafauna/hierophant/proc/burst(turf/original, spread_speed = 0.5) //release a wave of blasts
 	playsound(original,'sound/machines/airlockopen.ogg', 200, 1)
 	var/last_dist = 0
+	var/list/hit_mobs = list()		//don't hit people multiple times.
 	for(var/t in spiral_range_turfs(burst_range, original))
 		var/turf/T = t
 		if(!T)
@@ -434,7 +436,7 @@ Difficulty: Normal
 		if(dist > last_dist)
 			last_dist = dist
 			sleep(1 + min(burst_range - last_dist, 12) * spread_speed) //gets faster as it gets further out
-		new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE)
+		new /obj/effect/temp_visual/hierophant/blast(T, src, FALSE, hit_mobs)
 
 /mob/living/simple_animal/hostile/megafauna/hierophant/AltClickOn(atom/A) //player control handler(don't give this to a player holy fuck)
 	if(!istype(A) || get_dist(A, src) <= 2)
@@ -472,7 +474,7 @@ Difficulty: Normal
 	duration = 100
 	smooth = SMOOTH_TRUE
 
-/obj/effect/temp_visual/hierophant/wall/Initialize(mapload, new_caster)
+/obj/effect/temp_visual/hierophant/wall/Initialize(mapload, new_caste r)
 	. = ..()
 	queue_smooth_neighbors(src)
 	queue_smooth(src)
@@ -591,8 +593,10 @@ Difficulty: Normal
 	var/friendly_fire_check = FALSE
 	var/bursting = FALSE //if we're bursting and need to hit anyone crossing us
 
-/obj/effect/temp_visual/hierophant/blast/Initialize(mapload, new_caster, friendly_fire)
+/obj/effect/temp_visual/hierophant/blast/Initialize(mapload, new_caster, friendly_fire, list/only_hit_once)
 	. = ..()
+	if(only_hit_once)
+		hit_things = only_hit_once
 	friendly_fire_check = friendly_fire
 	if(new_caster)
 		hit_things += new_caster

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/hierophant.dm
@@ -158,7 +158,8 @@ Difficulty: Normal
 				else
 					burst_range = 3
 					INVOKE_ASYNC(src, .proc/burst, get_turf(src), 0.25) //melee attacks on living mobs cause it to release a fast burst if on cooldown
-				OpenFire()
+				if(L.stat == CONSCIOUS && L.health >= 30)
+					OpenFire()
 			else
 				devour(L)
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Hierophant no longer ignores its more powerful ranged capabilities in melee mode if the target's health is above near-critical. 
Hierophant melee "wave" bursts can no longer multi-hit.

## Why It's Good For The Game

Megafauna are supposed to take skill, not a bag of cores and tanking. This fixes that.
Multi-hit is just terrible since it hits you harder if you run from it, unlike any of the others.

## Changelog
:cl:
balance: Hierophant now goes sicko mode, but hey, at least you can't be multi-hit by melee waves!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
