### PR TITLE
Makes Ashwalkers unable to wear Masks

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -94,7 +94,8 @@
 	limbs_id = "lizard"
 	species_traits = list(MUTCOLORS,EYECOLOR,LIPS,DIGITIGRADE)
 	inherent_traits = list(TRAIT_NOGUNS)
-	mutantlungs = /obj/item/organ/lungs/ashwalker
+	mutantlungs = /obj/item/organ/lungs/ashwalker //Lungs that keep them from breathing station atmosphere.
+	no_equip = list(SLOT_WEAR_MASK) //Now asswalkers can't bypass internals issues preventing them from getting onto station.
 	burnmod = 0.9
 	brutemod = 0.9
 


### PR DESCRIPTION
## About The Pull Request

Adds mask to ashwalker no_equip.
Doesn't let ashwalkers wear masks, their snouts r too big anyways theres ur excuse

## Why It's Good For The Game

Now they will never get onto the station and stay alive thanks to the lungs they were given.

## Changelog
:cl: JTGSZ
tweak: Makes Ashwalkers unable to wear masks
/:cl:
