### PR TITLE
Adds looc hotkey - on examination, just makes it better

### DIFF
--- a/code/controllers/subsystem/input.dm
+++ b/code/controllers/subsystem/input.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(input)
 // This is for when macro sets are eventualy datumized
 /datum/controller/subsystem/input/proc/setup_default_macro_sets()
 	var/list/static/default_macro_sets
-	
+
 	if(default_macro_sets)
 		macro_sets = default_macro_sets
 		return
@@ -49,6 +49,7 @@ SUBSYSTEM_DEF(input)
 		"old_hotkeys" = list(
 			"Tab" = "\".winset \\\"mainwindow.macro=old_default input.focus=true input.background-color=[COLOR_INPUT_ENABLED]\\\"\"",
 			"O" = "ooc",
+			"L" = "looc",
 			"T" = "say",
 			"M" = "me",
 			"Back" = "\".winset \\\"input.text=\\\"\\\"\\\"\"", // This makes it so backspace can remove default inputs


### PR DESCRIPTION
## About The Pull Request

Makes an looc hotkey, L.
## Why It's Good For The Game

Because it's infuriating that we have ooc hotkey and not looc hotkey.
On further examination, we do, it's control + o, but it doesn't work without pressing a button first, and this is much easier.

## Changelog
:cl:
add: Added looc hotkey
/:cl:
