### PR TITLE
leftover legcuffs/handcuffs overlays fix.

### DIFF
--- a/code/modules/mob/living/carbon/update_icons.dm
+++ b/code/modules/mob/living/carbon/update_icons.dm
@@ -189,7 +189,7 @@
 		var/mutable_appearance/legcuffs = mutable_appearance('icons/mob/restraints.dmi', legcuffed.item_state, -LEGCUFF_LAYER)
 		legcuffs.color = legcuffed.color
 
-		overlays_standing[HANDCUFF_LAYER] = legcuffs
+		overlays_standing[LEGCUFF_LAYER] = legcuffs
 		apply_overlay(LEGCUFF_LAYER)
 		throw_alert("legcuffed", /obj/screen/alert/restrained/legcuffed, new_master = legcuffed)
 


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. One line, bad copypasta.

## Why It's Good For The Game
Fixes some overlay bug that happens when legcuffed and then handcuffed.

## Changelog
:cl:
fix: Fixed some overlay bug that happens when legcuffed and then handcuffed.
/:cl: