### PR TITLE
Makes Medsprays align with patches

### DIFF
--- a/code/modules/reagents/reagent_containers/medspray.dm
+++ b/code/modules/reagents/reagent_containers/medspray.dm
@@ -19,8 +19,8 @@
 	var/can_fill_from_container = TRUE
 	var/apply_type = PATCH
 	var/apply_method = "spray"
-	var/self_delay = 30
-	var/squirt_mode = 0
+	var/self_delay = 3 SECONDS
+	var/squirt_mode = FALSE
 	var/squirt_amount = 5
 
 /obj/item/reagent_containers/medspray/attack_self(mob/user)
@@ -31,40 +31,51 @@
 		amount_per_transfer_from_this = initial(amount_per_transfer_from_this)
 	to_chat(user, "<span class='notice'>You will now apply the medspray's contents in [squirt_mode ? "short bursts":"extended sprays"]. You'll now use [amount_per_transfer_from_this] units per use.</span>")
 
-/obj/item/reagent_containers/medspray/attack(mob/M, mob/user, def_zone)
+/obj/item/reagent_containers/medspray/attack(mob/living/L, mob/user, def_zone)
 	if(!reagents || !reagents.total_volume)
 		to_chat(user, "<span class='warning'>[src] is empty!</span>")
 		return
 
-	if(M == user)
-		M.visible_message("<span class='notice'>[user] attempts to [apply_method] [src] on [user.p_them()]self.</span>")
+	if(ishuman(L))
+		var/obj/item/bodypart/affecting = L.get_bodypart(check_zone(user.zone_selected))
+		if(!affecting)
+			to_chat(user, "<span class='warning'>The limb is missing!</span>")
+			return
+		if(!L.can_inject(user, TRUE, user.zone_selected, FALSE, TRUE)) //stopped by clothing, like patches
+			return
+		if(affecting.status != BODYPART_ORGANIC)
+			to_chat(user, "<span class='notice'>Medicine won't work on a robotic limb!</span>")
+			return
+
+	if(L == user)
+		L.visible_message("<span class='notice'>[user] attempts to [apply_method] [src] on [user.p_them()]self.</span>")
 		if(self_delay)
-			if(!do_mob(user, M, self_delay))
+			if(!do_mob(user, L, self_delay))
 				return
 			if(!reagents || !reagents.total_volume)
 				return
-		to_chat(M, "<span class='notice'>You [apply_method] yourself with [src].</span>")
+		to_chat(L, "<span class='notice'>You [apply_method] yourself with [src].</span>")
 
 	else
-		log_combat(user, M, "attempted to apply", src, reagents.log_list())
-		M.visible_message("<span class='danger'>[user] attempts to [apply_method] [src] on [M].</span>", \
-							"<span class='userdanger'>[user] attempts to [apply_method] [src] on [M].</span>")
-		if(!do_mob(user, M))
+		log_combat(user, L, "attempted to apply", src, reagents.log_list())
+		L.visible_message("<span class='danger'>[user] attempts to [apply_method] [src] on [L].</span>", \
+							"<span class='userdanger'>[user] attempts to [apply_method] [src] on [L].</span>")
+		if(!do_mob(user, L))
 			return
 		if(!reagents || !reagents.total_volume)
 			return
-		M.visible_message("<span class='danger'>[user] [apply_method]s [M] down with [src].</span>", \
-							"<span class='userdanger'>[user] [apply_method]s [M] down with [src].</span>")
+		L.visible_message("<span class='danger'>[user] [apply_method]s [L] down with [src].</span>", \
+							"<span class='userdanger'>[user] [apply_method]s [L] down with [src].</span>")
 
 	if(!reagents || !reagents.total_volume)
 		return
 
 	else
-		log_combat(user, M, "applied", src, reagents.log_list())
+		log_combat(user, L, "applied", src, reagents.log_list())
 		playsound(src, 'sound/effects/spray2.ogg', 50, 1, -6)
 		var/fraction = min(amount_per_transfer_from_this/reagents.total_volume, 1)
-		reagents.reaction(M, apply_type, fraction)
-		reagents.trans_to(M, amount_per_transfer_from_this)
+		reagents.reaction(L, apply_type, fraction)
+		reagents.trans_to(L, amount_per_transfer_from_this)
 	return
 
 /obj/item/reagent_containers/medspray/styptic


### PR DESCRIPTION
Also ensures you can't spray it on ghosts, ai eyes, etc.

## About The Pull Request

Makes med sprays, which were more or less patch code when they were added, perform the same as patches do now. Yes, I double checked to make sure I was using Ghommie's fix too.

## Why It's Good For The Game

It doesn't make sense for a sealed space suit to receive medical attention when syringes, patches, cryo, and most other healing doesn't either. 

## Changelog
:cl:
balance: Med Sprays are now more aligned with patch mechanics
/:cl: