### PR TITLE
Set clockcult teleport in Captain's Quarters to false.

### DIFF
--- a/code/game/area/Space_Station_13_areas.dm
+++ b/code/game/area/Space_Station_13_areas.dm
@@ -339,6 +339,7 @@ NOTE: there are two lists of areas in the end of this file: centcom and station 
 /area/crew_quarters/heads/captain
 	name = "Captain's Office"
 	icon_state = "captain"
+	clockwork_warp_allowed = FALSE
 
 /area/crew_quarters/heads/captain/private
 	name = "Captain's Quarters"


### PR DESCRIPTION
## About The Pull Request

Changes the "Captain's Quarters" area to block Clockwork Cult teleports, a very simple change that many players have requested on Discord.

## Why It's Good For The Game

Prevents CWC from doing the "port into captain's bedroom to steal the spare" cheese as easily. Cultists will now have to port outside the office and hack in or transform the doors.

## Changelog
:cl:
code: Adds the clockwork_warp_allowed flag to the Captain's Office area, set to FALSE the same way it is for the chapel and armory.
/:cl: