### PR TITLE
pAI ID Hosting

### DIFF
--- a/code/game/machinery/doors/airlock.dm
+++ b/code/game/machinery/doors/airlock.dm
@@ -675,7 +675,8 @@
 		else
 			to_chat(user, "It looks very robust.")
 
-	if(issilicon(user) && (!stat & BROKEN))
+//No longer gives pAI the borg/AI text about manipulating doors
+	if(issilicon(user) && (!stat & BROKEN) && !ispAI(user))
 		to_chat(user, "<span class='notice'>Shift-click [src] to [ density ? "open" : "close"] it.</span>")
 		to_chat(user, "<span class='notice'>Ctrl-click [src] to [ locked ? "raise" : "drop"] its bolts.</span>")
 		to_chat(user, "<span class='notice'>Alt-click [src] to [ secondsElectrified ? "un-electrify" : "permanently electrify"] it.</span>")

--- a/code/game/objects/items/devices/paicard.dm
+++ b/code/game/objects/items/devices/paicard.dm
@@ -9,6 +9,8 @@
 	slot_flags = ITEM_SLOT_BELT
 	var/mob/living/silicon/pai/pai
 	resistance_flags = FIRE_PROOF | ACID_PROOF | INDESTRUCTIBLE
+		//Let's the pAI card be used as an ID in hand or thrown (Still sorting out undefined var error when nulling this)
+	//var/obj/item/card/id/paiCard_ID = null
 
 /obj/item/paicard/suicide_act(mob/living/user)
 	user.visible_message("<span class='suicide'>[user] is staring sadly at [src]! [user.p_they()] can't keep living without real human intimacy!</span>")

--- a/code/modules/jobs/access.dm
+++ b/code/modules/jobs/access.dm
@@ -5,8 +5,12 @@
 	if(src.check_access(null))
 		return TRUE
 	if(issilicon(M))
-		if(ispAI(M))
-			return FALSE
+		if(ispAI(M)) //Got rid of pAI having hard coded no access
+			var/mob/living/silicon/pai/P = M
+			if (check_access(P.access_card))
+				return TRUE
+			else
+				return FALSE
 		return TRUE	//AI can do whatever it wants
 	if(IsAdminGhost(M))
 		//Access can't stop the abuse

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -55,6 +55,7 @@
 	var/obj/item/integrated_signaler/signaler // AI's signaller
 
 	var/holoform = FALSE
+	var/idmod = FALSE
 	var/canholo = TRUE
 	var/obj/item/card/id/access_card = null
 	var/chassis = "repairbot"
@@ -289,3 +290,38 @@
 
 /mob/living/silicon/pai/process()
 	emitterhealth = CLAMP((emitterhealth + emitterregen), -50, emittermaxhealth)
+
+/obj/item/paicard/attackby(obj/item/W, mob/user, params)
+	..()
+	user.set_machine(src)
+	if (pai && pai.idmod == TRUE)
+		if (istype(W, /obj/item/card/id))
+			var/obj/item/card/id/idcard = W
+			pai.pda.attackby(idcard, user, params)
+			pai.pda.owner = pai.name
+			pai.pda.ownjob = idcard.assignment
+			pai.pda.name = pai.name + " (" + pai.pda.ownjob + ")"
+			pai.access_card = idcard
+			//paiCard_ID = idcard
+	else
+		to_chat(user, "The pAI is not correctly configured for this item.")
+
+//Lets anyone Alt Click the pAI card to remove the ID
+/obj/item/paicard/AltClick()
+	..()
+
+	if (pai.pda.id)
+		pai.pda.remove_id()
+		pai.access_card = null
+	//	paiCard_ID = null
+
+//ID Reader supporting proc to remove the ID on the pAI's end
+/mob/living/silicon/pai/proc/paiRemoveID(obj/item/pda/paiPDA)
+	if (paiPDA.id)
+		usr.put_in_hands(paiPDA.id)
+		to_chat(usr, "<span class='notice'>You eject the ID.</span>")
+		paiPDA.id = null
+		access_card = null
+		//paiCard_ID = null
+	else
+		return

--- a/code/modules/mob/living/silicon/pai/software.dm
+++ b/code/modules/mob/living/silicon/pai/software.dm
@@ -20,6 +20,7 @@
 															"universal translator" = 35,
 															//"projection array" = 15
 															"remote signaller" = 5,
+															"id reader" = 30
 															)
 
 /mob/living/silicon/pai/proc/paiInterface()
@@ -64,6 +65,8 @@
 				left_part = softwareCamera()
 			if("signaller")
 				left_part = softwareSignal()
+			if("idReader")
+				left_part = softwareIDReader()
 
 	//usr << browse_rsc('windowbak.png')		// This has been moved to the mob's Login() proc
 
@@ -269,6 +272,15 @@
 				var/turf/T = get_turf(loc)
 				cable = new /obj/item/pai_cable(T)
 				T.visible_message("<span class='warning'>A port on [src] opens to reveal [cable], which promptly falls to the floor.</span>", "<span class='italics'>You hear the soft click of something light and hard falling to the ground.</span>")
+
+		if("idReader")
+			if(href_list["toggle"])
+				idmod = TRUE
+				pda.owner = name
+			if(href_list["ejectID"])
+				paiRemoveID(pda)
+
+
 	//updateUsrDialog()		We only need to account for the single mob this is intended for, and he will *always* be able to call this window
 	paiInterface()		 // So we'll just call the update directly rather than doing some default checks
 	return
@@ -323,6 +335,8 @@
 			dat += "<a href='byond://?src=[REF(src)];software=camerajack;sub=0'>Camera Jack</a> <br>"
 		if(s == "door jack")
 			dat += "<a href='byond://?src=[REF(src)];software=doorjack;sub=0'>Door Jack</a> <br>"
+		if(s == "id reader")
+			dat += "<a href='byond://?src=[REF(src)];software=idReader;sub=0'>ID Scanner Software</a>[(idmod) ? "<font color=#55FF55> On</font>" : "<font color=#FF5555> Off</font>"] <br>"
 	dat += "<br>"
 	dat += "<br>"
 	dat += "<a href='byond://?src=[REF(src)];software=buy;sub=0'>Download additional software</a>"
@@ -624,4 +638,13 @@
 	dat += "</ul>"
 	dat += "<br><br>"
 	dat += "Messages: <hr> [pda.tnote]"
+	return dat
+
+// ID Reader
+/mob/living/silicon/pai/proc/softwareIDReader()
+	var/dat = {"<h3>ID Hosting Software</h3><br>
+				When enabled, this device will be able to host one ID card for use with Station airlocks.<br><br>
+				The device is currently [idmod ? "<font color=#55FF55>en" : "<font color=#FF5555>dis" ]abled.</font><br>[idmod ? "" : "<a href='byond://?src=[REF(src)];software=idReader;sub=0;toggle=1'>Activate ID Hosting Software</a><br>"]"}
+
+	dat += {"Hosted ID: <a href='byond://?src=[REF(src)];software=idReader;sub=0;ejectID=1'>[pda.id ? "[pda.id.registered_name], [pda.id.assignment]" : "----------"]"}
 	return dat


### PR DESCRIPTION


<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds in a new pAI software, ID reader, which allows the pAI to host an ID card and use its access. Adds in some additional functionality to the pAI and pAI card so that the hosted ID can be dropped by the pAI (menu) or by anyone who can grab the pAI card (alt click).

To make any of this work, I had to remove the hard coded global no access for pAI. Since they're still under the silicon mob type, I changed any access checks to check their inherent ID object. Removing the ID card from the pAI, through either method, resets the inherent ID value to null.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
At the moment, pAI are rarely if ever used and have almost no game impact. I think that it'd be more enjoyable for pAI to have more potential game impact and more independence from their masters. Adding the ability for pAI to have their own ID lets go out on their own (if given an ID), and adds some interesting opportunities for Antags and the station. However, needing their own ID means that some effort needs to be invested to allow the pAI to go out on their own, instead of cloning the ID which could open the door for abuse.

There are potential other additions, such as radio encryption key usage, that could be added as well. However, I don't want to overload pAI with options and abilities and would rather add them individually.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Add: Adds in a new pAI software, ID Reader
Add: ID Reader functionality lets the pAI host an ID card and use that same ID card's access
Add: Alt clicking a pAICard now removes a hosted ID card
Add: pAI can drop their hosted ID via the ID Reader menu
Tweak: pAI no longer see the silicon text when examining doors ("Shift-Click to open", etc.)
Del: Removes the hardcoded no access for pAI
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
