### PR TITLE
classic & telebaton no longer have attack delay

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -242,7 +242,7 @@
 	item_flags = NONE
 	force = 0
 	on = FALSE
-	cooldown = 0
+	total_mass = TOTAL_MASS_SMALL_ITEM
 
 /obj/item/melee/classic_baton/telescopic/suicide_act(mob/user)
 	var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -226,7 +226,7 @@
 				target.LAssailant = null
 			else
 				target.LAssailant = user
-			cooldown = world.time + 40
+			cooldown = world.time
 			user.adjustStaminaLossBuffered(getweight())//CIT CHANGE - makes swinging batons cost stamina
 
 /obj/item/melee/classic_baton/telescopic
@@ -242,7 +242,7 @@
 	item_flags = NONE
 	force = 0
 	on = FALSE
-	cooldown = 10
+	cooldown = 0
 
 /obj/item/melee/classic_baton/telescopic/suicide_act(mob/user)
 	var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -242,6 +242,7 @@
 	item_flags = NONE
 	force = 0
 	on = FALSE
+	cooldown = 10
 
 /obj/item/melee/classic_baton/telescopic/suicide_act(mob/user)
 	var/mob/living/carbon/human/H = user

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -242,7 +242,6 @@
 	item_flags = NONE
 	force = 0
 	on = FALSE
-	total_mass = TOTAL_MASS_SMALL_ITEM
 
 /obj/item/melee/classic_baton/telescopic/suicide_act(mob/user)
 	var/mob/living/carbon/human/H = user

--- a/modular_citadel/code/game/objects/items/melee/misc.dm
+++ b/modular_citadel/code/game/objects/items/melee/misc.dm
@@ -4,7 +4,7 @@
 	var/hardstun_ds = 1
 	var/softstun_ds = 0
 	var/stam_dmg = 30
-	cooldown = 20
+	cooldown = 0
 	total_mass = 3.75
 
 /obj/item/melee/classic_baton/attack(mob/living/target, mob/living/user)


### PR DESCRIPTION
what it says on the tin, can't just aggrograb someone batonning you effortlessly now
little slower than a stunbaton and still does less stam damage than one