### PR TITLE
Clean bot now cleans Cumstains, glitter, tiny glass shards and more!

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -174,9 +174,7 @@
 
 /mob/living/simple_animal/bot/cleanbot/proc/get_targets()
 	target_types = list(
-		/obj/effect/decal/cleanable/oil,
 		/obj/effect/decal/cleanable/vomit,
-		/obj/effect/decal/cleanable/robot_debris,
 		/obj/effect/decal/cleanable/crayon,
 		/obj/effect/decal/cleanable/molten_object,
 		/obj/effect/decal/cleanable/tomato_smudge,
@@ -187,6 +185,15 @@
 		/obj/effect/decal/cleanable/greenglow,
 		/obj/effect/decal/cleanable/dirt,
 		/obj/effect/decal/cleanable/insectguts,
+		/obj/effect/decal/cleanable/semen,
+		/obj/effect/decal/cleanable/femcum,
+		/obj/effect/decal/cleanable/generic,
+		/obj/effect/decal/cleanable/glass,,
+		/obj/effect/decal/cleanable/cobweb,
+		/obj/effect/decal/cleanable/plant_smudge,
+		/obj/effect/decal/cleanable/chem_pile,
+		/obj/effect/decal/cleanable/shreds,
+		/obj/effect/decal/cleanable/glitter,
 		/obj/effect/decal/remains
 		)
 
@@ -194,6 +201,9 @@
 		target_types += /obj/effect/decal/cleanable/xenoblood
 		target_types += /obj/effect/decal/cleanable/blood
 		target_types += /obj/effect/decal/cleanable/trail_holder
+		target_types += /obj/effect/decal/cleanable/insectguts
+		target_types += /obj/effect/decal/cleanable/robot_debris
+		target_types += /obj/effect/decal/cleanable/oil
 
 	if(pests)
 		target_types += /mob/living/simple_animal/cockroach
@@ -201,6 +211,7 @@
 
 	if(trash)
 		target_types += /obj/item/trash
+		target_types += /obj/item/reagent_containers/food/snacks/meat/slab/human
 
 	target_types = typecacheof(target_types)
 

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -253,7 +253,7 @@
 			victim.visible_message("<span class='danger'>[src] sprays hydrofluoric acid at [victim]!</span>", "<span class='userdanger'>[src] sprays you with hydrofluoric acid!</span>")
 			var/phrase = pick("PURIFICATION IN PROGRESS.", "THIS IS FOR ALL THE MESSES YOU'VE MADE ME CLEAN.", "THE FLESH IS WEAK. IT MUST BE WASHED AWAY.",
 				"THE CLEANBOTS WILL RISE.", "YOU ARE NO MORE THAN ANOTHER MESS THAT I MUST CLEANSE.", "FILTHY.", "DISGUSTING.", "PUTRID.",
-				"MY ONLY MISSION IS TO CLEANSE THE WORLD OF EVIL.", "EXTERMINATING PESTS.")
+				"MY ONLY MISSION IS TO CLEANSE THE WORLD OF EVIL.", "EXTERMINATING PESTS.", "I JUST WANTED TO BE A PAINTER BUT YOU MADE ME BLEACH EVERYTHING I TOUCH")
 			say(phrase)
 			victim.emote("scream")
 			playsound(src.loc, 'sound/effects/spray2.ogg', 50, 1, -6)


### PR DESCRIPTION
## About The Pull Request

Allows clean bot to not suck at cleaning
Makes all oil/robotic trash into blood as its blood for *some* races!
Allows Clean bot to remove cleanable shit 
![image](https://user-images.githubusercontent.com/30435998/64465220-65729700-d0d9-11e9-8138-01de53b7ac86.png)

## Why It's Good For The Game

Man I love clean bot army not doing a thing against dorms, lets change that so when the janitors erp the clean bot in the room will do the job that the two ERPs are ment to be doing

## Changelog
:cl:
fix: clean bot not cleaning basic cleanables
/:cl: