### PR TITLE
Re-adds the Qualifies for Rank Proc Checks.

### DIFF
--- a/code/controllers/subsystem/job.dm
+++ b/code/controllers/subsystem/job.dm
@@ -110,6 +110,9 @@ SUBSYSTEM_DEF(job)
 		if(job.required_playtime_remaining(player.client))
 			JobDebug("FOC player not enough xp, Player: [player]")
 			continue
+		if(!player.client.prefs.pref_species.qualifies_for_rank(job.title, player.client.prefs.features))
+			JobDebug("FOC non-human failed, Player: [player]")
+			continue
 		if(flag && (!(flag in player.client.prefs.be_special)))
 			JobDebug("FOC flag failed, Player: [player], Flag: [flag], ")
 			continue
@@ -143,6 +146,10 @@ SUBSYSTEM_DEF(job)
 
 		if(!job.player_old_enough(player.client))
 			JobDebug("GRJ player not old enough, Player: [player]")
+			continue
+
+		if(!player.client.prefs.pref_species.qualifies_for_rank(job.title, player.client.prefs.features))
+			JobDebug("GRJ non-human failed, Player: [player]")
 			continue
 
 		if(job.required_playtime_remaining(player.client))
@@ -326,6 +333,10 @@ SUBSYSTEM_DEF(job)
 
 				if(job.required_playtime_remaining(player.client))
 					JobDebug("DO player not enough xp, Player: [player], Job:[job.title]")
+					continue
+			
+				if(!player.client.prefs.pref_species.qualifies_for_rank(job.title, player.client.prefs.features))
+					JobDebug("DO non-human failed, Player: [player], Job:[job.title]")
 					continue
 
 				if(player.mind && job.title in player.mind.restricted_roles)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1039,6 +1039,12 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 				var/available_in_days = job.available_in_days(user.client)
 				HTML += "<font color=red>[rank]</font></td><td><font color=red> \[IN [(available_in_days)] DAYS\]</font></td></tr>"
 				continue
+			if(!user.client.prefs.pref_species.qualifies_for_rank(rank, user.client.prefs.features))
+				if(user.client.prefs.pref_species.id == "human")
+					HTML += "<font color=red>[rank]</font></td><td><font color=red><b> \[MUTANT\]</b></font></td></tr>"
+				else
+					HTML += "<font color=red>[rank]</font></td><td><font color=red><b> \[NON-HUMAN\]</b></font></td></tr>"
+				continue
 			if((job_preferences["[SSjob.overflow_role]"] == JP_LOW) && (rank != SSjob.overflow_role) && !jobban_isbanned(user, SSjob.overflow_role))
 				HTML += "<font color=orange>[rank]</font></td><td></td></tr>"
 				continue

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -133,10 +133,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	return
 
 //Please override this locally if you want to define when what species qualifies for what rank if human authority is enforced.
-/datum/species/proc/qualifies_for_rank(rank, list/features)
-	if(rank in GLOB.command_positions)
-		return 0
-	return 1
+/datum/species/proc/qualifies_for_rank(rank, list/features) //SPECIES JOB RESTRICTIONS
+	//if(rank in GLOB.command_positions) Left as an example: The format qualifies for rank takes.
+	//	return 0 //It returns false when it runs the proc so they don't get jobs from the global list.
+	return 1 //It returns 1 to say they are a-okay to continue.
 
 //Will regenerate missing organs
 /datum/species/proc/regenerate_organs(mob/living/carbon/C,datum/species/old_species,replace_current=TRUE)


### PR DESCRIPTION
## About The Pull Request

Its in the species code and wasn't tied to anything literally on any tg downstream, now you can restrict jobs based on species...
If you ever wanted to do so, maybe? Probably not.

## Why It's Good For The Game

Extra functionality.

## Changelog
:cl: JTGSZ
tweak: Gave Qualifies_for_Rank Check back its checks in job controller.
/:cl:
