### PR TITLE
Adds mining shuttle console to the techweb.

### DIFF
--- a/code/modules/research/designs/comp_board_designs/comp_board_designs_cargo .dm
+++ b/code/modules/research/designs/comp_board_designs/comp_board_designs_cargo .dm
@@ -34,7 +34,7 @@
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/board/mining
+/datum/design/board/miningshuttle
 	name = "Computer Design (Mining Shuttle Console)"
 	desc = "Allows for the construction of circuit boards used to build a Mining Shuttle Console."
 	id = "miningshuttle"

--- a/code/modules/research/designs/comp_board_designs/comp_board_designs_cargo .dm
+++ b/code/modules/research/designs/comp_board_designs/comp_board_designs_cargo .dm
@@ -33,3 +33,11 @@
 	build_path = /obj/item/circuitboard/computer/mining
 	category = list("Computer Boards")
 	departmental_flags = DEPARTMENTAL_FLAG_CARGO | DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/board/mining
+	name = "Computer Design (Mining Shuttle Console)"
+	desc = "Allows for the construction of circuit boards used to build a Mining Shuttle Console."
+	id = "miningshuttle"
+	build_path = /obj/item/circuitboard/computer/mining_shuttle
+	category = list("Computer Boards")
+	departmental_flags = DEPARTMENTAL_FLAG_CARGO

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -432,7 +432,7 @@
 	display_name = "Computer Consoles"
 	description = "Computers and how they work."
 	prereq_ids = list("datatheory")
-	design_ids = list("cargo", "cargorequest", "libraryconsole", "mining", "crewconsole", "rdcamera", "comconsole", "idcardconsole", "seccamera")
+	design_ids = list("cargo", "cargorequest", "libraryconsole", "mining", "miningshuttle", "crewconsole", "rdcamera", "comconsole", "idcardconsole", "seccamera")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
 	export_price = 5000
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Mining shuttle consoles will be able to be printed from the cargo techfab after computer consoles are researched.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It's incredibly easy to just deconstruct the shuttle consoles and then put the circuit board into an autolathe to destroy it, rendering mining completely compromised for the rest of the round, so this'll let you print replacements.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: mining shuttle console can now be printed after computer consoles have been researched
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
