### PR TITLE
[draft] Reworks magic (and holy) resistance into a % based modifier, build from the sum of the resistance sources on a player.

### DIFF
--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -25,25 +25,18 @@
 
 /datum/component/anti_magic/proc/on_drop(datum/source, mob/user)
 	UnregisterSignal(user, COMSIG_MOB_RECEIVE_MAGIC)
-	if(magic["source"])
-		magic -= list("[parent]" = _magic)
-	if(holy["source"])
-		holy -= list("[parent]" = _holy)
+	if(magic["[source]"])
+		magic -= magic[parent]
+	if(holy["[source]"])
+		holy -= holy[parent]
 
 //Returns the percentage resist, if the spell is holy AND magic, and the item is holy AND magic, then it will use both of the object's resist boons.
 /datum/component/anti_magic/proc/can_protect(datum/source, _magic, _holy, list/protection_sources)
 	if(_magic && LAZYLEN(magic))
 		protection_sources += magic
 
-
 	if(_holy && LAZYLEN(holy))
-		var/temp_holy = holy
-
-		for(var/i in holy) //Merge duplicate entries into one single entry
-		    if(protection_sources[i])
-		        protection_sources[i] += holy[i]
-				temp_holy -= "[i]"
-		protection_sources += temp_holy
+		protection_sources += holy
 
 	if(!len(protection_sources))//If no sources then nothing
 		return

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -12,8 +12,12 @@
 		return COMPONENT_INCOMPATIBLE
 
 	if(_magic)
+		if(_magic == TRUE)
+			_magic = 100
 		magic["[parent]"] += _magic
 	if(_holy)
+		if(_holy == TRUE)
+			_holy = 100
 		holy["[parent]"] += _holy
 
 /datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -1,26 +1,47 @@
 /datum/component/anti_magic
-	var/magic = FALSE
-	var/holy = FALSE
+	var/magic = list()
+	var/holy = list()
 
 /datum/component/anti_magic/Initialize(_magic = FALSE, _holy = FALSE)
 	if(isitem(parent))
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 		RegisterSignal(parent, COMSIG_ITEM_DROPPED, .proc/on_drop)
-	else if(ismob(parent))
+	else if(ismob(parent)) //Can this ever be removed? At the moment I don't see if it can, but if it can, you need to remove it from the magic/holy lists
 		RegisterSignal(parent, COMSIG_MOB_RECEIVE_MAGIC, .proc/can_protect)
 	else
 		return COMPONENT_INCOMPATIBLE
 
-	magic = _magic
-	holy = _holy
+	if(_magic)
+		magic["[parent]"] += _magic
+	if(_holy)
+		holy["[parent]"] += _holy
 
 /datum/component/anti_magic/proc/on_equip(datum/source, mob/equipper, slot)
 	RegisterSignal(equipper, COMSIG_MOB_RECEIVE_MAGIC, .proc/can_protect, TRUE)
 
 /datum/component/anti_magic/proc/on_drop(datum/source, mob/user)
 	UnregisterSignal(user, COMSIG_MOB_RECEIVE_MAGIC)
+	if(magic["source"])
+		magic -= list("[parent]" = _magic)
+	if(holy["source"])
+		holy -= list("[parent]" = _holy)
 
+//Returns the percentage resist, if the spell is holy AND magic, and the item is holy AND magic, then it will use both of the object's resist boons.
 /datum/component/anti_magic/proc/can_protect(datum/source, _magic, _holy, list/protection_sources)
-	if((_magic && magic) || (_holy && holy))
-		protection_sources += parent
-		return COMPONENT_BLOCK_MAGIC
+	if(_magic && LAZYLEN(magic))
+		protection_sources += magic
+
+
+	if(_holy && LAZYLEN(holy))
+	var/temp_holy = holy
+
+	for(var/i in holy) //Merge duplicate entries into one single entry
+	    if(protection_sources[i])
+	        protection_sources[i] += holy[i]
+			temp_holy -= "[i]"
+	protection_sources += temp_holy
+
+	if(!len(protection_sources))//If no sources then nothing
+		return
+
+	return COMPONENT_BLOCK_MAGIC

