### PR TITLE
[Needs Testing] Players without antag prefs will no longer be force-selected for traitor or changeling.

### DIFF
--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -24,6 +24,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 
 	var/const/changeling_amount = 4 //hard limit on changelings if scaling is turned off
 	var/list/changelings = list()
+	var/antags_required = FALSE // allows for possibility of no antags
 
 /datum/game_mode/changeling/pre_setup()
 
@@ -41,19 +42,22 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	else
 		num_changelings = max(1, min(num_players(), changeling_amount))
 
-	if(antag_candidates.len>0)
-		for(var/i = 0, i < num_changelings, i++)
-			if(!antag_candidates.len)
-				break
-			var/datum/mind/changeling = antag_pick(antag_candidates)
-			antag_candidates -= changeling
-			changelings += changeling
-			changeling.special_role = ROLE_CHANGELING
-			changeling.restricted_roles = restricted_jobs
-		return 1
-	else
+	for(var/i = 0, i < num_changelings, i++)
+		if(!antag_candidates.len)
+			break
+		var/datum/mind/changeling = antag_pick(antag_candidates)
+		antag_candidates -= changeling
+		changelings += changeling
+		changeling.special_role = ROLE_CHANGELING
+		changeling.restricted_roles = restricted_jobs
+
+	var/enough_antags = !antags_required || antag_candidates.len > 0
+
+	if(!enough_antags)
 		setup_error = "Not enough changeling candidates"
-		return 0
+		return FALSE
+	else
+		return TRUE
 
 /datum/game_mode/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)

--- a/code/game/gamemodes/changeling/changeling.dm
+++ b/code/game/gamemodes/changeling/changeling.dm
@@ -13,7 +13,7 @@ GLOBAL_VAR(changeling_team_objective_type) //If this is not null, we hand our th
 	restricted_jobs = list("AI", "Cyborg")
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")	//citadel change - adds HoP, CE, CMO, and RD to ling role blacklist
 	required_players = 15
-	required_enemies = 1
+	required_enemies = 0 //Cit change - was 1
 	recommended_enemies = 4
 	reroll_friendly = 1
 

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -13,6 +13,7 @@
 	var/list/possible_changelings = list()
 	var/list/changelings = list()
 	var/const/changeling_amount = 1 //hard limit on changelings if scaling is turned off
+	var/antags_required = FALSE // allows for possibility of no antags
 
 /datum/game_mode/traitor/changeling/announce()
 	to_chat(world, "<B>The current game mode is - Traitor+Changeling!</B>")
@@ -43,19 +44,23 @@
 	else
 		num_changelings = max(1, min(num_players(), changeling_amount/2))
 
-	if(possible_changelings.len>0)
-		for(var/j = 0, j < num_changelings, j++)
-			if(!possible_changelings.len)
-				break
-			var/datum/mind/changeling = antag_pick(possible_changelings)
-			antag_candidates -= changeling
-			possible_changelings -= changeling
-			changeling.special_role = ROLE_CHANGELING
-			changelings += changeling
-			changeling.restricted_roles = restricted_jobs
-		return ..()
+	for(var/j = 0, j < num_changelings, j++)
+		if(!possible_changelings.len)
+			break
+		var/datum/mind/changeling = antag_pick(possible_changelings)
+		antag_candidates -= changeling
+		possible_changelings -= changeling
+		changeling.special_role = ROLE_CHANGELING
+		changelings += changeling
+		changeling.restricted_roles = restricted_jobs
+
+	var/enough_antags = !antags_required || possible_changelings.len > 0
+
+	if(!enough_antags)
+		setup_error = "Not enough changeling candidates"
+		return FALSE
 	else
-		return 0
+		return ..()
 
 /datum/game_mode/traitor/changeling/post_setup()
 	for(var/datum/mind/changeling in changelings)

--- a/code/game/gamemodes/changeling/traitor_chan.dm
+++ b/code/game/gamemodes/changeling/traitor_chan.dm
@@ -5,7 +5,8 @@
 	traitors_possible = 3 //hard limit on traitors if scaling is turned off
 	restricted_jobs = list("AI", "Cyborg")
 	required_players = 25
-	required_enemies = 1	// how many of each type are required
+	required_enemies = 0	// how many of each type are required
+	                        // Cit change - was 1
 	recommended_enemies = 3
 	reroll_friendly = 1
 

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -390,7 +390,7 @@
 
 	drafted = shuffle(drafted) // Will hopefully increase randomness, Donkie
 
-	while(candidates.len < recommended_enemies)				// Pick randomlly just the number of people we need and add them to our list of candidates
+	while(candidates.len < required_enemies)				// Pick randomlly just the number of people we need and add them to our list of candidates
 		if(drafted.len > 0)
 			applicant = pick(drafted)
 			if(applicant)
@@ -408,7 +408,7 @@
 
 	drafted = shuffle(drafted) // Will hopefully increase randomness, Donkie
 
-	while(candidates.len < recommended_enemies)				// Pick randomlly just the number of people we need and add them to our list of candidates
+	while(candidates.len < required_enemies)				// Pick randomlly just the number of people we need and add them to our list of candidates
 		if(drafted.len > 0)
 			applicant = pick(drafted)
 			if(applicant)

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -7,7 +7,7 @@
 	config_tag = "internal_affairs"
 	false_report_weight = 10
 	required_players = 25
-	required_enemies = 2 // Cit change - was 5
+	required_enemies = 5
 	recommended_enemies = 8
 	reroll_friendly = 0
 	traitor_name = "Nanotrasen Internal Affairs Agent"

--- a/code/game/gamemodes/traitor/double_agents.dm
+++ b/code/game/gamemodes/traitor/double_agents.dm
@@ -7,7 +7,7 @@
 	config_tag = "internal_affairs"
 	false_report_weight = 10
 	required_players = 25
-	required_enemies = 5
+	required_enemies = 2 // Cit change - was 5
 	recommended_enemies = 8
 	reroll_friendly = 0
 	traitor_name = "Nanotrasen Internal Affairs Agent"

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -27,7 +27,7 @@
 	var/traitors_possible = 4 //hard limit on traitors if scaling is turned off
 	var/num_modifier = 0 // Used for gamemodes, that are a child of traitor, that need more than the usual.
 	var/antag_datum = /datum/antagonist/traitor //what type of antag to create
-	var/traitors_required = TRUE //Will allow no traitors
+	var/traitors_required = FALSE //Will allow no traitors
 
 
 /datum/game_mode/traitor/pre_setup()

--- a/code/game/gamemodes/traitor/traitor.dm
+++ b/code/game/gamemodes/traitor/traitor.dm
@@ -13,7 +13,7 @@
 	restricted_jobs = list("Cyborg")//They are part of the AI if he is traitor so are they, they use to get double chances
 	protected_jobs = list("Security Officer", "Warden", "Detective", "Head of Security", "Captain", "Head of Personnel", "Chief Engineer", "Chief Medical Officer", "Research Director", "Quartermaster")	//citadel change - adds HoP, CE, CMO, and RD to ling role blacklist
 	required_players = 0
-	required_enemies = 1
+	required_enemies = 0 // Cit change - was 1
 	recommended_enemies = 4
 	reroll_friendly = 1
 	enemy_minimum_age = 0


### PR DESCRIPTION
Slightly changes the way that antags are selected. It will aim to always satisfy the minimum required number of antags instead of the recommended number of antags. If enough players with antag preferences are available, it should function as normal. If there are not enough players with antag preferences available, it will properly respect each gamemode's set required antags number, but won't force any roles past that.
This means for specifically traitor, changeling, and traitor+changeling, the minimum number of antags is zero. If no players have antag preferences on when these game modes are rolled, there will be no forced antags. (IAA is an exception).
Other game modes will force roles up to the non-zero required antags.
required_enemies numbers for game modes may need to be adjusted to compensate, but should act normally under most circumstances.

:cl:
tweak: Some game modes will not force antag roles anymore.
/:cl: