### PR TITLE
 Skeleton and zombie tweaks/balance (featuring "makes halloween skeletons not the overpowered pirate ones")

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -561,7 +561,7 @@
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
 	mob_name = "a space pirate"
-	mob_species = /datum/species/skeleton/pirate
+	mob_species = /datum/species/skeleton/space
 	outfit = /datum/outfit/pirate/space
 	roundstart = FALSE
 	death = FALSE

--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -198,7 +198,7 @@
 		to_chat(user, "<span class='warning'>This artifact can only affect three undead at a time!</span>")
 		return
 
-	M.set_species(/datum/species/skeleton, icon_update=0)
+	M.set_species(/datum/species/skeleton/space, icon_update=0)
 	M.revive(full_heal = 1, admin_revive = 1)
 	spooky_scaries |= M
 	to_chat(M, "<span class='userdanger'>You have been revived by </span><B>[user.real_name]!</B>")

--- a/code/modules/mob/living/carbon/human/species_types/skeletons.dm
+++ b/code/modules/mob/living/carbon/human/species_types/skeletons.dm
@@ -3,7 +3,7 @@
 	name = "Spooky Scary Skeleton"
 	id = "skeleton"
 	say_mod = "rattles"
-	blacklisted = 1
+	blacklisted = 0
 	sexes = 0
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton
 	species_traits = list(NOBLOOD,NOGENITALS,NOAROUSAL)
@@ -12,13 +12,18 @@
 	mutanttongue = /obj/item/organ/tongue/bone
 	damage_overlay_type = ""//let's not show bloody wounds or burns over bones.
 	disliked_food = NONE
-	liked_food = GROSS | MEAT | RAW
+	liked_food = GROSS | MEAT | RAW | DAIRY
 
 /datum/species/skeleton/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE
 	return ..()
 
-/datum/species/skeleton/pirate
-	name = "Space Queen's Skeleton"
+/datum/species/skeleton/space
+	name = "Spooky Spacey Skeleton"
+	id = "spaceskeleton"
+	blacklisted = 1
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_FAKEDEATH, TRAIT_CALCIUM_HEALER)
+
+/datum/species/skeleton/pirate/check_roundstart_eligible()
+	return FALSE

--- a/code/modules/mob/living/carbon/human/species_types/zombies.dm
+++ b/code/modules/mob/living/carbon/human/species_types/zombies.dm
@@ -16,7 +16,12 @@
 	disliked_food = NONE
 	liked_food = GROSS | MEAT | RAW
 
-/datum/species/zombie/check_roundstart_eligible()
+/datum/species/zombie/notspaceproof
+	id = "notspaceproofzombie"
+	blacklisted = 0
+	inherent_traits = list(TRAIT_RESISTCOLD,TRAIT_RADIMMUNE,TRAIT_EASYDISMEMBER,TRAIT_LIMBATTACHMENT,TRAIT_NOBREATH,TRAIT_NODEATH,TRAIT_FAKEDEATH)
+
+/datum/species/zombie/notspaceproof/check_roundstart_eligible()
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		return TRUE
 	return ..()
@@ -47,7 +52,7 @@
 /datum/species/zombie/infectious/spec_life(mob/living/carbon/C)
 	. = ..()
 	C.a_intent = INTENT_HARM // THE SUFFERING MUST FLOW
-	
+
 	//Zombies never actually die, they just fall down until they regenerate enough to rise back up.
 	//They must be restrained, beheaded or gibbed to stop being a threat.
 	if(regen_cooldown < world.time)
@@ -58,7 +63,7 @@
 		C.adjustToxLoss(-heal_amt)
 	if(!C.InCritical() && prob(4))
 		playsound(C, pick(spooks), 50, TRUE, 10)
-		
+
 //Congrats you somehow died so hard you stopped being a zombie
 /datum/species/zombie/infectious/spec_death(mob/living/carbon/C)
 	. = ..()

--- a/code/modules/spells/spell_types/lichdom.dm
+++ b/code/modules/spells/spell_types/lichdom.dm
@@ -57,7 +57,7 @@
 		new /obj/item/phylactery(marked_item, M.mind)
 
 		to_chat(M, "<span class='userdanger'>With a hideous feeling of emptiness you watch in horrified fascination as skin sloughs off bone! Blood boils, nerves disintegrate, eyes boil in their sockets! As your organs crumble to dust in your fleshless chest you come to terms with your choice. You're a lich!</span>")
-		M.set_species(/datum/species/skeleton)
+		M.set_species(/datum/species/skeleton/space)
 		if(ishuman(M))
 			var/mob/living/carbon/human/H = M
 			H.dropItemToGround(H.w_uniform)
@@ -132,7 +132,7 @@
 	lich.real_name = mind.name
 	mind.transfer_to(lich)
 	mind.grab_ghost(force=TRUE)
-	lich.hardset_dna(null,null,lich.real_name,null, new /datum/species/skeleton)
+	lich.hardset_dna(null,null,lich.real_name,null, new /datum/species/skeleton/space)
 	to_chat(lich, "<span class='warning'>Your bones clatter and shudder as you are pulled back into this world!</span>")
 	var/turf/body_turf = get_turf(old_body)
 	lich.Knockdown(200 + 200*resurrections)


### PR DESCRIPTION
## About The Pull Request
Tweaking skeletons, and zombies. renaming /datum/species/skeleton/pirate to /datum/species/skeleton/space. Added non space proof zombies for halloween (since the community was so bent on nerfing skellies they forget zombies still exist around, I don't like nerfing). Made necromantic stone and lich skeleton spaceproof. Skeletons also like dairy food now. Unblacklisted non-space-worthy skeletons and zombies.

## Why It's Good For The Game
Lichdom and necro stone skeletons well deserve spaceproofness, being wizardry magic (he necro stone also being quite a waste of spell points unless the user is specifically striving for the sweet claymore and roman shield, thanks to the pitiful playerbase), Dairy liked food because skeletons and milk. Non-spaceproof undead are also a more than fair pick for pride mirrors.

## Changelog
:cl: Ghommie && Kevinz000
balance: Lichdom and necromantic stone skeletons are now of the spaceproof kind too.
tweaks: skeletons now also like dairy products.
del: Halloween roundstart skeletons and zombies are no more spaceproof.
add: You can choose to set your species to zombie or skeleton through the pride mirror yet again, Alas they are not of the spaceproof kind either.
/:cl:
