### PR TITLE
Fixes "Silver Core Luminescents Can Spawn "Oops" #9215"

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1487,6 +1487,7 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 		/obj/item/reagent_containers/food/snacks/grown/nettle, // base type
 		/obj/item/reagent_containers/food/snacks/deepfryholder,
 		/obj/item/reagent_containers/food/snacks/grown/shell,
+		/obj/item/reagent_containers/food/snacks/clothing,
 		/obj/item/reagent_containers/food/snacks/store/bread
 		)
 	blocked |= typesof(/obj/item/reagent_containers/food/snacks/customizable)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Blacklists clothing from random food proc

## Why It's Good For The Game
bug crushed!

## Changelog
:cl:
fix: oops not being blacklisted
/:cl: