### PR TITLE
Changeling Buffs

### DIFF
--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -1,11 +1,11 @@
 /obj/effect/proc_holder/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
-	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 3 DNA gained through Absorb, and not through DNA sting. This ability is very loud, and will guarantee that our blood will react violently to heat."
+	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown.This ability is loud, and might cause our blood to react violently to heat."
 	chemical_cost = 45
 	dna_cost = 1
-	loudness = 4
-	req_absorbs = 3
+	loudness = 2
+	req_human = 1
 	action_icon = 'icons/effects/effects.dmi'
 	action_icon_state = "spiderling"
 	action_background_icon_state = "bg_ling"

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -5,7 +5,7 @@
 	chemical_cost = 45
 	dna_cost = 1
 	loudness = 2
-	req_human = 1
+	req_absorbs = 2
 	action_icon = 'icons/effects/effects.dmi'
 	action_icon_state = "spiderling"
 	action_background_icon_state = "bg_ling"

--- a/code/modules/antagonists/changeling/powers/spiders.dm
+++ b/code/modules/antagonists/changeling/powers/spiders.dm
@@ -1,11 +1,11 @@
 /obj/effect/proc_holder/changeling/spiders
 	name = "Spread Infestation"
 	desc = "Our form divides, creating arachnids which will grow into deadly beasts."
-	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown.This ability is loud, and might cause our blood to react violently to heat."
+	helptext = "The spiders are thoughtless creatures, and may attack their creators when fully grown. Requires at least 3 DNA gained through Absorb, and not through DNA sting. This ability is very loud, and will guarantee that our blood will react violently to heat."
 	chemical_cost = 45
 	dna_cost = 1
-	loudness = 2
-	req_absorbs = 2
+	loudness = 4
+	req_absorbs = 3
 	action_icon = 'icons/effects/effects.dmi'
 	action_icon_state = "spiderling"
 	action_background_icon_state = "bg_ling"

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -198,7 +198,7 @@
 	sting_icon = "sting_mute"
 	chemical_cost = 20
 	dna_cost = 2
-	loudness = 1
+	loudness = 2
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_mute"
 	action_background_icon_state = "bg_ling"
@@ -253,7 +253,7 @@
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing. This ability is somewhat loud, and carries a small risk of our blood gaining violent sensitivity to heat."
 	sting_icon = "sting_cryo"
 	chemical_cost = 15
-	dna_cost = 1
+	dna_cost = 2
 	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_cryo"

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -198,7 +198,7 @@
 	sting_icon = "sting_mute"
 	chemical_cost = 20
 	dna_cost = 2
-	loudness = 2
+	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_mute"
 	action_background_icon_state = "bg_ling"
@@ -233,7 +233,7 @@
 	desc = "Causes terror in the target and deals a minor amount of toxin damage."
 	helptext = "We evolve the ability to sting a target with a powerful toxic hallucinogenic chemical. The target does not notice they have been stung, and the effect begins instantaneously. This ability is somewhat loud, and carries a small risk of our blood gaining violent sensitivity to heat."
 	sting_icon = "sting_lsd"
-	chemical_cost = 10
+	chemical_cost = 15
 	dna_cost = 1
 	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
@@ -243,8 +243,8 @@
 /obj/effect/proc_holder/changeling/sting/LSD/sting_action(mob/user, mob/target)
 	log_combat(user, target, "stung", "LSD sting")
 	if(target.reagents)
-		target.reagents.add_reagent("regenerative_materia", 5)
-		target.reagents.add_reagent("mindbreaker", 5)
+		target.reagents.add_reagent("regenerative_materia", 10)
+		target.reagents.add_reagent("mindbreaker", 10)
 	return TRUE
 
 /obj/effect/proc_holder/changeling/sting/cryo
@@ -253,7 +253,7 @@
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing. This ability is somewhat loud, and carries a small risk of our blood gaining violent sensitivity to heat."
 	sting_icon = "sting_cryo"
 	chemical_cost = 15
-	dna_cost = 2
+	dna_cost = 1
 	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_cryo"

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -198,7 +198,7 @@
 	sting_icon = "sting_mute"
 	chemical_cost = 20
 	dna_cost = 2
-	loudness = 2
+	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_mute"
 	action_background_icon_state = "bg_ling"
@@ -253,7 +253,7 @@
 	helptext = "Does not provide a warning to the victim, though they will likely realize they are suddenly freezing. This ability is somewhat loud, and carries a small risk of our blood gaining violent sensitivity to heat."
 	sting_icon = "sting_cryo"
 	chemical_cost = 15
-	dna_cost = 2
+	dna_cost = 1
 	loudness = 1
 	action_icon = 'icons/mob/actions/actions_changeling.dmi'
 	action_icon_state = "ling_sting_cryo"


### PR DESCRIPTION
## About The Pull Request
Makes the spider ability able to be gained on round start and not after three absorbs.
Lowered the loudness of spiderlings and mute sting.
Lowered the DNA cost of cryo sting.
Increased the chemical cost of Hallucination sting while doubling the Mindbreaker toxin and regenerative materia.

## Why It's Good For The Game
A small step in adding a bit more interest to the changeling gamemode. More to come soon, hopefully.

## Editlog
09/15/2019 18:00pm CST
Adjusted spider requirement to require absorbs but still lowered by 1. 3 -> 2 required.
Reverted Cryo and mute sting changes

## Changelog
:cl:
tweak: tweaked a few things
balance: rebalanced something
/:cl:
