### PR TITLE
Reduces jetpack speed bonus on CERTAIN jetpacks while doubling efficiency

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1339,9 +1339,9 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		if(!istype(J) && istype(C))
 			J = C.jetpack
 		if(istype(J) && J.full_speed && J.allow_thrust(0.005, H))	//Prevents stacking
-			. -= 1
+			. -= 0.4
 		else if(istype(T) && T.allow_thrust(0.005, H))
-			. -= 1
+			. -= 0.4
 
 	if(!ignoreslow && gravity)
 		if(H.wear_suit)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1338,10 +1338,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		var/obj/item/organ/cyberimp/chest/thrusters/T = H.getorganslot(ORGAN_SLOT_THRUSTERS)
 		if(!istype(J) && istype(C))
 			J = C.jetpack
-		if(istype(J) && J.full_speed && J.allow_thrust(0.01, H))	//Prevents stacking
-			. -= 2
-		else if(istype(T) && T.allow_thrust(0.01, H))
-			. -= 2
+		if(istype(J) && J.full_speed && J.allow_thrust(0.005, H))	//Prevents stacking
+			. -= 1
+		else if(istype(T) && T.allow_thrust(0.005, H))
+			. -= 1
 
 	if(!ignoreslow && gravity)
 		if(H.wear_suit)


### PR DESCRIPTION
## About The Pull Request

Jetpack flat slowdown reduction reduced from 2 to 0.4, and jetpack fuel consumption per tile halved from 0.01 to 0.005.

Affects: 
- jetpack (empty)
- jetpack (carbon dioxide)
- jetpack (oxygen)
- jet harness (oxygen)
- Captain's Jetpack

Anything not listed here, such as engineering and security jetpacks, is not affected and uses the original slowdown calculation.

## Why It's Good For The Game

Special jetpack movement speed is a bit of a joke in space. Most bullets travel slower than a person in a jetpack and the speed of which a jetpack user moves is ludicrous. This is because movement code is a bit of a joke and the adjustment is a flat damage reduction for those certain jetpacks. To get an idea how silly it is, **there is actually no difference between a change from -2 to -1** because while flying, it ignores most slowdown modifiers so you move at max movement speed anyways. There is a slight difference at 0.4, but it is still fast enough to ALMOST outrun a bullet which is why it is specifically set to 0.4.

Again, this does not affect most jetpacks that you can get. These are the special jetpacks with DIFFERENT movement calculations that antags are usually given or the captain is usually given. **The ones in EVA, engineering, or mining will be the same and are not touched by this PR.**

## Changelog
:cl:
balance: Rebalanced special jetpacks.
/:cl:
