### PR TITLE
RCDs now ONLY accept matter cartridges. Matter cartridges now have adjusted size, and can be worn on utility belts.

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -55,7 +55,6 @@ RLD
 /obj/item/construction/attackby(obj/item/W, mob/user, params)
 	if(iscyborg(user))
 		return
-	var/loaded = 0
 	if(istype(W, /obj/item/rcd_ammo))
 		var/obj/item/rcd_ammo/R = W
 		var/load = min(R.ammoamt, max_matter - matter)
@@ -67,20 +66,6 @@ RLD
 			qdel(R)
 		matter += load
 		playsound(src.loc, 'sound/machines/click.ogg', 50, 1)
-		loaded = 1
-	else if(istype(W, /obj/item/stack/sheet/metal) || istype(W, /obj/item/stack/sheet/glass))
-		loaded = loadwithsheets(W, sheetmultiplier, user)
-	else if(istype(W, /obj/item/stack/sheet/plasteel))
-		loaded = loadwithsheets(W, plasteelmultiplier*sheetmultiplier, user) //12 matter for 1 plasteel sheet
-	else if(istype(W, /obj/item/stack/sheet/plasmarglass))
-		loaded = loadwithsheets(W, plasmarglassmultiplier*sheetmultiplier, user) //8 matter for one plasma rglass sheet
-	else if(istype(W, /obj/item/stack/sheet/rglass))
-		loaded = loadwithsheets(W, rglassmultiplier*sheetmultiplier, user) //6 matter for one rglass sheet
-	else if(istype(W, /obj/item/stack/rods))
-		loaded = loadwithsheets(W, sheetmultiplier * 0.5, user) // 2 matter for 1 rod, as 2 rods are produced from 1 metal
-	else if(istype(W, /obj/item/stack/tile/plasteel))
-		loaded = loadwithsheets(W, sheetmultiplier * 0.25, user) // 1 matter for 1 floortile, as 4 tiles are produced from 1 metal
-	if(loaded)
 		to_chat(user, "<span class='notice'>[src] now holds [matter]/[max_matter] matter-units.</span>")
 	else
 		return ..()
@@ -565,6 +550,7 @@ RLD
 	desc = "Highly compressed matter for the RCD."
 	icon = 'icons/obj/ammo.dmi'
 	icon_state = "rcd"
+	w_class = WEIGHT_CLASS_SMALL
 	item_state = "rcdammo"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
@@ -574,6 +560,7 @@ RLD
 /obj/item/rcd_ammo/large
 	name = "large compressed matter cartridge"
 	desc = "Highly compressed matter for the RCD. Has four times the matter packed into the same space as a normal cartridge."
+	w_class = WEIGHT_CLASS_LARGE
 	materials = list(MAT_METAL=48000, MAT_GLASS=32000)
 	ammoamt = 160
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -555,13 +555,12 @@ RLD
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
 	materials = list(MAT_METAL=12000, MAT_GLASS=8000)
-	var/ammoamt = 40
+	var/ammoamt = 80
 
 /obj/item/rcd_ammo/large
 	name = "large compressed matter cartridge"
-	desc = "Highly compressed matter for the RCD. Has four times the matter packed into the same space as a normal cartridge."
-	w_class = WEIGHT_CLASS_NORMAL
-	materials = list(MAT_METAL=48000, MAT_GLASS=32000)
+	desc = "Highly compressed matter for the RCD. Has twice as much the matter packed into the same space as a normal cartridge."
+	materials = list(MAT_METAL=24000, MAT_GLASS=16000)
 	ammoamt = 160
 
 

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -560,7 +560,7 @@ RLD
 /obj/item/rcd_ammo/large
 	name = "large compressed matter cartridge"
 	desc = "Highly compressed matter for the RCD. Has four times the matter packed into the same space as a normal cartridge."
-	w_class = WEIGHT_CLASS_LARGE
+	w_class = WEIGHT_CLASS_NORMAL
 	materials = list(MAT_METAL=48000, MAT_GLASS=32000)
 	ammoamt = 160
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -60,7 +60,9 @@
 		/obj/item/radio,
 		/obj/item/clothing/gloves,
 		/obj/item/holosign_creator,
-		/obj/item/assembly/signaler
+		/obj/item/assembly/signaler,
+		/obj/item/rcd_ammo,
+		/obj/item/construction/rcd/
 		))
 	STR.can_hold = can_hold
 

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -61,8 +61,7 @@
 		/obj/item/clothing/gloves,
 		/obj/item/holosign_creator,
 		/obj/item/assembly/signaler,
-		/obj/item/rcd_ammo,
-		/obj/item/construction/rcd/
+		/obj/item/rcd_ammo
 		))
 	STR.can_hold = can_hold
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

RCDs can no longer accept anything other than matter cartridges.
RCD matter cartridges now have a weight class of "small". Larger ones have a weight class of "normal".
RCD matter cartridges can be worn on belts.

## Why It's Good For The Game

RCDs are seriously unbalanced. I tried making a PR to make them rarer but people just said "just nerf how it takes ammo" so here it is. It's a fair nerf, honestly, and it makes sense.

## Changelog
:cl: BurgerBB
balance: RCDs only take matter cartridges as ammo. Matter cartridges are smaller, and can be worn on belts.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
