### PR TITLE
Made PanD.E.M.I.C beaker stuff more like ChemMaster

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -125,12 +125,6 @@
 	else
 		cut_overlays()
 
-/obj/machinery/computer/pandemic/proc/eject_beaker()
-	if(beaker)
-		beaker.forceMove(drop_location())
-		beaker = null
-		update_icon()
-
 /obj/machinery/computer/pandemic/ui_interact(mob/user, ui_key = "main", datum/tgui/ui, force_open = FALSE, datum/tgui/master_ui, datum/ui_state/state = GLOB.default_state)
 	ui = SStgui.try_update_ui(user, src, ui_key, ui, force_open)
 	if(!ui)
@@ -165,7 +159,7 @@
 		return
 	switch(action)
 		if("eject_beaker")
-			eject_beaker()
+			replace_beaker(usr)
 			. = TRUE
 		if("empty_beaker")
 			if(beaker)
@@ -174,7 +168,7 @@
 		if("empty_eject_beaker")
 			if(beaker)
 				beaker.reagents.clear_reagents()
-				eject_beaker()
+				replace_beaker(usr)
 			. = TRUE
 		if("rename_disease")
 			var/id = get_virus_id_by_index(text2num(params["index"]))
@@ -232,18 +226,32 @@
 		. = TRUE //no afterattack
 		if(stat & (NOPOWER|BROKEN))
 			return
-		if(beaker)
-			to_chat(user, "<span class='warning'>A container is already loaded into [src]!</span>")
+		var/obj/item/reagent_containers/B = I
+		if(!user.transferItemToLoc(B, src))
 			return
-		if(!user.transferItemToLoc(I, src))
-			return
-
-		beaker = I
+		replace_beaker(user, B)
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
 		update_icon()
 	else
 		return ..()
 
+/obj/machinery/computer/pandemic/AltClick(mob/living/user)
+	if(!istype(user) || !user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		return
+	replace_beaker(user)
+	return
+
+/obj/machinery/computer/pandemic/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
+	if(beaker)
+		beaker.forceMove(drop_location())
+		if(user && Adjacent(user) && !issiliconoradminghost(user))
+			user.put_in_hands(beaker)
+	if(new_beaker)
+		beaker = new_beaker
+	else
+		beaker = null
+	return TRUE
+
 /obj/machinery/computer/pandemic/on_deconstruction()
-	eject_beaker()
+	replace_beaker(usr)
 	. = ..()

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -231,7 +231,6 @@
 			return
 		replace_beaker(user, B)
 		to_chat(user, "<span class='notice'>You insert [I] into [src].</span>")
-		update_icon()
 	else
 		return ..()
 
@@ -250,6 +249,7 @@
 		beaker = new_beaker
 	else
 		beaker = null
+	update_icon()
 	return TRUE
 
 /obj/machinery/computer/pandemic/on_deconstruction()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes the PanD.E.M.I.C 2200's beaker functionality act more like the ChemMaster 3000's: 

1. Using an inhand beaker on the PanD.E.M.I.C will swap the inhand beaker with the PanD.E.M.I.C's internal beaker
2. Ejecting from the PanD.E.M.I.C puts the beaker in the user's hand.

## Why It's Good For The Game

Consistent operation of similar-looking machinery is good. Also, I was getting really goddamn annoyed with the virology shuffle. This might have knock-on effects vis-a-vis virology speed and tedium (seriously, a huge chunk of virology play is beaker inventory management), mind, so it should probably be test-merged first.

## Changelog
:cl:
tweak: Bottles in PanD.E.M.I.C 2200 can now be replaced with an inhand bottle directly
tweak: Ejecting a bottle from the PanD.E.M.I.C 2200 puts it directly into the user's hand
tweak: Alt-clicking the PanD.E.M.I.C 2200 ejects the current bottle
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
