### PR TITLE
Allows Furranium grown from organic sources.

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -382,6 +382,9 @@
 	FermiChem 		= TRUE
 	PurityMin		= 0.3
 
+/datum/chemical_reaction/fermi/furranium/organic
+	required_reagents = list("aphro" = 0.1, "catnip" = 0.1, "silver" = 0.2, "salglu_solution" = 0.1)
+
 //FOR INSTANT REACTIONS - DO NOT MULTIPLY LIMIT BY 10.
 //There's a weird rounding error or something ugh.
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

**Requires #9109 !!!**
Adds an alternative reaction for furranium, which uses catnip from #9109 instead of moonsugar.

## Why It's Good For The Game

Moonsugar is described in game as synthetic catnip, it stands to reason that organically grown catnip would work in the reaction as well.

## Changelog
tweak: Furranium now uses catnip or moonsugar
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
