### PR TITLE
Makes abandoned crates less prone to explosions.

### DIFF
--- a/code/modules/mining/abandoned_crates.dm
+++ b/code/modules/mining/abandoned_crates.dm
@@ -169,6 +169,7 @@
 				locked = FALSE
 				cut_overlays()
 				add_overlay("securecrateg")
+				tamperproof = 0 // set explosion chance to zero, so we dont accidently hit it with a multitool and instantly die
 			else if (input == null || sanitycheck == null || length(input) != codelen)
 				to_chat(user, "<span class='notice'>You leave the crate alone.</span>")
 			else
@@ -213,6 +214,12 @@
 			return
 	return ..()
 
+/obj/structure/closet/secure/loot/dive_into(mob/living/user)
+	if(!locked)
+		return ..()
+	to_chat(user, "<span class='notice'>That seems like a stupid idea.</span>")
+	return FALSE
+
 /obj/structure/closet/crate/secure/loot/emag_act(mob/user)
 	. = SEND_SIGNAL(src, COMSIG_ATOM_EMAG_ACT)
 	if(!locked)
@@ -227,4 +234,6 @@
 		..()
 
 /obj/structure/closet/crate/secure/loot/deconstruct(disassembled = TRUE)
+	if(!locked && disassembled)
+		return ..()
 	boom()


### PR DESCRIPTION
## About The Pull Request
Ports tg's PRs #42957 and #46314. Also making explosive crates safe to deconstruct once unlocked since it's hard to dispatch it otherwise.

## Why It's Good For The Game
The abandoned crate's tamperment explosion should stop triggering after being unlocked. I had so much fun in the past with this punishing feature but damn.

## Changelog
:cl: Ghommie (original PRs by Time-Green and Qustinnus)
tweak: loot crates can't explode after unlocking anymore
fix: jumping into loot crates no longers causes them to go boom
fix: You can now deconstruct abandoned crates with a welder without making them go boom. After unlocking them, of course.
/:cl: