### PR TITLE
Adds a config option to determine the minimum alert level for secborgs (defaulting to red alert)

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -50,3 +50,7 @@
 #define ASSEMBLY_THIRD_STEP     2
 #define ASSEMBLY_FOURTH_STEP    3
 #define ASSEMBLY_FIFTH_STEP     4
+
+
+//Checks to determine borg availability depending on the server's config. These are defines in the interest of reducing copypasta
+#define BORG_SEC_AVAILABLE (!CONFIG_GET(flag/disable_secborg) && GLOB.security_level >= CONFIG_GET(number/minimum_secborg_alert))

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -70,6 +70,9 @@
 
 /datum/config_entry/flag/disable_peaceborg
 
+/datum/config_entry/number/minimum_secborg_alert	//Minimum alert level for secborgs to be chosen.
+	config_entry_value = 3
+
 /datum/config_entry/number/traitor_scaling_coeff	//how much does the amount of players get divided by to determine traitors
 	config_entry_value = 6
 	min_val = 1

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -226,6 +226,9 @@
 		to_chat(src,"<span class='userdanger'>ERROR: Module installer reply timeout. Please check internal connections.</span>")
 		return
 
+	if(!CONFIG_GET(flag/disable_secborg) && GLOB.security_level < CONFIG_GET(number/minimum_secborg_alert))
+		to_chat(src, "<span class='notice'>NOTICE: Due to local station regulations, the security cyborg module and its variants are only available during [num2seclevel(CONFIG_GET(number/minimum_secborg_alert))] alert and greater.</span>")
+
 	var/list/modulelist = list("Standard" = /obj/item/robot_module/standard, \
 	"Engineering" = /obj/item/robot_module/engineering, \
 	"Medical" = /obj/item/robot_module/medical, \
@@ -234,7 +237,7 @@
 	"Service" = /obj/item/robot_module/butler)
 	if(!CONFIG_GET(flag/disable_peaceborg))
 		modulelist["Peacekeeper"] = /obj/item/robot_module/peacekeeper
-	if(!CONFIG_GET(flag/disable_secborg))
+	if(BORG_SEC_AVAILABLE)
 		modulelist["Security"] = /obj/item/robot_module/security
 
 	modulelist += get_cit_modules() //Citadel change - adds Citadel's borg modules.

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -267,6 +267,10 @@ ALLOW_AI_MULTICAM
 ## Uncomment to prevent the security cyborg module from being chosen
 #DISABLE_SECBORG
 
+## Determines the minimum alert level for the security cyborg model to be chosen
+## 0: Green, 1:Blue, 2:Amber, 3:Red, 4:Delta
+MINIMUM_SECBORG_ALERT 3
+
 ## Peacekeeper Borg ###
 ## Uncomment to prevent the peacekeeper cyborg module from being chosen
 #DISABLE_PEACEBORG

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -13,7 +13,7 @@
 /mob/living/silicon/robot/proc/get_cit_modules()
 	var/list/modulelist = list()
 	modulelist["MediHound"] = /obj/item/robot_module/medihound
-	if(!CONFIG_GET(flag/disable_secborg))
+	if(BORG_SEC_AVAILABLE)
 		modulelist["Security K-9"] = /obj/item/robot_module/k9
 	modulelist["Scrub Puppy"] = /obj/item/robot_module/scrubpup
 	modulelist["Borgi"] = /obj/item/robot_module/borgi


### PR DESCRIPTION
## About The Pull Request
Title. Does exactly as it says on the tin. Sechounds are included under "secborg", and the game will give a notice if the conditions for secborgs aren't met.

## Why It's Good For The Game
**The alternative to this PR is to take TG's route of just removing secborgs entirely.** This PR allows secborgs to still exist, but only when shit is hitting the fan aboard the station. The primary issue with security borgs is that they're designed primarily for validhunting, which directly conflicts with the third party nature that silicons are supposed to have. This also makes it much easier to handle from an administrator standpoint, because we won't have to repeat "Secborgs obey their laws first, not space law" like a broken record multiple rounds in a row, and most cases where red alert is raised are cases where a borg would side with the crew regardless. This also has interesting implications for slaved borgs if the AI is malf!

## Changelog
:cl: Bhijn
tweak: Security borgs and K9s are now only available during red alert or higher.
server: Headmins or other folks with access to the server's config can choose the minimum alert level for secborgs to be chosen via the MINIMUM_SECBORG_ALERT config option. See the default game_options.txt for more info.
/:cl:
