### PR TITLE
No digitigrade plasmaman suits sprites for the time being, thank you.

### DIFF
--- a/code/modules/clothing/under/miscellaneous.dm
+++ b/code/modules/clothing/under/miscellaneous.dm
@@ -599,6 +599,7 @@
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 0, "fire" = 95, "acid" = 95)
 	slowdown = 1
 	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	mutantrace_variation = NO_MUTANTRACE_VARIATION
 	can_adjust = FALSE
 	strip_delay = 80
 	var/next_extinguish = 0


### PR DESCRIPTION
## About The Pull Request
Forgot about the snowflake digitigrade on mob sprites for the new plasmaman departmental suits. I'll be working on those versions (why would an antro wear a plasmaman suit anyway...), but for the time being we'll avoid the missing jumpsuit icon_state floating text this way.

## Why It's Good For The Game
Fixing some potential issues.

## Changelog
none.