### PR TITLE
Makes femur breakers adminspawn only

### DIFF
--- a/code/modules/crafting/recipes.dm
+++ b/code/modules/crafting/recipes.dm
@@ -671,15 +671,6 @@
 		        /obj/item/stack/cable_coil = 10)
 	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
 	category = CAT_MISC
-
-/datum/crafting_recipe/femur_breaker
-	name = "Femur Breaker"
-	result = /obj/structure/femur_breaker
-	time = 150 
-	reqs = list(/obj/item/stack/sheet/metal = 20,
-		        /obj/item/stack/cable_coil = 30)
-	tools = list(TOOL_SCREWDRIVER, TOOL_WRENCH, TOOL_WELDER)
-	category = CAT_MISC
 	
 /datum/crafting_recipe/lizardhat
 	name = "Lizard Cloche Hat"


### PR DESCRIPTION
Yeah nah, femur breakers are a meme that's already being beaten to death and back. If sec mains weren't going out of their way to make femur breakers *EVERY SINGLE FUCKING ROUND IN A ROW* then this wouldn't be an issue. If that's how they're gonna be used, then what's the point of having them accessible to players? It's why we can't have fun things.

## Changelog
:cl:
del: Removed the crafting recipe of femur breakers, making them adminspawn only.
/:cl:
