### PR TITLE
Removes a redunant Remove() from high luminosity eyes.

### DIFF
--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -184,7 +184,7 @@
 
 /obj/item/organ/eyes/robotic/glow/proc/terminate_effects()
 	if(owner && active)
-		deactivate()
+		deactivate(TRUE)
 	active = FALSE
 	clear_visuals(TRUE)
 	STOP_PROCESSING(SSfastprocess, src)
@@ -236,12 +236,6 @@
 	if(!active || . & EMP_PROTECT_SELF)
 		return
 	deactivate(silent = TRUE)
-
-/obj/item/organ/eyes/robotic/glow/Remove(mob/living/carbon/M)
-	. = ..()
-	if(active)
-		UnregisterSignal(M, COMSIG_ATOM_DIR_CHANGE)
-		active = FALSE
 
 /obj/item/organ/eyes/robotic/glow/proc/activate(silent = FALSE)
 	start_visuals()


### PR DESCRIPTION
## About The Pull Request
Its own specific Remove() was already define on line 181, yet I did not notice that on the previous PR.
Also set the silent arg TRUE on line 187 deactivate() since it's no player controlled toogling.
No bug but just an oversight.

## Why It's Good For The Game
Removes useless bits of code and suppressing an unwanted feedback message.

## Changelog
It's not relevant enough to have a changelog entry.