### PR TITLE
Optional Species based clothing restrictions

### DIFF
--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -41,6 +41,13 @@
 	var/dynamic_hair_suffix = ""//head > mask for head hair
 	var/dynamic_fhair_suffix = ""//mask > head for facial hair
 
+	//basically a restriction list.
+	var/list/species_restricted = null
+	//Basically syntax is species_restricted = list("Species Name","Species Name")
+	//Add a "exclude" string to do the opposite, making it only only species listed that can't wear it.
+	//You append this to clothing objects.j
+
+
 /obj/item/clothing/Initialize()
 	. = ..()
 	if(CHECK_BITFIELD(clothing_flags, VOICEBOX_TOGGLABLE))
@@ -338,3 +345,38 @@ BLIND     // can't see anything
 		deconstruct(FALSE)
 	else
 		..()
+
+
+//Species-restricted clothing check. - Thanks Oraclestation, BS13, /vg/station etc.
+/obj/item/clothing/mob_can_equip(mob/M, slot, disable_warning = TRUE)
+
+	//if we can't equip the item anyway, don't bother with species_restricted (also cuts down on spam)
+	if(!..())
+		return FALSE
+
+	// Skip species restriction checks on non-equipment slots
+	if(slot in list(SLOT_IN_BACKPACK, SLOT_L_STORE, SLOT_R_STORE))
+		return TRUE
+
+	if(species_restricted && ishuman(M))
+
+		var/wearable = null
+		var/exclusive = null
+		var/mob/living/carbon/human/H = M
+
+		if("exclude" in species_restricted) //TURNS IT INTO A BLACKLIST - AKA ALL MINUS SPECIES LISTED.
+			exclusive = TRUE
+
+		if(H.dna.species)
+			if(exclusive)
+				if(!(H.dna.species.name in species_restricted))
+					wearable = TRUE
+			else
+				if(H.dna.species.name in species_restricted)
+					wearable = TRUE
+
+			if(!wearable)
+				to_chat(M, "<span class='warning'>Your species cannot wear [src].</span>")
+				return FALSE
+
+	return TRUE

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -45,7 +45,7 @@
 	var/list/species_restricted = null
 	//Basically syntax is species_restricted = list("Species Name","Species Name")
 	//Add a "exclude" string to do the opposite, making it only only species listed that can't wear it.
-	//You append this to clothing objects.j
+	//You append this to clothing objects.
 
 
 /obj/item/clothing/Initialize()


### PR DESCRIPTION
## About The Pull Request

A port of species based clothing restrictions.... If anyone decided to ever use it

## Why It's Good For The Game

qualifies_for_rank species job checks function now, here is species clothing restrictions.
Its extra functionality for the higher atmosphere downstream who want to make equipment
for EXTREMELY different sized mob bodies and want the equipment scarcity to be a mechanic.

Or if you are just giving things to ashwalkers/golems/etc nobody else should put on.

## Changelog
:cl: JTGSZ
add: Optional species based clothing restrictions
/:cl: