### PR TITLE
Fixing machinery's alt-click rotation.

### DIFF
--- a/code/game/machinery/_machinery.dm
+++ b/code/game/machinery/_machinery.dm
@@ -566,6 +566,7 @@ Class Procs:
 		updateUsrDialog()
 
 /obj/machinery/AltClick(mob/user)
+	. = ..()
 	if(!user.canUseTopic(src, !issilicon(user)) || !is_operational())
 		return
 	if(inserted_modify_id)


### PR DESCRIPTION
## About The Pull Request
This will fix and close #9330. Someone kind of broke it when porting the shortcut to remove IDs from consoles.

## Why It's Good For The Game
Fixing a bug. It's critical for some procs to call parent, especially when signals are involved, such as in click procs.

## Changelog
:cl:
fix: You can now alt-click to rotate machinery such as the tachyon-droppler array or emitters again.
/:cl: