### PR TITLE
 Removes the minimum player cap for the war ops in favour or a more proportional telecrystal bonus.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,6 +1,8 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define PLAYER_SCALING 1.5
 #define CHALLENGE_TIME_LIMIT 3000
+#define CHALLENGE_PLAYERS_TARGET 50 //target players population. anything below is a malus to the challenge tc bonus.
+#define TELECRYSTALS_MALUS_SCALING 1 //the higher the value, the bigger the malus.
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
@@ -65,8 +67,11 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
   GLOB.war_declared = TRUE
 	var/list/nukeops = get_antag_minds(/datum/antagonist/nukeop)
 	var/actual_players = GLOB.joined_player_list.len - nukeops.len
+	var/tc_malus = 0
+	if(actual_players < CHALLENGE_PLAYERS_TARGET)
+		tc_malus = (CHALLENGE_TELECRYSTALS - actual_players * INVERSE(CHALLENGE_PLAYERS_TARGET)) * TELECRYSTALS_MALUS_SCALING
 
-	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS + CEILING(PLAYER_SCALING * actual_players, 1))
+	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS - tc_malus + CEILING(PLAYER_SCALING * actual_players, 1))
 
 	CONFIG_SET(number/shuttle_refuel_delay, max(CONFIG_GET(number/shuttle_refuel_delay), CHALLENGE_SHUTTLE_DELAY))
 	SSblackbox.record_feedback("amount", "nuclear_challenge_mode", 1)
@@ -96,4 +101,6 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT
+#undef CHALLENGE_PLAYERS_TARGET
+#undef TELECRYSTALS_MALUS_SCALING
 #undef CHALLENGE_SHUTTLE_DELAY

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -1,7 +1,6 @@
 #define CHALLENGE_TELECRYSTALS 280
 #define PLAYER_SCALING 1.5
 #define CHALLENGE_TIME_LIMIT 3000
-#define CHALLENGE_MIN_PLAYERS 50
 #define CHALLENGE_SHUTTLE_DELAY 15000 // 25 minutes, so the ops have at least 5 minutes before the shuttle is callable.
 
 GLOBAL_LIST_EMPTY(jam_on_wardec)
@@ -62,7 +61,7 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 
 	for(var/obj/machinery/computer/camera_advanced/shuttle_docker/D in GLOB.jam_on_wardec)
 		D.jammed = TRUE
-    
+
   GLOB.war_declared = TRUE
 	var/list/nukeops = get_antag_minds(/datum/antagonist/nukeop)
 	var/actual_players = GLOB.joined_player_list.len - nukeops.len
@@ -79,11 +78,6 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 		to_chat(user, "You are already in the process of declaring war! Make your mind up.")
 		return FALSE
 
-	var/list/nukeops = get_antag_minds(/datum/antagonist/nukeop)
-	var/actual_players = GLOB.joined_player_list.len - nukeops.len
-	if(actual_players < CHALLENGE_MIN_PLAYERS)
-		to_chat(user, "The enemy crew is too small to be worth declaring war on.")
-		return FALSE
 	if(!user.onSyndieBase())
 		to_chat(user, "You have to be at your base to use this.")
 		return FALSE
@@ -102,5 +96,4 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 
 #undef CHALLENGE_TELECRYSTALS
 #undef CHALLENGE_TIME_LIMIT
-#undef CHALLENGE_MIN_PLAYERS
 #undef CHALLENGE_SHUTTLE_DELAY

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -69,7 +69,7 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 	var/actual_players = GLOB.joined_player_list.len - nukeops.len
 	var/tc_malus = 0
 	if(actual_players < CHALLENGE_PLAYERS_TARGET)
-		tc_malus = (CHALLENGE_TELECRYSTALS - actual_players * INVERSE(CHALLENGE_PLAYERS_TARGET)) * TELECRYSTALS_MALUS_SCALING
+		tc_malus = FLOOR((CHALLENGE_TELECRYSTALS - actual_players * INVERSE(CHALLENGE_PLAYERS_TARGET)) * TELECRYSTALS_MALUS_SCALING)
 
 	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS - tc_malus + CEILING(PLAYER_SCALING * actual_players, 1))
 

--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -69,7 +69,7 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 	var/actual_players = GLOB.joined_player_list.len - nukeops.len
 	var/tc_malus = 0
 	if(actual_players < CHALLENGE_PLAYERS_TARGET)
-		tc_malus = FLOOR((CHALLENGE_TELECRYSTALS - actual_players * INVERSE(CHALLENGE_PLAYERS_TARGET)) * TELECRYSTALS_MALUS_SCALING)
+		tc_malus = FLOOR((CHALLENGE_TELECRYSTALS - actual_players * INVERSE(CHALLENGE_PLAYERS_TARGET)) * TELECRYSTALS_MALUS_SCALING, 1)
 
 	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS - tc_malus + CEILING(PLAYER_SCALING * actual_players, 1))
 


### PR DESCRIPTION
## About The Pull Request
What's said on the tin. the server rarely ever reaches the required 50 roundstart players (excluding nukies). And players keep complaining about it and blitz/stealth ops.
To prevent lowpop war ops from getting their gloved grubby hands on a whooping 280 TCs, a malus inversely proportional to the target population of 50 and then added. The amount withdrawn by this malus is regulated by a multiplier define, currently set to 1.
Considering the already existing population tc bonus and the minimum population for nukies that should be 25, the minimum war bonus tc given to nukies should be approximately 160.

## Why It's Good For The Game
Making war ops viable for low population rounds without adminnery intervention.

## Changelog
:cl:
tweak: war ops is now lowpop friendly and doesn't require roughly 54 starting players anymore.
/:cl: