### PR TITLE
Ports "Makes supermatter melt walls if it finds itself in one"

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -329,6 +329,12 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	if(power)
 		soundloop.volume = min(40, (round(power/100)/50)+1) // 5 +1 volume per 20 power. 2500 power is max
 
+	if(isclosedturf(T))
+		var/turf/did_it_melt = T.Melt()
+		if(!isclosedturf(did_it_melt)) //In case some joker finds way to place these on indestructible walls
+			visible_message("<span class='warning'>[src] melts through [T]!</span>")
+		return
+
 	//Ok, get the air from the turf
 	var/datum/gas_mixture/env = T.return_air()
 


### PR DESCRIPTION
## About The Pull Request
Had a cool PDA chat yesterday with a traitor engi that blew up the SM into a tesloth within minutes from the start of the round and they mentioned about how such exploit would have been a better move to get the singularity instead. That made me remember how I haven't ported the fix yet (well, the first half, I did port the "stops SM radios from blowing up" bit).

So, porting /tg/station PR #44068.

## Why It's Good For The Game
Fixing an exploit, since gases don't spread out while inside walls.

## Changelog
:cl: Ghommie (original PR by AnturK)
fix: Supermatter now melt walls if it finds itself in one.
/:cl: