### PR TITLE
Makes Blue/Amber alarms not allow random searches to be allowed

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -164,13 +164,13 @@
 	config_entry_value = "All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced."
 
 /datum/config_entry/string/alert_blue_upto
-	config_entry_value = "The station has received reliable information about potential threats to the station. Security staff may have weapons visible, random searches are permitted."
+	config_entry_value = "The station has received reliable information about potential threats to the station. Security staff may have weapons visible, searches within reason are permitted."
 
 /datum/config_entry/string/alert_blue_downto
-	config_entry_value = "Significant confirmed threats have been neutralized. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still permitted."
+	config_entry_value = "Significant confirmed threats have been neutralized. Security may no longer have weapons drawn at all times, but may continue to have them visible. Searches within reason are still permitted."
 
 /datum/config_entry/string/alert_amber_upto
-	config_entry_value = "There are significant confirmed threats to the station. Security staff may have weapons unholstered at all times. Random searches are allowed and advised."
+	config_entry_value = "There are significant confirmed threats to the station. Security staff may have weapons unholstered at all times. Searches within reason are still permitted and advised."
 
 /datum/config_entry/string/alert_amber_downto
 	config_entry_value = "The immediate threat has passed. Security is no longer authorized to use lethal force, but may continue to have weapons drawn. Access requirements have been restored."

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -57,9 +57,9 @@ MULTIPLICATIVE_MOVESPEED /mob/living/simple_animal 1
 
 ## ALERT LEVELS ###
 ALERT_GREEN All threats to the station have passed. Security may not have weapons visible, privacy laws are once again fully enforced.
-ALERT_BLUE_UPTO The station has received reliable information about potential threats to the station. Security staff may have weapons visible, random searches are permitted.
-ALERT_BLUE_DOWNTO Significant confirmed threats have been neutralized. Security may no longer have weapons drawn at all times, but may continue to have them visible. Random searches are still permitted.
-ALERT_AMBER_UPTO There are signficant confirmed threats to the station. Security staff may have weapons unholstered at all times. Random searches are allowed and advised.
+ALERT_BLUE_UPTO The station has received reliable information about potential threats to the station. Security staff may have weapons visible, searches within reason are permitted.
+ALERT_BLUE_DOWNTO Significant confirmed threats have been neutralized. Security may no longer have weapons drawn at all times, but may continue to have them visible. Searches within reason are still permitted.
+ALERT_AMBER_UPTO There are signficant confirmed threats to the station. Security staff may have weapons unholstered at all times. Searches within reason are allowed and advised.
 ALERT_AMBER_DOWNTO The immediate threat has passed. Security is no longer authorized to use lethal force, but may continue to have weapons drawn. Access requirements have been restored.
 ALERT_RED_UPTO There is an immediate serious threat to the station. Security is now authorized to use lethal force. Additionally, access requirements on some machines have been lifted.
 ALERT_RED_DOWNTO The station's destruction has been averted. There is still however an immediate serious threat to the station. Security is still authorized to use lethal force.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Blue/Amber alarms messages say your able to do random searches even though this is against are rules. Mr.White has pointed this out and thus im fixing it

## Why It's Good For The Game

People can fain In game reason to justify rule braking, or be mislead into thinking you can when you cant

## Changelog
:cl:
spellcheck: updates alarms to are rule standerds
config: config wording bad mans
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
