### PR TITLE
Captain can now be converted in CWC/Bloodcult without a mindshield

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -52,7 +52,7 @@ Credit where due:
 	if(!istype(M))
 		return FALSE
 	if(M.mind)
-		if(M.mind.assigned_role in list("Captain", "Chaplain"))
+		if(M.mind.assigned_role in list("Chaplain"))
 			return FALSE
 		if(M.mind.enslaved_to && !is_servant_of_ratvar(M.mind.enslaved_to))
 			return FALSE

--- a/code/game/gamemodes/cult/cult.dm
+++ b/code/game/gamemodes/cult/cult.dm
@@ -16,7 +16,7 @@
 	if(!istype(M))
 		return FALSE
 	if(M.mind)
-		if(M.mind.assigned_role in list("Captain", "Chaplain"))
+		if(M.mind.assigned_role in list("Chaplain"))
 			return FALSE
 		if(specific_cult && specific_cult.is_sacrifice_target(M.mind))
 			return FALSE


### PR DESCRIPTION
There was no real reason to prevent the Captain from getting converted during either of these gamemodes, especially when the HoS is still a valid conversion target. If the cult can manage to convert the Cap without getting called out, then they're probably competent enough to win anyway.

## Changelog
:cl:
balance: The Captain is no longer 100% immune to being converted by both cult types.
/:cl: