### PR TITLE
Ports sleepy pens and emagged borg cookies buffs (also "chloralhydratedelayed" removal), plus tirizene buff.

### DIFF
--- a/code/game/objects/items/RSF.dm
+++ b/code/game/objects/items/RSF.dm
@@ -182,7 +182,7 @@ RSF
 	to_chat(user, "Fabricating Cookie..")
 	var/obj/item/reagent_containers/food/snacks/cookie/S = new /obj/item/reagent_containers/food/snacks/cookie(T)
 	if(toxin)
-		S.reagents.add_reagent("chloralhydratedelayed", 10)
+		S.reagents.add_reagent("chloralhydrate", 10)
 	if (iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		R.cell.charge -= 100

--- a/code/modules/paperwork/pen.dm
+++ b/code/modules/paperwork/pen.dm
@@ -164,7 +164,7 @@
 /obj/item/pen/sleepy/Initialize()
 	. = ..()
 	create_reagents(45, OPENCONTAINER)
-	reagents.add_reagent("chloralhydratedelayed", 20)
+	reagents.add_reagent("chloralhydrate", 20)
 	reagents.add_reagent("mutetoxin", 15)
 	reagents.add_reagent("tirizene", 10)
 

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -313,25 +313,6 @@
 			. = 1
 	..()
 
-/datum/reagent/toxin/chloralhydratedelayed //sedates half as quickly and does not cause toxloss. same name/desc so it doesn't give away sleepypens
-	name = "Chloral Hydrate"
-	id = "chloralhydratedelayed"
-	description = "A powerful sedative that induces confusion and drowsiness before putting its target to sleep."
-	reagent_state = SOLID
-	color = "#000067" // rgb: 0, 0, 103
-	toxpwr = 0
-	metabolization_rate = 1 * REAGENTS_METABOLISM
-
-/datum/reagent/toxin/chloralhydratedelayed/on_mob_life(mob/living/carbon/M)
-	switch(current_cycle)
-		if(10 to 20)
-			M.confused += 1
-			M.drowsyness += 1
-			M.adjustStaminaLoss(7.5)
-		if(20 to INFINITY)
-			M.Sleeping(40, 0)
-	..()
-
 /datum/reagent/toxin/fakebeer	//disguised as normal beer for use by emagged brobots
 	name = "Beer"
 	id = "fakebeer"
@@ -389,12 +370,12 @@
 	id = "tirizene"
 	description = "A nonlethal poison that causes extreme fatigue and weakness in its victim."
 	color = "#6E2828"
-	data = 13
+	data = 15
 	toxpwr = 0
 
 /datum/reagent/toxin/staminatoxin/on_mob_life(mob/living/carbon/M)
 	M.adjustStaminaLoss(REM * data, 0)
-	data = max(data - 1, 3)
+	data = max(data - 1, 5)
 	..()
 	. = 1
 


### PR DESCRIPTION
## About The Pull Request
Ports /tg/station PR  #43973, replacing the emagged borg cookies and sleepy pens delayed chloral hydrate with the authentic one, also buffing tirizene a bit because the upped maximum stamina values from Bijhn old stamina combat rework unintentionally made it weaker (chances it will need a little extra buff idk).

## Why It's Good For The Game
The cookies and sleepy pens barely are even effective, their chloral hydrate is slow to act and only sleeps for barely more than a dozen seconds before depleting out the system. The tirizene is pretty weak too.
While some maintainers may frown upon these chemical buffs, I point out the sleepy pen standard mix is actually underpowered, requiring the user to ominously stalk the target while hoping they won't realize what's going on, retaliate or escape to safety and then reveal the user's antag status.

## Changelog
:cl: Ghommie (original PR by CrazyClown12)
tweak: The chloral hydrate inside of the sleepy pen is no longer slower acting than chloral hydrate made in chemistry.
tweak: The chloral hydrate inside of cookies synthesised by emagged borgs is no longer slower acting than chloral hydrate made in chemistry.
balance: Slight tirizene buff.
del: Delayed chloral hydrate
/:cl: