### PR TITLE
Adds a new way to get research points.

### DIFF
--- a/code/modules/research/machinery/pointgiver.dm
+++ b/code/modules/research/machinery/pointgiver.dm
@@ -1,16 +1,16 @@
 /obj/machinery/rnd/pointgiver
   name = "virtual technology node"
-  desc = "This shouldn't exist."
+  desc = "A virtual representation of stored research, ideas and knowledge. This one belongs to [factionname] and will give [reward] points if destoyed."
   layer = BELOW_OBJ_LAYER
-  var/reward
+
 
 /obj/machinery/rnd/pointgiver/Destroy()
-  SSresearch.points += reward
-  . = ..()
+	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, reward)
+	. = ..()
 
 
 /obj/machinery/rnd/pointgiver/syndicate
   name = "syndicate virtual technology node"
-  desc = "A virtual representation of stored research, ideas and knowledge. This one belongs to the Syndicate and will give [pointsgiven] points if destoyed."
   layer = BELOW_OBJ_LAYER
   reward = 1000
+  factionname = "the Syndicate"

--- a/code/modules/research/machinery/pointgiver.dm
+++ b/code/modules/research/machinery/pointgiver.dm
@@ -1,8 +1,13 @@
 /obj/machinery/rnd/pointgiver
-  name = "virtual technology node"
-  desc = "A virtual representation of stored research, ideas and knowledge. This one belongs to [factionname] and will give [reward] points if destoyed."
-  layer = BELOW_OBJ_LAYER
+	name = "virtual technology node"
+	desc = "A virtual representation of stored research, ideas and knowledge."
+	layer = BELOW_OBJ_LAYER
+	var/reward = 0
+	var/factionname = "blank"
 
+/obj/machinery/rnd/pointgiver/examine(mob/living/user)
+	..()
+	to_chat(user, "<span class='notice'>This one belongs to [factionname] and will give [reward] points if destoyed.</span>")
 
 /obj/machinery/rnd/pointgiver/Destroy()
 	SSresearch.science_tech.add_point_type(TECHWEB_POINT_TYPE_DEFAULT, reward)
@@ -10,7 +15,7 @@
 
 
 /obj/machinery/rnd/pointgiver/syndicate
-  name = "syndicate virtual technology node"
-  layer = BELOW_OBJ_LAYER
-  reward = 1000
-  factionname = "the Syndicate"
+	name = "syndicate virtual technology node"
+	layer = BELOW_OBJ_LAYER
+	reward = 1000
+	factionname = "the Syndicate"

--- a/code/modules/research/machinery/pointgiver.dm
+++ b/code/modules/research/machinery/pointgiver.dm
@@ -2,10 +2,15 @@
   name = "virtual technology node"
   desc = "This shouldn't exist."
   layer = BELOW_OBJ_LAYER
-  var/pointsgiven
+  var/reward
+
+/obj/machinery/rnd/pointgiver/Destroy()
+  SSresearch.points += reward
+  . = ..()
+
 
 /obj/machinery/rnd/pointgiver/syndicate
   name = "syndicate virtual technology node"
   desc = "A virtual representation of stored research, ideas and knowledge. This one belongs to the Syndicate and will give [pointsgiven] points if destoyed."
   layer = BELOW_OBJ_LAYER
-  pointsgiven = 1000
+  reward = 1000

--- a/code/modules/research/machinery/pointgiver.dm
+++ b/code/modules/research/machinery/pointgiver.dm
@@ -1,0 +1,11 @@
+/obj/machinery/rnd/pointgiver
+  name = "virtual technology node"
+  desc = "This shouldn't exist."
+  layer = BELOW_OBJ_LAYER
+  var/pointsgiven
+
+/obj/machinery/rnd/pointgiver/syndicate
+  name = "syndicate virtual technology node"
+  desc = "A virtual representation of stored research, ideas and knowledge. This one belongs to the Syndicate and will give [pointsgiven] points if destoyed."
+  layer = BELOW_OBJ_LAYER
+  pointsgiven = 1000

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -7,8 +7,6 @@
 	icon = 'icons/obj/machines/research.dmi'
 	density = TRUE
 	use_power = IDLE_POWER_USE
-	var/reward = 0
-	var/factionname = "blank"
 	var/busy = FALSE
 	var/hacked = FALSE
 	var/console_link = TRUE		//allow console link.
@@ -16,6 +14,8 @@
 	var/disabled = FALSE
 	var/obj/machinery/computer/rdconsole/linked_console
 	var/obj/item/loaded_item = null //the item loaded inside the machine (currently only used by experimentor and destructive analyzer)
+	var/reward = 0
+	var/factionname = "blank"
 
 /obj/machinery/rnd/proc/reset_busy()
 	busy = FALSE

--- a/code/modules/research/rdmachines.dm
+++ b/code/modules/research/rdmachines.dm
@@ -7,6 +7,8 @@
 	icon = 'icons/obj/machines/research.dmi'
 	density = TRUE
 	use_power = IDLE_POWER_USE
+	var/reward = 0
+	var/factionname = "blank"
 	var/busy = FALSE
 	var/hacked = FALSE
 	var/console_link = TRUE		//allow console link.

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2613,6 +2613,7 @@
 #include "code\modules\research\machinery\departmental_circuit_imprinter.dm"
 #include "code\modules\research\machinery\departmental_protolathe.dm"
 #include "code\modules\research\machinery\departmental_techfab.dm"
+#include "code\modules\research\machinery\pointgiver.dm"
 #include "code\modules\research\machinery\protolathe.dm"
 #include "code\modules\research\machinery\techfab.dm"
 #include "code\modules\research\nanites\nanite_chamber.dm"


### PR DESCRIPTION

## About The Pull Request

tldr: vr away missions but they give points

Adds a new way to get research points. Scientists log into a special VR sleeper, which takes them to cyberspace. In cyberspace they have a "base" with some weapons, equipment, a vendor and a protolathe linked to the science techweb. To get points they must raid other faction's "bases" and destroy their "node" to steal their research (i.e get points)  These bases are defended by turrets, faction simplemobs, etc. These drop things like materials (to use in the protolathe), point cards (to buy things from the vendor) as well as the occasional new weapon or something. More challenging bases give more points and rewards, while easier ones give less. Dying as a VR instance in cyberspace will delete all the items you had on you at the time.

## Checklist

- [ ] point nodes
- [ ] maps
- [ ] simplemobs
- [ ] virtual techweb linking

## Why It's Good For The Game

feature man good, rushing bomb in 6 minutes and getting 50k points bad

## Changelog
:cl:
add: Added new way to get points.
/:cl:

