### PR TITLE
Nerfs Autocloning Pt. 2.1: Autoscan

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -63,9 +63,11 @@
 /obj/machinery/computer/cloning/process()
 	if(!(scanner && LAZYLEN(pods) && autoprocess))
 		return
-
-	if(scanner.occupant && scanner.scan_level > 2)
-		scan_occupant(scanner.occupant)
+		
+	if(ismob(scanner.occupant))
+		var/mob/M = scanner.occpuant
+		if(M.stat == DEAD) //you must be kill to autoscan.
+			scan_occupant(scanner.occupant) //I blame kevin
 
 	for(var/datum/data/record/R in records)
 		var/obj/machinery/clonepod/pod = GetAvailableEfficientPod(R.fields["mind"])

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -63,11 +63,6 @@
 /obj/machinery/computer/cloning/process()
 	if(!(scanner && LAZYLEN(pods) && autoprocess))
 		return
-		
-	if(ismob(scanner.occupant))
-		var/mob/M = scanner.occpuant
-		if(M.stat == DEAD) //you must be kill to autoscan.
-			scan_occupant(scanner.occupant) //I blame kevin
 
 	for(var/datum/data/record/R in records)
 		var/obj/machinery/clonepod/pod = GetAvailableEfficientPod(R.fields["mind"])


### PR DESCRIPTION
Second attempt at #9159 but with a refreshed fork

## About The Pull Request
Removes the automatic scanning function of cloning autoprocess. All occupants in the scanner must be manually added to the cloning database.

## Why It's Good For The Game

Cloning will now require someone press the "Scan" button whenever anyone alive is in the DNA scanner. This will things slightly more tedious for anyone attempting to pre-scan, but will also prevent a lot of cloning cheese available when autocloning becomes possible.

**This PR is NOT removing the following:
-Autocloning
-Pre-scanning***

*So long as you have a buddy to scan you

What this WILL remove:
-Making autocloners in space/maint where nobody can find them
-Scanning yourself for autoclone immediately after cloning
-Autocloning removing all interaction from medical from the cloner.

## Changelog
:cl: Yakumo Chen
del: Removes autoscan
balance:  Scanning people now requires someone to operate the cloning computer regardless of part level.
/:cl:

**Warning: If you make a comment complaining about the Autocloning Balance I will laugh at you for not reading the PR.**