### PR TITLE
Makes gangs unable to convert the captain

### DIFF
--- a/modular_citadel/code/game/gamemodes/gangs/gang_pen.dm
+++ b/modular_citadel/code/game/gamemodes/gangs/gang_pen.dm
@@ -26,6 +26,9 @@
 	if(!M.client || !M.mind)
 		to_chat(user, "<span class='warning'>A braindead gangster is an useless gangster!</span>")
 		return
+	if(M.mind.assigned_role in list("Captain"))
+		to_chat(user, "<span class='warning'>This mind is to loyal to be a gangster!</span>")
+		return
 	var/datum/team/gang/gang = L.gang
 	if(!add_gangster(user, gang, M.mind))
 		return
@@ -51,9 +54,6 @@
 		return
 	if(check && HAS_TRAIT(gangster_mind.current, TRAIT_MINDSHIELD))  //Check to see if the potential gangster is implanted
 		to_chat(user, "<span class='danger'>This mind is too strong to control!</span>")
-		return
-	if(M.mind.assigned_role in list("Captain")
-		to_chat(user, "<span class='danger'>This mind is too loyal to control!</span>")
 		return
 	var/mob/living/carbon/human/H = gangster_mind.current // we are sure the dude's human cause it's checked in attack()
 	H.silent = max(H.silent, 5)

--- a/modular_citadel/code/game/gamemodes/gangs/gang_pen.dm
+++ b/modular_citadel/code/game/gamemodes/gangs/gang_pen.dm
@@ -52,6 +52,9 @@
 	if(check && HAS_TRAIT(gangster_mind.current, TRAIT_MINDSHIELD))  //Check to see if the potential gangster is implanted
 		to_chat(user, "<span class='danger'>This mind is too strong to control!</span>")
 		return
+	if(M.mind.assigned_role in list("Captain")
+		to_chat(user, "<span class='danger'>This mind is too loyal to control!</span>")
+		return
 	var/mob/living/carbon/human/H = gangster_mind.current // we are sure the dude's human cause it's checked in attack()
 	H.silent = max(H.silent, 5)
 	H.Knockdown(100)


### PR DESCRIPTION
## About The Pull Request
Corrects gangs being able to convert captain into a gang if they were to remove a implant

## Why It's Good For The Game

No other game mode other then a removed one allows the captain to be converted. Not even old Cit-gangs allowed the captain/hos to become gang.

## Changelog
:cl:
fix: cap being gangable
/:cl: