### PR TITLE
Fixes gang bosses being able to be deconverted with headbeatings, Adds 1 more boss slot

### DIFF
--- a/code/__DEFINES/antagonists.dm
+++ b/code/__DEFINES/antagonists.dm
@@ -38,5 +38,5 @@
 
 //Gangshit
 #define NOT_DOMINATING			-1
-#define MAX_LEADERS_GANG		3
+#define MAX_LEADERS_GANG		4
 #define INITIAL_DOM_ATTEMPTS	3

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1696,7 +1696,7 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 
 					if(H.stat == CONSCIOUS && H != user && prob(I.force + ((100 - H.health) * 0.5))) // rev deconversion through blunt trauma.
 						var/datum/antagonist/rev/rev = H.mind.has_antag_datum(/datum/antagonist/rev)
-						var/datum/antagonist/gang/gang = H.mind.has_antag_datum(/datum/antagonist/gang/)
+						var/datum/antagonist/gang/gang = H.mind.has_antag_datum(/datum/antagonist/gang && !/datum/antagonist/gang/boss)
 						if(rev)
 							rev.remove_revolutionary(FALSE, user)
 						if(gang)


### PR DESCRIPTION
## About The Pull Request

Fixes gang bosses being able to be deconverted with headbeatings, Adds 1 more boss slot

## Why It's Good For The Game

One was a bug, and people apparently have issues getting equipment.

## Changelog
:cl:JTGSZ
tweak: Added one more gang boss slot bringing total to 4 from 3
fix: Fixed Gang Boss being able to be deconverted
/:cl:
