### PR TITLE
fixes roundstart runtimes by job_preferences index checks be explicit key checks instead, plus some extra sanity checks

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -182,7 +182,7 @@ SUBSYSTEM_DEF(job)
 			if((job.current_positions >= job.total_positions) && job.total_positions != -1)
 				continue
 			var/list/candidates = FindOccupationCandidates(job, level)
-			if(!candidates.len)
+			if(!candidates?.len)
 				continue
 			var/mob/dead/new_player/candidate = pick(candidates)
 			if(AssignRole(candidate, command_position))
@@ -200,7 +200,7 @@ SUBSYSTEM_DEF(job)
 		if((job.current_positions >= job.total_positions) && job.total_positions != -1)
 			continue
 		var/list/candidates = FindOccupationCandidates(job, level)
-		if(!candidates.len)
+		if(!candidates?.len)
 			continue
 		var/mob/dead/new_player/candidate = pick(candidates)
 		AssignRole(candidate, command_position)

--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -116,7 +116,7 @@ SUBSYSTEM_DEF(job)
 		if(player.mind && job.title in player.mind.restricted_roles)
 			JobDebug("FOC incompatible with antagonist role, Player: [player]")
 			continue
-		if(player.client.prefs.job_preferences[job.title] == level)
+		if(player.client.prefs.job_preferences["[job.title]"] == level)
 			JobDebug("FOC pass, Player: [player], Level:[level]")
 			candidates += player
 	return candidates
@@ -246,7 +246,7 @@ SUBSYSTEM_DEF(job)
 
 	initial_players_to_assign = unassigned.len
 
-	JobDebug("DO, Len: [unassigned.len]")
+	JobDebug("DO, Len: [unassigned?.len]")
 	if(unassigned.len == 0)
 		return validate_required_jobs(required_jobs)
 
@@ -270,7 +270,7 @@ SUBSYSTEM_DEF(job)
 	JobDebug("DO, Running Overflow Check 1")
 	var/datum/job/overflow = GetJob(SSjob.overflow_role)
 	var/list/overflow_candidates = FindOccupationCandidates(overflow, JP_LOW)
-	JobDebug("AC1, Candidates: [overflow_candidates.len]")
+	JobDebug("AC1, Candidates: [overflow_candidates?.len]")
 	for(var/mob/dead/new_player/player in overflow_candidates)
 		JobDebug("AC1 pass, Player: [player]")
 		AssignRole(player, SSjob.overflow_role)
@@ -333,7 +333,7 @@ SUBSYSTEM_DEF(job)
 					continue
 
 				// If the player wants that job on this level, then try give it to him.
-				if(player.client.prefs.job_preferences[job.title] == level)
+				if(player.client.prefs.job_preferences["[job.title]"] == level)
 					// If the job isn't filled
 					if((job.current_positions < job.spawn_positions) || job.spawn_positions == -1)
 						JobDebug("DO pass, Player: [player], Level:[level], Job:[job.title]")
@@ -540,7 +540,7 @@ SUBSYSTEM_DEF(job)
 			if(job.required_playtime_remaining(player.client))
 				young++
 				continue
-			switch(player.client.prefs.job_preferences[job.title])
+			switch(player.client.prefs.job_preferences["[job.title]"])
 				if(JP_HIGH)
 					high++
 				if(JP_MEDIUM)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1039,7 +1039,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/available_in_days = job.available_in_days(user.client)
 				HTML += "<font color=red>[rank]</font></td><td><font color=red> \[IN [(available_in_days)] DAYS\]</font></td></tr>"
 				continue
-			if((job_preferences[SSjob.overflow_role] == JP_LOW) && (rank != SSjob.overflow_role) && !jobban_isbanned(user, SSjob.overflow_role))
+			if((job_preferences["[SSjob.overflow_role]"] == JP_LOW) && (rank != SSjob.overflow_role) && !jobban_isbanned(user, SSjob.overflow_role))
 				HTML += "<font color=orange>[rank]</font></td><td></td></tr>"
 				continue
 			if((rank in GLOB.command_positions) || (rank == "AI"))//Bold head jobs
@@ -1054,7 +1054,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			var/prefUpperLevel = -1 // level to assign on left click
 			var/prefLowerLevel = -1 // level to assign on right click
 
-			switch(job_preferences[job.title])
+			switch(job_preferences["[job.title]"])
 				if(JP_HIGH)
 					prefLevelLabel = "High"
 					prefLevelColor = "slateblue"
@@ -1079,7 +1079,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			HTML += "<a class='white' href='?_src_=prefs;preference=job;task=setJobLevel;level=[prefUpperLevel];text=[rank]' oncontextmenu='javascript:return setJobPrefRedirect([prefLowerLevel], \"[rank]\");'>"
 
 			if(rank == SSjob.overflow_role)//Overflow is special
-				if(job_preferences[SSjob.overflow_role] == JP_LOW)
+				if(job_preferences["[SSjob.overflow_role]"] == JP_LOW)
 					HTML += "<font color=green>Yes</font>"
 				else
 					HTML += "<font color=red>No</font>"
@@ -1115,11 +1115,11 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 	if (level == JP_HIGH) // to high
 		//Set all other high to medium
 		for(var/j in job_preferences)
-			if(job_preferences[j] == JP_HIGH)
-				job_preferences[j] = JP_MEDIUM
+			if(job_preferences["[j]"] == JP_HIGH)
+				job_preferences["[j]"] = JP_MEDIUM
 				//technically break here
 
-	job_preferences[job.title] = level
+	job_preferences["[job.title]"] = level
 	return TRUE
 
 /datum/preferences/proc/UpdateJobPreference(mob/user, role, desiredLvl)
@@ -1147,7 +1147,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 			jpval = JP_HIGH
 
 	if(role == SSjob.overflow_role)
-		if(job_preferences[job.title] == JP_LOW)
+		if(job_preferences["[job.title]"] == JP_LOW)
 			jpval = null
 		else
 			jpval = JP_LOW

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -101,7 +101,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 					else if(job_engsec_low & fval)
 						new_value = JP_LOW
 			if(new_value)
-				job_preferences[initial(J.title)] = new_value
+				job_preferences["[initial(J.title)]"] = new_value
 	if((current_version < 22) && features["meat_type"] && (features["meat_type"] == null))
 		features["meat_type"] = "Mammalian"
 
@@ -485,7 +485,7 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	joblessrole	= sanitize_integer(joblessrole, 1, 3, initial(joblessrole))
 	//Validate job prefs
 	for(var/j in job_preferences)
-		if(job_preferences[j] != JP_LOW && job_preferences[j] != JP_MEDIUM && job_preferences[j] != JP_HIGH)
+		if(job_preferences["[j]"] != JP_LOW && job_preferences["[j]"] != JP_MEDIUM && job_preferences["[j]"] != JP_HIGH)
 			job_preferences -= j
 
 	all_quirks = SANITIZE_LIST(all_quirks)

--- a/code/modules/mob/dead/new_player/preferences_setup.dm
+++ b/code/modules/mob/dead/new_player/preferences_setup.dm
@@ -28,9 +28,9 @@
 	var/datum/job/previewJob
 	var/highest_pref = 0
 	for(var/job in job_preferences)
-		if(job_preferences[job] > highest_pref)
+		if(job_preferences["[job]"] > highest_pref)
 			previewJob = SSjob.GetJob(job)
-			highest_pref = job_preferences[job]
+			highest_pref = job_preferences["[job]"]
 
 	if(previewJob)
 		// Silicons only need a very basic preview since there is no customization for them.


### PR DESCRIPTION
When everyone's panicking, things like this go unnoticed.

## Changelog
:cl:
fix: Things that access job_preferences now explicitly access keys, which means it no longer attempts to access invalid indices and runtimes as a result.
/:cl:
