### PR TITLE
Thinking green on Box Station.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -9471,7 +9471,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/lawoffice)
+/area/maintenance/fore)
 "avj" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -17917,6 +17917,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-20"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aPu" = (
@@ -21195,6 +21198,11 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 2
 	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-21";
+	pixel_x = -3;
+	pixel_y = 3
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aXu" = (
@@ -21294,6 +21302,9 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-05"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
@@ -21932,6 +21943,9 @@
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-08"
 	},
 /turf/open/floor/wood,
 /area/library)
@@ -24557,6 +24571,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-13"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bfX" = (
@@ -24602,6 +24619,9 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-10"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -27271,11 +27291,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"bml" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "bmm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -30319,6 +30334,9 @@
 "bth" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-16"
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
@@ -39710,6 +39728,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/item/twohanded/required/kirbyplants,
 /turf/open/floor/plasteel/white/side{
 	dir = 1
 	},
@@ -57100,6 +57119,18 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
+"hwu" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-24"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hEm" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "hRa" = (
 /obj/structure/table/reinforced,
 /obj/machinery/light{
@@ -57559,6 +57590,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"qoW" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-18"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "quT" = (
 /obj/structure/lattice,
 /obj/structure/grille/broken,
@@ -57570,6 +57610,12 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"qQP" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-14"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "rcD" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -57580,6 +57626,15 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
+"rjA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-04"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "rmX" = (
 /obj/structure/table,
 /obj/item/reagent_containers/food/drinks/beer,
@@ -57723,6 +57778,12 @@
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
+"tlO" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "applebush"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
 "tqg" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -57879,6 +57940,20 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"uZN" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-03"
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "vbD" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -58053,6 +58128,20 @@
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"xFY" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
@@ -67425,7 +67514,7 @@ apN
 apN
 apN
 apJ
-awY
+xFY
 ayk
 awW
 aAD
@@ -67449,7 +67538,7 @@ aaa
 aaa
 aaa
 arB
-awY
+uZN
 ayk
 awW
 aAD
@@ -70021,7 +70110,7 @@ awW
 arB
 awZ
 aym
-azB
+qoW
 awW
 aaf
 aaa
@@ -79775,7 +79864,7 @@ aKt
 aLN
 aMS
 aOi
-aLE
+tlO
 aPK
 aSl
 aTH
@@ -81083,7 +81172,7 @@ boS
 bfm
 bNK
 bkN
-bml
+bfm
 bwe
 bwe
 bwd
@@ -81831,7 +81920,7 @@ aKA
 aLN
 aMS
 aOz
-aLE
+qQP
 aPQ
 aSa
 aSr
@@ -85383,7 +85472,7 @@ aaG
 aaK
 aaP
 aaX
-aat
+hwu
 aat
 acd
 acD
@@ -94951,7 +95040,7 @@ aYV
 aYV
 bet
 bfH
-bhh
+hEm
 bhh
 bhg
 bln
@@ -97287,7 +97376,7 @@ bCR
 bqQ
 bGX
 bCR
-bqQ
+rjA
 bRN
 bIK
 bPq


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

Fixes #9409 by changing the tile's area designation. While I was at it, I decided to add some potted plants around the map.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

**Consistency.** Not only in maintenance being safe from radiation but also cargo not being prevented from completing a bounty (potted plants) simply because of the map chosen (one of the more popular ones at that).

## Changelog
:cl:
add: Adds some potted plants around Box Station
fix: The tile mentioned in #9409 should now be radiation-free.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
