### PR TITLE
Removes RCDs from autolathes (Alternative to PR #9089 and #9087)

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -49,6 +49,14 @@
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
 
+/datum/design/rpd
+	name = "Rapid Pipe Dispenser (RPD)"
+	id = "rpd"
+	build_type = AUTOLATHE
+	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500)
+	build_path = /obj/item/pipe_dispenser
+	category = list("hacked", "Construction")
+
 /datum/design/handcuffs
 	name = "Handcuffs"
 	id = "handcuffs"

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -49,22 +49,6 @@
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
 
-/datum/design/rcd
-	name = "Rapid Construction Device (RCD)"
-	id = "rcd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 30000)
-	build_path = /obj/item/construction/rcd
-	category = list("hacked", "Construction")
-
-/datum/design/rpd
-	name = "Rapid Pipe Dispenser (RPD)"
-	id = "rpd"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 75000, MAT_GLASS = 37500)
-	build_path = /obj/item/pipe_dispenser
-	category = list("hacked", "Construction")
-
 /datum/design/handcuffs
 	name = "Handcuffs"
 	id = "handcuffs"


### PR DESCRIPTION
## About The Pull Request

Does what it says on the tin. Removes RCDs as printable items in the autolathe.

UPDATE: NO LONGER REMOVES RPDs 

## Why It's Good For The Game

RCDs are very powerful pieces of equipment that should certainly be powerful, and (I presume) they were originally intended as a quicker and more versatile tool to make engineer's lives easier and more efficient, AND give them a leg up on the common masses. Unfortunately, with the addition of them to the autolathe, their power is free to anyone with a few mats. It was inevitable that this power would be noticed by players, and result in Pull Requests to nerf RCDs as a whole. This just hurts engineers, and does nothing to consider the facts that RCDs should have been a tool to make playing engineer just that little bit more special. No non engineering role should have ever had easy access to a tool that effectively nullifies the need to carry a variety of mats and tools to deal with obstacles. Printable RCDs also make airlock electronics useless, emags less useful, armblades less useful, carrying a variety of mats pointless, and that's not ideal.

Simply put, RCDs are fine where they are, but they shouldn't be available to everyone (easily) and should be a limited resource. Any direct nerf to RCDs is just a nerf to engineering, and of all the roles on the station, engineering is probably one of the least deserving of nerfs.

## Changelog
:cl:
balance: removes RCD from the autolathe
/:cl: