### PR TITLE
APC UI autoupdates properly

### DIFF
--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -802,8 +802,6 @@
 	if(!ui)
 		ui = new(user, src, ui_key, "apc", name, 535, 515, master_ui, state)
 		ui.open()
-	if(ui)
-		ui.set_autoupdate(state = (failure_timer ? 1 : 0))
 
 /obj/machinery/power/apc/ui_data(mob/user)
 	var/list/data = list(


### PR DESCRIPTION
Ports the effects of # 46841 of /tg/ by Actioninja, Ensures that you don't need to re-click to see the effects of your changes on the UI

## Changelog
:cl: actioninja
fix: APC UI autoupdates correctly
/:cl:
