### PR TITLE
Increase the amount of canned peaches that spawn within maintenance

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/storage/toolbox/artistic = 2,
 	/obj/item/toy/eightball = 1,
 	/obj/item/reagent_containers/pill/floorpill = 1,
-	/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 1,
+	/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 2,
 	/obj/item/storage/daki = 3, //VERY IMPORTANT CIT CHANGE - adds bodypillows to maint
 	/obj/item/storage/pill_bottle/penis_enlargement = 2,
 	/obj/item/storage/pill_bottle/breast_enlargement = 2,

--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -107,7 +107,7 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/storage/toolbox/artistic = 2,
 	/obj/item/toy/eightball = 1,
 	/obj/item/reagent_containers/pill/floorpill = 1,
-	/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 2,
+	/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 1,
 	/obj/item/storage/daki = 3, //VERY IMPORTANT CIT CHANGE - adds bodypillows to maint
 	/obj/item/storage/pill_bottle/penis_enlargement = 2,
 	/obj/item/storage/pill_bottle/breast_enlargement = 2,


### PR DESCRIPTION
## About The Pull Request
Maintenance_Loot.dm, Line 110:
/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 1
to
/obj/item/reagent_containers/food/snacks/cannedpeaches/maint = 2

## Why It's Good For The Game
A simple request to make peach juice more accessible, this change is to simply double the amount of peach cans that can spawn within maintenance. The peach juice from a single can only provides enough to make a single glass of 'blazaam'.

## Changelog
:cl:
tweak: Doubled peach spawn rate
/:cl: