### PR TITLE
Partially fixes tiny runaway decimals in reagents.

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -873,7 +873,7 @@
 		var/datum/reagent/R = A
 		if (R.id == reagent) //IF MERGING
 			//Add amount and equalize purity
-			R.volume += amount
+			R.volume += round(amount, CHEMICAL_QUANTISATION_LEVEL)
 			R.purity = ((R.purity * R.volume) + (other_purity * amount)) /((R.volume + amount)) //This should add the purity to the product
 
 			update_total()
@@ -895,7 +895,7 @@
 	var/datum/reagent/R = new D.type(data)
 	cached_reagents += R
 	R.holder = src
-	R.volume = amount
+	R.volume = round(amount, CHEMICAL_QUANTISATION_LEVEL)
 	R.purity = other_purity
 	R.loc = get_turf(my_atom)
 	if(data)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -1,4 +1,4 @@
-#define CHEMICAL_QUANTISATION_LEVEL 0.0001
+#define CHEMICAL_QUANTISATION_LEVEL 0.001
 
 /proc/build_chemical_reagent_list()
 	//Chemical Reagents - Initialises all /datum/reagent into a list indexed by reagent id
@@ -745,7 +745,6 @@
 			del_reagent(R.id)
 		else
 			total_volume += R.volume
-
 	return 0
 
 /datum/reagents/proc/clear_reagents()

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -332,7 +332,7 @@
 				var/vol_part = min(reagents.total_volume, 30)
 				if(text2num(many))
 					amount_full = round(reagents.total_volume / 30)
-					vol_part = reagents.total_volume % 30
+					vol_part = ((reagents.total_volume*1000) % 30000) / 1000 //% operator doesn't support decimals.
 				var/name = stripped_input(usr, "Name:","Name your bottle!", (reagents.total_volume ? reagents.get_master_reagent_name() : " "), MAX_NAME_LEN)
 				if(!name || !reagents.total_volume || !src || QDELETED(src) || !usr.canUseTopic(src, !issilicon(usr)))
 					return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->
## Abstract
Partially fixes tiny runaway decimals in reagents system.


## About The Pull Request

Fixes a problem that changing the quantification PR made with small rounding errors, as well as lets the chem master dispense decimals correctly. There might need to be another follow-up to this with fringe fermichem reactions, but we'll see.

Much like the previous one, I recommend test merging this first.

I know that ammonia still results in residue, and I'm not quite sure how to fix this without an overblown thing but, at least for now the chem master isn't borking up, so i'm putting this up as is so I can continue to work at it without the chemmaster problem.

## Why It's Good For The Game

Removes residual chems in beakers and the like.

## Changelog
:cl: Fermi
fix: Fixes tiny runaway decimals in reagents system.
/:cl:


<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
