### PR TITLE
Central Command informs you when a Meteor Storm is about to hit 5 to 10 minutes before it happens

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -15,6 +15,12 @@
 	var/list/wave_type
 	var/wave_name = "normal"
 
+/datum/round_event/meteor_wave/setup()
+	announceWhen = 1
+	startWhen = rand(300, 600) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	endWhen = startWhen + 60
+
+
 /datum/round_event/meteor_wave/New()
 	..()
 	if(!wave_type)
@@ -46,7 +52,7 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	priority_announce("Meteors have been detected on collision course with the station.", "Meteor Alert", 'sound/ai/meteors.ogg')
+	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round(startWhen/60)] minutes.", "Meteor Alert", 'sound/ai/meteors.ogg')
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))


### PR DESCRIPTION
## About the Pull Request

5 to 10 minutes before a Meteor Storm occurs, Central Command informs you that one is about to occur.

## Why It's Good For The Game

Before anyone screams muh hugbox, I suggest reading this section in full.

This is what the PR will do:
- Remind engineers that meteors exist and that they probably should've set them up earlier. 5 to 10 minutes is very short notice so it will very likely stress them out while setting it up. They'll probably take note of this and perhaps get in the habit of setting up shields.
- Puts a spotlight on engineering's laziness. People will be extra pissed at engineering if they refuse to setup shields with the fair warning.
- Gives antags to prepare for the meteor storm. They can make plans, possibly sabotage the meteor defense system, or prepare to loot the armory which is almost always hit by the storm.
- Put some actual realism in the game. NASA is able to track space debris larger than a softball in space that orbits earth. In the year 2500 or whatever the fuck, NanoTrasen should be able to track large objects that enter the station's orbit at least 10 minutes before they hit.

## Changelog
:cl: BurgerBB
balance: Central Command informs you when a Meteor Storm is about to hit 5 to 10 minutes before it happens.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
