### PR TITLE
addition of the "assistant response team" a pack of assistants sent in from CComm

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -9840,7 +9840,7 @@
 	id = "XCCFerry";
 	name = "Hanger Bay Shutters";
 	pixel_y = 24;
-	req_access_txt = "2"
+	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5

--- a/code/datums/ert.dm
+++ b/code/datums/ert.dm
@@ -55,3 +55,13 @@
 	rename_team = "Inquisition"
 	mission = "Destroy any traces of paranormal activity aboard the station."
 	polldesc = "a Nanotrasen paranormal response team"
+
+/datum/ert/greybois
+	code = "Green"
+	teamsize = 1
+	opendoors = FALSE
+	enforce_human = FALSE
+	roles = /datum/antagonist/greybois
+	leader_role = /datum/antagonist/greybois/greygod
+	rename_team = "Emergency Assistants"
+	polldesc = "an Emergency Assistant"

--- a/code/modules/antagonists/greybois/greybois.dm
+++ b/code/modules/antagonists/greybois/greybois.dm
@@ -1,0 +1,23 @@
+/datum/antagonist/greybois
+	name = "Emergency Assistant"
+	show_name_in_check_antagonists = TRUE
+	show_in_antagpanel = FALSE
+	var/mission = "Assist the station."
+	var/datum/outfit/outfit = /datum/outfit/ert/greybois
+
+/datum/antagonist/greybois/greygod
+	outfit = /datum/outfit/ert/greybois/greygod
+
+/datum/antagonist/greybois/greet()
+	to_chat(owner, "<B><font size=3 color=red>You are an Emergency Assistant.</font></B>")
+	to_chat(owner, "Central Command is sending you to [station_name()] with the task: [mission]")
+
+/datum/antagonist/greybois/on_gain()
+	equipERT()
+	. = ..()
+
+/datum/antagonist/greybois/proc/equipERT()
+	var/mob/living/carbon/human/H = owner.current
+	if(!istype(H))
+		return
+	H.equipOutfit(outfit)

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -163,6 +163,33 @@
 		/obj/item/gun/energy/pulse/pistol/loyalpin=1,\
 		/obj/item/construction/rcd/combat=1)
 
+/datum/outfit/ert/greybois
+	name = "Emergency Assistant"
+
+	uniform = /obj/item/clothing/under/color/grey/glorf
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	gloves = /obj/item/clothing/gloves/color/fyellow
+	ears = /obj/item/radio/headset
+	head = /obj/item/clothing/head/soft/grey
+	belt = /obj/item/storage/belt/utility/full
+	back = /obj/item/storage/backpack
+	mask = /obj/item/clothing/mask/gas
+	l_pocket = /obj/item/tank/internals/emergency_oxygen
+	l_hand = /obj/item/storage/toolbox/emergency/old
+	id = /obj/item/card/id
+
+/datum/outfit/ert/greybois/greygod
+	suit = /obj/item/clothing/suit/hazardvest
+	l_hand = /obj/item/storage/toolbox/plastitanium
+
+/datum/outfit/ert/greybois/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
+	if(visualsOnly)
+		return
+	var/obj/item/card/id/W = H.wear_id
+	W.registered_name = H.real_name
+	W.assignment = "Assistant"
+	W.access = list(ACCESS_MAINT_TUNNELS,ACCESS_CENT_GENERAL)
+	W.update_label(W.registered_name, W.assignment)
 
 /datum/outfit/centcom_official
 	name = "CentCom Official"

--- a/code/modules/clothing/outfits/ert.dm
+++ b/code/modules/clothing/outfits/ert.dm
@@ -181,6 +181,7 @@
 /datum/outfit/ert/greybois/greygod
 	suit = /obj/item/clothing/suit/hazardvest
 	l_hand = /obj/item/storage/toolbox/plastitanium
+	gloves = /obj/item/clothing/gloves/color/yellow
 
 /datum/outfit/ert/greybois/post_equip(mob/living/carbon/human/H, visualsOnly = FALSE)
 	if(visualsOnly)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -1279,6 +1279,7 @@
 #include "code\modules\antagonists\disease\disease_mob.dm"
 #include "code\modules\antagonists\ert\ert.dm"
 #include "code\modules\antagonists\greentext\greentext.dm"
+#include "code\modules\antagonists\greybois\greybois.dm"
 #include "code\modules\antagonists\highlander\highlander.dm"
 #include "code\modules\antagonists\monkey\monkey.dm"
 #include "code\modules\antagonists\morph\morph.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Basically just an assistant ERT for the memes. Comes equipped with a full toolbelt, budget insuls and an emergency toolbox.
Leader gets a plastitanium toolbox and actual insuls.

also fixed up access on the centcom hangar button
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Just a funny tool for admins to use when they want to send in assistance, but not full on pulse rifle/ERT gear.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: added in the assistant response team
fix: fixed up access on the centcom hangar button
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
