### PR TITLE
Rebalances k9borg pounce/bite around the secborg's baton.

### DIFF
--- a/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
@@ -4,7 +4,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 */
 
 /obj/item/dogborg/jaws
-	var/cellcost
+	var/cellcost = 0
 	name = "Dogborg jaws"
 	desc = "The jaws of the debug errors oh god."
 	icon = 'icons/mob/dogborg.dmi'
@@ -20,7 +20,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	desc = "The jaws of the law. Very sharp."
 	icon_state = "jaws"
 	force = 12
-	cellcost = 1000 // Secborg can only harm with the baton, why does the K9 get a free module to do 12 damage with?
+	cellcost = 250
 	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
 
 
@@ -29,14 +29,17 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	desc = "Rubberized teeth designed to protect accidental harm. Sharp enough for specialized tasks however."
 	icon_state = "smalljaws"
 	force = 6
-	cellcost = 500 // Less cell use for the smaller jaws.
 	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
 	var/status = 0
 
 /obj/item/dogborg/jaws/attack(atom/A, mob/living/silicon/robot/user)
 	..()
-	user.cell.use(cellcost)
-	user.do_attack_animation(A, ATTACK_EFFECT_BITE)
+	if(user.cell.charge <= cellcost)
+		to_chat(src,"<span class='danger'>Insufficent energy for jaws!</span>")
+		return
+	else
+		user.cell.use(cellcost)
+		user.do_attack_animation(A, ATTACK_EFFECT_BITE)
 
 /obj/item/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot.R = user
@@ -352,7 +355,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		pixel_y = 10
 		update_icons()
 		throw_at(A, MAX_K9_LEAP_DIST, 1, spin=0, diagonals_first = 1)
-		cell.use(750) //Same as stunbaton
+		cell.use(750) //Less than a stunbaton since stunbatons hit everytime.
 		weather_immunities -= "lava"
 
 /mob/living/silicon/robot/throw_impact(atom/A)

--- a/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
@@ -4,6 +4,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 */
 
 /obj/item/dogborg/jaws
+	var/cellcost
 	name = "Dogborg jaws"
 	desc = "The jaws of the debug errors oh god."
 	icon = 'icons/mob/dogborg.dmi'
@@ -19,28 +20,23 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	desc = "The jaws of the law. Very sharp."
 	icon_state = "jaws"
 	force = 12
+	cellcost = 1000 // Secborg can only harm with the baton, why does the K9 get a free module to do 12 damage with?
 	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
+
 
 /obj/item/dogborg/jaws/small
 	name = "puppy jaws"
 	desc = "Rubberized teeth designed to protect accidental harm. Sharp enough for specialized tasks however."
 	icon_state = "smalljaws"
 	force = 6
+	cellcost = 500 // Less cell use for the smaller jaws.
 	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
 	var/status = 0
 
-/obj/item/dogborg/jaws/small/attack(atom/A, mob/living/silicon/robot/user)
+/obj/item/dogborg/jaws/attack(atom/A, mob/living/silicon/robot/user)
 	..()
-	user.cell.use(500) // Less cell use for the smaller jaws.
+	user.cell.use(cellcost)
 	user.do_attack_animation(A, ATTACK_EFFECT_BITE)
-	log_combat(user, A, "bit")
-
-/obj/item/dogborg/jaws/big/attack(atom/A, mob/living/silicon/robot/user)
-	..()
-	user.cell.use(1000) // Secborg can only harm with the baton, why does the K9 get a free module to do 12 damage with?
-	user.do_attack_animation(A, ATTACK_EFFECT_BITE)
-	log_combat(user, A, "bit")
-
 
 /obj/item/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot.R = user
@@ -316,7 +312,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	var/leaping = 0
 	var/pounce_cooldown = 0
 	var/pounce_cooldown_time = 20 //Buffed to counter balance changes
-	var/pounce_spoolup = 2
+	var/pounce_spoolup = 1
 	var/leap_at
 	var/disabler
 	var/laser
@@ -346,7 +342,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
 
-	if(cell.charge <= 1000)
+	if(cell.charge <= 750)
 		to_chat(src,"<span class='danger'>Insufficent reserves for jump actuators!</span>")
 		return
 
@@ -356,7 +352,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		pixel_y = 10
 		update_icons()
 		throw_at(A, MAX_K9_LEAP_DIST, 1, spin=0, diagonals_first = 1)
-		cell.use(1000) //Same as stunbaton
+		cell.use(750) //Same as stunbaton
 		weather_immunities -= "lava"
 
 /mob/living/silicon/robot/throw_impact(atom/A)
@@ -374,13 +370,13 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 					blocked = 1
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
-				L.Knockdown(iscarbon(L) ? 225 : 25) // Temporary. If someone could rework how dogborg pounces work to accomodate for combat changes, that'd be nice.
+				L.Knockdown(iscarbon(L) ? 225 : 45) // Temporary. If someone could rework how dogborg pounces work to accomodate for combat changes, that'd be nice.
 				playsound(src, 'sound/weapons/Egloves.ogg', 50, 1)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 				log_combat(src, L, "borg pounced")
 			else
-				Knockdown(25, 1, 1)
+				Knockdown(15, 1, 1)
 
 			pounce_cooldown = !pounce_cooldown
 			spawn(pounce_cooldown_time) //3s by default
@@ -388,7 +384,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		else if(A.density && !A.CanPass(src))
 			visible_message("<span class ='danger'>[src] smashes into [A]!</span>", "<span class ='userdanger'>You smash into [A]!</span>")
 			playsound(src, 'sound/items/trayhit1.ogg', 50, 1)
-			Knockdown(25, 1, 1)
+			Knockdown(15, 1, 1)
 
 		if(leaping)
 			leaping = 0

--- a/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
@@ -29,10 +29,18 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	attack_verb = list("nibbled", "bit", "gnawed", "chomped", "nommed")
 	var/status = 0
 
-/obj/item/dogborg/jaws/attack(atom/A, mob/living/silicon/robot/user)
+/obj/item/dogborg/jaws/small/attack(atom/A, mob/living/silicon/robot/user)
 	..()
+	user.cell.use(500) // Less cell use for the smaller jaws.
 	user.do_attack_animation(A, ATTACK_EFFECT_BITE)
 	log_combat(user, A, "bit")
+
+/obj/item/dogborg/jaws/big/attack(atom/A, mob/living/silicon/robot/user)
+	..()
+	user.cell.use(1000) // Secborg can only harm with the baton, why does the K9 get a free module to do 12 damage with?
+	user.do_attack_animation(A, ATTACK_EFFECT_BITE)
+	log_combat(user, A, "bit")
+
 
 /obj/item/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot.R = user
@@ -307,8 +315,8 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 /mob/living/silicon/robot
 	var/leaping = 0
 	var/pounce_cooldown = 0
-	var/pounce_cooldown_time = 50 //Nearly doubled, u happy?
-	var/pounce_spoolup = 3
+	var/pounce_cooldown_time = 20 //Buffed to counter balance changes
+	var/pounce_spoolup = 2
 	var/leap_at
 	var/disabler
 	var/laser
@@ -338,7 +346,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		//It's also extremely buggy visually, so it's balance+bugfix
 		return
 
-	if(cell.charge <= 500)
+	if(cell.charge <= 1000)
 		to_chat(src,"<span class='danger'>Insufficent reserves for jump actuators!</span>")
 		return
 
@@ -348,7 +356,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		pixel_y = 10
 		update_icons()
 		throw_at(A, MAX_K9_LEAP_DIST, 1, spin=0, diagonals_first = 1)
-		cell.use(500) //Doubled the energy consumption
+		cell.use(1000) //Same as stunbaton
 		weather_immunities -= "lava"
 
 /mob/living/silicon/robot/throw_impact(atom/A)
@@ -366,13 +374,13 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 					blocked = 1
 			if(!blocked)
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
-				L.Knockdown(iscarbon(L) ? 450 : 45) // Temporary. If someone could rework how dogborg pounces work to accomodate for combat changes, that'd be nice.
+				L.Knockdown(iscarbon(L) ? 225 : 25) // Temporary. If someone could rework how dogborg pounces work to accomodate for combat changes, that'd be nice.
 				playsound(src, 'sound/weapons/Egloves.ogg', 50, 1)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 				log_combat(src, L, "borg pounced")
 			else
-				Knockdown(45, 1, 1)
+				Knockdown(25, 1, 1)
 
 			pounce_cooldown = !pounce_cooldown
 			spawn(pounce_cooldown_time) //3s by default
@@ -380,7 +388,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 		else if(A.density && !A.CanPass(src))
 			visible_message("<span class ='danger'>[src] smashes into [A]!</span>", "<span class ='userdanger'>You smash into [A]!</span>")
 			playsound(src, 'sound/items/trayhit1.ogg', 50, 1)
-			Knockdown(45, 1, 1)
+			Knockdown(25, 1, 1)
 
 		if(leaping)
 			leaping = 0

--- a/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/dogborg_equipment.dm
@@ -4,7 +4,6 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 */
 
 /obj/item/dogborg/jaws
-	var/cellcost = 0
 	name = "Dogborg jaws"
 	desc = "The jaws of the debug errors oh god."
 	icon = 'icons/mob/dogborg.dmi'
@@ -19,8 +18,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 	name = "combat jaws"
 	desc = "The jaws of the law. Very sharp."
 	icon_state = "jaws"
-	force = 12
-	cellcost = 250
+	force = 10 //Lowered to match secborg. No reason it should be more than a secborg's baton.
 	attack_verb = list("chomped", "bit", "ripped", "mauled", "enforced")
 
 
@@ -34,12 +32,7 @@ SLEEPER CODE IS IN game/objects/items/devices/dogborg_sleeper.dm !
 
 /obj/item/dogborg/jaws/attack(atom/A, mob/living/silicon/robot/user)
 	..()
-	if(user.cell.charge <= cellcost)
-		to_chat(src,"<span class='danger'>Insufficent energy for jaws!</span>")
-		return
-	else
-		user.cell.use(cellcost)
-		user.do_attack_animation(A, ATTACK_EFFECT_BITE)
+	user.do_attack_animation(A, ATTACK_EFFECT_BITE)
 
 /obj/item/dogborg/jaws/small/attack_self(mob/user)
 	var/mob/living/silicon/robot.R = user


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The K9's pounce fully stamcrits from just one pounce. This nerfs it to do about 50~ stamdamage and knockdown. Spoolup was buffed. Cooldown was buffed. Knockout time if you miss was buffed. Cell use was tweaked to match what the baton has. Bite now has a cell-use because a free 12 damage(baton does 10) is bullshit. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
K9 secborgs are overpowered compared to normal secborgs, and while normal secborgs can stunlock better, an instacrit pounce was bullshit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: rebalanced k9dogborgs
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
