### PR TITLE
Removes an obnoxious temporary overlay var.

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -702,7 +702,7 @@
 		clear_fullscreen("critvision")
 
 	//Oxygen damage overlay
-	var/windedup = getOxyLoss() + getStaminaLoss() * 0.2 + stamdamageoverlaytemp
+	var/windedup = getOxyLoss() + getStaminaLoss() * 0.2
 	if(windedup)
 		var/severity = 0
 		switch(windedup)

--- a/code/modules/mob/living/carbon/carbon_defines.dm
+++ b/code/modules/mob/living/carbon/carbon_defines.dm
@@ -61,6 +61,5 @@
 	var/next_hallucination = 0
 	var/cpr_time = 1 //CPR cooldown.
 	var/damageoverlaytemp = 0
-	var/stamdamageoverlaytemp = 0
 
 	var/drunkenness = 0 //Overall drunkenness - check handle_alcohol() in life.dm for effects

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1781,7 +1781,6 @@ GLOBAL_LIST_EMPTY(roundstart_races)
 		if(CLONE)
 			H.adjustCloneLoss(damage * hit_percent * H.physiology.clone_mod)
 		if(STAMINA)
-			H.stamdamageoverlaytemp = 20
 			if(BP)
 				if(damage > 0 ? BP.receive_damage(0, 0, damage * hit_percent * H.physiology.stamina_mod) : BP.heal_damage(0, 0, abs(damage * hit_percent * H.physiology.stamina_mod), only_robotic = FALSE, only_organic = FALSE))
 					H.update_stamina()

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -4,9 +4,8 @@
 	if(notransform)
 		return
 
-	if(damageoverlaytemp || stamdamageoverlaytemp)
+	if(damageoverlaytemp)
 		damageoverlaytemp = 0
-		stamdamageoverlaytemp = 0
 		update_damage_hud()
 
 	if(stat != DEAD) //Reagent processing needs to come before breathing, to prevent edge cases.


### PR DESCRIPTION
## About The Pull Request
Resolves the issue brought up by Kevinz on #9055.
The idea of replicating the idea of replicating the tempdamageoverlay var but for stamina turned out lame, I understimated how much apply_damage() was extensively used even for the slightiest actions of **the stamcombat feature**, and that niche inconspicious STAMINA dam_type toolbox is not really a big deal anyway as melee weapons takes stamina to use due to **the stamcombat feature**.

## Why It's Good For The Game
Resolves the obnoxiousness of my older "Makes staminaloss also apply the oxyloss fullscreen overlay." PR.

## Changelog
:cl:
del: Removes an obnoxious temporary overlay var.
/:cl:
