### PR TITLE
Fixes Tea Aspera

### DIFF
--- a/code/modules/hydroponics/grown/tea_coffee.dm
+++ b/code/modules/hydroponics/grown/tea_coffee.dm
@@ -14,6 +14,7 @@
 	icon_dead = "tea-dead"
 	genes = list(/datum/plant_gene/trait/repeated_harvest)
 	mutatelist = list(/obj/item/seeds/tea/astra)
+	reagents_add = list("teapowder" = 0.1)
 
 /obj/item/reagent_containers/food/snacks/grown/tea
 	seed = /obj/item/seeds/tea


### PR DESCRIPTION
## About The Pull Request
 
Gives the teapowder reagent to Tea Aspera so it actually has tea instead of not having tea

## Why It's Good For The Game

Tea should have tea

## Changelog

:cl: Cebutris
fix: Tea Aspera now properly contains tea powder
/:cl:
