### PR TITLE
[speedmerge] Quickfixforfood and fixes the chem hindenburg

### DIFF
--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -402,7 +402,7 @@
 
 
 				for(var/B in cached_required_reagents)
-					if(!has_reagent(B, cached_required_reagents[B]*CHEMICAL_QUANTISATION_LEVEL))//Allows vols at less than 1 to react.
+					if(!has_reagent(B, cached_required_reagents[B]))//Allows vols at less than 1 to react.
 						break
 					total_matching_reagents++
 				for(var/B in cached_required_catalysts)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -503,6 +503,8 @@
 
 				for(var/B in cached_required_reagents) //
 					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), CHEMICAL_QUANTISATION_LEVEL))
+				if(multiplier < 1)
+					return 0
 
 				for(var/B in cached_required_reagents)
 					remove_reagent(B, (multiplier * cached_required_reagents[B]), safety = 1, ignore_pH = TRUE)
@@ -545,11 +547,11 @@
 
 	var/list/cached_required_reagents = C.required_reagents//update reagents list
 	var/list/cached_results = C.results//resultant chemical list
-	var/multiplier = INFINITY
+	var/multiplier = 0
 
 	for(var/B in cached_required_reagents) //
 		multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), 0.0001))
-	if (multiplier == 0)//clarity
+	if (multiplier <= 0)//clarity
 		fermiEnd()
 		return
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -500,7 +500,7 @@
 					return 0
 
 				for(var/B in cached_required_reagents) //
-					multiplier = min(multiplier, round(get_reagent_amount(B) / cached_required_reagents[B]))
+					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), CHEMICAL_QUANTISATION_LEVEL))
 
 
 				for(var/B in cached_required_reagents)

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -544,18 +544,18 @@
 
 	var/list/cached_required_reagents = C.required_reagents//update reagents list
 	var/list/cached_results = C.results//resultant chemical list
-	var/multiplier = 0
-
+	var/multiplier = INFINITY
 	for(var/B in cached_required_reagents) //
 		multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), 0.0001))
 	if (multiplier <= 0)//clarity
 		fermiEnd()
 		return
 
-	for(var/P in C.required_catalysts)
-		if(!has_reagent(P))
-			fermiEnd()
-			return
+	if(C.required_catalysts)
+		for(var/P in C.required_catalysts)
+			if(!has_reagent(P))
+				fermiEnd()
+				return
 
 	if (!fermiIsReacting)
 		CRASH("Fermi has refused to stop reacting even though we asked her nicely.")

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -768,7 +768,7 @@
 			del_reagent(R.id)
 		else
 			total_volume += R.volume
-	if(!total_volume)
+	if(!reagent_list || !total_volume)
 		pH = REAGENT_NORMAL_PH
 	return 0
 

--- a/code/modules/reagents/chemistry/holder.dm
+++ b/code/modules/reagents/chemistry/holder.dm
@@ -128,14 +128,12 @@
 
 /datum/reagents/proc/remove_all(amount = 1)
 	var/list/cached_reagents = reagent_list
-	if((total_volume - amount) <= 0)//Because this can result in 0, I don't want it to crash.
-		pH = 7
 	if(total_volume > 0)
 		var/part = amount / total_volume
 		for(var/reagent in cached_reagents)
 			var/datum/reagent/R = reagent
 			remove_reagent(R.id, R.volume * part, ignore_pH = TRUE)
-
+		pH = REAGENT_NORMAL_PH
 		update_total()
 		handle_reactions()
 		return amount
@@ -502,9 +500,8 @@
 					return 0
 
 				for(var/B in cached_required_reagents) //
-					multiplier = min(multiplier, round((get_reagent_amount(B) / cached_required_reagents[B]), CHEMICAL_QUANTISATION_LEVEL))
-				if(multiplier < 1)
-					return 0
+					multiplier = min(multiplier, round(get_reagent_amount(B) / cached_required_reagents[B]))
+
 
 				for(var/B in cached_required_reagents)
 					remove_reagent(B, (multiplier * cached_required_reagents[B]), safety = 1, ignore_pH = TRUE)
@@ -771,7 +768,7 @@
 			del_reagent(R.id)
 		else
 			total_volume += R.volume
-	if(!reagent_list || !total_volume)
+	if(!total_volume)
 		pH = REAGENT_NORMAL_PH
 	return 0
 
@@ -871,7 +868,6 @@
 	var/new_total = cached_total + amount
 	var/cached_temp = chem_temp
 	var/list/cached_reagents = reagent_list
-
 	var/cached_pH = pH
 
 
@@ -965,7 +961,7 @@
 		var/datum/reagent/R = A
 		if (R.id == reagent)
 			if((total_volume - amount) <= 0)//Because this can result in 0, I don't want it to crash.
-				pH = 7
+				pH = REAGENT_NORMAL_PH
 			//In practice this is really confusing and players feel like it randomly melts their beakers, but I'm not sure how else to handle it. We'll see how it goes and I can remove this if it confuses people.
 			else if (!ignore_pH)
 				//if (((pH > R.pH) && (pH <= 7)) || ((pH < R.pH) && (pH >= 7)))

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -101,7 +101,8 @@
 	if(St.purity < 1)
 		St.volume *= St.purity
 		St.purity = 1
-	N.volume -= 0.002
+	var/amount = CLAMP(0.002, 0, N.volume)
+	N.volume -= amount
 	St.data["grown_volume"] = St.data["grown_volume"] + added_volume
 
 /datum/chemical_reaction/styptic_powder

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -28,7 +28,7 @@
 	return
 
 //Called when temperature is above a certain threshold, or if purity is too low.
-/datum/chemical_reaction/proc/FermiExplode(datum/reagents, var/atom/my_atom, volume, temp, pH, Exploding = FALSE)
+/datum/chemical_reaction/proc/FermiExplode(datum/reagents/R0, var/atom/my_atom, volume, temp, pH, Exploding = FALSE)
 	if (Exploding == TRUE)
 		return
 
@@ -76,7 +76,7 @@
 	var/datum/effect_system/smoke_spread/chem/s = new()
 	R.my_atom = my_atom //Give the gas a fingerprint
 
-	for (var/datum/reagent/reagent in my_atom.reagents.reagent_list) //make gas for reagents, has to be done this way, otherwise it never stops Exploding
+	for (var/datum/reagent/reagent in R0.reagent_list) //make gas for reagents, has to be done this way, otherwise it never stops Exploding
 		R.add_reagent(reagent.id, reagent.volume/3) //Seems fine? I think I fixed the infinite explosion bug.
 
 		if (reagent.purity < 0.6)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I didn't realise that food relied on whole ratios, so we can't have small number normal reactions. This fixes that along with a runtime in the explosion proc.

## Why It's Good For The Game

I'd rather not get chefs angry.
Or the server sad.

## Changelog
:cl: Fermis
fix: fixes food reactions and explosion runtimes,
fix: fixes the too much yes problem
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
