### PR TITLE
quickfixes lowpop nuclear war tc malus calculation.

### DIFF
--- a/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
+++ b/code/modules/antagonists/nukeop/equipment/nuclear_challenge.dm
@@ -69,7 +69,7 @@ GLOBAL_VAR_INIT(war_declared, FALSE)
 	var/actual_players = GLOB.joined_player_list.len - nukeops.len
 	var/tc_malus = 0
 	if(actual_players < CHALLENGE_PLAYERS_TARGET)
-		tc_malus = FLOOR((CHALLENGE_TELECRYSTALS - actual_players * INVERSE(CHALLENGE_PLAYERS_TARGET)) * TELECRYSTALS_MALUS_SCALING, 1)
+		tc_malus = FLOOR(((CHALLENGE_TELECRYSTALS / CHALLENGE_PLAYERS_TARGET) * (CHALLENGE_PLAYERS_TARGET - actual_players)) * TELECRYSTALS_MALUS_SCALING, 1)
 
 	new uplink_type(get_turf(user), user.key, CHALLENGE_TELECRYSTALS - tc_malus + CEILING(PLAYER_SCALING * actual_players, 1))
 


### PR DESCRIPTION
## About The Pull Request
Turns out I was a bit too tired when I made #9415, consider speedmerging.

## Why It's Good For The Game
Fixing an issue that makes nukies have less tc the bigger the population is, rather than the opposite. 

## Changelog
none, server shouldn't have updated yet. Got the bad vice of spotting some issues within my PRs only post-merge.