### PR TITLE
Changes beforeShuttleMove on airlock to addtimer(0) rather than InvokeAsync

### DIFF
--- a/code/modules/shuttle/on_move.dm
+++ b/code/modules/shuttle/on_move.dm
@@ -179,7 +179,7 @@ All ShuttleMove procs go here
 	for(var/obj/machinery/door/airlock/A in range(1, src))  // includes src
 		A.shuttledocked = FALSE
 		A.air_tight = TRUE
-		INVOKE_ASYNC(A, /obj/machinery/door/.proc/close)
+		addtimer(CALLBACK(A, /obj/machinery/door/.proc/close), 0)
 
 /obj/machinery/door/airlock/afterShuttleMove(turf/oldT, list/movement_force, shuttle_dir, shuttle_preferred_direction, move_dir, rotation)
 	. = ..()


### PR DESCRIPTION
Emergency shuttle got chopped in half by a runtime caused by something moving during shuttle preflight_check(), this is the literal only thing that I see that can possibly be moving things. Better safe than sorry tbh.