### PR TITLE
Prevents runtime spam from Hugs of the North Star

### DIFF
--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -65,6 +65,9 @@
 	var/warcry = "AT"
 
 /obj/item/clothing/gloves/rapid/Touch(mob/living/target,proximity = TRUE)
+	if(!istype(target))
+		return
+
 	var/mob/living/M = loc
 
 	if(M.a_intent == INTENT_HARM)
@@ -87,6 +90,9 @@
 	warcry = "owo" //Shouldn't ever come into play
 
 /obj/item/clothing/gloves/rapid/hug/Touch(mob/living/target,proximity = TRUE)
+	if(!istype(target))
+		return
+
 	var/mob/living/M = loc
 
 	if(M.a_intent == INTENT_HELP)


### PR DESCRIPTION
Also fixes an unintended oversight of the Gloves of the North Star, with them causing the warcry upon picking up any item or clicking on any item/floor/etc. in harm intent.
