### PR TITLE
Spiders that spawn from player-laid eggs are now AI controlled.

### DIFF
--- a/code/game/objects/effects/spiders.dm
+++ b/code/game/objects/effects/spiders.dm
@@ -53,8 +53,6 @@
 	desc = "They seem to pulse slightly with an inner life."
 	icon_state = "eggs"
 	var/amount_grown = 0
-	var/player_spiders = 0
-	var/directive = "" //Message from the mother
 	var/poison_type = "toxin"
 	var/poison_per_bite = 5
 	var/list/faction = list("spiders")
@@ -74,9 +72,6 @@
 			S.poison_type = poison_type
 			S.poison_per_bite = poison_per_bite
 			S.faction = faction.Copy()
-			S.directive = directive
-			if(player_spiders)
-				S.player_spiders = 1
 		qdel(src)
 
 /obj/structure/spider/spiderling
@@ -198,7 +193,6 @@
 			S.poison_per_bite = poison_per_bite
 			S.poison_type = poison_type
 			S.faction = faction.Copy()
-			S.directive = directive
 			if(player_spiders)
 				S.playable_spider = TRUE
 				notify_ghosts("Spider [S.name] can be controlled", null, enter_link="<a href=?src=[REF(S)];activate=1>(Click to play)</a>", source=S, action=NOTIFY_ATTACK, ignore_key = POLL_IGNORE_SPIDER)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Spiders that spawn from player-laid eggs are now AI controlled, meaning that they are no longer ALSO player controlled.

## Why It's Good For The Game

Let's compare spiders to xenos in terms of balance when controlled by players.

| Point | Spiders | Xenomorphs |
| --- | --- | --- |
Breeding Method | Lay an egg in a monkey or a human, regardless of health, and you'll get ~10 spiderlings in a few minutes. | Lay a single egg in a conscious human to get one larvae. |
| Childhood | Scatter into vents at the speed of bullshit. Takes 3 hits with an object to kill. Turn into an adult instantly without warning. Since there is so many of you, there will ALWAYS be adults. | Sit inside a conscious human hoping they don't escape their bed. Pop out of them when it's time and then wait another x minutes to evolve while anything more powerful than a fart can kill you.
Speed | Lightning fucking fast. | Lightning fucking fast. |
Health | 200 god damn health | 125 health. |
Melee Damage | 15 to 20. Deals 60 damage to objects. | 25. Deals 60 damage to objects. |
Player Obtainment | Xenobiology Gold Core Slime RNG and Sentient Transfer Potion. Takes about 30-45 minutes to get if you know what you're doing. | Xenomorph Alien Hive raid + Surgery. Takes about 20-30 minutes to clear a dangerous Xeno Hive. Another 10-15 minutes to find and have someone do surgery for you to insert ALL the organs.
| Weaknesses | Lack of Air. | Fire. |

![image](https://user-images.githubusercontent.com/8602857/62841726-59bdbd00-bc60-11e9-819e-fa4e91471154.png)

Spiders are literally xenomorphs except better. Their numbers are absolutely insane compared to xenomorphs and that is because of this fundamental fact: Spiders are balanced around being controlled by an AI and not players who override their movement and attack speed. Antags can easily create situations by throwing a few corpses to the spiders and it then making a nest and making more spiders; that is the purpose of spiders. The balance did not anticipate that a player would preemptively hoard the maximum amount of monkeys and then turn themselves into a spider to then lay eggs in all the monkeys to create a near infinite stream of player-controlled spiders as long as there were salty players looking to murderbone.

You can still create bullshit spider armies, however they are not player controlled and do not have the benefits of being player controlled, which means that spiders are now balanced as they should be.

## Changelog
:cl: BurgerBB
balance: Spiders can no longer be ghost controlled if they're laid by players.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
