### PR TITLE
Service QoL

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -498,6 +498,23 @@ Code:
 				else
 					menu += "[ldat]"
 
+				menu += "<h4>Pimpin' Ride:</h4>"
+
+				ldat = null
+				for (var/obj/vehicle/ridden/janicart/M in world)
+					var/turf/ml = get_turf(M)
+
+					if(ml)
+						if (ml.z != cl.z)
+							continue
+						var/direction = get_dir(src, M)
+						ldat += "Ride - <b>\[[ml.x],[ml.y] ([uppertext(dir2text(direction))])\]</b><br>"
+
+				if (!ldat)
+					menu += "None"
+				else
+					menu += "[ldat]"
+
 				menu += "<h4>Located Janitorial Cart:</h4>"
 
 				ldat = null

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -524,12 +524,15 @@
 		/obj/item/grenade/chem_grenade,
 		/obj/item/lightreplacer,
 		/obj/item/flashlight,
+		/obj/item/reagent_containers/glass/beaker,
+		/obj/item/reagent_containers/glass/bottle,
 		/obj/item/reagent_containers/spray,
 		/obj/item/soap,
 		/obj/item/holosign_creator,
 		/obj/item/key/janitor,
 		/obj/item/clothing/gloves,
 		/obj/item/melee/flyswatter,
+		/obj/item/paint/paint_remover,
 		/obj/item/assembly/mousetrap
 		))
 

--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -1699,7 +1699,7 @@
 /datum/supply_pack/service/janitor/janpremium
 	name = "Janitor Premium Supplies"
 	desc = "Do to the union for better supplies, we have desided to make a deal for you, In this crate you can get a brand new chem, Drying Angent this stuff is the work of slimes or magic! This crate also contains a rag to test out the Drying Angent magic, three wet floor signs, and some spare bottles of ammonia."
-	cost = 3000
+	cost = 1750
 	access = ACCESS_JANITOR
 	contains = list(/obj/item/caution,
 					/obj/item/caution,
@@ -1707,8 +1707,19 @@
 					/obj/item/reagent_containers/rag,
 					/obj/item/reagent_containers/glass/bottle/ammonia,
 					/obj/item/reagent_containers/glass/bottle/ammonia,
+					/obj/item/reagent_containers/glass/bottle/ammonia,
 					/obj/item/reagent_containers/spray/drying_agent)
 	crate_name = "janitor backpack crate"
+
+/datum/supply_pack/service/janitor/janpimp
+	name = "Custodial Cruiser"
+	desc = "Clown steal your ride? Assistant lock it in the dorms? Order a new one and get back to cleaning in style!"
+	cost = 3000
+	access = ACCESS_JANITOR
+	contains = list(/obj/vehicle/ridden/janicart,
+					/obj/item/key/janitor)
+	crate_name = "janitor ride crate"
+	crate_type = /obj/structure/closet/crate/large
 
 /datum/supply_pack/service/mule
 	name = "MULEbot Crate"

--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -69,6 +69,8 @@
 	if(default_deconstruction_screwdriver(user, "dnamod", "dnamod", I))
 		update_icon()
 		return
+	else if(default_unfasten_wrench(user, I))
+		return
 	if(default_deconstruction_crowbar(I))
 		return
 	if(iscyborg(user))

--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -290,6 +290,16 @@
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
 
+/datum/design/light_replacer
+	name = "Light Replacer"
+	desc = "A device to automatically replace lights. Refill with working light bulbs."
+	id = "light_replacer"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 1500, MAT_SILVER = 150, MAT_GLASS = 3000)
+	build_path = /obj/item/lightreplacer
+	category = list("Equipment")
+	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
+
 /datum/design/blutrash
 	name = "Trashbag of Holding"
 	desc = "An advanced trash bag with bluespace properties; capable of holding a plethora of garbage."

--- a/code/modules/research/designs/power_designs.dm
+++ b/code/modules/research/designs/power_designs.dm
@@ -57,16 +57,6 @@
 	category = list("Misc","Power Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_SCIENCE | DEPARTMENTAL_FLAG_ENGINEERING
 
-/datum/design/light_replacer
-	name = "Light Replacer"
-	desc = "A device to automatically replace lights. Refill with working light bulbs."
-	id = "light_replacer"
-	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 1500, MAT_SILVER = 150, MAT_GLASS = 3000)
-	build_path = /obj/item/lightreplacer
-	category = list("Power Designs")
-	departmental_flags = DEPARTMENTAL_FLAG_SERVICE
-
 /datum/design/inducer
 	name = "Inducer"
 	desc = "The NT-75 Electromagnetic Power Inducer can wirelessly induce electric charge in an object, allowing you to recharge power cells without having to remove them."


### PR DESCRIPTION
**About The Pull Request**

-Adds the Pimpin' Ride to the Custodial Locator Cartridge.
-Makes additional Pimpin' Rides orderable through cargo.
-Moves Light Replacer from power_designs to misc_designs and properly places it in equipment (where all other advanced sanitation research items appear.)
-Reduces Cost for Janitor Premium Supplies, and adds an additional bottle of ammonia. (Personally I still feel it's overpriced.)
-Makes plant DNA manipulator unwrenchable.
-Adds a few additional items to the janibelt whitelist due to its limited usefulness/item pool.

**Why It's Good For The Game**

I've had the Janicart get lost on several occasions, either from someone stealing it, it getting pushed down the hall, or the roundstart janitor hiding it somewhere, going SSD, and nobody can find it. This allows janitors to A, locate their ride, and B. Order additional rides in case the first one is destroyed, spaced, or a second janitor wishes to have one.

The Light Replacer was the only janitorial equipment -not- listed under equipment. It also makes no sense for it to be in power designs. The janibelt had a limited amount of usefulness, as you could carry the items needed for your work in your pockets. Being able to store more bottles/beakers of space cleaner, water, or ammonia (as well as the paint remover) makes it more attractive to bring the belt along.

The DNA manipulator change is a QoL improvement for botanists as they no longer need to deconstruct/reconstruct it in order to move it.

## Changelog
:cl:
add: custodial cruiser cargo crate
tweak: removed light replacer from power designs and moved to misc designs
tweak: added pimpin ride to custodial locator
tweak: added additional items to janibelt whitelist
tweak: made plant DNA manipulator unwrenchable
balance: reduced janitor premium supply costs
/:cl:
