### PR TITLE
Fixing the blood cult radial menu unholy flask option's icon.

### DIFF
--- a/code/modules/antagonists/cult/cult_structures.dm
+++ b/code/modules/antagonists/cult/cult_structures.dm
@@ -86,7 +86,7 @@
 
 	var/static/image/radial_whetstone = image(icon = 'icons/obj/kitchen.dmi', icon_state = "cult_sharpener")
 	var/static/image/radial_shell = image(icon = 'icons/obj/wizard.dmi', icon_state = "construct-cult")
-	var/static/image/radial_unholy_water = image(icon = 'icons/obj/chemical.dmi', icon_state = "holyflask")
+	var/static/image/radial_unholy_water = image(icon = 'icons/obj/drinks.dmi', icon_state = "holyflask")
 
 /obj/structure/destructible/cult/talisman/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
I wasn't fast enough to push this to that PR before it went merged. I did a little mistake with the icon var. Fixing it.

## Why It's Good For The Game
I tested it locally and it works (minus for tooltips being waaay off-placed, but that's an issue with radial tooltips themselves which could be resolved on another PR once I get around it), except this foul up.

## Changelog
none.