### PR TITLE
Gives emags 5 more uses on buy

### DIFF
--- a/modular_citadel/code/game/objects/ids.dm
+++ b/modular_citadel/code/game/objects/ids.dm
@@ -49,7 +49,7 @@
 
 /obj/item/emagrecharge
 	name = "electromagnet charging device"
-	desc = "A small cell with two prongs lazily jabbed into it. It looks like it's made for charging the small batteries found in electromagnetic devices, sadly this cant be recharged like a normal cell."
+	desc = "A small cell with two prongs lazily jabbed into it. It looks like it's made for charging the small batteries found in electromagnetic devices, sadly this can't be recharged like a normal cell."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cell_mini"
 	item_flags = NOBLUDGEON

--- a/modular_citadel/code/game/objects/ids.dm
+++ b/modular_citadel/code/game/objects/ids.dm
@@ -49,7 +49,7 @@
 
 /obj/item/emagrecharge
 	name = "electromagnet charging device"
-	desc = "A small cell with two prongs lazily jabbed into it. It looks like it's made for charging the small batteries found in electromagnetic devices."
+	desc = "A small cell with two prongs lazily jabbed into it. It looks like it's made for charging the small batteries found in electromagnetic devices, sadly this cant be recharged like a normal cell."
 	icon = 'icons/obj/module.dmi'
 	icon_state = "cell_mini"
 	item_flags = NOBLUDGEON
@@ -63,7 +63,7 @@
 		to_chat(user, "<span class='warning'>It has a small, red, blinking light coming from inside of it. It's spent.</span>")
 
 /obj/item/card/emag
-	var/uses = 10
+	var/uses = 15
 
 /obj/item/card/emag/examine(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds in a bit of flavor text for the recharging bit
Adds in 5 more uses for a emag

## Why It's Good For The Game

Lots of things can be emaged and the main goal of nerfing the emags all those moons ago were to stop people spamming them on every door ever, well it worked! To well...
10 uses dosnt do a whole lot unless your working for the station and emaging useful things,
This 15, still making the emag charger usefull as its cheap and 5 recharges 1/3 of the price making it balanced, well also being able to become discounted. 
This also helps nukies, whom one thing is to emag doors open they dont have access to and that REALLY chews throw emag charges

## Changelog
:cl:
tweak: emag charge amount
/:cl: