### PR TITLE
buffs c4 on mobs

### DIFF
--- a/code/game/objects/items/grenades/plastic.dm
+++ b/code/game/objects/items/grenades/plastic.dm
@@ -174,6 +174,7 @@
 	gender = PLURAL
 	var/open_panel = 0
 	can_attach_mob = TRUE
+	full_damage_on_mobs = TRUE
 
 /obj/item/grenade/plastic/c4/New()
 	wires = new /datum/wires/explosive/c4(src)


### PR DESCRIPTION
it should now instakill people without bomb armor and instacrit anyone else

reason: parapen/c4 days are long gone and i nerfed it too hard no one even uses this dumb thing let's make it slightly more useful even if there's easier ways to kill someone /shrug