--- a/code/datums/components/anti_magic.dm
+++ b/code/datums/components/anti_magic.dm
@@ -33,13 +33,13 @@
 
 
 	if(_holy && LAZYLEN(holy))
-	var/temp_holy = holy
+		var/temp_holy = holy
 
-	for(var/i in holy) //Merge duplicate entries into one single entry
-	    if(protection_sources[i])
-	        protection_sources[i] += holy[i]
-			temp_holy -= "[i]"
-	protection_sources += temp_holy
+		for(var/i in holy) //Merge duplicate entries into one single entry
+		    if(protection_sources[i])
+		        protection_sources[i] += holy[i]
+				temp_holy -= "[i]"
+		protection_sources += temp_holy
 
 	if(!len(protection_sources))//If no sources then nothing
 		return

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -183,26 +183,22 @@
 		var/mob/living/L = target
 		if(is_servant_of_ratvar(L) || L.stat || L.has_status_effect(STATUS_EFFECT_KINDLE))
 			return
-		var/atom/O = L.anti_magic_check()
+		var/m_susc = L.is_magic_susceptible("glows white-hot against [L] as it absorbs [src]'s power!")
 		playsound(L, 'sound/magic/fireball.ogg', 50, TRUE, frequency = 1.25)
-		if(O)
-			if(isitem(O))
-				L.visible_message("<span class='warning'>[L]'s eyes flare with dim light!</span>", \
-				"<span class='userdanger'>Your [O] glows white-hot against you as it absorbs [src]'s power!</span>")
-			else if(ismob(O))
-				L.visible_message("<span class='warning'>[L]'s eyes flare with dim light!</span>")
+		if(!m_susc)
 			playsound(L, 'sound/weapons/sear.ogg', 50, TRUE)
 		else
 			L.visible_message("<span class='warning'>[L]'s eyes blaze with brilliant light!</span>", \
 			"<span class='userdanger'>Your vision suddenly screams with white-hot light!</span>")
-			L.Knockdown(15, TRUE, FALSE, 15)
-			L.apply_status_effect(STATUS_EFFECT_KINDLE)
-			L.flash_act(1, 1)
+			L.Knockdown(15*m_susc, TRUE, FALSE, 15)
+			if(prob((m_susc*100)))
+				L.apply_status_effect(STATUS_EFFECT_KINDLE)
+				L.flash_act(1, 1)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
 				S.emp_act(EMP_HEAVY)
 			if(iscultist(L))
-				L.adjustFireLoss(15)
+				L.adjustFireLoss(15*m_susc)
 	..()
 
 

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -434,19 +434,42 @@
 				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
 									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 		else
+			//Do they have a melon? Are they a felon?
+			//This is bad code but it'll work until I finish my dumb thesis and other projects
+			var/melonPower = 1
+			var/obj/item/W1 = M.l_hand
+			var/obj/item/W2 = M.r_hand
+			if(istype(W1, /obj/item/reagent_containers/food/snacks/grown/holymelon))
+				var/obj/item/reagent_containers/food/snacks/grown/holymelon/melon = W1
+
+			if(istype(W2, /obj/item/reagent_containers/food/snacks/grown/holymelon))
+				var/obj/item/reagent_containers/food/snacks/grown/holymelon/melon = W2
+				melonPower = 1 - ((melon.potency * 7)/1000) //reduction = 1 - 0.3
+
+				melon.potency -= 20
+				if(melon.potency < 0)
+					melon.name = "Unholy melon"
+					target.visible_message("<span class='warning'>[L] starts to give off an unholy glow!</span>", \
+										   "<span class='userdanger'>Your Unholy melon begins to glow, emitting a blanket of darkness which surrounds you and makes you succumb futher!</span>")
+
+				else
+					target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
+									   "<span class='userdanger'>Your Holy melon begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
+
+
 			to_chat(user, "<span class='cultitalic'>In an brilliant flash of red, [L] falls to the ground!</span>")
-			L.Knockdown(160)
-			L.adjustStaminaLoss(140) //Ensures hard stamcrit
+			L.Knockdown(160 * melonPower)
+			L.adjustStaminaLoss(140 * melonPower) //Ensures hard stamcrit
 			L.flash_act(1,1)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
 				S.emp_act(EMP_HEAVY)
 			else if(iscarbon(target))
 				var/mob/living/carbon/C = L
-				C.silent += 6
-				C.stuttering += 15
-				C.cultslurring += 15
-				C.Jitter(15)
+				C.silent += 6 * melonPower
+				C.stuttering += 15 * melonPower
+				C.cultslurring += 15 * melonPower
+				C.Jitter(15 * melonPower)
 			if(is_servant_of_ratvar(L))
 				L.adjustBruteLoss(15)
 		uses--

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -418,60 +418,30 @@
 
 		user.mob_light(_color = LIGHT_COLOR_BLOOD_MAGIC, _range = 3, _duration = 2)
 
-		var/anti_magic_source = L.anti_magic_check()
-		if(anti_magic_source)
+		var/magic_multiplier = L.is_magic_susceptible(TRUE, TRUE, message = "begins to glow, emitting a blanket of holy light which surrounds [L] and protects them from the flash of light!")
+		if(!magic_multiplier)
 
 			L.mob_light(_color = LIGHT_COLOR_HOLY_MAGIC, _range = 2, _duration = 100)
 			var/mutable_appearance/forbearance = mutable_appearance('icons/effects/genetics.dmi', "servitude", -MUTATIONS_LAYER)
 			L.add_overlay(forbearance)
 			addtimer(CALLBACK(L, /atom/proc/cut_overlay, forbearance), 100)
 
-			if(istype(anti_magic_source, /obj/item))
-				var/obj/item/ams_object = anti_magic_source
-				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
-									   "<span class='userdanger'>Your [ams_object.name] begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
-			else
-				target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
-									   "<span class='userdanger'>A feeling of warmth washes over you, rays of holy light surround your body and protect you from the flash of light!</span>")
 		else
-			//Do they have a melon? Are they a felon?
-			//This is bad code but it'll work until I finish my dumb thesis and other projects
-			var/melonPower = 1
-			var/obj/item/W1 = M.l_hand
-			var/obj/item/W2 = M.r_hand
-			if(istype(W1, /obj/item/reagent_containers/food/snacks/grown/holymelon))
-				var/obj/item/reagent_containers/food/snacks/grown/holymelon/melon = W1
-
-			if(istype(W2, /obj/item/reagent_containers/food/snacks/grown/holymelon))
-				var/obj/item/reagent_containers/food/snacks/grown/holymelon/melon = W2
-				melonPower = 1 - ((melon.potency * 7)/1000) //reduction = 1 - 0.3
-
-				melon.potency -= 20
-				if(melon.potency < 0)
-					melon.name = "Unholy melon"
-					target.visible_message("<span class='warning'>[L] starts to give off an unholy glow!</span>", \
-										   "<span class='userdanger'>Your Unholy melon begins to glow, emitting a blanket of darkness which surrounds you and makes you succumb futher!</span>")
-
-				else
-					target.visible_message("<span class='warning'>[L] starts to glow in a halo of light!</span>", \
-									   "<span class='userdanger'>Your Holy melon begins to glow, emitting a blanket of holy light which surrounds you and protects you from the flash of light!</span>")
-
-
 			to_chat(user, "<span class='cultitalic'>In an brilliant flash of red, [L] falls to the ground!</span>")
-			L.Knockdown(160 * melonPower)
-			L.adjustStaminaLoss(140 * melonPower) //Ensures hard stamcrit
+			L.Knockdown(160 * magic_multiplier)
+			L.adjustStaminaLoss(140 * magic_multiplier) //Ensures hard stamcrit
 			L.flash_act(1,1)
 			if(issilicon(target))
 				var/mob/living/silicon/S = L
 				S.emp_act(EMP_HEAVY)
 			else if(iscarbon(target))
 				var/mob/living/carbon/C = L
-				C.silent += 6 * melonPower
-				C.stuttering += 15 * melonPower
-				C.cultslurring += 15 * melonPower
-				C.Jitter(15 * melonPower)
+				C.silent += 6 * magic_multiplier
+				C.stuttering += 15 * magic_multiplier
+				C.cultslurring += 15 * magic_multiplier
+				C.Jitter(15 * magic_multiplier)
 			if(is_servant_of_ratvar(L))
-				L.adjustBruteLoss(15)
+				L.adjustBruteLoss(15 * magic_multiplier)
 		uses--
 	..()
 

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -60,4 +60,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, FALSE, TRUE) //deliver us from evil o melon god
+	if(regaents.has_reagent("holywater"))
+		var/datum/reagent/R = has_reagent("holywater")
+	var/holy_reist = (R.volume * 2.5) //20u = 50%
+	AddComponent(/datum/component/anti_magic, FALSE, holy_reist) //deliver us from evil o melon god

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -62,5 +62,5 @@
 	. = ..()
 	if(regaents.has_reagent("holywater"))
 		var/datum/reagent/R = has_reagent("holywater")
-	var/holy_reist = (R.volume * 2.5) //20u = 50%
+	var/holy_reist = (R.volume * 3) //20u = 60%
 	AddComponent(/datum/component/anti_magic, FALSE, holy_reist) //deliver us from evil o melon god

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -60,4 +60,4 @@
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize()
 	. = ..()
-	AddComponent(/datum/component/anti_magic, TRUE, TRUE) //deliver us from evil o melon god
+	AddComponent(/datum/component/anti_magic, FALSE, TRUE) //deliver us from evil o melon god

--- a/code/modules/hydroponics/grown/melon.dm
+++ b/code/modules/hydroponics/grown/melon.dm
@@ -60,7 +60,7 @@
 
 /obj/item/reagent_containers/food/snacks/grown/holymelon/Initialize()
 	. = ..()
-	if(regaents.has_reagent("holywater"))
+	if(reagents.has_reagent("holywater"))
 		var/datum/reagent/R = has_reagent("holywater")
-	var/holy_reist = (R.volume * 3) //20u = 60%
-	AddComponent(/datum/component/anti_magic, FALSE, holy_reist) //deliver us from evil o melon god
+		var/holy_reist = (R.volume * 3) //20u = 60%
+		AddComponent(/datum/component/anti_magic, FALSE, holy_reist) //deliver us from evil o melon god

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -732,24 +732,31 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 //If you're using this to cast a spell, you can use the returned value to adjust stun, damage, and whatever numerics involved too, otherwise it'll work unless 100% resistance
 //USED TO return nothing if no magic resist, and an atom if resisted
 //Checks to see if user is succeptable to magic, 0 means immune, 1 is normal, greater than 1 is extra succeptable
-/mob/proc/is_magic_susceptible(magic = TRUE, holy = FALSE, message = "")
+/mob/proc/is_magic_susceptible(magic = TRUE, holy = FALSE, message)
 	if(!magic && !holy)
 		return
+	if(!message)
+		message = "glows brightly, protecting [src]!"
 	var/list/protection_sources = list()
 	if(SEND_SIGNAL(src, COMSIG_MOB_RECEIVE_MAGIC, magic, holy, protection_sources) & COMPONENT_BLOCK_MAGIC)
 		if(protection_sources.len)
 			var/resist_value = 0
 			for(var/i in protection_sources)
-				var/resist_value += [protection_sources[i]] //gets the ADDITIVE percentage
+				message_admins("[i]")
+				resist_value += [protection_sources[i]] //gets the ADDITIVE percentage
 				if(message)
 					visible_message("<span class='warning'>The [i] [message]!</span>", \
 									   "<span class='userdanger'>Your [i] tries to protect you from the spell!</span>")
 			resist_value = 1 - (resist_value/100) //turns it into a multipliable form. I.e. 1 is no effect, 0.6 is a 40% reduction, 1.2 is a 20% extention.
 			if(resist_value <= 0) //If your resistance is over 100%, then you resist all effects.
 				resist_value = 0
+				visible_message("<span class='warning'>[src] shimmers as the spell is fully blocked!</span>", \
+								   "<span class='userdanger'>Your resistance fully protect you from the spell!</span>")
 			return resist_value
 		else
 			return 1 //changed from src to 1
+
+
 
 //You can buckle on mobs if you're next to them since most are dense
 /mob/buckle_mob(mob/living/M, force = FALSE, check_loc = TRUE)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -731,7 +731,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 // anti_magic_check() = !is_magic_susceptible()
 //If you're using this to cast a spell, you can use the returned value to adjust stun, damage, and whatever numerics involved too, otherwise it'll work unless 100% resistance
 //USED TO return nothing if no magic resist, and an atom if resisted
-//Checks to see if user is succeptable to magic, 0 means immune, 1 is normal, less than 1 is extra succeptable
+//Checks to see if user is succeptable to magic, 0 means immune, 1 is normal, greater than 1 is extra succeptable
 /mob/proc/is_magic_susceptible(magic = TRUE, holy = FALSE, message = "")
 	if(!magic && !holy)
 		return

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -732,7 +732,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 //If you're using this to cast a spell, you can use the returned value to adjust stun, damage, and whatever numerics involved too, otherwise it'll work unless 100% resistance
 //USED TO return nothing if no magic resist, and an atom if resisted
 //Checks to see if user is succeptable to magic, 0 means immune, 1 is normal, less than 1 is extra succeptable
-/mob/proc/is_magic_susceptible(magic = TRUE, holy = FALSE)
+/mob/proc/is_magic_susceptible(magic = TRUE, holy = FALSE, message = "")
 	if(!magic && !holy)
 		return
 	var/list/protection_sources = list()
@@ -741,6 +741,9 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 			var/resist_value = 0
 			for(var/i in protection_sources)
 				var/resist_value += [protection_sources[i]] //gets the ADDITIVE percentage
+				if(message)
+					visible_message("<span class='warning'>The [i] [message]!</span>", \
+									   "<span class='userdanger'>Your [i] tries to protect you from the spell!</span>")
 			resist_value = 1 - (resist_value/100) //turns it into a multipliable form. I.e. 1 is no effect, 0.6 is a 40% reduction, 1.2 is a 20% extention.
 			if(resist_value <= 0) //If your resistance is over 100%, then you resist all effects.
 				resist_value = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

### Reworks:

 anti_magic_check(), as it works currently, it checks for sources of magic resist, then returns a random one. there are 4-5 cases of this returned atom in the code, that is used for a "your object resists the spell!" message.

The way I've reworked it is; I've renamed it to is_magic_susceptible() to improve clarity. It checks the mob to see if it has any resistance items, calculates the sum additive percentage of all items on the mob, converts this percentage into a range of 0 - 2 (or more) where 0 is full resistance, 1 is standard, and over 1 is weakness. (i.e. this value can be easily applied to all current stuns, damages and effects with whatever number * is_magic_susceptible() So, for example

stun(200 * is_magic_susceptible()):
for 40% resistance stun(200 * 0.6) = stun(120)
for 150% resistance stun(200 * 1.5) = stun(300)

However, the src return was removed, and the 5 cases of resistance messages have been moved into the proccall itself.

### Old description (still applies)

**THIS NEEDS TESTING, I CAN'T TEST AWAY FROM HOME**

Everyone's a bit mad about melons, so I thought I'd offer a solution that hopefully makes everyone happy!

This hasn't been tested atm, since I'm currently on **Thesis lockdown** but it should serve as a proof of concept.

I'll be reworking how antimagic and antiholy work in the future anyways with tamiorgans into something that isn't a binary, and instead is a %age, but this should work as a placeholder until then. It's a little rough, but basically what it does is based off the potency of melon in the person's hands, it reduces the effects of the stun. At the moment it reduces every effect of the stun, but I'm open the discussion/suggestions. The range of reduction is 70% for a 100 potency melon, to none for a 0 potency melon. This means, even with the best melon, you will still be knockdowned() for just under 5s, which I think is the cooldown? I'm not sure.

After your melon protects you, then it loses 20 potency from itself. If the potency becomes negative, it'll buff the length of the stuns instead, and it's name will change to unholy melon to reflect that.

What I could do, if people like, is turn the holy water in the melon into unholy water! _Remember to comment below based on what you think and don't forget to like and subscribe!_

These numbers are open to peanut gallery tweaking too.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

Hopefully makes both parties happy. No longer invincible to stuns, but also a useful item to have. Also potency matters!

## Changelog
:cl: Fermis
tweak: tweaked holy melons
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
