### PR TITLE
Ports "nerfs cakehat for realsies" & co as an alternative to Pooj's PR

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -41,6 +41,17 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
+"aad" = (
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "aae" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -17906,18 +17917,6 @@
 /area/bridge)
 "aPY" = (
 /obj/structure/chair/stool,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"aPZ" = (
-/obj/structure/table,
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/obj/item/clothing/head/hardhat/cakehat,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
@@ -91623,7 +91622,7 @@ aAh
 aMq
 adq
 aQb
-aPZ
+aad
 aRu
 aQc
 aUf

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -124,6 +124,20 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
+"aaq" = (
+/obj/structure/table/wood,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar/atrium)
 "aas" = (
 /obj/docking_port/stationary/random{
 	id = "pod_lavaland1";
@@ -23559,21 +23573,6 @@
 "aTI" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar/atrium)
-"aTJ" = (
-/obj/structure/table/wood,
-/obj/item/clothing/head/hardhat/cakehat,
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
@@ -165218,7 +165217,7 @@ aNh
 aOL
 aQu
 aLL
-aTJ
+aaq
 aVt
 aNh
 aLL

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -2,6 +2,24 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
+"aab" = (
+/obj/machinery/newscaster{
+	pixel_x = -30
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants{
+	desc = "A reminder of why we can't have nice things.";
+	name = "Potty the plant"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
 "aac" = (
 /obj/effect/landmark/carpspawn,
 /turf/open/space,
@@ -44775,22 +44793,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bIt" = (
-/obj/structure/table,
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
 "bIu" = (
 /obj/item/radio/intercom{
 	freerange = 0;
@@ -117531,7 +117533,7 @@ bBT
 bwO
 bFk
 bGZ
-bIt
+aab
 bKe
 bLI
 bNw

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -2,6 +2,12 @@
 "aaa" = (
 /turf/open/space/basic,
 /area/space)
+"aab" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/crew_quarters/bar)
 "aad" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating{
@@ -22704,13 +22710,6 @@
 /obj/structure/chair/stool/bar,
 /obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"bbo" = (
-/obj/item/clothing/head/hardhat/cakehat,
-/obj/structure/table/wood/fancy,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
 /area/crew_quarters/bar)
 "bbp" = (
 /obj/structure/chair/wood/normal{
@@ -94182,7 +94181,7 @@ bah
 aYf
 aZc
 bah
-bbo
+aab
 bco
 bdw
 beA

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -69,7 +69,9 @@ GLOBAL_LIST_EMPTY(all_cakehats)
 
 /obj/item/clothing/head/hardhat/cakehat/proc/calculate_shared_power()
 	var/n_cakehats = length(GLOB.all_cakehats)
-	if(n_cakehats && (n_cakehats % CAKEHAT_MASS_PRODUCTION_TOLERANCE) == 0)
+	if(n_cakehats > STANDARD_CAKEHAT_DAMAGE * CAKEHAT_MASS_PRODUCTION_TOLERANCE) //better safe than sorry, stops negative power cakehats
+		return
+	if(n_cakehats && (!(n_cakehats % CAKEHAT_MASS_PRODUCTION_TOLERANCE) || (n_cakehats < CAKEHAT_MASS_PRODUCTION_TOLERANCE && cakehat_damage != STANDARD_CAKEHAT_DAMAGE)))
 		cakehat_damage = STANDARD_CAKEHAT_DAMAGE - FLOOR(n_cakehats / CAKEHAT_MASS_PRODUCTION_TOLERANCE, 1)
 		for(var/A in GLOB.all_cakehats)
 			var/obj/item/clothing/head/hardhat/cakehat/C = A

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -37,6 +37,12 @@
 /*
  * Cakehat
  */
+
+#define STANDARD_CAKEHAT_DAMAGE 15
+#define CAKEHAT_MASS_PRODUCTION_TOLERANCE 5
+
+GLOBAL_LIST_EMPTY(all_cakehats)
+
 /obj/item/clothing/head/hardhat/cakehat
 	name = "cakehat"
 	desc = "You put the cake on your head. Brilliant."
@@ -49,6 +55,27 @@
 	brightness_on = 2 //luminosity when on
 	flags_cover = HEADCOVERSEYES
 	heat = 999
+	var/static/cakehat_damage = STANDARD_CAKEHAT_DAMAGE
+
+/obj/item/clothing/head/hardhat/cakehat/Initialize()
+	. = ..()
+	GLOB.all_cakehats += src
+	calculate_shared_power()
+
+/obj/item/clothing/head/hardhat/cakehat/Destroy()
+	GLOB.all_cakehats -= src
+	calculate_shared_power()
+	return ..()
+
+/obj/item/clothing/head/hardhat/cakehat/proc/calculate_shared_power()
+	var/n_cakehats = length(GLOB.all_cakehats)
+	if(n_cakehats && (n_cakehats % CAKEHAT_MASS_PRODUCTION_TOLERANCE) == 0)
+		cakehat_damage = STANDARD_CAKEHAT_DAMAGE - FLOOR(n_cakehats / CAKEHAT_MASS_PRODUCTION_TOLERANCE, 1)
+		for(var/A in GLOB.all_cakehats)
+			var/obj/item/clothing/head/hardhat/cakehat/C = A
+			if(C.on)
+				C.force = cakehat_damage
+				C.throwforce = cakehat_damage
 
 /obj/item/clothing/head/hardhat/cakehat/process()
 	var/turf/location = src.loc
@@ -62,8 +89,8 @@
 
 /obj/item/clothing/head/hardhat/cakehat/turn_on()
 	..()
-	force = 15
-	throwforce = 15
+	force = cakehat_damage
+	throwforce = cakehat_damage
 	damtype = BURN
 	hitsound = 'sound/weapons/sear.ogg'
 	START_PROCESSING(SSobj, src)
@@ -78,6 +105,10 @@
 
 /obj/item/clothing/head/hardhat/cakehat/is_hot()
 	return on * heat
+
+#undef STANDARD_CAKEHAT_DAMAGE
+#undef CAKEHAT_MASS_PRODUCTION_TOLERANCE
+
 /*
  * Ushanka
  */

--- a/code/modules/clothing/head/misc_special.dm
+++ b/code/modules/clothing/head/misc_special.dm
@@ -48,7 +48,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
 	brightness_on = 2 //luminosity when on
 	flags_cover = HEADCOVERSEYES
-	heat = 1000
+	heat = 999
 
 /obj/item/clothing/head/hardhat/cakehat/process()
 	var/turf/location = src.loc
@@ -65,7 +65,7 @@
 	force = 15
 	throwforce = 15
 	damtype = BURN
-	hitsound = 'sound/items/welder.ogg'
+	hitsound = 'sound/weapons/sear.ogg'
 	START_PROCESSING(SSobj, src)
 
 /obj/item/clothing/head/hardhat/cakehat/turn_off()

--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -176,6 +176,10 @@
 	tastes = list("cake" = 5, "sweetness" = 1)
 	foodtype = GRAIN | DAIRY | JUNKFOOD | SUGAR
 
+/obj/item/reagent_containers/food/snacks/store/cake/birthday/microwave_act(obj/machinery/microwave/M) //super sekrit club
+	new /obj/item/clothing/head/hardhat/cakehat(get_turf(src))
+	qdel(src)
+
 /obj/item/reagent_containers/food/snacks/cakeslice/birthday
 	name = "birthday cake slice"
 	desc = "A slice of your birthday."

--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -76,6 +76,22 @@
 	required_reagents = list("corn_starch" = 1, "sacid" = 1)
 	required_temp = 374
 
+/datum/chemical_reaction/caramel
+	name = "Caramel"
+	id = "caramel"
+	results = list("caramel" = 1)
+	required_reagents = list("sugar" = 1)
+	required_temp = 413.15
+	mob_react = FALSE
+
+/datum/chemical_reaction/caramel_burned
+	name = "Caramel burned"
+	id = "caramel_burned"
+	results = list("carbon" = 1)
+	required_reagents = list("caramel" = 1)
+	required_temp = 483.15
+	mob_react = FALSE
+
 /datum/chemical_reaction/cheesewheel
 	name = "Cheesewheel"
 	id = "cheesewheel"

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -69,8 +69,10 @@
 /datum/crafting_recipe/food/birthdaycake
 	name = "Birthday cake"
 	reqs = list(
-		/obj/item/clothing/head/hardhat/cakehat = 1,
-		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
+		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1,
+		/obj/item/candle = 1,
+		/datum/reagent/consumable/sugar = 5,
+		/datum/reagent/consumable/caramel = 2
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday
 	subcategory = CAT_CAKE

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_misc.dm
@@ -5,8 +5,8 @@
 
 /datum/crafting_recipe/food/candiedapple
 	name = "Candied apple"
-	reqs = list(/datum/reagent/water = 5,
-		/datum/reagent/consumable/sugar = 5,
+	reqs = list(
+		/datum/reagent/consumable/caramel = 5,
 		/obj/item/reagent_containers/food/snacks/grown/apple = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/candiedapple

--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -741,7 +741,7 @@
 	. = TRUE
 
 /datum/reagent/consumable/secretsauce
-	name = "secret sauce"
+	name = "Secret Sauce"
 	id = "secret_sauce"
 	description = "What could it be."
 	nutriment_factor = 2 * REAGENTS_METABOLISM
@@ -750,3 +750,13 @@
 	quality = FOOD_AMAZING
 	taste_mult = 100
 	can_synth = FALSE
+
+/datum/reagent/consumable/caramel
+	name = "Caramel"
+	id = "caramel"
+	description = "Who would have guessed that heating sugar is so delicious?"
+	nutriment_factor = 10 * REAGENTS_METABOLISM
+	color = "#C65A00"
+	taste_mult = 2
+	taste_description = "bitter sweetness"
+	reagent_state = SOLID


### PR DESCRIPTION
## About The Pull Request
Ports /tg/station PRs #45001 and #44006, also #44419 (ergo caramel), used for the birthday cake recipe.

## Why It's Good For The Game
Debating over a mere 15 points burn damage hardhat to people willing to make it worse than a match just because they don't enjoy its hilarity is simply not worth it.

What this PR does is stop the early round assistant from gaining free access to a ghetto weapon, adds caramel, make candied apples use caramel, uppercases "secret sauce" reagent initials, changes the recipe of birthday cakes, makes cakehats require birthday cakes, not the other way around, as well as two line changes on it.
That's enough to make its popularity wane a little and reduce the "salt".

Open to suggestions and tweaks for the birthday cake recipe and etcetera.

## Changelog
:cl: Ghommie (original PRs by nemvar and imsxz from /tg/station)
add: You can now make caramel by heating sugar. Be careful not to overcook it.
add: Adjusted the candied apple recipe
balance: cakehat has been nerfed
tweak: cakehat sounds cooler
add: You now get the cakehat by cooking a whole birthday cake.
del: The cakehat has been removed from all maps.
tweak: Birthday cake recipe no longer requires a cakehat. It now needs a candle, sugar and caramel.
add: Metastation bar now has a new plant. Her name is Potty.
/:cl:
