### PR TITLE
Adds rooms to Meta, Box, and Delta for sci to play with fusion a but in

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -28748,10 +28748,13 @@
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "bqg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "bqh" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -29425,12 +29428,13 @@
 	},
 /area/science/explab)
 "brE" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_one_access_txt = "8;12"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Launch Room";
+	req_access_txt = "7"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/science/mixing)
 "brF" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -29442,27 +29446,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"brG" = (
-/obj/machinery/atmospherics/components/binary/valve{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"brH" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "brI" = (
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
+/obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "brJ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -29918,7 +29908,7 @@
 	dir = 4
 	},
 /turf/closed/wall,
-/area/maintenance/starboard)
+/area/science/mixing)
 "bsK" = (
 /obj/structure/table/glass,
 /obj/item/storage/box/disks{
@@ -30145,16 +30135,26 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "btp" = (
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"btq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+/obj/machinery/portable_atmospherics/scrubber,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/machinery/airalarm/unlocked{
+	pixel_y = 24
+	},
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
+"btq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/bot{
+	dir = 2
+	},
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "btr" = (
 /obj/machinery/camera{
 	c_tag = "Cargo Receiving Dock";
@@ -31308,18 +31308,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"bvQ" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"bvR" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/freezer{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bvS" = (
 /obj/machinery/conveyor{
 	dir = 8;
@@ -32018,13 +32006,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/explab)
 "bxt" = (
-/obj/machinery/meter,
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/structure/cable{
-	icon_state = "2-4"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "bxu" = (
 /turf/closed/wall,
 /area/quartermaster/qm)
@@ -32507,12 +32493,6 @@
 /obj/machinery/door/firedoor/heavy,
 /turf/open/floor/engine,
 /area/science/explab)
-"byx" = (
-/obj/machinery/atmospherics/components/unary/thermomachine/heater{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "byy" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
@@ -34278,15 +34258,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/explab)
-"bCm" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bCn" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -34657,18 +34628,9 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "bDg" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"bDh" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "bDi" = (
 /obj/structure/sign/warning/docking{
 	pixel_y = 32
@@ -35964,9 +35926,13 @@
 /obj/effect/turf_decal/bot{
 	dir = 2
 	},
-/turf/open/floor/plasteel{
-	dir = 2
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
 	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGe" = (
 /turf/closed/wall,
@@ -36181,7 +36147,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGH" = (
 /obj/structure/cable{
@@ -36215,14 +36181,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGL" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -36515,13 +36481,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"bHv" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bHw" = (
 /obj/item/target,
@@ -37190,7 +37150,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIT" = (
 /obj/effect/spawner/structure/window,
@@ -37209,17 +37169,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"bIV" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIW" = (
 /obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bIX" = (
 /obj/structure/sign/warning/securearea{
@@ -37729,7 +37683,7 @@
 	req_access_txt = "7"
 	},
 /obj/effect/turf_decal/loading_area,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bKg" = (
 /turf/open/floor/plating/airless,
@@ -43865,10 +43819,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"bZi" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/maintenance/starboard)
 "bZj" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 4
@@ -54137,10 +54087,7 @@
 	pixel_y = 24
 	},
 /obj/effect/landmark/event_spawn,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "cBB" = (
 /obj/effect/landmark/event_spawn,
@@ -56023,53 +55970,11 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "cNR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cNS" = (
-/obj/machinery/power/apc{
-	dir = 4;
-	name = "Starboard Maintenance APC";
-	areastring = "/area/maintenance/starboard";
-	pixel_x = 26
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cNT" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cNU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
-"cNV" = (
-/obj/machinery/door/airlock/maintenance/abandoned{
-	req_one_access_txt = "8;12"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard)
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "cNW" = (
 /turf/closed/wall,
 /area/maintenance/starboard/aft)
@@ -57285,7 +57190,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "pHl" = (
 /obj/structure/table,
@@ -57392,7 +57297,7 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 "saK" = (
 /obj/structure/closet/crate,
@@ -57418,6 +57323,12 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"soT" = (
+/obj/machinery/autolathe{
+	name = "public autolathe"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "sxs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
@@ -57460,6 +57371,12 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"sUf" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/science/mixing)
 "sWR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57581,6 +57498,19 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"uml" = (
+/obj/machinery/power/apc{
+	dir = 4;
+	name = "Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard";
+	pixel_x = 26
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "uoB" = (
 /obj/structure/table/reinforced,
 /obj/item/multitool,
@@ -57591,12 +57521,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"urE" = (
-/obj/machinery/autolathe{
-	name = "public autolathe"
+"upQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "usO" = (
 /obj/machinery/vending/snack/random,
 /obj/machinery/light/small{
@@ -57827,6 +57762,10 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"xUX" = (
+/obj/machinery/suit_storage_unit/rd,
+/turf/open/floor/plasteel/white,
+/area/science/mixing)
 "ycu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -57835,8 +57774,7 @@
 /area/science/circuit)
 "ydD" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/suit_storage_unit/rd,
-/turf/open/floor/plasteel,
+/turf/open/floor/plasteel/white,
 /area/science/mixing)
 
 (1,1,1) = {"
@@ -81618,7 +81556,7 @@ cNG
 cNJ
 bLF
 aZK
-urE
+soT
 bbR
 bqt
 cBq
@@ -107851,7 +107789,7 @@ bGG
 bKb
 cNX
 cNZ
-cNZ
+upQ
 jCq
 bSl
 bSl
@@ -108108,7 +108046,7 @@ bGL
 bKd
 cNY
 bMC
-cOb
+uml
 jHt
 bPO
 kob
@@ -108613,12 +108551,12 @@ buz
 buz
 buz
 buz
-cNU
+buz
 buz
 bEI
 bFZ
 bHu
-bIV
+bxt
 bKf
 bLk
 bEs
@@ -108866,12 +108804,12 @@ bhG
 bhG
 bsJ
 brE
-bhG
-bhG
-bhG
-bhG
-cNV
-bhG
+bEH
+bEH
+sUf
+bEH
+brE
+bEH
 bEH
 bGb
 cBA
@@ -109121,17 +109059,17 @@ aaa
 aaa
 aaa
 aaa
-bky
-btp
-brH
-bvQ
-bxt
-cNT
-bCm
-bDh
 bEs
+btp
+bFU
+bFU
+bxt
+bFU
+bFU
+bFU
+bFU
 ydD
-bHv
+bFU
 bIW
 bKe
 vHY
@@ -109378,15 +109316,15 @@ aaa
 aaa
 aaa
 aaa
-bZi
+bGc
 bqg
-brG
-brG
+bFU
+bFU
 cNR
-brG
-brG
+bFU
+bFU
 bDg
-bEs
+xUX
 bGd
 poc
 rNc
@@ -109635,16 +109573,16 @@ aaa
 aaa
 aaa
 aaa
-bZi
+bGc
 btq
+bNx
+bNx
+bNx
+bNx
 brI
-bvR
-cNS
-byx
-brI
-bky
-bky
 bEs
+bGc
+bGc
 bGc
 bGc
 bEs
@@ -109892,14 +109830,14 @@ aaa
 aaa
 aaa
 aaa
-bky
-bky
-bky
-bky
-bky
-bky
-bky
-bky
+bEs
+bEs
+bGc
+bGc
+bGc
+bGc
+bEs
+bEs
 aaf
 gXs
 gXs

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1010,10 +1010,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"aez" = (
-/obj/machinery/keycard_auth,
-/turf/closed/wall,
-/area/quartermaster/qm)
 "aeB" = (
 /obj/machinery/status_display,
 /turf/closed/wall,
@@ -2018,6 +2014,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
+"ait" = (
+/obj/effect/decal/cleanable/dirt,
+/turf/closed/wall/r_wall,
+/area/chapel/office)
 "aiz" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -87964,6 +87964,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cRK" = (
@@ -97794,18 +97795,21 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dhQ" = (
 /turf/closed/wall,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dhR" = (
 /turf/closed/wall/r_wall,
 /area/science/circuit)
 "dhS" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/barricade/wooden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dhT" = (
 /obj/machinery/door/airlock/maintenance_hatch{
 	name = "Maintenance Hatch";
@@ -98740,9 +98744,10 @@
 /area/science/circuit)
 "djo" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "djp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/cell_charger,
@@ -98763,7 +98768,9 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "djt" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -98791,17 +98798,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"djw" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
 "djx" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -99798,28 +99794,17 @@
 	dir = 9
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dlg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
-"dlh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dli" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dlj" = (
 /turf/open/floor/plasteel,
 /area/science/circuit)
@@ -100316,12 +100301,6 @@
 	dir = 4
 	},
 /area/science/circuit)
-"dms" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "dmt" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -100330,19 +100309,6 @@
 	dir = 6
 	},
 /area/science/circuit)
-"dmu" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "dmv" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/white/side{
@@ -100361,13 +100327,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"dmy" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "dmA" = (
 /obj/effect/landmark/blobstart,
 /obj/effect/turf_decal/bot,
@@ -101221,10 +101180,6 @@
 	dir = 5
 	},
 /area/science/circuit)
-"doi" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "doj" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/holopad,
@@ -101250,11 +101205,16 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "don" = (
 /obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "doo" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -102210,13 +102170,11 @@
 	},
 /area/science/circuit)
 "dpY" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dpZ" = (
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dqa" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
@@ -102340,7 +102298,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -103144,8 +103101,8 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "drI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -103837,7 +103794,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dtd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
+/turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "dte" = (
 /obj/effect/decal/cleanable/dirt,
@@ -104459,67 +104416,75 @@
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dum" = (
 /obj/machinery/light/small{
 	dir = 1
 	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dun" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "duo" = (
 /obj/structure/table/reinforced,
-/obj/item/mmi,
-/obj/item/assembly/prox_sensor,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dup" = (
-/obj/structure/frame/machine,
-/obj/item/stack/cable_coil/white,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "duq" = (
 /obj/structure/rack,
-/obj/item/book/manual/wiki/robotics_cyborgs,
 /obj/item/storage/belt/utility,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dur" = (
-/obj/machinery/mecha_part_fabricator,
 /obj/machinery/light/small{
 	dir = 1
 	},
 /obj/effect/turf_decal/delivery,
+/obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dus" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/glass,
-/obj/item/stock_parts/micro_laser,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dut" = (
 /obj/structure/table/reinforced,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
-/obj/item/assembly/flash/handheld,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "duu" = (
-/obj/structure/reagent_dispensers/fueltank,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -104527,10 +104492,9 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "duv" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
@@ -104539,8 +104503,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "duw" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -105482,18 +105446,20 @@
 /obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dwa" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dwb" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
@@ -105503,7 +105469,9 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dwc" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -105516,8 +105484,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "dwe" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light,
@@ -106448,60 +106416,44 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/abandoned_gambling_den)
 "dxH" = (
-/obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dxI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dxJ" = (
-/turf/open/floor/circuit/green,
-/area/science/research/abandoned)
-"dxK" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 4
-	},
-/turf/open/floor/circuit/green,
-/area/science/research/abandoned)
-"dxL" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dxM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dxN" = (
-/obj/effect/decal/cleanable/oil,
-/obj/effect/turf_decal/delivery,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dxO" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/light_switch{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dxP" = (
 /obj/machinery/light{
 	dir = 8
@@ -107321,79 +107273,24 @@
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
 "dze" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/status_display{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dzf" = (
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dzg" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/mech_bay_recharge_floor,
-/area/science/research/abandoned)
-"dzh" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dzi" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/effect/landmark/xeno_spawn,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dzj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/white{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dzk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -107401,26 +107298,19 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dzl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
 /obj/effect/turf_decal/delivery,
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dzm" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/barricade/wooden,
-/obj/machinery/door/airlock/maintenance_hatch{
-	name = "Maintenance Hatch";
-	req_access_txt = "12"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -107430,21 +107320,24 @@
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
+/obj/machinery/door/airlock/research{
+	name = "Toxins Fusion Lab";
+	req_access_txt = "8"
+	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dzn" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
 	icon_state = "1-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "dzo" = (
 /obj/structure/cable/white{
 	icon_state = "4-8"
@@ -108050,42 +107943,29 @@
 	},
 /area/crew_quarters/abandoned_gambling_den)
 "dAp" = (
-/obj/structure/frame/machine,
-/obj/item/circuitboard/machine/cyborgrecharger,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
-"dAq" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dAr" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 1
+/obj/structure/table,
+/obj/machinery/light{
+	dir = 8
 	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/science/research/abandoned)
-"dAs" = (
-/obj/item/robot_suit,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dAt" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dAu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/structure/reagent_dispensers/water_cooler,
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "dAv" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -109035,32 +108915,33 @@
 /obj/item/crowbar/red,
 /obj/item/wrench,
 /obj/item/clothing/mask/gas,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dBU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"dBV" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dBW" = (
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dBX" = (
 /obj/structure/rack,
 /obj/item/storage/toolbox/mechanical,
 /obj/item/clothing/head/welding,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dBY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -109697,54 +109578,52 @@
 /area/solar/starboard/aft)
 "dDg" = (
 /obj/structure/table,
-/obj/item/stack/rods{
-	amount = 23
-	},
 /obj/item/stack/cable_coil/white,
-/obj/item/flashlight/seclite,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dDh" = (
 /obj/machinery/light/small,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dDi" = (
 /obj/structure/table,
 /obj/item/clipboard,
 /obj/item/folder/white,
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dDj" = (
-/obj/structure/frame/computer{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dDk" = (
-/obj/structure/frame/machine,
 /obj/machinery/light/small,
-/obj/item/stack/sheet/glass,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dDl" = (
 /obj/structure/table,
-/obj/item/clothing/gloves/color/black,
 /obj/item/storage/toolbox/electrical,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dDm" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -119456,6 +119335,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
+"dTM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/delivery,
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "dTR" = (
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
@@ -126308,13 +126203,6 @@
 /obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"eMD" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/science/research/abandoned)
 "eMJ" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 8
@@ -126331,6 +126219,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"eSI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "eTv" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -126367,6 +126265,28 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"fdR" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/computer/pod/old{
+	density = 0;
+	icon = 'icons/obj/airlock_machines.dmi';
+	icon_state = "airlock_control_standby";
+	id = "chapelgun";
+	name = "Mass Driver Controller";
+	pixel_x = 0;
+	pixel_y = -24
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "fhE" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/medical{
@@ -126408,13 +126328,6 @@
 /obj/machinery/door/airlock/research/glass/incinerator/toxmix_interior,
 /turf/open/floor/engine,
 /area/science/mixing)
-"fwr" = (
-/obj/machinery/door/poddoor{
-	id = "chapelgun";
-	name = "Chapel Launcher Door"
-	},
-/turf/open/floor/plating,
-/area/chapel/office)
 "fFK" = (
 /obj/machinery/ore_silo,
 /obj/effect/turf_decal/tile/neutral{
@@ -126433,10 +126346,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"fHS" = (
-/obj/structure/sign/warning/vacuum,
-/turf/closed/wall/r_wall,
-/area/chapel/office)
 "fLR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -126444,15 +126353,15 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "fRT" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/port)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "gbV" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
 	dir = 1
@@ -126469,22 +126378,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/circuit)
-"gJj" = (
-/obj/machinery/door/window/northleft{
-	name = "Mass Driver"
-	},
-/obj/machinery/mass_driver{
-	id = "chapelgun";
-	name = "Holy Driver"
-	},
-/turf/open/floor/plating,
-/area/chapel/office)
-"gKr" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1
-	},
-/turf/open/floor/circuit/green,
-/area/science/research/abandoned)
 "gNw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/table/glass,
@@ -126496,22 +126389,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
-"gNJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "gNS" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -126576,10 +126453,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"hei" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/closed/wall/r_wall,
-/area/chapel/office)
 "hic" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -126641,22 +126514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"hLO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/delivery,
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
 "hNZ" = (
 /obj/structure/chair/office/light{
 	dir = 8
@@ -126703,9 +126560,6 @@
 	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
-"iyd" = (
-/turf/open/space,
-/area/space)
 "iQh" = (
 /obj/structure/bodycontainer/morgue{
 	dir = 1
@@ -126762,17 +126616,13 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"jhK" = (
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "jjN" = (
 /obj/structure/table/reinforced,
 /obj/machinery/camera{
@@ -126807,6 +126657,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
+"jtK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/closed/wall,
+/area/maintenance/port)
 "juf" = (
 /obj/machinery/atmospherics/components/binary/valve,
 /obj/effect/turf_decal/stripes/line{
@@ -126870,28 +126730,6 @@
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
-"jPA" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/computer/pod/old{
-	density = 0;
-	icon = 'icons/obj/airlock_machines.dmi';
-	icon_state = "airlock_control_standby";
-	id = "chapelgun";
-	name = "Mass Driver Controller";
-	pixel_x = 0;
-	pixel_y = -24
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "jRy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -126912,6 +126750,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/science/mixing)
+"jXC" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plasteel,
+/area/maintenance/port)
 "kam" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/conveyor{
@@ -126920,6 +126769,12 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
+"kcP" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
+/turf/open/floor/plating,
+/area/chapel/office)
 "kvf" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -126932,7 +126787,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "kyo" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -126943,8 +126797,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/port)
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "kLu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -126965,6 +126819,19 @@
 	dir = 10
 	},
 /area/science/circuit)
+"lnc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "loI" = (
 /obj/machinery/autolathe,
 /obj/machinery/door/window/southleft{
@@ -126982,6 +126849,20 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
+"lpL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "lti" = (
 /obj/machinery/atmospherics/components/trinary/mixer/flipped,
 /obj/effect/turf_decal/tile/neutral{
@@ -127018,18 +126899,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
+"lBo" = (
+/turf/open/space,
+/area/space)
 "lEl" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
 	},
 /obj/structure/cable/white{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "lEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -127127,27 +127010,33 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
-"mvm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "4-8"
+"mkS" = (
+/obj/machinery/door/window/northleft{
+	name = "Mass Driver"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/mass_driver{
+	id = "chapelgun";
+	name = "Holy Driver"
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/plating,
+/area/chapel/office)
+"mqB" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
+"mta" = (
+/obj/machinery/door/poddoor{
+	id = "chapelgun";
+	name = "Chapel Launcher Door"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
-"mxm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/circuit/green,
-/area/science/research/abandoned)
+/turf/open/floor/plating,
+/area/chapel/office)
+"mEp" = (
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall/r_wall,
+/area/chapel/office)
 "mIi" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
@@ -127176,54 +127065,30 @@
 	},
 /turf/open/floor/engine,
 /area/science/mixing)
-"mXJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
-"nht" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "nyN" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"nSh" = (
-/obj/machinery/atmospherics/pipe/simple/general/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"owr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+"nME" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"nSh" = (
+/obj/machinery/atmospherics/pipe/simple/general/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "oIl" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -127253,6 +127118,20 @@
 	},
 /turf/open/floor/plating,
 /area/construction/mining/aux_base)
+"oMO" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance_hatch{
+	name = "Maintenance Hatch";
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
 "oNd" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -127296,6 +127175,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"oUe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/misc_lab)
 "oUW" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -127322,6 +127205,21 @@
 	},
 /turf/open/floor/wood,
 /area/bridge/showroom/corporate)
+"ply" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
+"pmy" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "pmQ" = (
 /obj/structure/table/reinforced,
 /obj/machinery/newscaster{
@@ -127356,30 +127254,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"ptI" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/science/research/abandoned)
-"pQm" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/cable/white{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/research/abandoned)
 "qhc" = (
 /obj/structure/table/reinforced,
 /obj/item/integrated_electronics/analyzer,
@@ -127402,12 +127276,6 @@
 /obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"qMR" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/chapel/office)
 "rhO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
@@ -127462,6 +127330,14 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing)
+"spD" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/obj/effect/turf_decal/delivery,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "svv" = (
 /obj/machinery/door/poddoor/incinerator_toxmix,
 /turf/open/floor/engine/vacuum,
@@ -127497,6 +127373,15 @@
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"uhK" = (
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/misc_lab)
 "upk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -127517,18 +127402,16 @@
 /area/crew_quarters/fitness/recreation)
 "upw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light,
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/effect/turf_decal/stripes/corner,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"urM" = (
+/obj/machinery/keycard_auth,
+/turf/closed/wall,
+/area/quartermaster/qm)
 "uNP" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -127546,6 +127429,25 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"uSw" = (
+/obj/structure/bodycontainer/morgue{
+	dir = 2
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "uYS" = (
 /obj/machinery/door/airlock/atmos/glass/critical{
 	heat_proof = 1;
@@ -127557,14 +127459,19 @@
 	},
 /turf/open/floor/engine,
 /area/engine/supermatter)
-"uZN" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
+"vbi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/maintenance/port/aft)
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel/dark,
+/area/chapel/office)
 "vhA" = (
 /obj/item/clothing/under/color/grey,
 /turf/open/floor/plating,
@@ -127578,10 +127485,21 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"vDo" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "wei" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"wsx" = (
+/turf/open/floor/plasteel,
+/area/maintenance/port/aft)
 "wAA" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall/r_wall,
@@ -127591,10 +127509,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/purple,
+/obj/machinery/light{
+	dir = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
 "xaf" = (
@@ -127640,15 +127558,16 @@
 /turf/open/floor/plasteel,
 /area/science/circuit)
 "xze" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/structure/cable/white{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
-/area/science/research/abandoned)
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "xDZ" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -127702,25 +127621,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/research)
-"xWZ" = (
-/obj/structure/bodycontainer/morgue{
-	dir = 2
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/office)
 "xXn" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/toxins_mixing_output,
 /turf/open/floor/engine/vacuum,
@@ -127745,16 +127645,18 @@
 /area/science/mixing)
 "yjc" = (
 /obj/machinery/power/apc{
-	areastring = "/area/science/research/abandoned";
+	areastring = "/area/science/research/fusion";
 	dir = 1;
-	name = "Abandoned Research Lab APC";
+	name = "Fusion Research Lab APC";
 	pixel_y = 24
 	},
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
-/area/science/research/abandoned)
+/turf/open/floor/plasteel,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 
 (1,1,1) = {"
 aaa
@@ -151842,7 +151744,7 @@ poI
 dfY
 ajr
 aad
-aad
+aaa
 aad
 aaa
 aad
@@ -152862,11 +152764,11 @@ dhR
 djs
 dlf
 dxI
-dms
-dpZ
+dxI
+dxI
 dBU
 djo
-dhQ
+mqB
 aad
 aad
 abj
@@ -153118,12 +153020,12 @@ drA
 dhR
 dum
 dli
-dpZ
-dzf
-dAq
+dup
+dup
+dup
 dpY
 dDh
-dhQ
+mqB
 aad
 aaa
 abj
@@ -153375,12 +153277,12 @@ drB
 dhR
 yjc
 jeu
-mxm
-gKr
-dxJ
-dBV
-dlg
-dhQ
+dup
+dup
+dup
+dpY
+dup
+mqB
 aad
 aad
 abj
@@ -153632,12 +153534,12 @@ lXM
 dhR
 dun
 lEl
-dxK
-dzg
-dAr
-doi
+dup
+dup
+dup
+dpY
 don
-dhQ
+mqB
 aad
 aaa
 aaa
@@ -153888,13 +153790,13 @@ dqa
 drC
 dhR
 duo
-dmu
-eMD
-pQm
-dxM
-doi
-dun
-dhQ
+lEl
+dup
+dup
+dup
+dpY
+spD
+mqB
 aad
 ajr
 aaa
@@ -154145,10 +154047,10 @@ dqb
 drD
 dhR
 dup
-ptI
-dxL
-mvm
-dAs
+lEl
+dup
+dup
+dup
 dpY
 dDi
 dhQ
@@ -154402,10 +154304,10 @@ dqc
 gUH
 dhR
 duq
-dlh
-dxM
-dzi
-dzh
+lEl
+dup
+dup
+dup
 dBW
 dDj
 dhQ
@@ -154662,8 +154564,8 @@ dur
 xze
 dxN
 dzj
-don
-doi
+dup
+dpY
 dDk
 dhQ
 aad
@@ -154919,9 +154821,9 @@ dus
 dwa
 dom
 dzk
-dmy
-dAt
-djs
+dom
+vDo
+dun
 dhQ
 aad
 aaa
@@ -155688,10 +155590,10 @@ upw
 dtd
 duu
 kyo
-djw
+duu
 fRT
 dAu
-caE
+tCh
 aaa
 aad
 aad
@@ -155942,13 +155844,13 @@ faI
 dor
 dqh
 wBO
-dhT
+ply
 duv
 dwc
 drH
 dzn
-cLt
-caE
+eSI
+oUe
 aad
 drP
 dEn
@@ -156200,12 +156102,12 @@ dos
 dqi
 gSi
 gSi
-djA
-djA
-djA
-cJT
-cLx
-cOj
+gSi
+gSi
+gSi
+uhK
+eSI
+oUe
 aaa
 dEn
 dFz
@@ -156460,9 +156362,9 @@ dte
 duw
 dtf
 djA
-cJS
-cLu
-cOj
+oMO
+jtK
+caE
 aad
 dEn
 dFA
@@ -156718,7 +156620,7 @@ dux
 dwe
 djA
 dzo
-cLt
+jXC
 caE
 aaa
 drP
@@ -159833,7 +159735,7 @@ dZN
 dZN
 dZN
 dZN
-fHS
+mEp
 dZN
 dLY
 dLY
@@ -160084,20 +159986,20 @@ dWJ
 dLW
 dYu
 dZg
-jhK
-jhK
+wsx
+wsx
 dZN
-owr
-mXJ
-gJj
-qMR
-fwr
+vbi
+lnc
+mkS
+kcP
+mta
 aaa
 aaa
-iyd
+lBo
 aaa
 aaa
-iyd
+lBo
 aaa
 aaa
 aaa
@@ -160341,11 +160243,11 @@ dTw
 dTw
 dTw
 dTw
-hLO
-uZN
-hei
-gNJ
-jPA
+dTM
+pmy
+ait
+nME
+fdR
 dTw
 dTw
 dTw
@@ -160601,8 +160503,8 @@ dTw
 dZN
 dZN
 dZN
-xWZ
-nht
+uSw
+lpL
 dTw
 dTw
 dTw
@@ -174623,7 +174525,7 @@ aaa
 aaa
 aad
 aQQ
-aez
+urM
 aUp
 aVY
 aXE

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -66305,7 +66305,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "cxN" = (
 /obj/effect/turf_decal/stripes/line{
@@ -71323,10 +71323,6 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "cHh" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "Toxins Lab Maintenance";
-	req_access_txt = "8"
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -71337,12 +71333,14 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/obj/machinery/door/airlock/research{
+	name = "Toxins Mixing Lab";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "cHi" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
 "cHk" = (
@@ -71921,7 +71919,7 @@
 /obj/item/storage/box/lights/mixed,
 /obj/item/flashlight,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "cIi" = (
 /obj/structure/cable/yellow{
@@ -71933,7 +71931,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "cIj" = (
 /obj/structure/cable/yellow{
@@ -71945,7 +71943,7 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_y = 32
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "cIk" = (
 /obj/structure/cable/yellow{
@@ -72922,34 +72920,38 @@
 	},
 /area/maintenance/aft)
 "cJY" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/costume,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/portable_atmospherics/pump,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cJZ" = (
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/reagent_dispensers/watertank,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cKa" = (
-/obj/structure/closet,
-/obj/item/clothing/glasses/science,
-/obj/effect/spawner/lootdrop/maintenance,
 /obj/effect/turf_decal/stripes/line{
 	dir = 2
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cKb" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -73319,43 +73321,41 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "cKL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance/abandoned{
-	name = "Storage Room";
-	req_one_access_txt = "12;47"
+/obj/machinery/door/airlock/research{
+	name = "Toxins Mixing Lab";
+	req_access_txt = "8"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cKM" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cKN" = (
-/obj/item/storage/box/lights/mixed,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cKO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cKP" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/solars/starboard/aft)
@@ -73803,21 +73803,20 @@
 	},
 /area/maintenance/starboard/aft)
 "cLH" = (
-/obj/machinery/space_heater,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/airalarm/unlocked{
+	dir = 4;
+	pixel_x = -23
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cLJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet,
-/obj/item/storage/box/lights/mixed,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cLK" = (
 /obj/machinery/power/smes,
 /obj/structure/cable/yellow{
@@ -74706,54 +74705,22 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/aft)
 "cNi" = (
-/obj/machinery/biogenerator,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cNj" = (
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/banana,
-/obj/item/reagent_containers/food/snacks/grown/wheat,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/watermelon,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
-/obj/item/reagent_containers/food/snacks/grown/grapes,
-/obj/item/reagent_containers/food/snacks/grown/cocoapod,
-/obj/structure/rack,
-/obj/item/seeds/wheat,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/watermelon,
-/obj/item/seeds/grape,
-/obj/item/seeds/glowshroom,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/seeds/cannabis/rainbow,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cNk" = (
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/storage/bag/plants/portaseeder,
-/obj/item/plant_analyzer,
-/obj/item/cultivator,
-/obj/item/reagent_containers/glass/bucket,
-/obj/structure/rack,
-/obj/item/seeds/corn,
-/obj/item/seeds/cabbage,
-/obj/item/seeds/ambrosia,
-/obj/item/seeds/grass,
-/obj/item/reagent_containers/food/snacks/grown/mushroom/glowshroom,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cNl" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
 	},
-/obj/item/seeds/carrot,
-/obj/effect/turf_decal/stripes/line,
-/obj/item/seeds/cannabis/white,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
+"cNj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cNm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -74769,14 +74736,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cNn" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/plant_analyzer,
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cNo" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -75072,40 +75031,14 @@
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cNW" = (
-/obj/structure/sink/kitchen{
-	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
-	name = "old sink";
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"cNZ" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/starboard/aft)
-"cNX" = (
-/obj/item/seeds/watermelon,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cNY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/grille,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cNZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/chair,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cOa" = (
 /obj/structure/cable,
 /obj/machinery/power/turbine{
@@ -75394,26 +75327,14 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cOB" = (
-/obj/item/seeds/sunflower/moonflower,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/obj/effect/landmark/xeno_spawn,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cOD" = (
-/obj/item/seeds/berry,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "cOE" = (
-/obj/structure/reagent_dispensers/watertank,
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cOF" = (
 /obj/structure/table,
 /obj/item/storage/box/bodybags{
@@ -75614,57 +75535,14 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "cPf" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/seeds/glowshroom,
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 10
 	},
-/obj/item/seeds/cannabis/ultimate,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPg" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/cultivator,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPh" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/seeds/ambrosia,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPi" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/seeds/watermelon,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/item/seeds/cannabis,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"cPj" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/seeds/berry,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "cPk" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
@@ -78421,10 +78299,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard)
-"dbl" = (
-/obj/structure/easel,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "dbm" = (
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -81626,16 +81500,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"diU" = (
-/obj/structure/closet/crate,
-/obj/item/poster/random_official,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/effect/landmark/blobstart,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "diV" = (
 /obj/machinery/light{
 	dir = 8
@@ -81655,18 +81519,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"diW" = (
-/obj/machinery/hydroponics/soil{
-	pixel_y = 8
-	},
-/obj/item/seeds/glowshroom,
-/obj/item/seeds/corn,
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "djg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -82323,8 +82175,7 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAh" = (
-/obj/item/storage/box,
-/turf/open/floor/plating,
+/turf/open/floor/plasteel/white,
 /area/maintenance/starboard/aft)
 "dAn" = (
 /obj/structure/cable/yellow{
@@ -82337,15 +82188,6 @@
 	dir = 4
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"dAp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
 /area/maintenance/starboard/aft)
 "dAw" = (
 /obj/structure/cable/yellow{
@@ -82375,16 +82217,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "dAZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"dBe" = (
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
-	},
-/area/maintenance/starboard/aft)
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "dBu" = (
 /turf/closed/wall,
 /area/engine/gravity_generator)
@@ -83269,6 +83106,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"fAL" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Toxins Lab Maintenance";
+	req_access_txt = "8"
+	},
+/turf/open/floor/plasteel/white,
+/area/maintenance/starboard/aft)
 "fDD" = (
 /obj/machinery/light_switch{
 	pixel_y = -25
@@ -83389,6 +83239,13 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"htM" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/white,
+/area/maintenance/starboard/aft)
 "hvt" = (
 /obj/structure/kitchenspike_frame,
 /obj/effect/decal/cleanable/blood/gibs/old,
@@ -83403,6 +83260,14 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"hAz" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "hIt" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/poddoor/shutters{
@@ -83410,6 +83275,17 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hXj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
+"iin" = (
+/turf/closed/wall,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -83525,6 +83401,20 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"kfQ" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	name = "Toxins Lab Maintenance";
+	req_access_txt = "8"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/maintenance/starboard/aft)
 "krD" = (
 /turf/closed/wall,
 /area/science/circuit)
@@ -83655,6 +83545,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"lTN" = (
+/obj/effect/landmark/xeno_spawn,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "lWY" = (
 /obj/machinery/door/airlock/hatch{
 	name = "Telecomms Server Room"
@@ -83710,6 +83604,18 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"mNx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
+"mVW" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/science/mixing)
 "mWg" = (
 /obj/structure/girder,
 /obj/structure/grille,
@@ -83717,6 +83623,14 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/port/aft)
+"naZ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "nnK" = (
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/paper_bin,
@@ -84355,6 +84269,15 @@
 	},
 /turf/open/floor/plating,
 /area/security/prison)
+"wmj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/maintenance/starboard/aft)
 "wmt" = (
 /obj/effect/decal/cleanable/flour,
 /turf/open/floor/plating,
@@ -84417,6 +84340,12 @@
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"xmX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/space/basic,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "xse" = (
 /obj/machinery/door/airlock/external{
 	name = "Solar Maintenance";
@@ -84430,6 +84359,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/solars/starboard/aft)
+"xsh" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel/white,
+/area/science/mixing{
+	name = "Fusion Mixing Lab"
+	})
 "xwG" = (
 /obj/machinery/door/airlock/maintenance{
 	name = "Library Maintenance";
@@ -103154,7 +103089,7 @@ dux
 dux
 dux
 cby
-bXE
+lTN
 cer
 dux
 dwb
@@ -115015,7 +114950,7 @@ cSd
 cRe
 cRe
 cRe
-cRe
+cKO
 cRe
 cRe
 aaa
@@ -116808,12 +116743,12 @@ cIX
 cJU
 cIg
 cLF
-dvY
-dvY
-dvY
-dvY
-dvY
-dvY
+iin
+iin
+xmX
+xmX
+xmX
+iin
 cRe
 djh
 cYT
@@ -117065,12 +117000,12 @@ cIY
 cIe
 cIg
 cPe
-dvY
+iin
 cNi
-cgs
-cOB
+hAz
+hAz
 cPf
-dvY
+iin
 cRe
 cRe
 cRe
@@ -117322,12 +117257,12 @@ cIZ
 cJW
 cIg
 dDF
-dvY
+iin
 cNj
-ciL
-ciL
-cPg
-dvY
+cKO
+cKO
+xsh
+hXj
 aaa
 aaa
 aaa
@@ -117578,13 +117513,13 @@ cIg
 cIg
 cIg
 cIg
-dxQ
-dvY
-cNk
-ciL
-ciL
-cPh
-dvY
+fAL
+iin
+cNj
+cKO
+cKO
+xsh
+hXj
 aaa
 aaa
 aaf
@@ -117833,15 +117768,15 @@ cGl
 cHg
 cIh
 dAh
-dbl
-dyc
-dxQ
-dvY
-dvY
-cNW
-cOC
-dvY
-dvY
+dAh
+dAh
+wmj
+iin
+cNj
+cKO
+cKO
+xsh
+hXj
 aaa
 aaa
 aaa
@@ -118089,16 +118024,16 @@ cDn
 cGm
 cHh
 cIi
-cJa
-dAp
+htM
+htM
 cKK
 cxM
-dvY
-cNl
-dAZ
-cOD
-cPi
-dvY
+iin
+cNj
+cKO
+cKO
+xsh
+hXj
 aaa
 aaa
 aaf
@@ -118346,16 +118281,16 @@ cFs
 cGn
 cHi
 cIj
-dvY
-dvY
+iin
+iin
 cKL
-dvY
-dvY
-diW
-cNX
-dBe
-cPj
-dvY
+iin
+iin
+cNj
+cKO
+cKO
+xsh
+hXj
 aaa
 aaa
 aaf
@@ -118601,18 +118536,18 @@ cDp
 cyK
 cyK
 cyK
-cyK
-cPe
-dvY
+mVW
+kfQ
+mNx
 cJY
 cKM
 cLH
-dvY
-cNn
+xsh
+cNj
 dAZ
 cOE
-cPh
-dvY
+cNZ
+iin
 aaa
 aaa
 aaf
@@ -118860,16 +118795,16 @@ dvY
 dyc
 cub
 diP
-dvY
+iin
 cJZ
 cKN
-diU
-dvY
-dvY
-cNY
-dvY
-dvY
-dvY
+cKO
+xsh
+cNj
+xsh
+iin
+iin
+iin
 aaa
 aaa
 aaa
@@ -119117,14 +119052,14 @@ dvY
 cEz
 dxQ
 dyc
-dvY
+iin
 cKa
 cKO
 cLJ
-cor
-cmZ
+xsh
+naZ
 cNZ
-dxk
+hXj
 aaa
 aaa
 aaa
@@ -119374,10 +119309,10 @@ czC
 dzI
 cIl
 dAd
-dvY
-dvY
-dvY
-dvY
+iin
+iin
+iin
+iin
 cKP
 cKP
 cKP


### PR DESCRIPTION
## About The Pull Request

Gives some blank rooms by toxins in each of the maps stated, mostly for them to test small scale cold fusion or other such things.

Each fusion lab has a little to no pipes, wiring or other things to get in the way. Other then at lest 1 scrubber in all and at lest 1 vent to get air close by or in the same room.
Note that delta dosnt have a vent into its room, thats do to the vent outside the room being able to do supple if needed 
Each fusion lab also has 2 scrubbers, and two pumps. Nothing more, nothing less

## Why It's Good For The Game

ATM toxins itself isn't modular at all, once 1 person fucks it its gone, really harder to fix and easy to cluck, but now we make are own custion cold and or hot fusion sets using the never used maints spaces. 

## Changelog
:cl:
add: Fusion labs
/:cl:
