### PR TITLE
standarizes mobs' can_equip arguments.

### DIFF
--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -157,7 +157,7 @@
 		var/image/item_overlay = image(holding)
 		item_overlay.alpha = 92
 
-		if(!user.can_equip(holding, slot_id, disable_warning = TRUE))
+		if(!user.can_equip(holding, slot_id, TRUE))
 			item_overlay.color = "#FF0000"
 		else
 			item_overlay.color = "#00ff00"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -421,10 +421,10 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 //the mob M is attempting to equip this item into the slot passed through as 'slot'. Return 1 if it can do this and 0 if it can't.
 //if this is being done by a mob other than M, it will include the mob equipper, who is trying to equip the item to mob M. equipper will be null otherwise.
 //If you are making custom procs but would like to retain partial or complete functionality of this one, include a 'return ..()' to where you want this to happen.
-//Set disable_warning to 1 if you wish it to not give you outputs.
+//Set disable_warning to TRUE if you wish it to not give you outputs.
 /obj/item/proc/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	if(!M)
-		return 0
+		return FALSE
 
 	return M.can_equip(src, slot, disable_warning, bypass_equip_delay_self)
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -158,7 +158,7 @@
 
 //Returns if a certain item can be equipped to a certain slot.
 // Currently invalid for two-handed items - call obj/item/mob_can_equip() instead.
-/mob/proc/can_equip(obj/item/I, slot, disable_warning = 0)
+/mob/proc/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	return FALSE
 
 /mob/proc/can_put_in_hand(I, hand_index)

--- a/code/modules/mob/living/carbon/monkey/inventory.dm
+++ b/code/modules/mob/living/carbon/monkey/inventory.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/monkey/can_equip(obj/item/I, slot, disable_warning = 0)
+/mob/living/carbon/monkey/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	switch(slot)
 		if(SLOT_HANDS)
 			if(get_empty_held_indexes())

--- a/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/inventory.dm
@@ -19,7 +19,7 @@
 	return 0
 
 
-/mob/living/simple_animal/drone/can_equip(obj/item/I, slot)
+/mob/living/simple_animal/drone/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	switch(slot)
 		if(SLOT_HEAD)
 			if(head)

--- a/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
+++ b/code/modules/mob/living/simple_animal/guardian/types/dextrous.dm
@@ -52,7 +52,7 @@
 		return 1
 	return 0
 
-/mob/living/simple_animal/hostile/guardian/dextrous/can_equip(obj/item/I, slot)
+/mob/living/simple_animal/hostile/guardian/dextrous/can_equip(obj/item/I, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
 	switch(slot)
 		if(SLOT_GENERC_DEXTROUS_STORAGE)
 			if(internal_storage)


### PR DESCRIPTION
## About The Pull Request
Fixing a bug caused by inventory slots adding the green/red item overlay indicator when hovered by non-human mobs:
https://github.com/Citadel-Station-13/Citadel-Station-13/blob/cf44c96be95b26d788b7b47cd60d54f23eeb3ca6/code/_onclick/hud/screen_objects.dm#L160
This threw bad arg name runtimes everytime since only human/can_equip() had the disable_warning arg set in.
So, doing what the title says.

## Why It's Good For The Game
Fixing runtime bugs.

## Changelog
:cl: Ghommie (original PR by ShizCalev)
fix: As a non-human mob, hovering your cursor over an inventory slot while holding an object in your active hand shouldn't runtime now.
/:cl: