### PR TITLE
Ports "Makes the illegal tech node harder to unlock"

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1045,7 +1045,7 @@
 	boost_item_paths = list()
 	for(var/path in GLOB.uplink_items)
 		var/datum/uplink_item/UI = new path
-		if(!UI.item)
+		if(!UI.item || !UI.illegal_tech)
 			continue
 		boost_item_paths |= UI.item	//allows deconning to unlock.
 

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -75,6 +75,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	var/player_minimum //The minimum crew size needed for this item to be added to uplinks.
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
 	var/restricted = FALSE // Adds restrictions for VR/Events
+	var/illegal_tech = TRUE // Can this item be deconstructed to unlock certain techweb research nodes?
 
 /datum/uplink_item/New()
 	. = ..()
@@ -769,6 +770,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/ammo_box/a357
 	cost = 4
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/a40mm
 	name = "40mm Grenade"
@@ -898,6 +900,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/ammo_box/foambox/riot
 	cost = 2
 	surplus = 0
+	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/bioterror
 	name = "Box of Bioterror Syringes"
@@ -1926,6 +1929,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/toy/syndicateballoon
 	cost = 20
 	cant_discount = TRUE
+	illegal_tech = FALSE
 
 /datum/uplink_item/badass/syndiecash
 	name = "Syndicate Briefcase Full of Cash"
@@ -1949,9 +1953,11 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	item = /obj/item/toy/cards/deck/syndicate
 	cost = 1
 	surplus = 40
+	illegal_tech = FALSE
 
 /datum/uplink_item/badass/syndiecigs
 	name = "Syndicate Smokes"
 	desc = "Strong flavor, dense smoke, infused with omnizine."
 	item = /obj/item/storage/fancy/cigarettes/cigpack_syndicate
 	cost = 2
+	illegal_tech = FALSE


### PR DESCRIPTION
## About The Pull Request
Ports /tg/station PR #41531. Illegal tech has been so cheesable for so long.
Also personally included syndie playing cards in the blacklist, since they can be found easily on any map. Unsure if I should also include foam force handguns to the blacklisted objects due to that one specimen found on delta's abandoned arcade and the contraband foam force cargo crate.

## Why It's Good For The Game
Heck, just like the original author said: the source of this node should be space ruins, lavaland, events or traitors, not the nearest available autolathe.

## Changelog
:cl: Ghommie (original PR by Denton)
balance: You can no longer reveal the 'illegal tech' research node by deconstructing .357 speedloaders, riot dart boxes, syndicate cigarettes, syndicate playing cards or syndicate balloons.
/:cl:
