### PR TITLE
obfuscates specific surgeries, gives generalized areas to anybody in viewing range

### DIFF
--- a/code/game/machinery/computer/Operating.dm
+++ b/code/game/machinery/computer/Operating.dm
@@ -44,7 +44,7 @@
 			table.computer = src
 			break
 
-/obj/machinery/computer/operating/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.default_state)
+/obj/machinery/computer/operating/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = 0, datum/tgui/master_ui = null, datum/ui_state/state = GLOB.not_incapacitated_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
 		ui = new(user, src, ui_key, "operating_computer", name, 350, 470, master_ui, state)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -116,17 +116,19 @@
 // vision_distance (optional) define how many tiles away the message can be seen.
 // ignored_mob (optional) doesn't show any message to a given mob if TRUE.
 
-/atom/proc/visible_message(message, self_message, blind_message, vision_distance, ignored_mob, no_ghosts = FALSE)
+/atom/proc/visible_message(message, self_message, blind_message, vision_distance, list/ignored_mobs, no_ghosts = FALSE)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
+	if(!islist(ignored_mobs))
+		ignored_mobs = list(ignored_mobs)
 	var/range = 7
 	if(vision_distance)
 		range = vision_distance
 	for(var/mob/M in get_hearers_in_view(range, src))
 		if(!M.client)
 			continue
-		if(M == ignored_mob)
+		if(M in ignored_mobs)
 			continue
 		var/msg = message
 		if(isobserver(M) && no_ghosts)

--- a/code/modules/surgery/advanced/bioware/nerve_grounding.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_grounding.dm
@@ -17,10 +17,14 @@
 	time = 155
 
 /datum/surgery_step/ground_nerves/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts splicing together [target]'s nerves.", "<span class='notice'>You start splicing together [target]'s nerves.</span>")
+	display_results(user, target, "<span class='notice'>You start rerouting [target]'s nerves.</span>",
+		"[user] starts rerouting [target]'s nerves.",
+		"[user] starts manipulating [target]'s nervous system.")
 
 /datum/surgery_step/ground_nerves/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully splices [target]'s nervous system!", "<span class='notice'>You successfully splice [target]'s nervous system!</span>")
+	display_results(user, target, "<span class='notice'>You successfully reroute [target]'s nervous system!</span>",
+		"[user] successfully reroutes [target]'s nervous system!",
+		"[user] finishes manipulating [target]'s nervous system.")
 	new /datum/bioware/grounded_nerves(target)
 	return TRUE
 

--- a/code/modules/surgery/advanced/bioware/nerve_splicing.dm
+++ b/code/modules/surgery/advanced/bioware/nerve_splicing.dm
@@ -10,17 +10,20 @@
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 	bioware_target = BIOWARE_NERVES
-
 /datum/surgery_step/splice_nerves
 	name = "splice nerves"
 	accept_hand = TRUE
 	time = 155
 
 /datum/surgery_step/splice_nerves/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts splicing together [target]'s nerves.", "<span class='notice'>You start splicing together [target]'s nerves.</span>")
+	display_results(user, target, "<span class='notice'>You start splicing together [target]'s nerves.</span>",
+		"[user] starts splicing together [target]'s nerves.",
+		"[user] starts manipulating [target]'s nervous system.")
 
 /datum/surgery_step/splice_nerves/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully splices [target]'s nervous system!", "<span class='notice'>You successfully splice [target]'s nervous system!</span>")
+	display_results(user, target, "<span class='notice'>You successfully splice [target]'s nervous system!</span>",
+		"[user] successfully splices [target]'s nervous system!",
+		"[user] finishes manipulating [target]'s nervous system.")
 	new /datum/bioware/spliced_nerves(target)
 	return TRUE
 
@@ -28,11 +31,9 @@
 	name = "Spliced Nerves"
 	desc = "Nerves are connected to each other multiple times, greatly reducing the impact of stunning effects."
 	mod_type = BIOWARE_NERVES
-
 /datum/bioware/spliced_nerves/on_gain()
 	..()
 	owner.physiology.stun_mod *= 0.5
-
 /datum/bioware/spliced_nerves/on_lose()
 	..()
 	owner.physiology.stun_mod *= 2

--- a/code/modules/surgery/advanced/bioware/vein_threading.dm
+++ b/code/modules/surgery/advanced/bioware/vein_threading.dm
@@ -10,17 +10,20 @@
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 	bioware_target = BIOWARE_CIRCULATION
-
 /datum/surgery_step/thread_veins
 	name = "thread veins"
 	accept_hand = TRUE
 	time = 125
 
 /datum/surgery_step/thread_veins/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts weaving [target]'s circulatory system.", "<span class='notice'>You start weaving [target]'s circulatory system.</span>")
+	display_results(user, target, "<span class='notice'>You start weaving [target]'s circulatory system.</span>",
+		"[user] starts weaving [target]'s circulatory system.",
+		"[user] starts manipulating [target]'s circulatory system.")
 
 /datum/surgery_step/thread_veins/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] weaves [target]'s circulatory system into a resistant mesh!", "<span class='notice'>You weave [target]'s circulatory system into a resistant mesh!</span>")
+	display_results(user, target, "<span class='notice'>You weave [target]'s circulatory system into a resistant mesh!</span>",
+		"[user] weaves [target]'s circulatory system into a resistant mesh!",
+		"[user] finishes manipulating [target]'s circulatory system.")
 	new /datum/bioware/threaded_veins(target)
 	return TRUE
 
@@ -28,11 +31,9 @@
 	name = "Threaded Veins"
 	desc = "The circulatory system is woven into a mesh, severely reducing the amount of blood lost from wounds."
 	mod_type = BIOWARE_CIRCULATION
-
 /datum/bioware/threaded_veins/on_gain()
 	..()
 	owner.physiology.bleed_mod *= 0.25
-
 /datum/bioware/threaded_veins/on_lose()
 	..()
 	owner.physiology.bleed_mod *= 4

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -2,7 +2,6 @@
 	name = "Brainwashing Surgery Disk"
 	desc = "The disk provides instructions on how to impress an order on a brain, making it the primary objective of the patient."
 	surgeries = list(/datum/surgery/advanced/brainwashing)
-
 /datum/surgery/advanced/brainwashing
 	name = "Brainwashing"
 	desc = "A surgical procedure which directly implants a directive into the patient's brain, making it their absolute priority. It can be cleared using a mindshield implant."
@@ -13,10 +12,9 @@
 	/datum/surgery_step/clamp_bleeders,
 	/datum/surgery_step/brainwash,
 	/datum/surgery_step/close)
-
+	
 	species = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_HEAD)
-
 /datum/surgery/advanced/brainwashing/can_start(mob/user, mob/living/carbon/target)
 	if(!..())
 		return FALSE
@@ -24,27 +22,29 @@
 	if(!B)
 		return FALSE
 	return TRUE
-
 /datum/surgery_step/brainwash
 	name = "brainwash"
 	implements = list(/obj/item/hemostat = 85, TOOL_WIRECUTTER = 50, /obj/item/stack/packageWrap = 35, /obj/item/stack/cable_coil = 15)
 	time = 200
 	var/objective
-
 /datum/surgery_step/brainwash/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	objective = stripped_input(user, "Choose the objective to imprint on your victim's brain.", "Brainwashing", null, MAX_MESSAGE_LEN)
 	if(!objective)
 		return -1
-	user.visible_message("[user] begins to tinker with [target]'s brain.", "<span class='notice'>You begin to brainwash [target]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to brainwash [target]...</span>",
+		"[user] begins to fix [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/brainwash/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(!target.mind)
-		user.visible_message("[target] doesn't respond to the brainwashing, as if [target.p_they()] lacked a mind...")
+		to_chat(user, "<span class='warning'>[target] doesn't respond to the brainwashing, as if [target.p_they()] lacked a mind...</span>")
 		return FALSE
 	if(HAS_TRAIT(target, TRAIT_MINDSHIELD))
-		user.visible_message("You hear a faint buzzing from a device inside [target]'s brain, and the brainwashing is erased.")
+		to_chat(user, "<span class='warning'>You hear a faint buzzing from a device inside [target]'s brain, and the brainwashing is erased.</span>")
 		return FALSE
-	user.visible_message("[user] successfully brainwashes [target]!", "<span class='notice'>You succeed in brainwashing [target].</span>")
+	display_results(user, target, "<span class='notice'>You succeed in brainwashing [target].</span>",
+		"[user] successfully fixes [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	to_chat(target, "<span class='userdanger'>A new compulsion fills your mind... you feel forced to obey it!</span>")
 	brainwash(target, objective)
 	message_admins("[ADMIN_LOOKUPFLW(user)] surgically brainwashed [ADMIN_LOOKUPFLW(target)] with the objective '[objective]'.")
@@ -53,7 +53,9 @@
 
 /datum/surgery_step/brainwash/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message("<span class='warning'>[user] damages some brain tissue!</span>", "<span class='warning'>You bruise some brain tissue!</span>")
+		display_results(user, target, "<span class='warning'>You screw up, bruising the brain tissue!</span>",
+			"<span class='warning'>[user] screws up, causing brain damage!</span>",
+			"[user] completes the surgery on [target]'s brain.")
 		target.adjustBrainLoss(40)
 	else
 		user.visible_message("<span class='warning'>[user] suddenly notices that the brain [user.p_they()] [user.p_were()] working on is not there anymore.", "<span class='warning'>You suddenly notice that the brain you were working on is not there anymore.</span>")

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -12,7 +12,6 @@
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-
 /datum/surgery/advanced/lobotomy/can_start(mob/user, mob/living/carbon/target)
 	if(!..())
 		return FALSE
@@ -20,23 +19,25 @@
 	if(!B)
 		return FALSE
 	return TRUE
-
 /datum/surgery_step/lobotomize
 	name = "perform lobotomy"
 	implements = list(/obj/item/scalpel = 85, /obj/item/melee/transforming/energy/sword = 55, /obj/item/kitchen/knife = 35,
 		/obj/item/shard = 25, /obj/item = 20)
 	time = 100
-
 /datum/surgery_step/lobotomize/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
 		return FALSE
 	return TRUE
 
 /datum/surgery_step/lobotomize/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to cut a piece of [target]'s brain.", "<span class='notice'>You begin to cut a piece of [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to perform a lobotomy on [target]'s brain...</span>",
+		"[user] begins to perform a lobotomy on [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/lobotomize/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully lobotomizes [target]!", "<span class='notice'>You succeed in lobotomizing [target].</span>")
+	display_results(user, target, "<span class='notice'>You succeed in lobotomizing [target].</span>",
+			"[user] successfully lobotomizes [target]!",
+			"[user] completes the surgery on [target]'s brain.")
 	target.cure_all_traumas(TRAUMA_RESILIENCE_LOBOTOMY)
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
@@ -51,7 +52,9 @@
 
 /datum/surgery_step/lobotomize/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message("<span class='warning'>[user] removes the wrong part, causing more damage!</span>", "<span class='warning'>You remove the wrong part, causing more damage!</span>")
+		display_results(user, target, "<span class='warning'>You remove the wrong part, causing more damage!</span>",
+			"[user] successfully lobotomizes [target]!",
+			"[user] completes the surgery on [target]'s brain.")
 		target.adjustBrainLoss(80)
 		switch(rand(1,3))
 			if(1)

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -7,9 +7,7 @@
 				/datum/surgery_step/clamp_bleeders,
 				/datum/surgery_step/bionecrosis,
 				/datum/surgery_step/close)
-
 	possible_locs = list(BODY_ZONE_HEAD)
-
 /datum/surgery/advanced/necrotic_revival/can_start(mob/user, mob/living/carbon/target)
 	. = ..()
 	var/obj/item/organ/zombie_infection/ZI = target.getorganslot(ORGAN_SLOT_ZOMBIE)
@@ -19,15 +17,20 @@
 /datum/surgery_step/bionecrosis
 	name = "start bionecrosis"
 	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
 	time = 50
 	chems_needed = list("zombiepowder", "rezadone")
 	require_all_chems = FALSE
 
 /datum/surgery_step/bionecrosis/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to stimulate [target]'s brain.", "<span class='notice'>You begin to stimulate [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to grow a romerol tumor on [target]'s brain...</span>",
+		"[user] begins to tinker with [target]'s brain...",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/bionecrosis/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully grows a necrotic tumor on [target]'s brain!", "<span class='notice'>You succeed in growing a necrotic tumor on [target]'s brain.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in growing a romerol tumor on [target]'s brain.</span>",
+		"[user] successfully grows a romerol tumor on [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	if(!target.getorganslot(ORGAN_SLOT_ZOMBIE))
 		var/obj/item/organ/zombie_infection/ZI = new()
 		ZI.Insert(target)

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -7,31 +7,34 @@
 				/datum/surgery_step/clamp_bleeders,
 				/datum/surgery_step/pacify,
 				/datum/surgery_step/close)
-
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-
 /datum/surgery/advanced/pacify/can_start(mob/user, mob/living/carbon/target)
 	. = ..()
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(!B)
 		return FALSE
-
 /datum/surgery_step/pacify
 	name = "rewire brain"
 	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	time = 40
 
 /datum/surgery_step/pacify/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to reshape [target]'s brain.", "<span class='notice'>You begin to reshape [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to pacify [target]...</span>",
+		"[user] begins to fix [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/pacify/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] reshapes [target]'s brain!", "<span class='notice'>You succeed in reshaping [target]'s brain.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in neurologically pacifying [target].</span>",
+		"[user] successfully fixes [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	target.gain_trauma(/datum/brain_trauma/severe/pacifism, TRAUMA_RESILIENCE_LOBOTOMY)
 	return TRUE
 
 /datum/surgery_step/pacify/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] reshapes [target]'s brain!", "<span class='notice'>You screwed up, and rewired [target]'s brain the wrong way around...</span>")
+	display_results(user, target, "<span class='notice'>You screw up, rewiring [target]'s brain the wrong way around...</span>",
+			"<span class='warning'>[user] screws up, causing brain damage!</span>",
+			"[user] completes the surgery on [target]'s brain.")
 	target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
-	return FALSE
+	return FALSE 

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -8,11 +8,9 @@
 				/datum/surgery_step/incise,
 				/datum/surgery_step/revive,
 				/datum/surgery_step/close)
-
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-
 /datum/surgery/advanced/revival/can_start(mob/user, mob/living/carbon/target)
 	if(!..())
 		return FALSE
@@ -24,12 +22,10 @@
 	if(!B)
 		return FALSE
 	return TRUE
-
 /datum/surgery_step/revive
 	name = "electrically stimulate brain"
 	implements = list(/obj/item/twohanded/shockpaddles = 100, /obj/item/abductor/gizmo = 100, /obj/item/melee/baton = 75, /obj/item/organ/cyberimp/arm/baton = 75, /obj/item/organ/cyberimp/arm/gun/taser = 60, /obj/item/gun/energy/e_gun/advtaser = 60, /obj/item/gun/energy/taser = 60)
 	time = 120
-
 /datum/surgery_step/revive/tool_check(mob/user, obj/item/tool)
 	. = TRUE
 	if(istype(tool, /obj/item/twohanded/shockpaddles))
@@ -51,25 +47,33 @@
 			return FALSE
 
 /datum/surgery_step/revive/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] prepares to shock [target]'s brain with [tool].", "<span class='notice'>You prepare to give [target]'s brain the spark of life with [tool].</span>")
+	display_results(user, target, "<span class='notice'>You prepare to give [target]'s brain the spark of life with [tool].</span>",
+		"[user] prepares to shock [target]'s brain with [tool].",
+		"[user] prepares to shock [target]'s brain with [tool].")
 	target.notify_ghost_cloning("Someone is trying to zap your brain. Re-enter your corpse if you want to be revived!", source = target)
 
 /datum/surgery_step/revive/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] send a powerful shock to [target]'s brain with [tool]...", "<span class='notice'>You successfully shock [target]'s brain with [tool]...</span>")
+	display_results(user, target, "<span class='notice'>You successfully shock [target]'s brain with [tool]...</span>",
+		"[user] send a powerful shock to [target]'s brain with [tool]...",
+		"[user] send a powerful shock to [target]'s brain with [tool]...")
 	playsound(get_turf(target), 'sound/magic/lightningbolt.ogg', 50, 1)
 	target.adjustOxyLoss(-50, 0)
 	target.updatehealth()
 	if(target.revive())
 		user.visible_message("...[target] wakes up, alive and aware!", "<span class='notice'><b>IT'S ALIVE!</b></span>")
+		target.visible_message("...[target] wakes up, alive and aware!")
 		target.emote("gasp")
 		target.adjustBrainLoss(50, 199) //MAD SCIENCE
 		return TRUE
 	else
 		user.visible_message("...[target.p_they()] convulses, then lies still.")
+		target.visible_message("...[target.p_they()] convulses, then lies still.")
 		return FALSE
 
 /datum/surgery_step/revive/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] send a powerful shock to [target]'s brain with [tool], but [target.p_they()] doesn't react.", "<span class='notice'>You shock [target]'s brain with [tool], but [target.p_they()] doesn't react.</span>")
+	display_results(user, target, "<span class='notice'>You shock [target]'s brain with [tool], but [target.p_they()] doesn't react.</span>",
+		"[user] send a powerful shock to [target]'s brain with [tool], but [target.p_they()] doesn't react.",
+		"[user] send a powerful shock to [target]'s brain with [tool], but [target.p_they()] doesn't react.")
 	playsound(get_turf(target), 'sound/magic/lightningbolt.ogg', 50, 1)
 	target.adjustBrainLoss(15, 199)
 	return FALSE

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -7,17 +7,14 @@
 				/datum/surgery_step/incise,
 				/datum/surgery_step/viral_bond,
 				/datum/surgery_step/close)
-
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-
 /datum/surgery/advanced/viral_bonding/can_start(mob/user, mob/living/carbon/target)
 	if(!..())
 		return FALSE
 	if(!LAZYLEN(target.diseases))
 		return FALSE
 	return TRUE
-
 /datum/surgery_step/viral_bond
 	name = "viral bond"
 	implements = list(/obj/item/cautery = 100, TOOL_WELDER = 50, /obj/item = 30) // 30% success with any hot item.
@@ -27,14 +24,17 @@
 /datum/surgery_step/viral_bond/tool_check(mob/user, obj/item/tool)
 	if(implement_type == TOOL_WELDER || implement_type == /obj/item)
 		return tool.is_hot()
-
 	return TRUE
 
 /datum/surgery_step/viral_bond/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] starts heating [target]'s bone marrow with [tool]...", "<span class='notice'>You start heating [target]'s bone marrow with [tool]...</span>")
+	display_results(user, target, "<span class='notice'>You start heating [target]'s bone marrow with [tool]...</span>",
+		"[user] starts heating [target]'s bone marrow with [tool]...",
+		"[user] starts heating something in [target]'s chest with [tool]...")
 
 /datum/surgery_step/viral_bond/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[target]'s bone marrow begins pulsing slowly.", "<span class='notice'>[target]'s bone marrow begins pulsing slowly. The viral bonding is complete.</span>")
+	display_results(user, target, "<span class='notice'>[target]'s bone marrow begins pulsing slowly. The viral bonding is complete.</span>",
+		"[target]'s bone marrow begins pulsing slowly.",
+		"[user] finishes the operation.")
 	for(var/X in target.diseases)
 		var/datum/disease/D = X
 		D.carrier = TRUE

--- a/code/modules/surgery/amputation.dm
+++ b/code/modules/surgery/amputation.dm
@@ -1,25 +1,25 @@
-
 /datum/surgery/amputation
-	name = "amputation"
+	name = "Amputation"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/saw, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/sever_limb)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-
-
 /datum/surgery_step/sever_limb
 	name = "sever limb"
 	implements = list(/obj/item/scalpel = 100, /obj/item/circular_saw = 100, /obj/item/melee/transforming/energy/sword/cyborg/saw = 100, /obj/item/melee/arm_blade = 80, /obj/item/twohanded/required/chainsaw = 80, /obj/item/mounted_chainsaw = 80, /obj/item/twohanded/fireaxe = 50, /obj/item/hatchet = 40, /obj/item/kitchen/knife/butcher = 25)
 	time = 64
 
 /datum/surgery_step/sever_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to sever [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You begin to sever [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to sever [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to sever [target]'s [parse_zone(target_zone)]!",
+		"[user] begins to sever [target]'s [parse_zone(target_zone)]!")
 
 /datum/surgery_step/sever_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/carbon/human/L = target
-	user.visible_message("[user] severs [L]'s [parse_zone(target_zone)]!", "<span class='notice'>You sever [L]'s [parse_zone(target_zone)].</span>")
+	display_results(user, target, "<span class='notice'>You sever [L]'s [parse_zone(target_zone)].</span>",
+		"[user] severs [L]'s [parse_zone(target_zone)]!",
+		"[user] severs [L]'s [parse_zone(target_zone)]!")
 	if(surgery.operated_bodypart)
 		var/obj/item/bodypart/target_limb = surgery.operated_bodypart
 		target_limb.drop_limb()
-
 	return 1

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -1,5 +1,5 @@
 /datum/surgery/brain_surgery
-	name = "brain surgery"
+	name = "Brain surgery"
 	steps = list(
 	/datum/surgery_step/incise,
 	/datum/surgery_step/retract_skin,
@@ -7,16 +7,13 @@
 	/datum/surgery_step/clamp_bleeders,
 	/datum/surgery_step/fix_brain,
 	/datum/surgery_step/close)
-
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-
 /datum/surgery_step/fix_brain
 	name = "fix brain"
 	implements = list(/obj/item/hemostat = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
-
 /datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(!B)
@@ -24,10 +21,14 @@
 	return TRUE
 
 /datum/surgery_step/fix_brain/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to fix [target]'s brain.", "<span class='notice'>You begin to fix [target]'s brain...</span>")
+	display_results(user, target, "<span class='notice'>You begin to fix [target]'s brain...</span>",
+		"[user] begins to fix [target]'s brain.",
+		"[user] begins to perform surgery on [target]'s brain.")
 
 /datum/surgery_step/fix_brain/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully fixes [target]'s brain!", "<span class='notice'>You succeed in fixing [target]'s brain.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in fixing [target]'s brain.</span>",
+		"[user] successfully fixes [target]'s brain!",
+		"[user] completes the surgery on [target]'s brain.")
 	if(target.mind && target.mind.has_antag_datum(/datum/antagonist/brainwashed))
 		target.mind.remove_antag_datum(/datum/antagonist/brainwashed)
 	target.adjustBrainLoss(-60)
@@ -36,7 +37,9 @@
 
 /datum/surgery_step/fix_brain/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorganslot(ORGAN_SLOT_BRAIN))
-		user.visible_message("<span class='warning'>[user] screws up, causing more damage!</span>", "<span class='warning'>You screw up, causing more damage!</span>")
+		display_results(user, target, "<span class='warning'>You screw up, causing more damage!</span>",
+			"<span class='warning'>[user] screws up, causing brain damage!</span>",
+			"[user] completes the surgery on [target]'s brain.")
 		target.adjustBrainLoss(60)
 		target.gain_trauma_type(BRAIN_TRAUMA_SEVERE, TRAUMA_RESILIENCE_LOBOTOMY)
 	else

--- a/code/modules/surgery/cavity_implant.dm
+++ b/code/modules/surgery/cavity_implant.dm
@@ -1,30 +1,32 @@
 /datum/surgery/cavity_implant
-	name = "cavity implant"
+	name = "Cavity implant"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/incise, /datum/surgery_step/handle_cavity, /datum/surgery_step/close)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-
-
 //handle cavity
 /datum/surgery_step/handle_cavity
 	name = "implant item"
 	accept_hand = 1
 	accept_any_item = 1
+	implements = list(/obj/item = 100)
+	repeatable = TRUE
 	time = 32
 	var/obj/item/IC = null
-
+/datum/surgery_step/handle_cavity/tool_check(mob/user, obj/item/tool)
+	if(istype(tool, /obj/item/cautery) || istype(tool, /obj/item/gun/energy/laser))
+		return FALSE
+	return !tool.is_hot()
 /datum/surgery_step/handle_cavity/preop(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/bodypart/chest/CH = target.get_bodypart(BODY_ZONE_CHEST)
 	IC = CH.cavity_item
 	if(tool)
-		if(istype(tool, /obj/item/surgical_drapes) || istype(tool, /obj/item/bedsheet))
-			var/obj/item/inactive = user.get_inactive_held_item()
-			if(istype(inactive, /obj/item/cautery) || istype(inactive, /obj/item/screwdriver) || iscyborg(user))
-				attempt_cancel_surgery(surgery, tool, target, user)
-				return -1
-		user.visible_message("[user] begins to insert [tool] into [target]'s [target_zone].", "<span class='notice'>You begin to insert [tool] into [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to insert [tool] into [target]'s [target_zone]...</span>",
+			"[user] begins to insert [tool] into [target]'s [target_zone].",
+			"[user] begins to insert [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "something"] into [target]'s [target_zone].")
 	else
-		user.visible_message("[user] checks for items in [target]'s [target_zone].", "<span class='notice'>You check for items in [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You check for items in [target]'s [target_zone]...</span>",
+			"[user] checks for items in [target]'s [target_zone].",
+			"[user] looks for something in [target]'s [target_zone].")
 
 /datum/surgery_step/handle_cavity/success(mob/user, mob/living/carbon/human/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/obj/item/bodypart/chest/CH = target.get_bodypart(BODY_ZONE_CHEST)
@@ -32,18 +34,18 @@
 		if(IC || tool.w_class > WEIGHT_CLASS_NORMAL || HAS_TRAIT(tool, TRAIT_NODROP) || istype(tool, /obj/item/organ))
 			to_chat(user, "<span class='warning'>You can't seem to fit [tool] in [target]'s [target_zone]!</span>")
 			return 0
-		var/obj/item/electronic_assembly/EA = tool
-		if(istype(EA) && EA.combat_circuits && tool.w_class > WEIGHT_CLASS_SMALL)
-			to_chat(user, "<span class='warning'>[tool] is too dangerous to put in [target]'s [target_zone]! Maybe if it was smaller...</span>")
-			return 0
 		else
-			user.visible_message("[user] stuffs [tool] into [target]'s [target_zone]!", "<span class='notice'>You stuff [tool] into [target]'s [target_zone].</span>")
+			display_results(user, target, "<span class='notice'>You stuff [tool] into [target]'s [target_zone].</span>",
+				"[user] stuffs [tool] into [target]'s [target_zone]!",
+				"[user] stuffs [tool.w_class > WEIGHT_CLASS_SMALL ? tool : "something"] into [target]'s [target_zone].")
 			user.transferItemToLoc(tool, target, TRUE)
 			CH.cavity_item = tool
 			return 1
 	else
 		if(IC)
-			user.visible_message("[user] pulls [IC] out of [target]'s [target_zone]!", "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>")
+			display_results(user, target, "<span class='notice'>You pull [IC] out of [target]'s [target_zone].</span>",
+				"[user] pulls [IC] out of [target]'s [target_zone]!",
+				"[user] pulls [IC.w_class > WEIGHT_CLASS_SMALL ? IC : "something"] out of [target]'s [target_zone].")
 			user.put_in_hands(IC)
 			CH.cavity_item = null
 			return 1

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -1,5 +1,5 @@
 /datum/surgery/core_removal
-	name = "core removal"
+	name = "Core removal"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/extract_core)
 	species = list(/mob/living/simple_animal/slime)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
@@ -8,7 +8,6 @@
 	if(target.stat == DEAD)
 		return 1
 	return 0
-
 //extract brain
 /datum/surgery_step/extract_core
 	name = "extract core"
@@ -16,13 +15,17 @@
 	time = 16
 
 /datum/surgery_step/extract_core/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to extract a core from [target].", "<span class='notice'>You begin to extract a core from [target]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to extract a core from [target]...</span>",
+		"[user] begins to extract a core from [target].",
+		"[user] begins to extract a core from [target].")
 
 /datum/surgery_step/extract_core/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	var/mob/living/simple_animal/slime/slime = target
 	if(slime.cores > 0)
 		slime.cores--
-		user.visible_message("[user] successfully extracts a core from [target]!", "<span class='notice'>You successfully extract a core from [target]. [slime.cores] core\s remaining.</span>")
+		display_results(user, target, "<span class='notice'>You successfully extract a core from [target]. [slime.cores] core\s remaining.</span>",
+			"[user] successfully extracts a core from [target]!",
+			"[user] successfully extracts a core from [target]!")
 
 		new slime.coretype(slime.loc)
 

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -1,16 +1,14 @@
 /datum/surgery/eye_surgery
-	name = "eye surgery"
+	name = "Eye surgery"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/fix_eyes, /datum/surgery_step/close)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_PRECISE_EYES)
 	requires_bodypart_type = 0
-
 //fix eyes
 /datum/surgery_step/fix_eyes
 	name = "fix eyes"
 	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 45, /obj/item/pen = 25)
 	time = 64
-
 /datum/surgery/eye_surgery/can_start(mob/user, mob/living/carbon/target)
 	var/obj/item/organ/eyes/E = target.getorganslot(ORGAN_SLOT_EYES)
 	if(!E)
@@ -19,10 +17,14 @@
 	return TRUE
 
 /datum/surgery_step/fix_eyes/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to fix [target]'s eyes.", "<span class='notice'>You begin to fix [target]'s eyes...</span>")
+	display_results(user, target, "<span class='notice'>You begin to fix [target]'s eyes...</span>",
+		"[user] begins to fix [target]'s eyes.",
+		"[user] begins to perform surgery on [target]'s eyes.")
 
 /datum/surgery_step/fix_eyes/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully fixes [target]'s eyes!", "<span class='notice'>You succeed in fixing [target]'s eyes.</span>")
+	display_results(user, target, "<span class='notice'>You succeed in fixing [target]'s eyes.</span>",
+		"[user] successfully fixes [target]'s eyes!",
+		"[user] completes the surgery on [target]'s eyes.")
 	target.cure_blind(list(EYE_DAMAGE))
 	target.set_blindness(0)
 	target.cure_nearsighted(list(EYE_DAMAGE))
@@ -32,8 +34,12 @@
 
 /datum/surgery_step/fix_eyes/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(target.getorgan(/obj/item/organ/brain))
-		user.visible_message("<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>", "<span class='warning'>You accidentally stab [target] right in the brain!</span>")
+		display_results(user, target, "<span class='warning'>You accidentally stab [target] right in the brain!</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>")
 		target.adjustBrainLoss(70)
 	else
-		user.visible_message("<span class='warning'>[user] accidentally stabs [target] right in the brain! Or would have, if [target] had a brain.</span>", "<span class='warning'>You accidentally stab [target] right in the brain! Or would have, if [target] had a brain.</span>")
+		display_results(user, target, "<span class='warning'>You accidentally stab [target] right in the brain! Or would have, if [target] had a brain.</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain! Or would have, if [target] had a brain.</span>",
+			"<span class='warning'>[user] accidentally stabs [target] right in the brain!</span>")
 	return FALSE

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -65,7 +65,7 @@
 
 			if(S.ignore_clothes || get_location_accessible(M, selected_zone))
 				var/datum/surgery/procedure = new S.type(M, selected_zone, affecting)
-				user.visible_message("[user] drapes [I] over [M]'s [parse_zone(selected_zone)] to prepare for \an [procedure.name].", \
+				user.visible_message("[user] drapes [I] over [M]'s [parse_zone(selected_zone)] to prepare for surgery.", \
 					"<span class='notice'>You drape [I] over [M]'s [parse_zone(selected_zone)] to prepare for \an [procedure.name].</span>")
 
 				log_combat(user, M, "operated on", null, "(OPERATION TYPE: [procedure.name]) (TARGET AREA: [selected_zone])")
@@ -110,15 +110,22 @@
 		return 0.5
 
 
-/proc/get_location_accessible(mob/living/M, location)
+/proc/get_location_accessible(mob/M, location)
 	var/covered_locations = 0	//based on body_parts_covered
 	var/face_covered = 0	//based on flags_inv
 	var/eyesmouth_covered = 0	//based on flags_cover
-	for(var/A in M.get_equipped_items())
-		var/obj/item/I = A
-		covered_locations |= I.body_parts_covered
-		face_covered |= I.flags_inv
-		eyesmouth_covered |= I.flags_cover
+	if(iscarbon(M))
+		var/mob/living/carbon/C = M
+		for(var/obj/item/clothing/I in list(C.back, C.wear_mask, C.head))
+			covered_locations |= I.body_parts_covered
+			face_covered |= I.flags_inv
+			eyesmouth_covered |= I.flags_cover
+		if(ishuman(C))
+			var/mob/living/carbon/human/H = C
+			for(var/obj/item/I in list(H.wear_suit, H.w_uniform, H.shoes, H.belt, H.gloves, H.glasses, H.ears))
+				covered_locations |= I.body_parts_covered
+				face_covered |= I.flags_inv
+				eyesmouth_covered |= I.flags_cover
 
 	switch(location)
 		if(BODY_ZONE_HEAD)
@@ -162,4 +169,3 @@
 				return 0
 
 	return 1
-

--- a/code/modules/surgery/implant_removal.dm
+++ b/code/modules/surgery/implant_removal.dm
@@ -3,27 +3,30 @@
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/extract_implant, /datum/surgery_step/close)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-
-
 //extract implant
 /datum/surgery_step/extract_implant
 	name = "extract implant"
 	implements = list(/obj/item/hemostat = 100, TOOL_CROWBAR = 65)
 	time = 64
 	var/obj/item/implant/I = null
-
 /datum/surgery_step/extract_implant/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	for(var/obj/item/O in target.implants)
 		I = O
 		break
 	if(I)
-		user.visible_message("[user] begins to extract [I] from [target]'s [target_zone].", "<span class='notice'>You begin to extract [I] from [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to extract [I] from [target]'s [target_zone]...</span>",
+			"[user] begins to extract [I] from [target]'s [target_zone].",
+			"[user] begins to extract something from [target]'s [target_zone].")
 	else
-		user.visible_message("[user] looks for an implant in [target]'s [target_zone].", "<span class='notice'>You look for an implant in [target]'s [target_zone]...</span>")
+		display_results(user, target, "<span class='notice'>You look for an implant in [target]'s [target_zone]...</span>",
+			"[user] looks for an implant in [target]'s [target_zone].",
+			"[user] looks for something in [target]'s [target_zone].")
 
 /datum/surgery_step/extract_implant/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(I)
-		user.visible_message("[user] successfully removes [I] from [target]'s [target_zone]!", "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>")
+		display_results(user, target, "<span class='notice'>You successfully remove [I] from [target]'s [target_zone].</span>",
+			"[user] successfully removes [I] from [target]'s [target_zone]!",
+			"[user] successfully removes something from [target]'s [target_zone]!")
 		I.removed(target)
 
 		var/obj/item/implantcase/case
@@ -36,14 +39,15 @@
 			case.imp = I
 			I.forceMove(case)
 			case.update_icon()
-			user.visible_message("[user] places [I] into [case]!", "<span class='notice'>You place [I] into [case].</span>")
+			display_results(user, target, "<span class='notice'>You place [I] into [case].</span>",
+				"[user] places [I] into [case]!",
+				"[user] places it into [case]!")
 		else
 			qdel(I)
 
 	else
 		to_chat(user, "<span class='warning'>You can't find anything in [target]'s [target_zone]!</span>")
 	return 1
-
 /datum/surgery/implant_removal/mechanic
 	name = "implant removal"
 	requires_bodypart_type = BODYPART_ROBOTIC

--- a/code/modules/surgery/limb_augmentation.dm
+++ b/code/modules/surgery/limb_augmentation.dm
@@ -1,9 +1,5 @@
-
 /////AUGMENTATION SURGERIES//////
-
-
 //SURGERY STEPS
-
 /datum/surgery_step/replace
 	name = "sever muscles"
 	implements = list(/obj/item/scalpel = 100, TOOL_WIRECUTTER = 55)
@@ -11,16 +7,15 @@
 
 
 /datum/surgery_step/replace/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to sever the muscles on [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You begin to sever the muscles on [target]'s [parse_zone(user.zone_selected)]...</span>")
-
+	display_results(user, target, "<span class ='notice'>You begin to sever the muscles on [target]'s [parse_zone(user.zone_selected)]...</span>",
+		"[user] begins to sever the muscles on [target]'s [parse_zone(user.zone_selected)].",
+		"[user] begins an incision on [target]'s [parse_zone(user.zone_selected)].")
 
 /datum/surgery_step/replace_limb
 	name = "replace limb"
 	implements = list(/obj/item/bodypart = 100, /obj/item/organ_storage = 100)
 	time = 32
 	var/obj/item/bodypart/L = null // L because "limb"
-
-
 /datum/surgery_step/replace_limb/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(istype(tool, /obj/item/organ_storage) && istype(tool.contents[1], /obj/item/bodypart))
 		tool = tool.contents[1]
@@ -33,22 +28,20 @@
 		return -1
 	L = surgery.operated_bodypart
 	if(L)
-		user.visible_message("[user] begins to augment [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>")
+		display_results(user, target, "<span class ='notice'>You begin to augment [target]'s [parse_zone(user.zone_selected)]...</span>",
+			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)] with [aug].",
+			"[user] begins to augment [target]'s [parse_zone(user.zone_selected)].")
 	else
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class ='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
 
-
 //ACTUAL SURGERIES
-
 /datum/surgery/augmentation
-	name = "augmentation"
+	name = "Augmentation"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/replace, /datum/surgery_step/saw, /datum/surgery_step/replace_limb)
 	species = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
 	requires_real_bodypart = TRUE
-
 //SURGERY STEP SUCCESSES
-
 /datum/surgery_step/replace_limb/success(mob/user, mob/living/carbon/target, target_zone, obj/item/bodypart/tool, datum/surgery/surgery)
 	if(L)
 		if(istype(tool, /obj/item/organ_storage))
@@ -58,7 +51,9 @@
 			tool = tool.contents[1]
 		if(istype(tool) && user.temporarilyRemoveItemFromInventory(tool))
 			tool.replace_limb(target, TRUE)
-		user.visible_message("[user] successfully augments [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>")
+		display_results(user, target, "<span class='notice'>You successfully augment [target]'s [parse_zone(target_zone)].</span>",
+			"[user] successfully augments [target]'s [parse_zone(target_zone)] with [tool]!",
+			"[user] successfully augments [target]'s [parse_zone(target_zone)]!")
 		log_combat(user, target, "augmented", addition="by giving him new [parse_zone(target_zone)] INTENT: [uppertext(user.a_intent)]")
 	else
 		to_chat(user, "<span class='warning'>[target] has no organic [parse_zone(target_zone)] there!</span>")

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -1,14 +1,11 @@
 /datum/surgery/lipoplasty
-	name = "lipoplasty"
+	name = "Lipoplasty"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/cut_fat, /datum/surgery_step/remove_fat, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
-
 /datum/surgery/lipoplasty/can_start(mob/user, mob/living/carbon/target)
 	if(HAS_TRAIT(target, TRAIT_FAT))
 		return 1
 	return 0
-
-
 //cut fat
 /datum/surgery_step/cut_fat
 	name = "cut excess fat"
@@ -16,10 +13,14 @@
 	time = 64
 
 /datum/surgery_step/cut_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to cut away [target]'s excess fat.", "<span class='notice'>You begin to cut away [target]'s excess fat...</span>")
+	display_results(user, target, "<span class='notice'>You begin to cut away [target]'s excess fat...</span>",
+			"[user] begins to cut away [target]'s excess fat.",
+			"[user] begins to cut [target]'s [target_zone] with [tool].")
 
 /datum/surgery_step/cut_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] cuts [target]'s excess fat loose!", "<span class='notice'>You cut [target]'s excess fat loose.</span>")
+	display_results(user, target, "<span class='notice'>You cut [target]'s excess fat loose.</span>",
+			"[user] cuts [target]'s excess fat loose!",
+			"[user] finishes the cut on [target]'s [target_zone].")
 	return 1
 
 //remove fat
@@ -29,25 +30,27 @@
 	time = 32
 
 /datum/surgery_step/remove_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to extract [target]'s loose fat!", "<span class='notice'>You begin to extract [target]'s loose fat...</span>")
+	display_results(user, target, "<span class='notice'>You begin to extract [target]'s loose fat...</span>",
+			"[user] begins to extract [target]'s loose fat!",
+			"[user] begins to extract something from [target]'s [target_zone].")
 
 /datum/surgery_step/remove_fat/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] extracts [target]'s fat!", "<span class='notice'>You extract [target]'s fat.</span>")
+	display_results(user, target, "<span class='notice'>You extract [target]'s fat.</span>",
+			"[user] extracts [target]'s fat!",
+			"[user] extracts [target]'s fat!")
 	target.overeatduration = 0 //patient is unfatted
 	var/removednutriment = target.nutrition
 	target.nutrition = NUTRITION_LEVEL_WELL_FED
 	removednutriment -= 450 //whatever was removed goes into the meat
 	var/mob/living/carbon/human/H = target
 	var/typeofmeat = /obj/item/reagent_containers/food/snacks/meat/slab/human
-
 	if(H.dna && H.dna.species)
 		typeofmeat = H.dna.species.meat
-
 	var/obj/item/reagent_containers/food/snacks/meat/slab/human/newmeat = new typeofmeat
 	newmeat.name = "fatty meat"
 	newmeat.desc = "Extremely fatty tissue taken from a patient."
 	newmeat.subjectname = H.real_name
 	newmeat.subjectjob = H.job
-	newmeat.reagents.add_reagent ("nutriment", (removednutriment / 15)) //To balance with nutriment_factor of nutriment
+	newmeat.reagents.add_reagent (/datum/reagent/consumable/nutriment, (removednutriment / 15)) //To balance with nutriment_factor of nutriment
 	newmeat.forceMove(target.loc)
 	return 1

--- a/code/modules/surgery/mechanic_steps.dm
+++ b/code/modules/surgery/mechanic_steps.dm
@@ -9,15 +9,14 @@
 	time = 24
 
 /datum/surgery_step/mechanic_open/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to unscrew the shell of [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to unscrew the shell of [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].",
+			"[user] begins to unscrew the shell of [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/mechanic_incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
 		return FALSE
-
 	return TRUE
-
 //close shell
 /datum/surgery_step/mechanic_close
 	name = "screw shell"
@@ -29,15 +28,14 @@
 	time = 24
 
 /datum/surgery_step/mechanic_close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to screw the shell of [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to screw the shell of [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to screw the shell of [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to screw the shell of [target]'s [parse_zone(target_zone)].",
+			"[user] begins to screw the shell of [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/mechanic_close/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
 		return FALSE
-
 	return TRUE
-
 //prepare electronics
 /datum/surgery_step/prepare_electronics
 	name = "prepare electronics"
@@ -47,8 +45,9 @@
 	time = 24
 
 /datum/surgery_step/prepare_electronics/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to prepare electronics in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to prepare electronics in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to prepare electronics in [target]'s [parse_zone(target_zone)].")
 
 //unwrench
 /datum/surgery_step/mechanic_unwrench
@@ -59,8 +58,9 @@
 	time = 24
 
 /datum/surgery_step/mechanic_unwrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to unwrench some bolts in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to unwrench some bolts in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to unwrench some bolts in [target]'s [parse_zone(target_zone)].")
 
 //wrench
 /datum/surgery_step/mechanic_wrench
@@ -71,8 +71,9 @@
 	time = 24
 
 /datum/surgery_step/mechanic_wrench/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to wrench some bolts in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to wrench some bolts in [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].",
+			"[user] begins to wrench some bolts in [target]'s [parse_zone(target_zone)].")
 
 //open hatch
 /datum/surgery_step/open_hatch
@@ -81,5 +82,6 @@
 	time = 10
 
 /datum/surgery_step/open_hatch/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to open the hatch holders in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to open the hatch holders in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to open the hatch holders in [target]'s [parse_zone(target_zone)].") 

--- a/code/modules/surgery/organ_manipulation.dm
+++ b/code/modules/surgery/organ_manipulation.dm
@@ -1,5 +1,5 @@
 /datum/surgery/organ_manipulation
-	name = "organ manipulation"
+	name = "Organ manipulation"
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
 	requires_real_bodypart = 1
@@ -13,7 +13,6 @@
 		//there should be bone fixing
 		/datum/surgery_step/close
 		)
-
 /datum/surgery/organ_manipulation/soft
 	possible_locs = list(BODY_ZONE_PRECISE_GROIN, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
 	steps = list(
@@ -24,9 +23,8 @@
 		/datum/surgery_step/manipulate_organs,
 		/datum/surgery_step/close
 		)
-
 /datum/surgery/organ_manipulation/alien
-	name = "alien organ manipulation"
+	name = "Alien organ manipulation"
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD, BODY_ZONE_PRECISE_GROIN, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
 	species = list(/mob/living/carbon/alien/humanoid)
 	steps = list(
@@ -37,9 +35,8 @@
 		/datum/surgery_step/manipulate_organs,
 		/datum/surgery_step/close
 		)
-
 /datum/surgery/organ_manipulation/mechanic
-	name = "prosthesis organ manipulation"
+	name = "Prosthesis organ manipulation"
 	possible_locs = list(BODY_ZONE_CHEST, BODY_ZONE_HEAD)
 	requires_bodypart_type = BODYPART_ROBOTIC
 	steps = list(
@@ -51,7 +48,6 @@
 		/datum/surgery_step/mechanic_wrench,
 		/datum/surgery_step/mechanic_close
 		)
-
 /datum/surgery/organ_manipulation/mechanic/soft
 	possible_locs = list(BODY_ZONE_PRECISE_GROIN, BODY_ZONE_PRECISE_EYES, BODY_ZONE_PRECISE_MOUTH, BODY_ZONE_L_ARM, BODY_ZONE_R_ARM)
 	steps = list(
@@ -61,7 +57,6 @@
 		/datum/surgery_step/manipulate_organs,
 		/datum/surgery_step/mechanic_close
 		)
-
 /datum/surgery_step/manipulate_organs
 	time = 64
 	name = "manipulate organs"
@@ -70,11 +65,9 @@
 	var/implements_extract = list(/obj/item/hemostat = 100, TOOL_CROWBAR = 55)
 	var/current_type
 	var/obj/item/organ/I = null
-
 /datum/surgery_step/manipulate_organs/New()
 	..()
 	implements = implements + implements_extract
-
 /datum/surgery_step/manipulate_organs/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	I = null
 	if(istype(tool, /obj/item/organ_storage))
@@ -92,9 +85,9 @@
 		if(target_zone != I.zone || target.getorganslot(I.slot))
 			to_chat(user, "<span class='notice'>There is no room for [I] in [target]'s [parse_zone(target_zone)]!</span>")
 			return -1
-
-		user.visible_message("[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)].",
-			"<span class='notice'>You begin to insert [tool] into [target]'s [parse_zone(target_zone)]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to insert [tool] into [target]'s [parse_zone(target_zone)]...</span>",
+			"[user] begins to insert [tool] into [target]'s [parse_zone(target_zone)].",
+			"[user] begins to insert something into [target]'s [parse_zone(target_zone)].")
 
 	else if(implement_type in implements_extract)
 		current_type = "extract"
@@ -107,21 +100,20 @@
 				O.on_find(user)
 				organs -= O
 				organs[O.name] = O
-
 			I = input("Remove which organ?", "Surgery", null, null) as null|anything in organs
 			if(I && user && target && user.Adjacent(target) && user.get_active_held_item() == tool)
 				I = organs[I]
 				if(!I)
 					return -1
-				user.visible_message("[user] begins to extract [I] from [target]'s [parse_zone(target_zone)].",
-					"<span class='notice'>You begin to extract [I] from [target]'s [parse_zone(target_zone)]...</span>")
+				display_results(user, target, "<span class='notice'>You begin to extract [I] from [target]'s [parse_zone(target_zone)]...</span>",
+					"[user] begins to extract [I] from [target]'s [parse_zone(target_zone)].",
+					"[user] begins to extract something from [target]'s [parse_zone(target_zone)].")
 			else
 				return -1
 
 	else if(istype(tool, /obj/item/reagent_containers/food/snacks/organ))
 		to_chat(user, "<span class='warning'>[tool] was bitten by someone! It's too damaged to use!</span>")
 		return -1
-
 /datum/surgery_step/manipulate_organs/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(current_type == "insert")
 		if(istype(tool, /obj/item/organ_storage))
@@ -134,17 +126,20 @@
 			I = tool
 		user.temporarilyRemoveItemFromInventory(I, TRUE)
 		I.Insert(target)
-		user.visible_message("[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!",
-			"<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>")
+		display_results(user, target, "<span class='notice'>You insert [tool] into [target]'s [parse_zone(target_zone)].</span>",
+			"[user] inserts [tool] into [target]'s [parse_zone(target_zone)]!",
+			"[user] inserts something into [target]'s [parse_zone(target_zone)]!")
 
 	else if(current_type == "extract")
 		if(I && I.owner == target)
-			user.visible_message("[user] successfully extracts [I] from [target]'s [parse_zone(target_zone)]!",
-				"<span class='notice'>You successfully extract [I] from [target]'s [parse_zone(target_zone)].</span>")
+			display_results(user, target, "<span class='notice'>You successfully extract [I] from [target]'s [parse_zone(target_zone)].</span>",
+				"[user] successfully extracts [I] from [target]'s [parse_zone(target_zone)]!",
+				"[user] successfully extracts something from [target]'s [parse_zone(target_zone)]!")
 			log_combat(user, target, "surgically removed [I.name] from", addition="INTENT: [uppertext(user.a_intent)]")
 			I.Remove(target)
 			I.forceMove(get_turf(target))
 		else
-			user.visible_message("[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
-				"<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>")
+			display_results(user, target, "<span class='notice'>You can't extract anything from [target]'s [parse_zone(target_zone)]!</span>",
+				"[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!",
+				"[user] can't seem to extract anything from [target]'s [parse_zone(target_zone)]!")
 	return 0

--- a/code/modules/surgery/organic_steps.dm
+++ b/code/modules/surgery/organic_steps.dm
@@ -1,4 +1,3 @@
-
 //make incision
 /datum/surgery_step/incise
 	name = "make incision"
@@ -7,13 +6,22 @@
 	time = 16
 
 /datum/surgery_step/incise/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to make an incision in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to make an incision in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to make an incision in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to make an incision in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/incise/tool_check(mob/user, obj/item/tool)
 	if(implement_type == /obj/item && !tool.is_sharp())
 		return FALSE
-
+	return TRUE
+/datum/surgery_step/incise/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	if ishuman(target)
+		var/mob/living/carbon/human/H = target
+		if (!(NOBLOOD in H.dna.species.species_traits))
+			display_results(user, target, "<span class='notice'>Blood pools around the incision in [H]'s [parse_zone(target_zone)].</span>",
+				"Blood pools around the incision in [H]'s [parse_zone(target_zone)].",
+				"")
+			H.bleed_rate += 3
 	return TRUE
 
 //clamp bleeders
@@ -23,15 +31,17 @@
 	time = 24
 
 /datum/surgery_step/clamp_bleeders/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to clamp bleeders in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to clamp bleeders in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/clamp_bleeders/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
 		target.heal_bodypart_damage(20,0)
+	if (ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.bleed_rate = max( (H.bleed_rate - 3), 0)
 	return ..()
-
-
 //retract skin
 /datum/surgery_step/retract_skin
 	name = "retract skin"
@@ -39,8 +49,9 @@
 	time = 24
 
 /datum/surgery_step/retract_skin/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to retract the skin in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to retract the skin in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to retract the skin in [target]'s [parse_zone(target_zone)].")
 
 
 
@@ -52,22 +63,21 @@
 	time = 24
 
 /datum/surgery_step/close/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to mend the incision in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to mend the incision in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/close/tool_check(mob/user, obj/item/tool)
 	if(implement_type == TOOL_WELDER || implement_type == /obj/item)
 		return tool.is_hot()
-
 	return TRUE
-
 /datum/surgery_step/close/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(locate(/datum/surgery_step/saw) in surgery.steps)
 		target.heal_bodypart_damage(45,0)
+	if (ishuman(target))
+		var/mob/living/carbon/human/H = target
+		H.bleed_rate = max( (H.bleed_rate - 3), 0)
 	return ..()
-
-
-
 //saw bone
 /datum/surgery_step/saw
 	name = "saw bone"
@@ -77,13 +87,15 @@
 	time = 54
 
 /datum/surgery_step/saw/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to saw through the bone in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to saw through the bone in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/saw/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	target.apply_damage(50, BRUTE, "[target_zone]")
-
-	user.visible_message("[user] saws [target]'s [parse_zone(target_zone)] open!", "<span class='notice'>You saw [target]'s [parse_zone(target_zone)] open.</span>")
+	display_results(user, target, "<span class='notice'>You saw [target]'s [parse_zone(target_zone)] open.</span>",
+		"[user] saws [target]'s [parse_zone(target_zone)] open!",
+		"[user] saws [target]'s [parse_zone(target_zone)] open!")
 	return 1
 
 //drill bone
@@ -93,10 +105,12 @@
 	time = 30
 
 /datum/surgery_step/drill/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].",
-		"<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>")
+	display_results(user, target, "<span class='notice'>You begin to drill into the bone in [target]'s [parse_zone(target_zone)]...</span>",
+		"[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].",
+		"[user] begins to drill into the bone in [target]'s [parse_zone(target_zone)].")
 
 /datum/surgery_step/drill/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] drills into [target]'s [parse_zone(target_zone)]!",
-		"<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>")
+	display_results(user, target, "<span class='notice'>You drill into [target]'s [parse_zone(target_zone)].</span>",
+		"[user] drills into [target]'s [parse_zone(target_zone)]!",
+		"[user] drills into [target]'s [parse_zone(target_zone)]!")
 	return 1

--- a/code/modules/surgery/plastic_surgery.dm
+++ b/code/modules/surgery/plastic_surgery.dm
@@ -1,8 +1,7 @@
 /datum/surgery/plastic_surgery
-	name = "plastic surgery"
+	name = "Plastic surgery"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/retract_skin, /datum/surgery_step/reshape_face, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_HEAD)
-
 //reshape_face
 /datum/surgery_step/reshape_face
 	name = "reshape face"
@@ -10,12 +9,16 @@
 	time = 64
 
 /datum/surgery_step/reshape_face/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to alter [target]'s appearance.", "<span class='notice'>You begin to alter [target]'s appearance...</span>")
+	display_results(user, target, "<span class='notice'>You begin to alter [target]'s appearance...</span>",
+		"[user] begins to alter [target]'s appearance.",
+		"[user] begins to make an incision in [target]'s face.")
 
 /datum/surgery_step/reshape_face/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(HAS_TRAIT_FROM(target, TRAIT_DISFIGURED, TRAIT_GENERIC))
 		REMOVE_TRAIT(target, TRAIT_DISFIGURED, TRAIT_GENERIC)
-		user.visible_message("[user] successfully restores [target]'s appearance!", "<span class='notice'>You successfully restore [target]'s appearance.</span>")
+		display_results(user, target, "<span class='notice'>You successfully restore [target]'s appearance.</span>",
+			"[user] successfully restores [target]'s appearance!",
+			"[user] finishes the operation on [target]'s face.")
 	else
 		var/list/names = list()
 		if(!isabductor(user))
@@ -31,8 +34,18 @@
 		var/oldname = target.real_name
 		target.real_name = chosen_name
 		var/newname = target.real_name	//something about how the code handles names required that I use this instead of target.real_name
-		user.visible_message("[user] alters [oldname]'s appearance completely, [target.p_they()] is now [newname]!", "<span class='notice'>You alter [oldname]'s appearance completely, [target.p_they()] is now [newname].</span>")
+		display_results(user, target, "<span class='notice'>You alter [oldname]'s appearance completely, [target.p_they()] is now [newname].</span>",
+			"[user] alters [oldname]'s appearance completely, [target.p_they()] is now [newname]!",
+			"[user] finishes the operation on [target]'s face.")
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		H.sec_hud_set_ID()
 	return 1
+	return TRUE
+
+/datum/surgery_step/reshape_face/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
+	display_results(user, target, "<span class='warning'>You screw up, leaving [target]'s appearance disfigured!</span>",
+		"[user] screws up, disfiguring [target]'s appearance!",
+		"[user] finishes the operation on [target]'s face.")
+	ADD_TRAIT(target, TRAIT_DISFIGURED, TRAIT_GENERIC)
+	return FALSE 

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -1,26 +1,21 @@
 /datum/surgery/prosthetic_replacement
-	name = "prosthetic replacement"
+	name = "Prosthetic replacement"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/add_prosthetic)
 	species = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)
 	requires_bodypart = FALSE //need a missing limb
 	requires_bodypart_type = 0
-
 /datum/surgery/prosthetic_replacement/can_start(mob/user, mob/living/carbon/target)
 	if(!iscarbon(target))
 		return 0
 	var/mob/living/carbon/C = target
 	if(!C.get_bodypart(user.zone_selected)) //can only start if limb is missing
 		return 1
-
-
-
 /datum/surgery_step/add_prosthetic
 	name = "add prosthetic"
 	implements = list(/obj/item/bodypart = 100, /obj/item/organ_storage = 100, /obj/item/twohanded/required/chainsaw = 100, /obj/item/melee/synthetic_arm_blade = 100)
 	time = 32
 	var/organ_rejection_dam = 0
-
 /datum/surgery_step/add_prosthetic/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(istype(tool, /obj/item/organ_storage))
 		if(!tool.contents.len)
@@ -48,16 +43,19 @@
 					organ_rejection_dam = 30
 
 		if(target_zone == BP.body_zone) //so we can't replace a leg with an arm, or a human arm with a monkey arm.
-			user.visible_message("[user] begins to replace [target]'s [parse_zone(target_zone)].", "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)]...</span>")
+			display_results(user, target, "<span class ='notice'>You begin to replace [target]'s [parse_zone(target_zone)] with [tool]...</span>",
+				"[user] begins to replace [target]'s [parse_zone(target_zone)] with [tool].",
+				"[user] begins to replace [target]'s [parse_zone(target_zone)].")
 		else
 			to_chat(user, "<span class='warning'>[tool] isn't the right type for [parse_zone(target_zone)].</span>")
 			return -1
 	else if(target_zone == BODY_ZONE_L_ARM || target_zone == BODY_ZONE_R_ARM)
-		user.visible_message("[user] begins to attach [tool] onto [target].", "<span class='notice'>You begin to attach [tool] onto [target]...</span>")
+		display_results(user, target, "<span class='notice'>You begin to attach [tool] onto [target]...</span>",
+			"[user] begins to attach [tool] onto [target]'s [parse_zone(target_zone)].",
+			"[user] begins to attach something onto [target]'s [parse_zone(target_zone)].")
 	else
 		to_chat(user, "<span class='warning'>[tool] must be installed onto an arm.</span>")
 		return -1
-
 /datum/surgery_step/add_prosthetic/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(istype(tool, /obj/item/organ_storage))
 		tool.icon_state = initial(tool.icon_state)
@@ -69,13 +67,17 @@
 		L.attach_limb(target)
 		if(organ_rejection_dam)
 			target.adjustToxLoss(organ_rejection_dam)
-		user.visible_message("[user] successfully replaces [target]'s [parse_zone(target_zone)]!", "<span class='notice'>You succeed in replacing [target]'s [parse_zone(target_zone)].</span>")
+		display_results(user, target, "<span class='notice'>You succeed in replacing [target]'s [parse_zone(target_zone)].</span>",
+			"[user] successfully replaces [target]'s [parse_zone(target_zone)] with [tool]!",
+			"[user] successfully replaces [target]'s [parse_zone(target_zone)]!")
 		return 1
 	else
 		var/obj/item/bodypart/L = target.newBodyPart(target_zone, FALSE, FALSE)
 		L.is_pseudopart = TRUE
 		L.attach_limb(target)
-		user.visible_message("[user] finishes attaching [tool]!", "<span class='notice'>You attach [tool].</span>")
+		display_results(user, target, "<span class='notice'>You attach [tool].</span>",
+			"[user] finishes attaching [tool]!",
+			"[user] finishes the attachment procedure!")
 		qdel(tool)
 		if(istype(tool, /obj/item/twohanded/required/chainsaw))
 			var/obj/item/mounted_chainsaw/new_arm = new(target)
@@ -85,4 +87,3 @@
 			var/obj/item/melee/arm_blade/new_arm = new(target,TRUE,TRUE)
 			target_zone == BODY_ZONE_R_ARM ? target.put_in_r_hand(new_arm) : target.put_in_l_hand(new_arm)
 			return 1
-

--- a/code/modules/surgery/remove_embedded_object.dm
+++ b/code/modules/surgery/remove_embedded_object.dm
@@ -2,22 +2,19 @@
 	name = "removal of embedded objects"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/retract_skin, /datum/surgery_step/remove_object)
 	possible_locs = list(BODY_ZONE_R_ARM,BODY_ZONE_L_ARM,BODY_ZONE_R_LEG,BODY_ZONE_L_LEG,BODY_ZONE_CHEST,BODY_ZONE_HEAD)
-
-
 /datum/surgery_step/remove_object
 	name = "remove embedded objects"
 	time = 32
 	accept_hand = 1
 	var/obj/item/bodypart/L = null
-
-
 /datum/surgery_step/remove_object/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	L = surgery.operated_bodypart
 	if(L)
-		user.visible_message("[user] looks for objects embedded in [target]'s [parse_zone(user.zone_selected)].", "<span class='notice'>You look for objects embedded in [target]'s [parse_zone(user.zone_selected)]...</span>")
+		display_results(user, target, "<span class='notice'>You look for objects embedded in [target]'s [parse_zone(user.zone_selected)]...</span>",
+			"[user] looks for objects embedded in [target]'s [parse_zone(user.zone_selected)].",
+			"[user] looks for something in [target]'s [parse_zone(user.zone_selected)].")
 	else
 		user.visible_message("[user] looks for [target]'s [parse_zone(user.zone_selected)].", "<span class='notice'>You look for [target]'s [parse_zone(user.zone_selected)]...</span>")
-
 
 /datum/surgery_step/remove_object/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	if(L)
@@ -33,11 +30,12 @@
 				SEND_SIGNAL(H, COMSIG_CLEAR_MOOD_EVENT, "embedded")
 
 			if(objects > 0)
-				user.visible_message("[user] successfully removes [objects] objects from [H]'s [L]!", "<span class='notice'>You successfully remove [objects] objects from [H]'s [L.name].</span>")
+				display_results(user, target, "<span class='notice'>You successfully remove [objects] objects from [H]'s [L.name].</span>",
+					"[user] successfully removes [objects] objects from [H]'s [L]!",
+					"[user] successfully removes [objects] objects from [H]'s [L]!")
 			else
 				to_chat(user, "<span class='warning'>You find no objects embedded in [H]'s [L]!</span>")
 
 	else
 		to_chat(user, "<span class='warning'>You can't find [target]'s [parse_zone(user.zone_selected)], let alone any objects embedded in it!</span>")
-
 	return 1

--- a/code/modules/surgery/surgery_step.dm
+++ b/code/modules/surgery/surgery_step.dm
@@ -2,13 +2,12 @@
 	var/name
 	var/list/implements = list()	//format is path = probability of success. alternatively
 	var/implement_type = null		//the current type of implement used. This has to be stored, as the actual typepath of the tool may not match the list type.
-	var/accept_hand = 0				//does the surgery step require an open hand? If true, ignores implements. Compatible with accept_any_item.
-	var/accept_any_item = 0			//does the surgery step accept any item? If true, ignores implements. Compatible with require_hand.
+	var/accept_hand = FALSE				//does the surgery step require an open hand? If true, ignores implements. Compatible with accept_any_item.
+	var/accept_any_item = FALSE			//does the surgery step accept any item? If true, ignores implements. Compatible with require_hand.
 	var/time = 10					//how long does the step take?
-	var/repeatable = 0				//can this step be repeated? Make shure it isn't last step, or it used in surgery with `can_cancel = 1`. Or surgion will be stuck in the loop
+	var/repeatable = FALSE				//can this step be repeated? Make shure it isn't last step, or it used in surgery with `can_cancel = 1`. Or surgion will be stuck in the loop
 	var/list/chems_needed = list()  //list of chems needed to complete the step. Even on success, the step will have no effect if there aren't the chems required in the mob.
 	var/require_all_chems = TRUE    //any on the list or all on the list?
-
 /datum/surgery_step/proc/try_op(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
 	var/success = FALSE
 	if(accept_hand)
@@ -16,104 +15,87 @@
 			success = TRUE
 		if(iscyborg(user))
 			success = TRUE
-
 	if(accept_any_item)
 		if(tool && tool_check(user, tool))
 			success = TRUE
-
 	else if(tool)
 		for(var/key in implements)
 			var/match = FALSE
-
 			if(ispath(key) && istype(tool, key))
 				match = TRUE
 			else if(tool.tool_behaviour == key)
 				match = TRUE
-
 			if(match)
 				implement_type = key
 				if(tool_check(user, tool))
 					success = TRUE
 					break
-
 	if(success)
 		if(target_zone == surgery.location)
 			if(get_location_accessible(target, target_zone) || surgery.ignore_clothes)
-				initiate(user, target, target_zone, tool, surgery, try_to_fail)
-				return 1
+				return initiate(user, target, target_zone, tool, surgery, try_to_fail)
 			else
 				to_chat(user, "<span class='warning'>You need to expose [target]'s [parse_zone(target_zone)] to perform surgery on it!</span>")
-				return 1	//returns 1 so we don't stab the guy in the dick or wherever.
-
+				return TRUE	//returns TRUE so we don't stab the guy in the dick or wherever.
 	if(repeatable)
 		var/datum/surgery_step/next_step = surgery.get_surgery_next_step()
 		if(next_step)
 			surgery.status++
 			if(next_step.try_op(user, target, user.zone_selected, user.get_active_held_item(), surgery))
-				return 1
+				return TRUE
 			else
 				surgery.status--
-
-	if(iscyborg(user) && user.a_intent != INTENT_HARM) //to save asimov borgs a LOT of heartache
-		return 1
-
-	return 0
-
-
+	return FALSE
 /datum/surgery_step/proc/initiate(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery, try_to_fail = FALSE)
-	surgery.step_in_progress = 1
-
+	surgery.step_in_progress = TRUE
 	var/speed_mod = 1
-
+	var/advance = FALSE
 	if(preop(user, target, target_zone, tool, surgery) == -1)
-		surgery.step_in_progress = 0
-		return
-
+		surgery.step_in_progress = FALSE
+		return FALSE
 	if(tool)
 		speed_mod = tool.toolspeed
-
 	if(do_after(user, time * speed_mod, target = target))
-		var/advance = 0
 		var/prob_chance = 100
-
 		if(implement_type)	//this means it isn't a require hand or any item step.
 			prob_chance = implements[implement_type]
 		prob_chance *= surgery.get_propability_multiplier()
-
 		if((prob(prob_chance) || iscyborg(user)) && chem_check(target) && !try_to_fail)
 			if(success(user, target, target_zone, tool, surgery))
-				advance = 1
+				advance = TRUE
 		else
 			if(failure(user, target, target_zone, tool, surgery))
-				advance = 1
-
+				advance = TRUE
 		if(advance && !repeatable)
 			surgery.status++
 			if(surgery.status > surgery.steps.len)
 				surgery.complete()
-
-	surgery.step_in_progress = 0
+	surgery.step_in_progress = FALSE
+	return advance
 
 
 /datum/surgery_step/proc/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] begins to perform surgery on [target].", "<span class='notice'>You begin to perform surgery on [target]...</span>")
-
+	display_results(user, target, "<span class='notice'>You begin to perform surgery on [target]...</span>",
+		"[user] begins to perform surgery on [target].",
+		"[user] begins to perform surgery on [target].")
 
 /datum/surgery_step/proc/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] succeeds!", "<span class='notice'>You succeed.</span>")
-	return 1
+	display_results(user, target, "<span class='notice'>You succeed.</span>",
+		"[user] succeeds!",
+		"[user] finishes.")
+	return TRUE
 
 /datum/surgery_step/proc/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("<span class='warning'>[user] screws up!</span>", "<span class='warning'>You screw up!</span>")
-	return 0
+	display_results(user, target, "<span class='warning'>You screw up!</span>",
+		"<span class='warning'>[user] screws up!</span>",
+		"[user] finishes.", TRUE) //By default the patient will notice if the wrong thing has been cut
+	return FALSE
 
 /datum/surgery_step/proc/tool_check(mob/user, obj/item/tool)
-	return 1
-
+	return TRUE
 /datum/surgery_step/proc/chem_check(mob/living/carbon/target)
 	if(!LAZYLEN(chems_needed))
 		return TRUE
-
 	if(require_all_chems)
 		. = TRUE
 		for(var/R in chems_needed)
@@ -124,7 +106,6 @@
 		for(var/R in chems_needed)
 			if(target.reagents.has_reagent(R))
 				return TRUE
-
 /datum/surgery_step/proc/get_chem_list()
 	if(!LAZYLEN(chems_needed))
 		return
@@ -135,3 +116,11 @@
 			var/chemname = temp.name
 			chems += chemname
 	return english_list(chems, and_text = require_all_chems ? " and " : " or ")
+
+//Replaces visible_message during operations so only people looking over the surgeon can tell what they're doing, allowing for shenanigans.
+/datum/surgery_step/proc/display_results(mob/user, mob/living/carbon/target, self_message, detailed_message, vague_message, target_detailed = FALSE)
+	var/list/detailed_mobs = get_hearers_in_view(1, user) //Only the surgeon and people looking over his shoulder can see the operation clearly
+	if(!target_detailed)
+		detailed_mobs -= target //The patient can't see well what's going on, unless it's something like getting cut
+	user.visible_message(detailed_message, self_message, vision_distance = 1, ignored_mobs = target_detailed ? null : target)
+	user.visible_message(vague_message, "", ignored_mobs = detailed_mobs)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
* Port of https://github.com/tgstation/tgstation/pull/44483
fix of https://github.com/Citadel-Station-13/Citadel-Station-13/pull/8814 because im an idiot who deletes his fork

* Surgery now gives detailed description to the surgeon, and more vague or ambiguous descriptions to the patient and anyone further away. This can lead to a surgeon being able to perform a brainwashing in place of a brain surgery with nobody being the wiser, or implanting a different organ than the one agreed on, and so on.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
* Helps add on some extra paranoia to surgery, since everybody hates using N2O in a MRP server.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: Sishen1542, original by XDTM
add: Surgery steps are now shown in detail only to the surgeon and anyone standing adjacent to them; the patient and people watching from further away get a more vague/ambiguous description.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
