### PR TITLE
Fixes Neurotoxin's ability to be made

### DIFF
--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -1373,6 +1373,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 
 /datum/reagent/consumable/ethanol/neurotoxin
 	name = "Neurotoxin"
+	id = "neurotoxin"
 	description = "A strong neurotoxin that puts the subject into a death-like state."
 	color = "#2E2E61" // rgb: 46, 46, 97
 	boozepwr = 50


### PR DESCRIPTION
## About The Pull Request
Currently bartenders are unable to combine Pan galactic gargle blaster with morphine to create a drink. This change re-allows them to do so. Not sure why the id for the drink was removed.
## Why It's Good For The Game
Fixes a bug/removed feature
## Changelog
:cl:
code: changed some code
/:cl:
