### PR TITLE
Makes Testicle Full Message Be Arousal Dependent

### DIFF
--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -53,7 +53,7 @@
 		linked_organ = null
 
 /obj/item/organ/genital/testicles/proc/send_full_message(msg = "Your balls finally feel full, again.")
-	if(owner && istext(msg))
+	if(owner && istext(msg) && M.canbearoused)
 		to_chat(owner, msg)
 		return TRUE
 

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -53,7 +53,7 @@
 		linked_organ = null
 
 /obj/item/organ/genital/testicles/proc/send_full_message(msg = "Your balls finally feel full, again.")
-	if(owner && istext(msg) && M.canbearoused)
+	if(owner && istext(msg))
 		to_chat(owner, msg)
 		return TRUE
 


### PR DESCRIPTION
#8877  About The Pull Request

Makes testicles being full need to check arousal.

## Why It's Good For The Game

Makes it so that the non-functional testicles of someone who has arousal off not make the user aware of the full or not full status.

## Changelog
:cl:
tweak: tweaked a few things
/:cl:
