### PR TITLE
Stops non-alphanumeric graffiti decals from being named "letter".

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -303,9 +303,10 @@
 			drawing = pick(all_drawables)
 
 	var/temp = "rune"
-	if(is_alpha(drawing))
+	var/ascii = (length(drawing) == 1) ? TRUE : FALSE
+	if(ascii && is_alpha(drawing))
 		temp = "letter"
-	else if(is_digit(drawing))
+	else if(ascii && is_digit(drawing))
 		temp = "number"
 	else if(drawing in punctuation)
 		temp = "punctuation mark"


### PR DESCRIPTION
## About The Pull Request
This is possibly a bug present on tgstation too (aaand just noticed I have to clone their repo on this potato yet , wack). I'll have to check, thing is text2ascii can still succeed even if the first arg was a text string of length higher than one, so we have to make sure it only runs if its length is one.

## Why It's Good For The Game
Fixing an issue.

## Changelog
:cl:
fix: non-alphanumeric graffiti decals will no longer display as "letter".
/:cl: