### PR TITLE
Hugs of the North Star

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -57,6 +57,7 @@
 		/obj/item/stack/tile/fakespace/loaded = ARCADE_WEIGHT_TRICK,
 		/obj/item/stack/tile/fakepit/loaded = ARCADE_WEIGHT_TRICK,
 		/obj/item/restraints/handcuffs/fake = ARCADE_WEIGHT_TRICK,
+		/obj/item/clothing/gloves/rapid/hug = ARCADE_WEIGHT_TRICK,
 
 		/obj/item/grenade/chem_grenade/glitter/pink = ARCADE_WEIGHT_TRICK,
 		/obj/item/grenade/chem_grenade/glitter/blue = ARCADE_WEIGHT_TRICK,

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -72,7 +72,15 @@
 		M.adjustStaminaLoss(-2) //Restore 2/3 of the stamina used assuming empty stam buffer. With proper stamina buffer management, this results in a net gain of +.5 stamina per click.
 		if(warcry)
 			M.say("[warcry]", ignore_spam = TRUE, forced = "north star warcry")
+
+	else if(M.a_intent == INTENT_HELP)
+		if(target.health >= 0 && !HAS_TRAIT(target, TRAIT_FAKEDEATH)) //Can't hug people who are dying/dead
+			if(target.on_fire || target.lying ) //No spamming extinguishing, helping them up, or other non-hugging/patting help interactions
+				return
+			else
+				M.changeNext_move(CLICK_CD_RAPID)
 	.= FALSE
+
 
 /obj/item/clothing/gloves/rapid/attack_self(mob/user)
 	var/input = stripped_input(user,"What do you want your battlecry to be? Max length of 6 characters.", ,"", 7)

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -73,12 +73,6 @@
 		if(warcry)
 			M.say("[warcry]", ignore_spam = TRUE, forced = "north star warcry")
 
-	else if(M.a_intent == INTENT_HELP)
-		if(target.health >= 0 && !HAS_TRAIT(target, TRAIT_FAKEDEATH)) //Can't hug people who are dying/dead
-			if(target.on_fire || target.lying ) //No spamming extinguishing, helping them up, or other non-hugging/patting help interactions
-				return
-			else
-				M.changeNext_move(CLICK_CD_RAPID)
 	.= FALSE
 
 
@@ -86,3 +80,22 @@
 	var/input = stripped_input(user,"What do you want your battlecry to be? Max length of 6 characters.", ,"", 7)
 	if(input)
 		warcry = input
+
+/obj/item/clothing/gloves/rapid/hug
+	name = "Hugs of the North Star"
+	desc = "Just looking at these fills you with an urge to hug the shit out of people"
+	warcry = "owo" //Shouldn't ever come into play
+
+/obj/item/clothing/gloves/rapid/hug/Touch(mob/living/target,proximity = TRUE)
+	var/mob/living/M = loc
+
+	if(M.a_intent == INTENT_HELP)
+		if(target.health >= 0 && !HAS_TRAIT(target, TRAIT_FAKEDEATH)) //Can't hug people who are dying/dead
+			if(target.on_fire || target.lying ) //No spamming extinguishing, helping them up, or other non-hugging/patting help interactions
+				return
+			else
+				M.changeNext_move(CLICK_CD_RAPID)
+	. = FALSE
+
+/obj/item/clothing/gloves/rapid/hug/attack_self(mob/user)
+	return FALSE


### PR DESCRIPTION
## About The Pull Request
Adds the Hugs of the North Star! They're gloves that you can get from arcade machines! They look like the Gloves of the North Star, and allow you to rapidly hug and headpat your friends! (And enemies!)

## Why It's Good For The Game
Arcade toys have historically been lookalike traitor items, and this is another one, with the added bonus of allowing you to hug the absolute shit out of people.

:cl: Cebutris
add: Hugs of the North Star! Get them from the arcades (if you're lucky) and hug your friends at INCREDIBLE hihg speeds!
/:cl:
