### PR TITLE
Fixing an issue with DNA scanners maintenance hatches with sleeper code updates.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -88,17 +88,50 @@
 		return
 	close_machine(target)
 
-/obj/machinery/sleeper/attackby(obj/item/I, mob/user, params)
-	if(!state_open && !occupant)
-		if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), I))
-			return
+/obj/machinery/sleeper/screwdriver_act(mob/living/user, obj/item/I)
+	. = TRUE
+	if(..())
+		return
+	if(occupant)
+		to_chat(user, "<span class='warning'>[src] is currently occupied!</span>")
+		return
+	if(state_open)
+		to_chat(user, "<span class='warning'>[src] must be closed to [panel_open ? "close" : "open"] its maintenance hatch!</span>")
+		return
+	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), I))
+		return
+	return FALSE
+
+/obj/machinery/sleeper/wrench_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(default_change_direction_wrench(user, I))
-		return
+		return TRUE
+
+/obj/machinery/sleeper/crowbar_act(mob/living/user, obj/item/I)
+	. = ..()
 	if(default_pry_open(I))
-		return
+		return TRUE
 	if(default_deconstruction_crowbar(I))
+		return TRUE
+
+/obj/machinery/sleeper/default_pry_open(obj/item/I) //wew
+	. = !(state_open || panel_open || (flags_1 & NODECONSTRUCT_1)) && I.tool_behaviour == TOOL_CROWBAR
+	if(.)
+		I.play_tool_sound(src, 50)
+		visible_message("<span class='notice'>[usr] pries open [src].</span>", "<span class='notice'>You pry open [src].</span>")
+		open_machine()
+
+/obj/machinery/sleeper/AltClick(mob/user)
+	if(!user.canUseTopic(src, !issilicon(user)))
 		return
-	return ..()
+	if(state_open)
+		close_machine()
+	else
+		open_machine()
+
+/obj/machinery/sleeper/examine(mob/user)
+	..()
+	to_chat(user, "<span class='notice'>Alt-click [src] to [state_open ? "close" : "open"] it.</span>")
 
 /obj/machinery/sleeper/ui_interact(mob/user, ui_key = "main", datum/tgui/ui = null, force_open = FALSE, \
 									datum/tgui/master_ui = null, datum/ui_state/state = GLOB.notcontained_state)
@@ -190,7 +223,7 @@
 			if(inject_chem(chem, usr))
 				. = TRUE
 				if(scrambled_chems && prob(5))
-					to_chat(usr, "<span class='warning'>Chem System Re-route detected, results may not be as expected!</span>")
+					to_chat(usr, "<span class='warning'>Chemical system re-route detected, results may not be as expected!</span>")
 
 /obj/machinery/sleeper/emag_act(mob/user)
 	. = ..()

--- a/code/game/machinery/harvester.dm
+++ b/code/game/machinery/harvester.dm
@@ -138,7 +138,7 @@
 		to_chat(user, "<span class='warning'>[src] is currently occupied!</span>")
 		return
 	if(state_open)
-		to_chat(user, "<span class='warning'>[src] must be closed to [panel_open ? "close" : "open"] it's maintenance hatch!</span>")
+		to_chat(user, "<span class='warning'>[src] must be closed to [panel_open ? "close" : "open"] its maintenance hatch!</span>")
 		return
 	if(default_deconstruction_screwdriver(user, "[initial(icon_state)]-o", initial(icon_state), I))
 		return


### PR DESCRIPTION
## About The Pull Request
More or less what's said on the tin, fixing some dna scanner issues with the power of sleeper ports copypasta. Ergo, porting /tg/station PRs #40850, a bit of #44020 for adjacenty sanity checks and some harmless parent calls on #45582 that I didn't care to remove.

## Why It's Good For The Game
This will close #9357 (and also close #9358, duplicate of the first), an issue concerning dna scanners being unable to be opened nor have their maint panel closed, resulting in "door stuck!" situations with non-sentient/catatonic beings such as monkeys and humanized monkeys.

Basically I'm changing the way DNA scanners have their maint panel open to match the more safe sleepers.

## Changelog
:cl: Ghommie (original PR by 81Denton, kriskog and nemvar)
spellcheck: Sleepers now show a message if players try to unscrew the maintenance hatch while they're occupied or open. Fixed typos in sleeper/organ harvester messages.
tweak: Sleepers and dna scanners can now be pried open with crowbars.
tweak: You can open and close sleepers and dna scanners by alt-clicking them.
fix: The scanner's hatch now must be closed (on top of being unoccupied), just like sleepers, before being screwdriverable. This fixes a tricky door stuck issue with the machine.
/:cl: