### PR TITLE
[SUGGESTED TESTMERGE] Fixes rounding errors with chemical reactions

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -96,7 +96,7 @@
 	var/list/data = list()
 	for(var/r in reagent_list) //no reagents will be left behind
 		var/datum/reagent/R = r
-		data += "[R.id] ([round(R.volume, 0.1)]u)"
+		data += "[R.id] ([round(R.volume, CHEMICAL_QUANTISATION_LEVEL)]u)"
 		//Using IDs because SOME chemicals (I'm looking at you, chlorhydrate-beer) have the same names as other chemicals.
 	return english_list(data)
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1,3 +1,5 @@
+#define CHEMICAL_QUANTISATION_LEVEL 0.0001
+
 /proc/build_chemical_reagent_list()
 	//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
 
@@ -471,7 +473,7 @@
 					return 0
 
 				for(var/B in cached_required_reagents)
-					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), 0.01))
+					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), CHEMICAL_QUANTISATION_LEVEL))
 				for(var/P in selected_reaction.results)
 					targetVol = cached_results[P]*multiplier
 
@@ -498,7 +500,7 @@
 					return 0
 
 				for(var/B in cached_required_reagents) //
-					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), 0.01))
+					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), CHEMICAL_QUANTISATION_LEVEL))
 
 				for(var/B in cached_required_reagents)
 					remove_reagent(B, (multiplier * cached_required_reagents[B]), safety = 1, ignore_pH = TRUE)
@@ -646,8 +648,8 @@
 		addChemAmmount = deltaT * stepChemAmmount
 		if (addChemAmmount >= (targetVol - reactedVol))
 			addChemAmmount = (targetVol - reactedVol)
-		if (addChemAmmount < 0.01)
-			addChemAmmount = 0.01
+		if (addChemAmmount < CHEMICAL_QUANTISATION_LEVEL)
+			addChemAmmount = CHEMICAL_QUANTISATION_LEVEL
 		removeChemAmmount = (addChemAmmount/cached_results[P])
 		//This is kept for future bugtesters.
 		//message_admins("Reaction vars: PreReacted: [reactedVol] of [targetVol]. deltaT [deltaT], multiplier [multiplier], Step [stepChemAmmount], uncapped Step [deltaT*(multiplier*cached_results[P])], addChemAmmount [addChemAmmount], removeFactor [removeChemAmmount] Pfactor [cached_results[P]], adding [addChemAmmount]")
@@ -693,7 +695,7 @@
 
 	//Make sure things are limited.
 	pH = CLAMP(pH, 0, 14)
-	
+
 	//return said amount to compare for next step.
 	return (reactedVol)
 
@@ -739,7 +741,7 @@
 	total_volume = 0
 	for(var/reagent in cached_reagents)
 		var/datum/reagent/R = reagent
-		if(R.volume < 0.1)
+		if(R.volume < CHEMICAL_QUANTISATION_LEVEL)
 			del_reagent(R.id)
 		else
 			total_volume += R.volume
@@ -808,7 +810,7 @@
 	if(!isnum(amount) || !amount)
 		return FALSE
 
-	if(amount <= 0.00)
+	if(amount <= CHEMICAL_QUANTISATION_LEVEL)//To prevent small ammount problems.
 		return FALSE
 
 	var/datum/reagent/D = GLOB.chemical_reagents_list[reagent]
@@ -967,7 +969,7 @@
 			if(!amount)
 				return R
 			else
-				if(R.volume >= amount)
+				if(round(R.volume, CHEMICAL_QUANTISATION_LEVEL) >= amount)
 					return R
 				else
 					return 0
@@ -979,7 +981,7 @@
 	for(var/_reagent in cached_reagents)
 		var/datum/reagent/R = _reagent
 		if (R.id == reagent)
-			return R.volume
+			return round(R.volume, CHEMICAL_QUANTISATION_LEVEL)
 
 	return 0
 


### PR DESCRIPTION
## About The Pull Request

Chemical reactions before would auto delete if the reagents were below 0.1, now, they won't do that anymore until a limit of 0.0001. This will stop fermireactions from "airolating" (i.e. consuming reacts but no yield) as well as preventing small amounts of reactions from stop star reacting.

This incorporates:
https://github.com/tgstation/tgstation/pull/43135
https://github.com/tgstation/tgstation/pull/43027

without the scanner changes. This should affect liver processing on fine levels, (and may fix the current bug with Astrogen I'm trying to fix too, but that's beyond the scope of this PR, this fix is needed regardless of Astrogen's bug.)

I suggest a testmerge because I don't know the scope of these changes on the other reagent systems, from what I can tell, it shouldn't break other things, but it might break the rare macro for people who rely on small numbers to be auto deleted from the system.

## Why It's Good For The Game

Fixes a bug that confuses new players learning the fermireactions

## 
:cl: Fermis
fix: fixes fermichem reactions for tiny volumes work
tweaks: makes quantisation level for chemistry finer
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
