### PR TITLE
underwear colors fix 2: The revenge of the crunch.

### DIFF
--- a/code/game/objects/structures/dresser.dm
+++ b/code/game/objects/structures/dresser.dm
@@ -79,4 +79,4 @@
 	var/n_color = input(H, "Choose your [garment_type]'\s color.", "Character Preference", default_color) as color|null
 	if(!n_color || !H.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 		return default_color
-	return sanitize_hexcolor(n_color, include_crunch= TRUE)
+	return sanitize_hexcolor(n_color)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -72,11 +72,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	var/gender = MALE					//gender of character (well duh)
 	var/age = 30						//age of character
 	var/underwear = "Nude"				//underwear type
-	var/undie_color = "#FFFFFF"
+	var/undie_color = "FFF"
 	var/undershirt = "Nude"				//undershirt type
-	var/shirt_color = "#FFFFFF"
+	var/shirt_color = "FFF"
 	var/socks = "Nude"					//socks type
-	var/socks_color = "#FFFFFF"
+	var/socks_color = "FFF"
 	var/backbag = DBACKPACK				//backpack type
 	var/jumpsuit_style = PREF_SUIT		//suit/skirt
 	var/hair_style = "Bald"				//Hair type
@@ -1533,7 +1533,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("undie_color")
 					var/n_undie_color = input(user, "Choose your underwear's color.", "Character Preference", undie_color) as color|null
 					if(n_undie_color)
-						undie_color = sanitize_hexcolor(n_undie_color, include_crunch= TRUE)
+						undie_color = sanitize_hexcolor(n_undie_color)
 
 				if("undershirt")
 					var/new_undershirt = input(user, "Choose your character's undershirt:", "Character Preference") as null|anything in GLOB.undershirt_list
@@ -1543,7 +1543,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("shirt_color")
 					var/n_shirt_color = input(user, "Choose your undershirt's color.", "Character Preference", shirt_color) as color|null
 					if(n_shirt_color)
-						shirt_color = sanitize_hexcolor(n_shirt_color, include_crunch= TRUE)
+						shirt_color = sanitize_hexcolor(n_shirt_color)
 
 				if("socks")
 					var/new_socks = input(user, "Choose your character's socks:", "Character Preference") as null|anything in GLOB.socks_list
@@ -1553,7 +1553,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				if("socks_color")
 					var/n_socks_color = input(user, "Choose your socks' color.", "Character Preference", socks_color) as color|null
 					if(n_socks_color)
-						socks_color = sanitize_hexcolor(n_socks_color, include_crunch= TRUE)
+						socks_color = sanitize_hexcolor(n_socks_color)
 
 				if("eyes")
 					var/new_eyes = input(user, "Choose your character's eye colour:", "Character Preference","#"+eye_color) as color|null

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -500,7 +500,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 				if(B)
 					var/mutable_appearance/MA = mutable_appearance(B.icon, B.icon_state, -BODY_LAYER)
 					if(UNDIE_COLORABLE(B))
-						MA.color = H.undie_color
+						MA.color = "#[H.undie_color]"
 					standing += MA
 
 		if(H.undershirt)
@@ -516,7 +516,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					else
 						MA = mutable_appearance(T.icon, T.icon_state, -BODY_LAYER)
 					if(UNDIE_COLORABLE(T))
-						MA.color = H.shirt_color
+						MA.color = "#[H.shirt_color]"
 					standing += MA
 
 		if(H.socks && H.get_num_legs(FALSE) >= 2)
@@ -529,7 +529,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 					var/digilegs = (DIGITIGRADE in species_traits) ? "_d" : ""
 					var/mutable_appearance/MA = mutable_appearance(S.icon, "[S.icon_state][digilegs]", -BODY_LAYER)
 					if(UNDIE_COLORABLE(S))
-						MA.color = H.socks_color
+						MA.color = "[H.socks_color]"
 					standing += MA
 
 	if(standing.len)


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. No need to update savefile version since underwear colors is already sanitized without crunch (#). 

## Why It's Good For The Game
Underwear coloring should now persist within rounds.

## Changelog
:cl:
fix: Fixes underwear colors a bit.
/:cl:
