### PR TITLE
Applies THICCness to security armor and hats

### DIFF
--- a/code/modules/clothing/head/helmet.dm
+++ b/code/modules/clothing/head/helmet.dm
@@ -13,6 +13,7 @@
 	resistance_flags = NONE
 	flags_cover = HEADCOVERSEYES
 	flags_inv = HIDEHAIR
+	clothing_flags = THICKMATERIAL
 
 	dog_fashion = /datum/dog_fashion/head/helmet
 

--- a/code/modules/clothing/head/jobs.dm
+++ b/code/modules/clothing/head/jobs.dm
@@ -31,6 +31,7 @@
 	icon_state = "captain"
 	item_state = "that"
 	flags_inv = 0
+	clothing_flags = THICKMATERIAL
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	strip_delay = 60
 	dog_fashion = /datum/dog_fashion/head/captain
@@ -134,6 +135,7 @@
 	desc = "The robust standard-issue cap of the Head of Security. For showing the officers who's in charge."
 	icon_state = "hoscap"
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 25, "energy" = 10, "bomb" = 25, "bio" = 10, "rad" = 0, "fire" = 50, "acid" = 60)
+	clothing_flags = THICKMATERIAL
 	strip_delay = 80
 	dynamic_hair_suffix = ""
 
@@ -156,6 +158,7 @@
 	icon_state = "policehelm"
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 30, "energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 30, "acid" = 60)
 	strip_delay = 60
+	clothing_flags = THICKMATERIAL
 	dog_fashion = /datum/dog_fashion/head/warden
 
 /obj/item/clothing/head/warden/drill
@@ -231,6 +234,7 @@
 	icon_state = "beret_badge"
 	armor = list("melee" = 40, "bullet" = 30, "laser" = 30,"energy" = 10, "bomb" = 25, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 	strip_delay = 60
+	clothing_flags = THICKMATERIAL
 	dog_fashion = null
 
 /obj/item/clothing/head/beret/sec/navyhos

--- a/code/modules/clothing/suits/armor.dm
+++ b/code/modules/clothing/suits/armor.dm
@@ -1,5 +1,6 @@
 /obj/item/clothing/suit/armor
 	allowed = null
+	clothing_flags = THICKMATERIAL
 	body_parts_covered = CHEST
 	cold_protection = CHEST|GROIN
 	min_cold_protection_temperature = ARMOR_MIN_TEMP_PROTECT


### PR DESCRIPTION
## About The Pull Request

adds THICKMATERIAL flags to security/captain armor and helmets/hats. 

## Why It's Good For The Game

Chem warfare meta is boring, also something able to stop bullets not being able to stop a generic syringe is kinda stupid. You'll need to do the same procedure as hardsuits to apply heals anyway.

This flag is only applied to coverage areas, so if you're using a generic vest, you can still be tagged in the arms and legs, for example.

## Changelog
:cl: Poojawa
balance: Security gear has been issued with real Kevlar now, able to resist your average medbay syringes
/:cl:
