### PR TITLE
[TESTMERGE ONLY] Ninja Rebalancing - Sleeping Carp, Cooldowns, Netting, oh my.

### DIFF
--- a/code/modules/antagonists/ninja/ninja.dm
+++ b/code/modules/antagonists/ninja/ninja.dm
@@ -22,6 +22,8 @@
 	update_ninja_icons_removed(M)
 
 /datum/antagonist/ninja/proc/equip_space_ninja(mob/living/carbon/human/H = owner.current)
+	var/datum/martial_art/the_sleeping_carp/ninja = new
+	ninja.teach(H)
 	return H.equipOutfit(/datum/outfit/ninja)
 
 /datum/antagonist/ninja/proc/addMemories()

--- a/code/modules/ninja/energy_katana.dm
+++ b/code/modules/ninja/energy_katana.dm
@@ -102,5 +102,5 @@
 /datum/action/innate/dash/ninja
 	current_charges = 3
 	max_charges = 3
-	charge_rate = 30
+	charge_rate = 60
 	recharge_sound = null

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -44,12 +44,6 @@ It is possible to destroy the net by the occupant or someone else.
 		qdel(src)//Get rid of the net.
 		return
 
-	if(ishuman(affecting))
-		var/mob/living/carbon/human/M = affecting
-		if(M.staminaloss <= 99 || M.stat != UNCONSCIOUS)
-			qdel(src)
-			return
-
 	if(check>0)
 		check--
 		return

--- a/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/energy_net_nets.dm
@@ -44,6 +44,12 @@ It is possible to destroy the net by the occupant or someone else.
 		qdel(src)//Get rid of the net.
 		return
 
+	if(ishuman(affecting))
+		var/mob/living/carbon/human/M = affecting
+		if(M.staminaloss <= 99 || M.stat != UNCONSCIOUS)
+			qdel(src)
+			return
+
 	if(check>0)
 		check--
 		return

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_net.dm
@@ -24,6 +24,10 @@
 	else
 		C = input("Select who to capture:","Capture who?",null) as null|mob in candidates
 
+	if(ishuman(C))
+		var/mob/living/carbon/human/M = C
+		if(M.staminaloss <= 99 && M.stat != UNCONSCIOUS)
+			return FALSE
 
 	if(QDELETED(C)||!(C in oview(H)))
 		return FALSE


### PR DESCRIPTION
Ninjas now spawn with Sleeping Carp. To compensate for this, the cooldown of their sword's dash ability has been increased, and the energy net has been changed/fixed to only affect people who are unconscious, IE critted or sleeping; or stamcritted, to account for being incapacitated by a baton or other method.

This should adjust the current meta of security using shotguns against nearly any threat against them, while also removing the current meta of ninjas grabbing a bag of holding and solely relying on ranged weapons and instant-stuns instead of their abilities and melee combat. Testmerge only for now, until more data can be gathered on whether this is a good change or not.

:cl: Chayse
balance: Gives Ninjas the ability to use Sleeping Carp at the cost of ranged weapon usage
balance: Increases the cooldown on the Energy Katana's dash ability
fix: Energy nets now no longer work on people who are not incapacitated or stamcritted, as originally intended.
/:cl: