### PR TITLE
Changes Abductor Spawntext

### DIFF
--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -56,6 +56,7 @@
 /datum/antagonist/abductor/greet()
 	to_chat(owner.current, "<span class='notice'>You are the [owner.special_role]!</span>")
 	to_chat(owner.current, "<span class='notice'>With the help of your teammate, kidnap and experiment on station crew members!</span>")
+	to_chat(owner.current, "<span class='notice'>Try not to disturb the habitat, it could lead to dead specimens.</span>")
 	to_chat(owner.current, "<span class='notice'>[greet_text]</span>")
 	owner.announce_objectives()
 

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -53,7 +53,7 @@
 		linked_organ = null
 
 /obj/item/organ/genital/testicles/proc/send_full_message(msg = "Your balls finally feel full, again.")
-	if(owner && istext(msg))
+	if(owner && istext(msg) && M.canbearoused)
 		to_chat(owner, msg)
 		return TRUE
 

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -53,7 +53,7 @@
 		linked_organ = null
 
 /obj/item/organ/genital/testicles/proc/send_full_message(msg = "Your balls finally feel full, again.")
-	if(owner && istext(msg) && M.canbearoused)
+	if(owner && istext(msg))
 		to_chat(owner, msg)
 		return TRUE
 


### PR DESCRIPTION
## About The Pull Request

Adds "Try not to disturb the habitat, it could lead to dead specimens." to the abductor spawntext

## Why It's Good For The Game

Makes it so that the round ending-ness of abductors is due to their experiments rather than them rolling up and breaking everything in their path.

## Changelog
:cl:
tweak: tweaked a few things
/:cl: