### PR TITLE
Equalized the power of the melon seed.

### DIFF
--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -279,12 +279,12 @@
 	name = "\improper Melon Seed \"Scattershot\""
 	desc = "A weapon for combat exosuits. Shoots a spread of pellets, shaped as seed."
 	icon_state = "mecha_scatter"
-	equip_cooldown = 30
+	equip_cooldown = 20
 	projectile = /obj/item/projectile/bullet/seed
-	projectiles = 4
-	projectile_energy_cost = 55
+	projectiles = 16
+	projectile_energy_cost = 25
 	projectiles_per_shot = 10
-	variance = 20
+	variance = 25
 	harmful = TRUE
 
 /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg

--- a/code/game/mecha/equipment/weapons/weapons.dm
+++ b/code/game/mecha/equipment/weapons/weapons.dm
@@ -281,7 +281,7 @@
 	icon_state = "mecha_scatter"
 	equip_cooldown = 20
 	projectile = /obj/item/projectile/bullet/seed
-	projectiles = 16
+	projectiles = 20
 	projectile_energy_cost = 25
 	projectiles_per_shot = 10
 	variance = 25


### PR DESCRIPTION
## About The Pull Request
Equalizes the power of Melon Seed when compared to LBX AC 10.

## Actual Changes
Equip cooldown lowered from 30 to 20. (More than likely a 1 second decrease and not 10 seconds)
Projectiles increased from 4 to 16.
Energy cost lowered from 55 to 25.
Variance increased from 20 to 25.

## Why It's Good For The Game
Balance man good
## Changelog
:cl:
balance: rebalanced something
/:cl:
