### PR TITLE
MedHud added to mining vendor

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -38,6 +38,7 @@
 		new /datum/data/mining_equipment("First-Aid Kit",				/obj/item/storage/firstaid/regular,									800),
 		new /datum/data/mining_equipment("Advanced Scanner",			/obj/item/t_scanner/adv_mining_scanner,								800),
 		new /datum/data/mining_equipment("Resonator",					/obj/item/resonator,												800),
+		new /datum/data/mining_equipment("medical HUDSunglasses",		/obj/item/clothing/glasses/hud/health/sunglasses,					1000),
 		new /datum/data/mining_equipment("Mini Extinguisher",			/obj/item/extinguisher/mini,										1000),
 		new /datum/data/mining_equipment("Fulton Pack",					/obj/item/extraction_pack,											1000),
 		new /datum/data/mining_equipment("Lazarus Injector",			/obj/item/lazarus_injector,											1000),


### PR DESCRIPTION
## About The Pull Request
Adds the medical hud sunglasses in the mining vendor for 1000 points.

## Why It's Good For The Game
Gives miners the ability to see the HP of mobs within lavaland. Provides knowledge of how TERRIBLE your damage is and how long you must suffer waiting for that damn HEIROPHANT to just die. :>

## Changelog
:cl:
add: Added more things
/:cl:

