### PR TITLE
Swaps syringe with a sleepy pen in poison kit

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -132,7 +132,7 @@
 			new /obj/item/card/emag(src) // 6 tc
 
 		if("ninja") // 40~ tc worth
-			new /obj/item/katana(src) // Unique , basicly a better esword. 10 tc? 
+			new /obj/item/katana(src) // Unique , basicly a better esword. 10 tc?
 			new /obj/item/implanter/adrenalin(src) // 8 tc
 			new /obj/item/throwing_star(src) // ~5 tc for all 6
 			new /obj/item/throwing_star(src)
@@ -250,7 +250,7 @@
 	new /obj/item/reagent_containers/glass/bottle/coniine(src)
 	new /obj/item/reagent_containers/glass/bottle/curare(src)
 	new /obj/item/reagent_containers/glass/bottle/amanitin(src)
-	new /obj/item/reagent_containers/syringe(src)
+	new /obj/item/pen/sleepy(src)
 
 /obj/item/storage/box/syndie_kit/nuke
 	name = "box"

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -610,7 +610,7 @@ GLOBAL_LIST_INIT(uplink_items, subtypesof(/datum/uplink_item))
 	name = "Poison Kit"
 	desc = "An assortment of deadly chemicals packed into a compact box. Comes with a syringe for more precise application."
 	item = /obj/item/storage/box/syndie_kit/chemical
-	cost = 6
+	cost = 8
 	surplus = 50
 
 /datum/uplink_item/stealthy_weapons/romerol_kit


### PR DESCRIPTION
#8877  About The Pull Request

Makes the syringe in the poison kit a sleepy pen, and increases the TC from 6 to 8 as compensation.
(Ignore the oopsies space deletion)

## Why It's Good For The Game

The poison kit is in a weird spot at the moment where it should be a stealthy item (it's in the stealth category, as well being... well poison), but it comes with a syringe. Anyone who's being injected will instantly scream that they're being injected because of the big red text that pops up, and it gives the name of the person, unless they are specifically a doctor who need to administer a weirdly specific healing chem. Then there's the syringe gun, which goes against the stealthy idea of a poison kit. 
It does make pouring poison on top of food 2 TC more viable, but it's still not a tactic that happens very often, and it's incredibly imprecise. 
Plus these are fun chemicals that are never used.

## Changelog
:cl:
tweak: tweaked a few things
balance: rebalanced something
/:cl:

