### PR TITLE
 Removes revenant blight's shabby tox damage in favor of negative mood effects, and necropolis curse if not cured

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -222,6 +222,8 @@
 //Mood
 #define COMSIG_ADD_MOOD_EVENT "add_mood" //Called when you send a mood event from anywhere in the code.
 #define COMSIG_CLEAR_MOOD_EVENT "clear_mood" //Called when you clear a mood event from anywhere in the code.
+#define COMSIG_INCREASE_SANITY "decrease_sanity" //Called when you want to increase sanity from anywhere in the code.
+#define COMSIG_DECREASE_SANITY "increase_sanity" //Same as above but to decrease sanity instead.
 
 //NTnet
 #define COMSIG_COMPONENT_NTNET_RECEIVE "ntnet_receive"			//called on an object by its NTNET connection component on receive. (sending_id(number), sending_netname(text), data(datum/netdata))

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -21,6 +21,8 @@
 
 	RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT, .proc/add_event)
 	RegisterSignal(parent, COMSIG_CLEAR_MOOD_EVENT, .proc/clear_event)
+	RegisterSignal(parent, COMSIG_INCREASE_SANITY, .proc/IncreaseSanity)
+	RegisterSignal(parent, COMSIG_DECREASE_SANITY, .proc/DecreaseSanity)
 
 	RegisterSignal(parent, COMSIG_MOB_HUD_CREATED, .proc/modify_hud)
 	var/mob/living/owner = parent
@@ -129,23 +131,23 @@
 
 	switch(mood_level)
 		if(1)
-			DecreaseSanity(0.2)
+			DecreaseSanity(src, 0.2)
 		if(2)
-			DecreaseSanity(0.125, SANITY_CRAZY)
+			DecreaseSanity(src, 0.125, SANITY_CRAZY)
 		if(3)
-			DecreaseSanity(0.075, SANITY_UNSTABLE)
+			DecreaseSanity(src, 0.075, SANITY_UNSTABLE)
 		if(4)
-			DecreaseSanity(0.025, SANITY_DISTURBED)
+			DecreaseSanity(src, 0.025, SANITY_DISTURBED)
 		if(5)
-			IncreaseSanity(0.1)
+			IncreaseSanity(src, 0.1)
 		if(6)
-			IncreaseSanity(0.15)
+			IncreaseSanity(src, 0.15)
 		if(7)
-			IncreaseSanity(0.20)
+			IncreaseSanity(src, 0.20)
 		if(8)
-			IncreaseSanity(0.25, SANITY_GREAT)
+			IncreaseSanity(src, 0.25, SANITY_GREAT)
 		if(9)
-			IncreaseSanity(0.4, SANITY_GREAT)
+			IncreaseSanity(src, 0.4, SANITY_GREAT)
 
 	if(insanity_effect != holdmyinsanityeffect)
 		if(insanity_effect > holdmyinsanityeffect)
@@ -218,7 +220,7 @@
 	master.crit_threshold = (master.crit_threshold - insanity_effect) + newval
 	insanity_effect = newval
 
-/datum/component/mood/proc/DecreaseSanity(amount, minimum = SANITY_INSANE)
+/datum/component/mood/proc/DecreaseSanity(datum/source, amount, minimum = SANITY_INSANE)
 	if(sanity < minimum) //This might make KevinZ stop fucking pinging me.
 		IncreaseSanity(0.5)
 	else
@@ -229,7 +231,7 @@
 			else
 				insanity_effect = (MINOR_INSANITY_PEN)
 
-/datum/component/mood/proc/IncreaseSanity(amount, maximum = SANITY_NEUTRAL)
+/datum/component/mood/proc/IncreaseSanity(datum/source, amount, maximum = SANITY_NEUTRAL)
 	// Disturbed stops you from getting any more sane - I'm just gonna bung this in here
 	var/mob/living/owner = parent
 	if(HAS_TRAIT(owner, TRAIT_UNSTABLE))
@@ -261,6 +263,8 @@
 
 	if(the_event.timeout)
 		addtimer(CALLBACK(src, .proc/clear_event, null, category), the_event.timeout, TIMER_UNIQUE|TIMER_OVERRIDE)
+
+	return the_event
 
 /datum/component/mood/proc/clear_event(datum/source, category)
 	var/datum/mood_event/event = mood_events[category]

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -222,7 +222,7 @@
 
 /datum/component/mood/proc/DecreaseSanity(datum/source, amount, minimum = SANITY_INSANE)
 	if(sanity < minimum) //This might make KevinZ stop fucking pinging me.
-		IncreaseSanity(0.5)
+		IncreaseSanity(src, 0.5)
 	else
 		sanity = max(minimum, sanity - amount)
 		if(sanity < SANITY_UNSTABLE)
@@ -237,7 +237,7 @@
 	if(HAS_TRAIT(owner, TRAIT_UNSTABLE))
 		return
 	if(sanity > maximum)
-		DecreaseSanity(0.5) //Removes some sanity to go back to our current limit.
+		DecreaseSanity(src, 0.5) //Removes some sanity to go back to our current limit.
 	else
 		sanity = min(maximum, sanity + amount)
 		if(sanity > SANITY_CRAZY)

--- a/code/datums/mood_events/generic_negative_events.dm
+++ b/code/datums/mood_events/generic_negative_events.dm
@@ -169,3 +169,10 @@
 
 /datum/mood_event/sad_empath/add_effects(mob/sadtarget)
 	description = "<span class='warning'>[sadtarget.name] seems upset...</span>\n"
+
+/datum/mood_event/revenant_blight
+	description = "<span class='umbra'>Just give up, honk...</span>\n"
+	mood_change = -5
+
+/datum/mood_event/revenant_blight/add_effects()
+	description = "<span class='umbra'>Just give up, [pick("no one will miss you", "there is nothing you can do to help", "even a clown would be more useful than you", "does it even matter in the end?")]...</span>\n"

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -380,7 +380,8 @@
 	var/obj/effect/temp_visual/curse/wasting_effect = new
 
 /datum/status_effect/necropolis_curse/on_creation(mob/living/new_owner, set_curse, _duration)
-	duration = _duration
+	if(_duration)
+		duration = _duration
 	. = ..()
 	if(.)
 		apply_curse(set_curse)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -363,7 +363,8 @@
 	if(!set_curse)
 		set_curse = pick(CURSE_BLINDING, CURSE_SPAWNING, CURSE_WASTING, CURSE_GRASPING)
 	if(QDELETED(C))
-		apply_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE, set_curse)
+		apply_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE, set_curse, duration)
+
 	else
 		C.apply_curse(set_curse)
 		C.duration += duration * 0.5 //additional curses add half their duration
@@ -378,7 +379,8 @@
 	var/effect_cooldown = 100
 	var/obj/effect/temp_visual/curse/wasting_effect = new
 
-/datum/status_effect/necropolis_curse/on_creation(mob/living/new_owner, set_curse)
+/datum/status_effect/necropolis_curse/on_creation(mob/living/new_owner, set_curse, _duration)
+	duration = _duration
 	. = ..()
 	if(.)
 		apply_curse(set_curse)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -358,7 +358,7 @@
 	else
 		new /obj/effect/temp_visual/bleed(get_turf(owner))
 
-/mob/living/proc/apply_necropolis_curse(set_curse)
+/mob/living/proc/apply_necropolis_curse(set_curse, duration = 10 MINUTES)
 	var/datum/status_effect/necropolis_curse/C = has_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE)
 	if(!set_curse)
 		set_curse = pick(CURSE_BLINDING, CURSE_SPAWNING, CURSE_WASTING, CURSE_GRASPING)
@@ -366,11 +366,11 @@
 		apply_status_effect(STATUS_EFFECT_NECROPOLIS_CURSE, set_curse)
 	else
 		C.apply_curse(set_curse)
-		C.duration += 3000 //additional curses add 5 minutes
+		C.duration += duration * 0.5 //additional curses add half their duration
 
 /datum/status_effect/necropolis_curse
 	id = "necrocurse"
-	duration = 6000 //you're cursed for 10 minutes have fun
+	duration = 10 MINUTES //you're cursed for 10 minutes have fun
 	tick_interval = 50
 	alert_type = null
 	var/curse_flags = NONE

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -70,5 +70,5 @@
 		return
 	affected_mob.playsound_local(affected_mob, 'sound/effects/curse5.ogg', 40, 1, -1)
 	to_chat(affected_mob, "<span class='revendanger'>You sense the terrific curse of a vengeful ghost befall upon you...</span>")
-	target_mob.apply_necropolis_curse(null, 7 MINUTES) //Once the blight has done its course without being cured beforehand, it will cast a necrocurse to compensate how underpowered it's.
+	affected_mob.apply_necropolis_curse(null, 7 MINUTES) //Once the blight has done its course without being cured beforehand, it will cast a necrocurse to compensate how underpowered it's.
 	cure()

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -12,8 +12,8 @@
 	disease_flags = CURABLE
 	permeability_mod = 1
 	severity = DISEASE_SEVERITY_HARMFUL
-	var/stagedamage = 0 //Highest stage reached.
 	var/finalstage = 0 //Because we're spawning off the cure in the final stage, we need to check if we've done the final stage's effects.
+	var/datum/mood_event/revenant_blight/depression
 
 /datum/disease/revblight/cure()
 	if(affected_mob)
@@ -21,22 +21,19 @@
 		if(affected_mob.dna && affected_mob.dna.species)
 			affected_mob.dna.species.handle_mutant_bodyparts(affected_mob)
 			affected_mob.dna.species.handle_hair(affected_mob)
-		to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
+		SEND_SIGNAL(affected_mob, COMSIG_CLEAR_MOOD_EVENT, "rev_blight")
 	..()
 
 /datum/disease/revblight/stage_act()
 	if(!finalstage)
-		if(affected_mob.lying && prob(stage*6))
+		if(affected_mob.lying && prob(stage*4))
+			to_chat(affected_mob, "<span class='notice'>You feel better.</span>")
 			cure()
 			return
 		if(prob(stage*3))
 			to_chat(affected_mob, "<span class='revennotice'>You suddenly feel [pick("sick and tired", "disoriented", "tired and confused", "nauseated", "faint", "dizzy")]...</span>")
 			affected_mob.confused += 8
 			affected_mob.adjustStaminaLoss(8)
-			new /obj/effect/temp_visual/revenant(affected_mob.loc)
-		if(stagedamage < stage)
-			stagedamage++
-			affected_mob.adjustToxLoss(stage*2) //should, normally, do about 30 toxin damage.
 			new /obj/effect/temp_visual/revenant(affected_mob.loc)
 		if(prob(45))
 			affected_mob.adjustStaminaLoss(stage)
@@ -46,9 +43,13 @@
 			if(prob(5))
 				affected_mob.emote("pale")
 		if(3)
+			if(!depression)
+				depression = SEND_SIGNAL(affected_mob, COMSIG_ADD_MOOD_EVENT, "rev_blight", /datum/mood_event/revenant_blight)
+			SEND_SIGNAL(affected_mob, COMSIG_DECREASE_SANITY, 0.12, SANITY_CRAZY)
 			if(prob(10))
 				affected_mob.emote(pick("pale","shiver"))
 		if(4)
+			SEND_SIGNAL(affected_mob, COMSIG_DECREASE_SANITY, 0.18, SANITY_CRAZY)
 			if(prob(15))
 				affected_mob.emote(pick("pale","shiver","cries"))
 		if(5)
@@ -56,12 +57,18 @@
 				finalstage = TRUE
 				to_chat(affected_mob, "<span class='revenbignotice'>You feel like [pick("nothing's worth it anymore", "nobody ever needed your help", "nothing you did mattered", "everything you tried to do was worthless")].</span>")
 				affected_mob.adjustStaminaLoss(45)
-				new /obj/effect/temp_visual/revenant(affected_mob.loc)
-				if(affected_mob.dna && affected_mob.dna.species)
+				if(affected_mob.dna?.species)
 					affected_mob.dna.species.handle_mutant_bodyparts(affected_mob,"#1d2953")
 					affected_mob.dna.species.handle_hair(affected_mob,"#1d2953")
 				affected_mob.visible_message("<span class='warning'>[affected_mob] looks terrifyingly gaunt...</span>", "<span class='revennotice'>You suddenly feel like your skin is <i>wrong</i>...</span>")
 				affected_mob.add_atom_colour("#1d2953", TEMPORARY_COLOUR_PRIORITY)
-				addtimer(CALLBACK(src, .proc/cure), 100)
-		else
-			return
+				new /obj/effect/temp_visual/revenant(affected_mob.loc)
+				addtimer(CALLBACK(src, .proc/curses), 150)
+
+/datum/disease/revblight/proc/curses()
+	if(QDELETED(affected_mob))
+		return
+	affected_mob.playsound_local(affected_mob, 'sound/effects/curse5.ogg', 40, 1, -1)
+	to_chat(affected_mob, "<span class='revendanger'>You sense the terrific curse of a vengeful ghost befall upon you...</span>")
+	target_mob.apply_necropolis_curse(null, 7 MINUTES) //Once the blight has done its course without being cured beforehand, it will cast a necrocurse to compensate how underpowered it's.
+	cure()

--- a/code/modules/antagonists/revenant/revenant_blight.dm
+++ b/code/modules/antagonists/revenant/revenant_blight.dm
@@ -11,7 +11,7 @@
 	viable_mobtypes = list(/mob/living/carbon/human)
 	disease_flags = CURABLE
 	permeability_mod = 1
-	severity = DISEASE_SEVERITY_HARMFUL
+	severity = DISEASE_SEVERITY_DANGEROUS
 	var/finalstage = 0 //Because we're spawning off the cure in the final stage, we need to check if we've done the final stage's effects.
 	var/datum/mood_event/revenant_blight/depression
 


### PR DESCRIPTION
## About The Pull Request
What is said on the tin. Tweaking the blob curse to be more effective while giving a pre-existing previously unused coded debuff a purpose beside admemery, plus adding some signals to modify sanity outside its specific component file.
Also made the disease ever so slighty harder to be cured by lying on the floor.

## Why It's Good For The Game
Blight is very underpowered for its cost, the toxin damage it deals is mild and more unreliable than malfunction, defile and overload for the purpose of killing someone, the stamina is simply... tiring at worst. Worst of all, the virus would cure itself on its own after a while, with no consequence to boot.
So yes, I'm buffing this noob bait.

## Changelog
:cl:
balance: Removes revenant blight's shabby toxin damage in favor of mood maluses, and a dangerous necropolis curse if not cured in time. Remember
/:cl: