### PR TITLE
Adds Windoors to all the flaps on DeltaStation

### DIFF
--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -15021,6 +15021,9 @@
 	location = "Bar"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "25"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aGc" = (
@@ -21299,6 +21302,9 @@
 	location = "Theatre"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	req_access_txt = "46"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
 "aQj" = (
@@ -26153,6 +26159,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastright{
+	req_one_access_txt = "48,50"
+	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aXg" = (
@@ -29213,6 +29222,9 @@
 	location = "Kitchen"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/eastleft{
+	req_access_txt = "28"
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bcd" = (
@@ -30865,6 +30877,9 @@
 	location = "Hydroponics"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	req_access_txt = "35"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
 "beW" = (
@@ -36055,6 +36070,9 @@
 /obj/structure/plasticflaps/opaque,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northright{
+	req_access_txt = "48"
+	},
 /turf/open/floor/plasteel,
 /area/maintenance/starboard/fore)
 "bnB" = (
@@ -41789,6 +41807,9 @@
 	location = "Atmospherics"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	req_access_txt = "24"
+	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bwH" = (
@@ -82547,6 +82568,9 @@
 	location = "Engineering"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northright{
+	req_access_txt = "10"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cIr" = (
@@ -87734,6 +87758,9 @@
 	location = "Medbay"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/westleft{
+	req_access_txt = "5"
+	},
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cRl" = (
@@ -114081,6 +114108,9 @@
 	location = "Robotics"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northright{
+	req_access_txt = "47"
+	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "dKl" = (
@@ -127273,6 +127303,19 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"oOb" = (
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/door/window{
+	req_one_access_txt = "48,50"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/quartermaster/sorting)
 "oSD" = (
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
@@ -167677,7 +167720,7 @@ aCP
 avQ
 aFe
 aGp
-aHH
+oOb
 aJg
 aKF
 aLP

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -71774,6 +71774,9 @@
 	location = "Security"
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/door/window/northleft{
+	req_access_txt = "63"
+	},
 /turf/open/floor/plasteel,
 /area/security/range)
 "cqh" = (


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds windoors to all flaps on delta.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Stops assistants from crawling everywhere. Plus, the other maps have windoors in their flaps to block this too.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added windoors to all the flaps on delta.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
