### PR TITLE
The niche singularity beacon now also moderately buffs meteor waves.

### DIFF
--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -31,7 +31,7 @@ GLOBAL_INIT_LIST(singularity_beacons)
 		return
 	GLOB.singularity_beacons += src
 	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
-		W.weight += round(initial(W.weight) * METEOR_DISASTER_MODIFIER))
+		W.weight += round(initial(W.weight) * METEOR_DISASTER_MODIFIER)
 	for(var/obj/singularity/singulo in GLOB.singularities)
 		if(singulo.z == z)
 			singulo.target = src
@@ -51,7 +51,7 @@ GLOBAL_INIT_LIST(singularity_beacons)
 		to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
 	GLOB.singularity_beacons -= src
 	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
-		W.weight -= round(initial(W.weight) * METEOR_DISASTER_MODIFIER))
+		W.weight -= round(initial(W.weight) * METEOR_DISASTER_MODIFIER)
 
 
 /obj/machinery/power/singularity_beacon/attack_ai(mob/user)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -25,10 +25,12 @@ GLOBAL_VAR_INIT(singularity_counter, 0)
 
 
 /obj/machinery/power/singularity_beacon/proc/Activate(mob/user = null)
+	if(active)
+		return FALSE
 	if(surplus() < 1500)
 		if(user)
 			to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
-		return
+		return FALSE
 	GLOB.singularity_counter++
 	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
 		W.weight += round(initial(W.weight) * METEOR_DISASTER_MODIFIER)
@@ -36,22 +38,26 @@ GLOBAL_VAR_INIT(singularity_counter, 0)
 		if(singulo.z == z)
 			singulo.target = src
 	icon_state = "[icontype]1"
-	active = 1
+	active = TRUE
 	if(user)
 		to_chat(user, "<span class='notice'>You activate the beacon.</span>")
+	return TRUE
 
 
-/obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user = null)
+/obj/machinery/power/singularity_beacon/proc/Deactivate(mob/user)
+	if(!active)
+		return FALSE
 	for(var/obj/singularity/singulo in GLOB.singularities)
 		if(singulo.target == src)
 			singulo.target = null
 	icon_state = "[icontype]0"
-	active = 0
+	active = FALSE
 	if(user)
 		to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
 	GLOB.singularity_counter--
 	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
 		W.weight -= round(initial(W.weight) * METEOR_DISASTER_MODIFIER)
+	return TRUE
 
 
 /obj/machinery/power/singularity_beacon/attack_ai(mob/user)

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -1,3 +1,7 @@
+GLOBAL_INIT_LIST(singularity_beacons)
+
+#define METEOR_DISASTER_MODIFIER 0.5
+
 ////////////////////////////////////////
 //Singularity beacon
 ////////////////////////////////////////
@@ -18,11 +22,16 @@
 	var/icontype = "beacon"
 
 
+
+
 /obj/machinery/power/singularity_beacon/proc/Activate(mob/user = null)
 	if(surplus() < 1500)
 		if(user)
 			to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
 		return
+	GLOB.singularity_beacons += src
+	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
+		W.weight += round(initial(W.weight) * METEOR_DISASTER_MODIFIER))
 	for(var/obj/singularity/singulo in GLOB.singularities)
 		if(singulo.z == z)
 			singulo.target = src
@@ -40,6 +49,9 @@
 	active = 0
 	if(user)
 		to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
+	GLOB.singularity_beacons -= src
+	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
+		W.weight -= round(initial(W.weight) * METEOR_DISASTER_MODIFIER))
 
 
 /obj/machinery/power/singularity_beacon/attack_ai(mob/user)
@@ -133,3 +145,5 @@
 /obj/item/sbeacondrop/clownbomb
 	desc = "A label on it reads: <i>Warning: Activating this device will send a silly explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb/badmin/clown
+
+#undef METEOR_DISASTER_MODIFIER

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -1,4 +1,4 @@
-GLOBAL_INIT_LIST(singularity_beacons)
+GLOBAL_VAR_INIT(singularity_counter, 0)
 
 #define METEOR_DISASTER_MODIFIER 0.5
 
@@ -29,7 +29,7 @@ GLOBAL_INIT_LIST(singularity_beacons)
 		if(user)
 			to_chat(user, "<span class='notice'>The connected wire doesn't have enough current.</span>")
 		return
-	GLOB.singularity_beacons += src
+	GLOB.singularity_counter++
 	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
 		W.weight += round(initial(W.weight) * METEOR_DISASTER_MODIFIER)
 	for(var/obj/singularity/singulo in GLOB.singularities)
@@ -49,7 +49,7 @@ GLOBAL_INIT_LIST(singularity_beacons)
 	active = 0
 	if(user)
 		to_chat(user, "<span class='notice'>You deactivate the beacon.</span>")
-	GLOB.singularity_beacons -= src
+	GLOB.singularity_counter--
 	for(var/datum/round_event_control/meteor_wave/W in SSevents.control)
 		W.weight -= round(initial(W.weight) * METEOR_DISASTER_MODIFIER)
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -1,5 +1,8 @@
 // Normal strength
 
+#define SINGULO_BEACON_DISTURBANCE 0.2 //singularity beacon also improve the odds of meteor waves and speed them up a little.
+#define SINGULO_BEACON_MAX_DISTURBANCE 0.6 //maximum cap due to how meteor waves can be potentially round ending.
+
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
@@ -18,6 +21,8 @@
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
 	startWhen = rand(300, 600) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	if(GLOB.singularity_beacons.len)
+		startWhen *= 1 - min(GLOB.singularity_beacons.len * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60
 
 
@@ -79,3 +84,6 @@
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"
+
+#undef SINGULO_BEACON_DISTURBANCE
+#undef SINGULO_BEACON_MAX_DISTURBANCE

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -21,8 +21,8 @@
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
 	startWhen = rand(300, 600) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
-	if(GLOB.singularity_beacons.len)
-		startWhen *= 1 - min(GLOB.singularity_beacons.len * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
+	if(GLOB.singularity_counter)
+		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60
 
 

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -57,7 +57,7 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round(startWhen/60)] minutes.[GLOB.singularity_counter ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely.", ""]", "Meteor Alert", 'sound/ai/meteors.ogg')
+	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round(startWhen/60)] minutes.[GLOB.singularity_counter ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely." : ""]", "Meteor Alert", 'sound/ai/meteors.ogg')
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -57,7 +57,7 @@
 			kill()
 
 /datum/round_event/meteor_wave/announce(fake)
-	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round(startWhen/60)] minutes.", "Meteor Alert", 'sound/ai/meteors.ogg')
+	priority_announce("Meteors have been detected on collision course with the station. Estimated time until impact: [round(startWhen/60)] minutes.[GLOB.singularity_counter ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely.", ""]", "Meteor Alert", 'sound/ai/meteors.ogg')
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1487,9 +1487,10 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 /datum/uplink_item/device_tools/singularity_beacon
 	name = "Power Beacon"
 	desc = "When screwed to wiring attached to an electric grid and activated, this large device pulls any \
-			active gravitational singularities or tesla balls towards it. This will not work when the engine is still \
-			in containment. Because of its size, it cannot be carried. Ordering this \
-			sends you a small beacon that will teleport the larger beacon to your location upon activation."
+			active gravitational singularities or tesla balls towards it (provided they are not safely \
+			contained), as well as increasing the odds of incoming meteor waves. \
+			Because of its size, it cannot be carried. Ordering this sends you a small beacon \
+			that will teleport the larger beacon to your location upon activation."
 	item = /obj/item/sbeacondrop
 	cost = 14
 


### PR DESCRIPTION
## About The Pull Request
Raising the versatility of this very costly and niche (since the singularity/tesla engine is no more standard issue) item. This doesn't affect the uplink item's cost or availability, only the description.
Basically each active singularity beacon will raise the weight of meteor waves events by half their initial value and speed up the estimeed time for the meteors to actually strike the station by 20% (up to a max of 60%). 
The required players cap is not affected, meteor waves won't happen unless the player population is of at least 25, even with multiple active beacons.

Current values may be up to changes.

## Why It's Good For The Game
This has been a closet idea for quite a bit, and considering how meteor waves are actually manageable now that the meteor shields are available each round and the wave does not initiate until at least 5 minutes after the announcement, so I'm of the opinion this shouldn't be much of a "powercreep" to such an underwhelming niche.
Most players who buy this will actively seek to unleash singuloth or tesloth anyway. This is aimed to the people who unfortunately got this from a surplus crate, screwed bundle, discount, or just don't care.

## Changelog
:cl:
add: Singularity beacons now also moderately increases the odds meteor waves, while lowering their estimeed arrival countdown.
/:cl: