### PR TITLE
Removes wah! from message_admins

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -331,7 +331,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 
 		if(86)//mean clone time!
 			if (!M.reagents.has_reagent("pen_acid"))//Counterplay is pent.)
-				message_admins("(non-infectious) Zombie spawned at [M.loc], produced by impure chem, wah!")
+				message_admins("(non-infectious) SDZF: Zombie spawned at [M]!")
 				M.nutrition = startHunger - 500//YOU BEST BE RUNNING AWAY AFTER THIS YOU BADDIE
 				M.next_move_modifier = 1
 				to_chat(M, "<span class='warning'>Your body splits away from the cell clone of yourself, your attempted clone birthing itself violently from you as it begins to shamble around, a terrifying abomination of science.</span>")

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -331,7 +331,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 
 		if(86)//mean clone time!
 			if (!M.reagents.has_reagent("pen_acid"))//Counterplay is pent.)
-				message_admins("(non-infectious) SDZF: Zombie spawned at [M]!")
+				message_admins("(non-infectious) SDZF: Zombie spawned at [M] [COORD(M)]!")
 				M.nutrition = startHunger - 500//YOU BEST BE RUNNING AWAY AFTER THIS YOU BADDIE
 				M.next_move_modifier = 1
 				to_chat(M, "<span class='warning'>Your body splits away from the cell clone of yourself, your attempted clone birthing itself violently from you as it begins to shamble around, a terrifying abomination of science.</span>")


### PR DESCRIPTION
## About The Pull Request

I missed one, oops!

## Why It's Good For The Game

Makes message_admin language more neutral, and gives a better description of what is happening to admins.

## Fermis
:cl:
fix: fixes message_admins in SDZF
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
