### PR TITLE
Nerfs cyborg disabler to hold 25 shots rather than 43, just like a normal disabler.

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -191,7 +191,7 @@
 
 /obj/item/stock_parts/cell/secborg
 	name = "security borg rechargeable D battery"
-	maxcharge = 1750	//35/17/8 disabler/laser/taser shots.
+	maxcharge = 1250	//25/12/6 disabler/laser/taser shots.
 	materials = list(MAT_GLASS=40)
 
 /obj/item/stock_parts/cell/secborg/empty/Initialize()

--- a/code/modules/projectiles/ammunition/energy/stun.dm
+++ b/code/modules/projectiles/ammunition/energy/stun.dm
@@ -25,3 +25,6 @@
 	fire_sound = 'sound/weapons/taser2.ogg'
 	harmful = FALSE
 	click_cooldown_override = 3.5
+
+/obj/item/ammo_casing/energy/disabler/secborg
+	e_cost = 50

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -49,6 +49,7 @@
 	name = "cyborg disabler"
 	desc = "An integrated disabler that draws from a cyborg's power cell. This one contains a limiter to prevent the cyborg's power cell from overheating."
 	can_charge = FALSE
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler/secborg)
 	selfcharge = EGUN_SELFCHARGE_BORG
 	cell_type = /obj/item/stock_parts/cell/secborg
 	charge_delay = 5


### PR DESCRIPTION
## About The Pull Request
Does exactly what's said on the tin.

## Why It's Good For The Game
removing the collateral buff caused by #8468 and brings them in line with standard issue disablers, both to avoid this sort of issues in the future and the absence of any counter outside the usual projectiles or cyborg ones which made it simply better combinated with their nonhuman total lack of firearm inaccuracy and more efficient power cell magazine.

## Changelog
:cl:
balance: Nerfs cyborg disabler and its internal power cell to hold 25 disabler beam shots rather than 43/44, just like a normal disabler.
/:cl: