### PR TITLE
Small vampire balance tweaks - Bat ventcrawling requires starvation, chapel is no longer instant death

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/vampire.dm
+++ b/code/modules/mob/living/carbon/human/species_types/vampire.dm
@@ -45,14 +45,14 @@
 		C.adjustOxyLoss(-4)
 		C.adjustCloneLoss(-4)
 		return
-	C.blood_volume -= 0.75
+	C.blood_volume -= 0.75 //Will take roughly 19.5 minutes to die from standard blood volume, roughly 83 minutes to die from max blood volume.
 	if(C.blood_volume <= (BLOOD_VOLUME_SURVIVE*C.blood_ratio))
 		to_chat(C, "<span class='danger'>You ran out of blood!</span>")
 		C.dust()
 	var/area/A = get_area(C)
 	if(istype(A, /area/chapel))
 		to_chat(C, "<span class='danger'>You don't belong here!</span>")
-		C.adjustFireLoss(20)
+		C.adjustFireLoss(5)
 		C.adjust_fire_stacks(6)
 		C.IgniteMob()
 
@@ -141,7 +141,7 @@
 	H = new(shape,src,caster)
 	if(istype(H, /mob/living/simple_animal))
 		var/mob/living/simple_animal/SA = H
-		if(ventcrawl_nude_only && length(caster.get_equipped_items(include_pockets = TRUE)))
+		if((caster.blood_volume >= (BLOOD_VOLUME_BAD*caster.blood_ratio)) || (ventcrawl_nude_only && length(caster.get_equipped_items(include_pockets = TRUE))))
 			SA.ventcrawler = FALSE
 	if(transfer_name)
 		H.name = caster.name


### PR DESCRIPTION
## About The Pull Request
Title. Halloween is soon so we might as well get this out of the way. This PR makes it so that vampires now have to be below the bad blood volume threshold in order to ventcrawl in batform. This PR also reduces the amount of burnloss that the mere act of being within the chapel does to vampires, from 20 burn per mob life cycle (10 second to fall into crit), to 5 per mob life cycle (40 seconds to fall into crit). This makes it so that a vampire is now capable of walking through the chapel if their life depends on it, though it's still a significant enough threat for the chapel to be worth avoiding.
These changes should hopefully massively reduce the amount of headaches caused by vampires for players and administrators alike, while also making a ventcrawling vampire be something fairly meaningful.

## Changelog
:cl: Bhijn
balance: Vampires can now only ventcrawl in bat form if their blood level is below the bad blood volume (224 blood total)
balance: Vampires now only take 5 burn per mob life cycle while within chapel areas, down from the original 20 burn per life cycle.
/:cl:
