### PR TITLE
grants poly the ability to automatically speak through the TGS relay (with a 0.01% chance)

### DIFF
--- a/code/modules/mob/living/simple_animal/parrot.dm
+++ b/code/modules/mob/living/simple_animal/parrot.dm
@@ -897,6 +897,11 @@
 
 	. = ..()
 
+/mob/living/simple_animal/parrot/Poly/say(message, bubble_type,var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
+	. = ..()
+	if(. && !client && prob(1) && prob(1)) //Only the one true bird may speak across dimensions.
+		world.TgsTargetedChatBroadcast("A stray squawk is heard... \"[message]\"", FALSE)
+
 /mob/living/simple_animal/parrot/Poly/Life()
 	if(!stat && SSticker.current_state == GAME_STATE_FINISHED && !memory_saved)
 		Write_Memory(FALSE)


### PR DESCRIPTION
Does this need a justification?

## Changelog
:cl: Bhijn
add: Poly now has a 0.01% chance per squawk to speak through the TGS relay.
/:cl:
