### PR TITLE
crew combat mechs are now spawned in with a tracking beacon

### DIFF
--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -20,3 +20,6 @@
 	..()
 	defense_action.Remove(user)
 
+/obj/mecha/combat/Initialize()
+	. = ..()
+	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -63,3 +63,6 @@
 	..()
 	thrusters_action.Remove(user)
 
+/obj/mecha/combat/Initialize()
+	. = ..()
+	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -154,4 +154,6 @@
 		color = color+pick(colors)
 	return color
 
-
+/obj/mecha/combat/Initialize()
+	. = ..()
+	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -28,3 +28,6 @@
 	switch_damtype_action.Remove(user)
 	phasing_action.Remove(user)
 
+/obj/mecha/combat/Initialize()
+	. = ..()
+	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/mecha_control_console.dm
+++ b/code/game/mecha/mecha_control_console.dm
@@ -109,7 +109,7 @@
 	var/obj/mecha/M = in_mecha()
 	if(M)
 		M.emp_act(EMP_HEAVY)
-		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 5 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
+		addtimer(CALLBACK(src, /obj/item/mecha_parts/mecha_tracking/proc/recharge), 15 SECONDS, TIMER_UNIQUE | TIMER_OVERRIDE)
 		recharging = 1
 
 /obj/item/mecha_parts/mecha_tracking/proc/recharge()


### PR DESCRIPTION
forgot to do this when I ported the mech EMP changes in https://github.com/Citadel-Station-13/Citadel-Station-13/pull/8795