### PR TITLE
Fixes katana's being cursed when not cursed

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -229,7 +229,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 /obj/item/katana/cursed
 	slot_flags = null
 
-/obj/item/katana/Initialize()
+/obj/item/katana/cursed/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, CURSED_ITEM_TRAIT)
 


### PR DESCRIPTION
## About The Pull Request

Fixes katana's being no drop and cursed when not meant to be.
Also fixes them being stuck onto belt

## Why It's Good For The Game

Bug fixing, this was not me for once!

## Changelog
:cl:
fix: /cursed from a item path
/:cl: