### PR TITLE
adds some new nullrods with some back end null rod refactors

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -68,6 +68,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/strip_delay = 40 //In deciseconds, how long an item takes to remove from another person
 	var/breakouttime = 0
 	var/list/materials
+	var/reskinned = FALSE
 
 	var/list/attack_verb //Used in attackby() to say how something was attacked "[x] has been [z.attack_verb] by [y] with [z]"
 	var/list/species_exception = null	// list() of species types, if a species cannot put items in a certain slot, but species type is in list, it will be able to wear that item

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -32,6 +32,19 @@
 	var/datum/integrated_io/selected_io = null  //functional for integrated circuits.
 	var/mode = 0
 
+/obj/item/multitool/chaplain
+	name = "\improper hypertool"
+	desc = "Used for pulsing wires to test which to cut. Seems to cause massive brain damage in certain targets."
+	damtype = BRAIN
+	force = 18
+	armour_penetration = 35
+	hitsound = 'sound/effects/sparks4.ogg'
+	var/chaplain_spawnable = TRUE
+
+/obj/item/multitool/chaplain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
 /obj/item/multitool/examine(mob/user)
 	..()
 	if(selected_io)

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -34,13 +34,17 @@
 
 /obj/item/multitool/chaplain
 	name = "\improper hypertool"
-	desc = "Used for pulsing wires to test which to cut. Seems to cause massive brain damage in certain targets."
+	desc = "Used for pulsing wires to test which to cut. Also emits microwaves to fry some brains!"
 	damtype = BRAIN
 	force = 18
 	armour_penetration = 35
 	hitsound = 'sound/effects/sparks4.ogg'
 	var/chaplain_spawnable = TRUE
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	throw_speed = 3
+	throw_range = 4
+	throwforce = 10
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/multitool/chaplain/Initialize()
 	. = ..()

--- a/code/game/objects/items/devices/multitool.dm
+++ b/code/game/objects/items/devices/multitool.dm
@@ -40,6 +40,7 @@
 	armour_penetration = 35
 	hitsound = 'sound/effects/sparks4.ogg'
 	var/chaplain_spawnable = TRUE
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 
 /obj/item/multitool/chaplain/Initialize()
 	. = ..()

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -275,6 +275,13 @@
 		qdel(src)
 		M.put_in_active_hand(holy_weapon)
 
+/obj/item/nullrod/proc/jedi_spin(mob/living/user)
+	for(var/i in list(NORTH,SOUTH,EAST,WEST,EAST,SOUTH,NORTH,SOUTH,EAST,WEST,EAST,SOUTH))
+		user.setDir(i)
+		if(i == WEST)
+			user.emote("flip")
+		sleep(1)
+
 /obj/item/nullrod/godhand
 	icon_state = "disintegrate"
 	item_state = "disintegrate"
@@ -661,6 +668,44 @@
 	item_state = "bostaff0"
 	lefthand_file = 'icons/mob/inhands/weapons/staves_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/staves_righthand.dmi'
+
+/obj/item/nullrod/claymore/bostaff/attack(mob/target, mob/living/user)
+	add_fingerprint(user)
+	if((HAS_TRAIT(user, TRAIT_CLUMSY)) && prob(50))
+		to_chat(user, "<span class ='warning'>You club yourself over the head with [src].</span>")
+		user.Knockdown(60)
+		if(ishuman(user))
+			var/mob/living/carbon/human/H = user
+			H.apply_damage(2*force, BRUTE, BODY_ZONE_HEAD)
+		else
+			user.take_bodypart_damage(2*force)
+		return
+	if(iscyborg(target))
+		return ..()
+	if(!isliving(target))
+		return ..()
+	var/mob/living/carbon/C = target
+	if(C.stat || C.health < 0 || C.staminaloss > 130 )
+		to_chat(user, "<span class='warning'>It would be dishonorable to attack a foe while they cannot retaliate.</span>")
+		return
+	if(user.a_intent == INTENT_DISARM)
+		if(!ishuman(target))
+			return ..()
+		var/mob/living/carbon/human/H = target
+		var/list/fluffmessages = list("[user] clubs [H] with [src]!", \
+									  "[user] smacks [H] with the butt of [src]!", \
+									  "[user] broadsides [H] with [src]!", \
+									  "[user] smashes [H]'s head with [src]!", \
+									  "[user] beats [H] with front of [src]!", \
+									  "[user] twirls and slams [H] with [src]!")
+		H.visible_message("<span class='warning'>[pick(fluffmessages)]</span>", \
+							   "<span class='userdanger'>[pick(fluffmessages)]</span>")
+		playsound(get_turf(user), 'sound/effects/woodhit.ogg', 75, 1, -1)
+		H.adjustStaminaLoss(rand(12,18))
+		if(prob(25))
+			(INVOKE_ASYNC(src, .proc/jedi_spin, user))
+	else
+		return ..()
 
 /obj/item/nullrod/tribal_knife
 	icon_state = "crysknife"

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -229,7 +229,6 @@
 	throwforce = 10
 	w_class = WEIGHT_CLASS_TINY
 	obj_flags = UNIQUE_RENAME
-	var/reskinned = FALSE
 	var/chaplain_spawnable = TRUE
 
 /obj/item/nullrod/Initialize()
@@ -247,9 +246,10 @@
 /obj/item/nullrod/proc/reskin_holy_weapon(mob/M)
 	if(GLOB.holy_weapon_type)
 		return
-	var/obj/item/nullrod/holy_weapon
+	var/obj/item/holy_weapon
 	var/list/holy_weapons_list = typesof(/obj/item/nullrod) + list(
-	/obj/item/melee/transforming/energy/sword/cx/chaplain
+	/obj/item/melee/transforming/energy/sword/cx/chaplain,
+	/obj/item/gun/energy/laser/redtag/hitscan/holyak
 	)
 	var/list/display_names = list()
 	for(var/V in holy_weapons_list)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -248,8 +248,9 @@
 		return
 	var/obj/item/holy_weapon
 	var/list/holy_weapons_list = typesof(/obj/item/nullrod) + list(
-	/obj/item/melee/transforming/energy/sword/cx/chaplain,
-	/obj/item/gun/energy/laser/redtag/hitscan/holyak
+	/obj/item/twohanded/dualsaber/hypereutactic/chaplain,
+	/obj/item/gun/energy/laser/redtag/hitscan/chaplain,
+	/obj/item/multitool/chaplain
 	)
 	var/list/display_names = list()
 	for(var/V in holy_weapons_list)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -251,7 +251,8 @@
 	var/list/holy_weapons_list = typesof(/obj/item/nullrod) + list(
 	/obj/item/twohanded/dualsaber/hypereutactic/chaplain,
 	/obj/item/gun/energy/laser/redtag/hitscan/chaplain,
-	/obj/item/multitool/chaplain
+	/obj/item/multitool/chaplain,
+	/obj/item/melee/baseball_bat/chaplain
 	)
 	var/list/display_names = list()
 	for(var/V in holy_weapons_list)

--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -230,6 +230,7 @@
 	w_class = WEIGHT_CLASS_TINY
 	obj_flags = UNIQUE_RENAME
 	var/chaplain_spawnable = TRUE
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 
 /obj/item/nullrod/Initialize()
 	. = ..()
@@ -329,7 +330,6 @@
 	sharpness = IS_SHARP
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 
 /obj/item/nullrod/claymore/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
 	if(attack_type == PROJECTILE_ATTACK)
@@ -523,7 +523,6 @@
 	slot_flags = ITEM_SLOT_BELT
 	w_class = WEIGHT_CLASS_HUGE
 	attack_verb = list("smashed", "bashed", "hammered", "crunched")
-	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 
 /obj/item/nullrod/chainsaw
 	name = "chainsaw hand"
@@ -586,6 +585,7 @@
 	lefthand_file = 'icons/mob/inhands/weapons/melee_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/weapons/melee_righthand.dmi'
 	slot_flags = ITEM_SLOT_BELT
+	force = 12
 	reach = 2
 	attack_verb = list("whipped", "lashed")
 	hitsound = 'sound/weapons/chainhit.ogg'
@@ -675,7 +675,6 @@
 	hitsound = 'sound/weapons/bladeslice.ogg'
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "torn", "ripped", "diced", "cut")
 	item_flags = SLOWS_WHILE_IN_HAND
-	total_mass = TOTAL_MASS_NORMAL_ITEM
 
 /obj/item/nullrod/tribal_knife/Initialize(mapload)
 	. = ..()

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -513,6 +513,19 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/homerun_able = 0
 	total_mass = 2.7 //a regular wooden major league baseball bat weighs somewhere between 2 to 3.4 pounds, according to google
 
+/obj/item/melee/baseball_bat/chaplain
+	name = "blessed baseball bat"
+	desc = "There ain't a cult in the league that can withstand a swatter."
+	force = 14
+	throwforce = 14
+	obj_flags = UNIQUE_RENAME
+	var/chaplain_spawnable = TRUE
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON 
+
+/obj/item/melee/baseball_bat/chaplain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
 /obj/item/melee/baseball_bat/homerun
 	name = "home run bat"
 	desc = "This thing looks dangerous... Dangerously good at baseball, that is."

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -61,8 +61,8 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 		if(do_after(user, 15, target = src))
 			to_chat(user, "<span class='notice'>You carefully erase the [lowertext(cultist_name)] rune.</span>")
 			qdel(src)
-	else if(istype(I, /obj/item/nullrod))
-		user.say("BEGONE FOUL MAGIKS!!", forced = "nullrod")
+	else if(istype(I, /obj/item/storage/book/bible))
+		user.say("BEGONE FOUL MAGICKS!!", forced = "bible")
 		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
 		qdel(src)
 

--- a/code/modules/antagonists/cult/runes.dm
+++ b/code/modules/antagonists/cult/runes.dm
@@ -61,7 +61,7 @@ Runes can either be invoked by one's self or with many different cultists. Each 
 		if(do_after(user, 15, target = src))
 			to_chat(user, "<span class='notice'>You carefully erase the [lowertext(cultist_name)] rune.</span>")
 			qdel(src)
-	else if(istype(I, /obj/item/storage/book/bible))
+	else if(istype(I, /obj/item/storage/book/bible) || istype(I, /obj/item/nullrod))
 		user.say("BEGONE FOUL MAGICKS!!", forced = "bible")
 		to_chat(user, "<span class='danger'>You disrupt the magic of [src] with [I].</span>")
 		qdel(src)

--- a/code/modules/projectiles/ammunition/energy/laser.dm
+++ b/code/modules/projectiles/ammunition/energy/laser.dm
@@ -59,6 +59,9 @@
 /obj/item/ammo_casing/energy/laser/redtag/hitscan
 	projectile_type = /obj/item/projectile/beam/lasertag/redtag/hitscan
 
+/obj/item/ammo_casing/energy/laser/redtag/hitscan/holy
+	projectile_type = /obj/item/projectile/beam/lasertag/redtag/hitscan/holy
+
 /obj/item/ammo_casing/energy/xray
 	projectile_type = /obj/item/projectile/beam/xray
 	e_cost = 50

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -173,6 +173,7 @@
 	lefthand_file = 'modular_citadel/icons/mob/citadel/guns_lefthand.dmi'
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	var/chaplain_spawnable = TRUE
+	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
 
 /obj/item/gun/energy/laser/redtag/hitscan/chaplain/Initialize()
 	. = ..()
@@ -210,7 +211,7 @@
 	playsound('sound/weapons/dink.ogg', 30, 1)
 
 	if((iscultist(target)) || (is_servant_of_ratvar(target)))
-		chambered.BB.damage *= 150
+		chambered.BB.damage *= 1500
 
 	else if(chambered && chambered.BB)
 		chambered.BB.damage *= 5

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -174,6 +174,10 @@
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	var/chaplain_spawnable = TRUE
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	throw_speed = 3
+	throw_range = 4
+	throwforce = 10
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/gun/energy/laser/redtag/hitscan/chaplain/Initialize()
 	. = ..()

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -160,7 +160,7 @@
 /obj/item/gun/energy/laser/redtag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan)
 
-/obj/item/gun/energy/laser/redtag/hitscan/holyak
+/obj/item/gun/energy/laser/redtag/hitscan/chaplain
 	name = "\improper holy lasrifle"
 	desc = "A lasrifle from the old Imperium. This one seems to be blessed by techpriests."
 	icon_state = "LaserAK"
@@ -169,10 +169,50 @@
 	pin = /obj/item/firing_pin/holy
 	icon = 'modular_citadel/icons/obj/guns/VGguns.dmi'
 	ammo_x_offset = 4
+	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan/holy)
 	lefthand_file = 'modular_citadel/icons/mob/citadel/guns_lefthand.dmi'
 	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
 	var/chaplain_spawnable = TRUE
 
-/obj/item/gun/energy/laser/redtag/hitscan/holyak/Initialize()
+/obj/item/gun/energy/laser/redtag/hitscan/chaplain/Initialize()
 	. = ..()
 	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
+
+/obj/item/gun/energy/laser/redtag/hitscan/chaplain/handle_suicide(mob/living/carbon/human/user, mob/living/carbon/human/target, params, bypass_timer)
+	if(!ishuman(user) || !ishuman(target))
+		return
+
+	if(semicd)
+		return
+
+	if(user == target)
+		target.visible_message("<span class='warning'>[user] sticks [src] in [user.p_their()] mouth, ready to pull the trigger...</span>", \
+			"<span class='userdanger'>You stick [src] in your mouth, ready to pull the trigger...</span>")
+	else
+		target.visible_message("<span class='warning'>[user] points [src] at [target]'s head, ready to pull the trigger...</span>", \
+			"<span class='userdanger'>[user] points [src] at your head, ready to pull the trigger...</span>")
+
+	semicd = TRUE
+
+	if(!bypass_timer && (!do_mob(user, target, 120) || user.zone_selected != BODY_ZONE_PRECISE_MOUTH))
+		if(user)
+			if(user == target)
+				user.visible_message("<span class='notice'>[user] decided not to shoot.</span>")
+			else if(target && target.Adjacent(user))
+				target.visible_message("<span class='notice'>[user] has decided to spare [target]</span>", "<span class='notice'>[user] has decided to spare your life!</span>")
+		semicd = FALSE
+		return
+
+	semicd = FALSE
+
+	target.visible_message("<span class='warning'>[user] pulls the trigger!</span>", "<span class='userdanger'>[user] pulls the trigger!</span>")
+
+	playsound('sound/weapons/dink.ogg', 30, 1)
+
+	if((iscultist(target)) || (is_servant_of_ratvar(target)))
+		chambered.BB.damage *= 150
+
+	else if(chambered && chambered.BB)
+		chambered.BB.damage *= 5
+
+	process_fire(target, user, TRUE, params)

--- a/code/modules/projectiles/guns/energy/laser.dm
+++ b/code/modules/projectiles/guns/energy/laser.dm
@@ -159,3 +159,20 @@
 
 /obj/item/gun/energy/laser/redtag/hitscan
 	ammo_type = list(/obj/item/ammo_casing/energy/laser/redtag/hitscan)
+
+/obj/item/gun/energy/laser/redtag/hitscan/holyak
+	name = "\improper holy lasrifle"
+	desc = "A lasrifle from the old Imperium. This one seems to be blessed by techpriests."
+	icon_state = "LaserAK"
+	item_state = null
+	force = 14
+	pin = /obj/item/firing_pin/holy
+	icon = 'modular_citadel/icons/obj/guns/VGguns.dmi'
+	ammo_x_offset = 4
+	lefthand_file = 'modular_citadel/icons/mob/citadel/guns_lefthand.dmi'
+	righthand_file = 'modular_citadel/icons/mob/citadel/guns_righthand.dmi'
+	var/chaplain_spawnable = TRUE
+
+/obj/item/gun/energy/laser/redtag/hitscan/holyak/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)

--- a/code/modules/projectiles/pins.dm
+++ b/code/modules/projectiles/pins.dm
@@ -188,6 +188,15 @@
 	desc = "This is a DNA-locked firing pin which only authorizes one user. Attempt to fire once to DNA-link. It has a small explosive charge on it."
 	selfdestruct = TRUE
 
+/obj/item/firing_pin/holy
+	name = "blessed pin"
+	desc = "A firing pin that only responds to those who are holier than thou."
+
+/obj/item/firing_pin/holy/pin_auth(mob/living/user)
+	if(user.mind.isholy)
+		return TRUE
+	return FALSE
+
 // Laser tag pins
 /obj/item/firing_pin/tag
 	name = "laser tag firing pin"

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -153,7 +153,7 @@
 
 /obj/item/projectile/beam/lasertag/redtag/hitscan/holy
 	name = "lasrifle beam"
-	damage = 1
+	damage = 0.1
 	damage_type = BURN
 
 /obj/item/projectile/beam/lasertag/bluetag

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -151,6 +151,11 @@
 /obj/item/projectile/beam/lasertag/redtag/hitscan
 	hitscan = TRUE
 
+/obj/item/projectile/beam/lasertag/redtag/hitscan/holy
+	name = "lasrifle beam"
+	damage = 1
+	damage_type = BURN
+
 /obj/item/projectile/beam/lasertag/bluetag
 	icon_state = "bluelaser"
 	suit_types = list(/obj/item/clothing/suit/redtag)

--- a/modular_citadel/code/game/objects/items/holy_weapons.dm
+++ b/modular_citadel/code/game/objects/items/holy_weapons.dm
@@ -30,24 +30,16 @@
 		"<span class='info'>You kneel[M == user ? null : " next to [M]"] and begin a prayer to [deity_name].</span>")
 
 	praying = TRUE
-	if(do_after(user, 100, target = M))
+	if(do_after(user, 20, target = M))
 		if(istype(M, /mob/living/carbon/human)) // This probably should not work on catpeople. They're unholy abominations.
 			var/mob/living/carbon/human/target = M
-
-			if(iscultist(M) || is_servant_of_ratvar(M)) //ripped from holywater code.
-				if(iscultist(M))
-					SSticker.mode.remove_cultist(M.mind, FALSE, TRUE)
-				else if(is_servant_of_ratvar(M))
-					remove_servant_of_ratvar(M)
-
+			M.reagents.add_reagent("holywater", 5)
 			to_chat(target, "<span class='notice'>[user]'s prayer to [deity_name] has eased your pain!</span>")
 			target.adjustToxLoss(-5, TRUE, TRUE)
 			target.adjustOxyLoss(-5)
 			target.adjustBruteLoss(-5)
 			target.adjustFireLoss(-5)
-
 			praying = FALSE
-
 	else
 		to_chat(user, "<span class='notice'>Your prayer to [deity_name] was interrupted.</span>")
 		praying = FALSE

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -271,6 +271,7 @@
 	block_chance = 50
 	armour_penetration = 0
 	var/chaplain_spawnable = TRUE
+	obj_flags = UNIQUE_RENAME
 
 /obj/item/twohanded/dualsaber/hypereutactic/chaplain/Initialize()
 	. = ..()

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -134,6 +134,7 @@
 	name = "divine lightblade"
 	force_on = 20		//haha i'll regret this
 	block_chance = 50
+	var/chaplain_spawnable = TRUE
 
 /obj/item/melee/transforming/energy/sword/cx/chaplain/Initialize()
 	. = ..()

--- a/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
+++ b/modular_citadel/code/game/objects/items/melee/eutactic_blades.dm
@@ -130,16 +130,6 @@
 	else
 		return ..()
 
-/obj/item/melee/transforming/energy/sword/cx/chaplain
-	name = "divine lightblade"
-	force_on = 20		//haha i'll regret this
-	block_chance = 50
-	var/chaplain_spawnable = TRUE
-
-/obj/item/melee/transforming/energy/sword/cx/chaplain/Initialize()
-	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
-
 //OBLIGATORY TOY MEMES	/////////////////////////////////////
 
 /obj/item/toy/sword/cx
@@ -271,6 +261,20 @@
 	attack_verb = list("attacked", "slashed", "stabbed", "sliced", "destroyed", "ripped", "devastated", "shredded")
 	spinnable = FALSE
 	total_mass_on = 4
+
+/obj/item/twohanded/dualsaber/hypereutactic/chaplain
+	name = "\improper divine lightblade"
+	desc = "A giant blade of bright and holy light, said to cut down the wicked with ease."
+	force = 5
+	force_unwielded = 5
+	force_wielded = 20
+	block_chance = 50
+	armour_penetration = 0
+	var/chaplain_spawnable = TRUE
+
+/obj/item/twohanded/dualsaber/hypereutactic/chaplain/Initialize()
+	. = ..()
+	AddComponent(/datum/component/anti_magic, TRUE, TRUE)
 
 /obj/item/twohanded/dualsaber/hypereutactic/pre_altattackby(atom/A, mob/living/user, params)	//checks if it can do right click memes
 	altafterattack(A, user, TRUE, params)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in three (two, but fixes one) new null rods for your chaplaining pleasure! 

- Laser AK with 0.1 burn on a hitscan laser, with typical laser tag cell/cost (10 shots per full cell, recharges over time) that does 150 burn if you execution style a cultist!
Has reduced melee force in exchange for the (laughable) laser.
![](https://cdn.discordapp.com/attachments/161574200581029888/617096622198751250/unknown.png)
- Divine Lightblade, a hyper-eutactic blade fit for any anime protagonist.
20 force, 50 block, takes up both hands.
![](http://puu.sh/EbGlZ/bf6137c6e9.png)
- Hypertool, a functional multitool that deals armor penetrating brain damage.
- Bo Staff now deals stamina damage on hit if you're in disarm intent. Cannot attack people if they're unconscious, in stam crit, or health crit. Also has a 25% chance to jedi spin.
- Blessed Baseball Bat. 14 force, 14 throwforce. Functional bat. BONK!

I also normalized all stamina values for the holy weapons, so they'll all take between 4-5 stamina to swing. This also comes with a regretful nerf to the holy whip, as 2 tile range proves very powerful with such a high force output. 

Also also added the destruction of runes to the bible object, since adding snowflake checks to all the holy weapons would be silly.

Also also also reworked the cultist removal bit from prayer beads into just an injection of holy water, shortened action timer in exchange for it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Funny fun fun fun, and flavorful too. Nothing is outright gamebreaking (150 damage seems like a lot, but it's tied to the execution style timer)

Prayer beads being a 10 second timer for an instant deconvert was dumb, so I just made it give some holy water to make it take longer (and more clicks) to work.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: holy lasrifle, hypertool, divine lightblade, and blessed baseball bat. Four new holy weapons!
balance: stamina and force tweaks for most holy weapons.
tweak: prayer beads no longer deconvert after a 10 second timer, now just inject holy water for delayed effect
tweak: cultist runes are now destroyed with a bible or a null rod
tweak: bo-staff now functions as a nerfed sleepy carp staff
fix: fixed kevinz code to add in non-null rod child items as holy weapons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
