### PR TITLE
Makes the femur breaker use the proper scream emote and makes the femur breaker guarantee the victim falls into crit

### DIFF
--- a/code/game/objects/structures/femur_breaker.dm
+++ b/code/game/objects/structures/femur_breaker.dm
@@ -85,7 +85,7 @@
 /obj/structure/femur_breaker/proc/damage_leg(mob/living/carbon/human/H)
 		H.emote("scream")
 		H.apply_damage(150, BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
-		H.adjustBruteLoss(rand(5,20) + (max(0, H.health)) //Make absolutely sure they end up in crit, so that they can succumb if they wish.
+		H.adjustBruteLoss(rand(5,20) + (max(0, H.health))) //Make absolutely sure they end up in crit, so that they can succumb if they wish.
 
 /obj/structure/femur_breaker/proc/raise_slat()
 	slat_status = BREAKER_SLAT_RAISED

--- a/code/game/objects/structures/femur_breaker.dm
+++ b/code/game/objects/structures/femur_breaker.dm
@@ -83,8 +83,9 @@
 				icon_state = "breaker_drop"
 
 /obj/structure/femur_breaker/proc/damage_leg(mob/living/carbon/human/H)
-		H.say("AAAAAAAAAAAAAAAAAAAAAAAAAAAHHHHHHHHHHHHHHHHHHH!!", forced = "femur broken")
+		H.emote("scream")
 		H.apply_damage(150, BRUTE, pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
+		H.adjustBruteLoss(rand(5,20) + (max(0, H.health)) //Make absolutely sure they end up in crit, so that they can succumb if they wish.
 
 /obj/structure/femur_breaker/proc/raise_slat()
 	slat_status = BREAKER_SLAT_RAISED


### PR DESCRIPTION
Title. Two birds, one stone. A fix a very annoying bug that got old *real* fast, and a fix for a very huge oversight in the original code.
## Changelog
:cl:
tweak: The femur breaker now uses `*scream` instead of forced speech. This means that the femur breaker will no longer spam deadchat with "AAAAAAAAAHHHHHHHHHH!!"
tweak: The femur breaker will now guarantee that the victim falls into crit, which will make it harder to perform torture scenes with it since the victim can just succumb.
/:cl:
