### PR TITLE
[READY] Fixes a few organ code and lets organs freeze based on ambient temperature.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -314,7 +314,7 @@ GLOBAL_LIST_INIT(pda_reskins, list(PDA_SKIN_CLASSIC = 'icons/obj/pda.dmi', PDA_S
 #define MAP_MAXZ 6
 
 // Defib stats
-#define DEFIB_TIME_LIMIT 960
+#define DEFIB_TIME_LIMIT 1500
 #define DEFIB_TIME_LOSS 60
 
 // Diagonal movement

--- a/code/__DEFINES/obj_flags.dm
+++ b/code/__DEFINES/obj_flags.dm
@@ -47,4 +47,4 @@
 #define ORGAN_FAILING			(1<<2)	//Failing organs perform damaging effects until replaced or fixed
 #define ORGAN_EXTERNAL			(1<<3)	//Was this organ implanted/inserted/etc, if true will not be removed during species change.
 #define ORGAN_VITAL				(1<<4)	//Currently only the brain
-#define ORGAN_NO_SPOIL			(1<<5)	//Currently only the brain
+#define ORGAN_NO_SPOIL			(1<<5)	//Do not spoil under any circumstances

--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -99,6 +99,25 @@
 	name = "freezer"
 	icon_state = "freezer"
 
+//Snowflake organ freezer code
+//Order is important, since we check source, we need to do the check whenever we have all the organs in the crate
+
+/obj/structure/closet/crate/freezer/open()
+	recursive_organ_check(src)
+	..()
+
+/obj/structure/closet/crate/freezer/close()
+	..()
+	recursive_organ_check(src)
+
+/obj/structure/closet/crate/freezer/Destroy()
+	recursive_organ_check(src)
+	..()
+
+/obj/structure/closet/crate/freezer/Initialize()
+	. = ..()
+	recursive_organ_check(src)
+
 /obj/structure/closet/crate/freezer/blood
 	name = "blood freezer"
 	desc = "A freezer containing packs of blood."

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -11,6 +11,7 @@
 	attack_verb = list("attacked", "slapped", "whacked")
 	///The brain's organ variables are significantly more different than the other organs, with half the decay rate for balance reasons, and twice the maxHealth
 	decay_factor = STANDARD_ORGAN_DECAY	/ 4		//30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
+	healing_factor = STANDARD_ORGAN_HEALING / 2
 
 	maxHealth	= BRAIN_DAMAGE_DEATH
 	low_threshold = 45
@@ -247,11 +248,13 @@
 		to_chat(owner, "<span class='userdanger'>The last spark of life in your brain fizzles out...</span>")
 		owner.death()
 		brain_death = TRUE
+		return
+	..()
 
 /obj/item/organ/brain/on_death()
 	if(damage <= BRAIN_DAMAGE_DEATH) //rip
 		brain_death = FALSE
-	applyOrganDamage(maxHealth * decay_factor)
+	..()
 
 
 /obj/item/organ/brain/applyOrganDamage(var/d, var/maximum = maxHealth)

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -1,6 +1,7 @@
 /obj/item/organ/alien
 	icon_state = "xgibmid2"
 	var/list/alien_powers = list()
+	organ_flags = ORGAN_NO_SPOIL
 
 /obj/item/organ/alien/Initialize()
 	. = ..()

--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -52,13 +52,11 @@
 		switch(from.pH)
 			if(11.5 to INFINITY)
 				to_chat(src, "<span class='warning'>You taste a strong alkaline flavour!</span>")
-				T.applyOrganDamage(1)
 			if(8.5 to 11.5)
 				to_chat(src, "<span class='notice'>You taste a sort of soapy tone in the mixture.</span>")
 			if(2.5 to 5.5)
 				to_chat(src, "<span class='notice'>You taste a sort of acid tone in the mixture.</span>")
 			if(-INFINITY to 2.5)
 				to_chat(src, "<span class='warning'>You taste a strong acidic flavour!</span>")
-				T.applyOrganDamage(1)
 
 #undef DEFAULT_TASTE_SENSITIVITY

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -103,6 +103,7 @@
 		St.purity = 1
 	N.volume -= 0.002
 	St.data["grown_volume"] = St.data["grown_volume"] + added_volume
+	St.name = "[initial(St.name)] [round(St.data["grown_volume"], 0.1)]u colony"
 
 /datum/chemical_reaction/styptic_powder
 	name = "Styptic Powder"

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -15,7 +15,7 @@
 //an incision but with greater bleed, and a 90% base success chance
 /datum/surgery_step/incise_heart
 	name = "incise heart"
-	implements = list(/obj/item/scalpel = 90, /obj/item/melee/transforming/energy/sword = 45, /obj/item/kitchen/knife = 45,
+	implements = list(TOOL_SCALPEL = 90, /obj/item/melee/transforming/energy/sword = 45, /obj/item/kitchen/knife = 45,
 		/obj/item/shard = 25)
 	time = 16
 

--- a/code/modules/surgery/embalming.dm
+++ b/code/modules/surgery/embalming.dm
@@ -11,8 +11,7 @@
 
 /datum/surgery_step/embalming
 	name = "embalming body"
-	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
-	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30)
+	implements = list(/obj/item/reagent_containers/syringe = 100, /obj/item/pen = 30) 
 	time = 10
 	chems_needed = list("drying_agent", "sterilizine")
 	require_all_chems = FALSE

--- a/code/modules/surgery/graft_synthtissue.dm
+++ b/code/modules/surgery/graft_synthtissue.dm
@@ -61,8 +61,8 @@
 	target.reagents.remove_reagent("synthtissue", 10)
 
 /datum/surgery_step/graft_synthtissue/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully grafts synthtissue to [chosen_organ].", "<span class='notice'>You succeed in grafting 10u to [chosen_organ].</span>")
-	chosen_organ.applyOrganDamage(health_restored)
+	user.visible_message("[user] successfully grafts synthtissue to [chosen_organ].", "<span class='notice'>You succeed in grafting 10u of the synthflesh to the [chosen_organ].</span>")
+	chosen_organ.applyOrganDamage(-health_restored)
 	return TRUE
 
 /datum/surgery_step/graft_synthtissue/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/graft_synthtissue.dm
+++ b/code/modules/surgery/graft_synthtissue.dm
@@ -19,7 +19,7 @@
 //repair organs
 /datum/surgery_step/graft_synthtissue
 	name = "graft synthtissue"
-	implements = list(/obj/item/hemostat = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
+	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15)
 	repeatable = TRUE
 	time = 75
 	chems_needed = list("synthtissue")
@@ -61,8 +61,9 @@
 	target.reagents.remove_reagent("synthtissue", 10)
 
 /datum/surgery_step/graft_synthtissue/success(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
-	user.visible_message("[user] successfully repairs part of [chosen_organ].", "<span class='notice'>You succeed in repairing parts of [chosen_organ].</span>")
+	user.visible_message("[user] successfully grafts synthtissue to [chosen_organ].", "<span class='notice'>You succeed in grafting 10u to [chosen_organ].</span>")
 	chosen_organ.applyOrganDamage(health_restored)
+	return TRUE
 
 /datum/surgery_step/graft_synthtissue/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)
 	user.visible_message("<span class='warning'>[user] accidentally damages part of [chosen_organ]!</span>", "<span class='warning'>You damage [chosen_organ]! Apply more synthtissue if it's run out.</span>")

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -26,7 +26,7 @@
 //remove fat
 /datum/surgery_step/remove_fat
 	name = "remove loose fat"
-	implements = list(/obj/item/retractor = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
+	implements = list(TOOL_RETRACTOR = 100, TOOL_SCREWDRIVER = 45, TOOL_WIRECUTTER = 35)
 	time = 32
 
 /datum/surgery_step/remove_fat/preop(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -17,9 +17,10 @@
 	if(starting_organ)
 		insert_organ(new starting_organ(src))
 
-/obj/item/autosurgeon/proc/insert_organ(var/obj/item/I)
+/obj/item/autosurgeon/proc/insert_organ(var/obj/item/organ/I)
 	storedorgan = I
 	I.forceMove(src)
+	I.organ_flags |= ORGAN_FROZEN //Stops decay
 	name = "[initial(name)] ([storedorgan.name])"
 
 /obj/item/autosurgeon/attack_self(mob/user)//when the object it used...

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -61,6 +61,7 @@
 	return S
 
 /obj/item/organ/heart/on_life()
+	..()
 	if(owner.client && beating)
 		failed = FALSE
 		var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -6,7 +6,7 @@
 	slot = ORGAN_SLOT_HEART
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = 4 * STANDARD_ORGAN_DECAY		//designed to fail about 5 minutes after death
+	decay_factor = 3 * STANDARD_ORGAN_DECAY		//designed to fail about 5 minutes after death
 
 	low_threshold_passed = "<span class='info'>Prickles of pain appear then die out from within your chest...</span>"
 	high_threshold_passed = "<span class='warning'>Something inside your chest hurts, and the pain isn't subsiding. You notice yourself breathing far faster than before.</span>"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -12,10 +12,12 @@
 	var/operated = FALSE	//whether we can still have our damages fixed through surgery
 
 	//health
-	maxHealth = LUNGS_MAX_HEALTH
+	maxHealth = 3 * STANDARD_ORGAN_THRESHOLD
 
 	healing_factor = STANDARD_ORGAN_HEALING
 	decay_factor = STANDARD_ORGAN_DECAY
+	high_threshold = 0.6 * LUNGS_MAX_HEALTH	//threshold at 30
+	low_threshold = 0.3 * LUNGS_MAX_HEALTH	//threshold at 15
 
 	high_threshold_passed = "<span class='warning'>You feel some sort of constriction around your chest as your breathing becomes shallow and rapid.</span>"
 	now_fixed = "<span class='warning'>Your lungs seem to once again be able to hold air.</span>"

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -16,8 +16,8 @@
 
 	healing_factor = STANDARD_ORGAN_HEALING
 	decay_factor = STANDARD_ORGAN_DECAY
-	high_threshold = 0.6 * LUNGS_MAX_HEALTH	//threshold at 30
-	low_threshold = 0.3 * LUNGS_MAX_HEALTH	//threshold at 15
+	high_threshold = 0.6 * LUNGS_MAX_HEALTH	//threshold at 180
+	low_threshold = 0.3 * LUNGS_MAX_HEALTH	//threshold at 90
 
 	high_threshold_passed = "<span class='warning'>You feel some sort of constriction around your chest as your breathing becomes shallow and rapid.</span>"
 	now_fixed = "<span class='warning'>Your lungs seem to once again be able to hold air.</span>"

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -72,7 +72,7 @@
 	on_death() //Kinda hate doing it like this, but I really don't want to call process directly.
 
 /obj/item/organ/proc/on_death()	//runs decay when outside of a person
-	if(organ_flags & ORGAN_SYNTHETIC)
+	if(CHECK_MULTIPLE_BITFIELDS(organ_flags, ORGAN_SYNTHETIC|ORGAN_FROZEN|ORGAN_NO_SPOIL))
 		return
 	if(organ_flags & ORGAN_FROZEN)
 		return

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -72,7 +72,11 @@
 	on_death() //Kinda hate doing it like this, but I really don't want to call process directly.
 
 /obj/item/organ/proc/on_death()	//runs decay when outside of a person
-	if(organ_flags & (ORGAN_SYNTHETIC | ORGAN_FROZEN | ORGAN_NO_SPOIL))
+	if(organ_flags & ORGAN_SYNTHETIC)
+		return
+	 if(organ_flags & ORGAN_FROZEN)
+	 	return
+	if(organ_flags & ORGAN_NO_SPOIL)
 		return
 	applyOrganDamage(maxHealth * decay_factor)
 

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -99,7 +99,7 @@
 //Checks to see if the organ is frozen from temperature
 /obj/item/organ/proc/is_cold()
 	if(istype(loc, /obj/))//Freezer of some kind, I hope.
-		if(istype(loc, /obj/structure/closet/crate/freezer) || istype(loc, /obj/structure/closet/secure_closet/freezer) || istype(loc, /obj/structure/bodycontainer))
+		if(istype(loc, /obj/structure/closet/crate/freezer) || istype(loc, /obj/structure/closet/secure_closet/freezer) || istype(loc, /obj/structure/bodycontainer) || istype(loc, /obj/item/autosurgeon))
 			if(!(organ_flags & ORGAN_FROZEN))//Incase someone puts them in when cold, but they warm up inside of the thing. (i.e. they have the flag, the thing turns it off, this rights it.)
 				organ_flags |= ORGAN_FROZEN
 		return

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -110,13 +110,13 @@
 		var/datum/gas_mixture/enviro = T.return_air()
 		local_temp = enviro.temperature
 
-	if(istype(loc, /mob/))
+	else if(istype(loc, /mob/))
 		var/mob/M = loc
 		var/turf/T = M.loc
 		var/datum/gas_mixture/enviro = T.return_air()
 		local_temp = enviro.temperature
 
-	else if(owner)
+	if(owner)
 		//Don't interfere with bodies frozen by structures.
 		if(istype(owner.loc, /obj/structure/closet/crate/freezer) || istype(owner.loc, /obj/structure/closet/secure_closet/freezer) || istype(owner.loc, /obj/structure/bodycontainer))
 			if(!(organ_flags & ORGAN_FROZEN))//Incase someone puts them in when cold, but they warm up inside of the thing. (i.e. they have the flag, the thing turns it off, this rights it.)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -74,10 +74,6 @@
 /obj/item/organ/proc/on_death()	//runs decay when outside of a person
 	if(CHECK_MULTIPLE_BITFIELDS(organ_flags, ORGAN_SYNTHETIC|ORGAN_FROZEN|ORGAN_NO_SPOIL))
 		return
-	if(organ_flags & ORGAN_FROZEN)
-		return
-	if(organ_flags & ORGAN_NO_SPOIL)
-		return
 	applyOrganDamage(maxHealth * decay_factor)
 
 /obj/item/organ/proc/on_life()	//repair organ damage if the organ is not failing

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -110,14 +110,18 @@
 
 	else if(istype(loc, /mob/) && !owner)
 		var/mob/M = loc
+		if(is_type_in_list(M.loc, freezing_objects))
+			if(!(organ_flags & ORGAN_FROZEN))
+				organ_flags |= ORGAN_FROZEN
+			return TRUE
 		var/turf/T = M.loc
 		var/datum/gas_mixture/enviro = T.return_air()
 		local_temp = enviro.temperature
 
 	if(owner)
 		//Don't interfere with bodies frozen by structures.
-		if(is_type_in_list(loc, freezing_objects))
-			if(!(organ_flags & ORGAN_FROZEN))//Incase someone puts them in when cold, but they warm up inside of the thing. (i.e. they have the flag, the thing turns it off, this rights it.)
+		if(is_type_in_list(owner.loc, freezing_objects))
+			if(!(organ_flags & ORGAN_FROZEN))
 				organ_flags |= ORGAN_FROZEN
 			return TRUE
 		local_temp = owner.bodytemperature

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -75,7 +75,7 @@
 	if(organ_flags & ORGAN_SYNTHETIC)
 		return
 	if(organ_flags & ORGAN_FROZEN)
-	 	return
+		return
 	if(organ_flags & ORGAN_NO_SPOIL)
 		return
 	applyOrganDamage(maxHealth * decay_factor)

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -74,7 +74,7 @@
 /obj/item/organ/proc/on_death()	//runs decay when outside of a person
 	if(organ_flags & ORGAN_SYNTHETIC)
 		return
-	 if(organ_flags & ORGAN_FROZEN)
+	if(organ_flags & ORGAN_FROZEN)
 	 	return
 	if(organ_flags & ORGAN_NO_SPOIL)
 		return

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -17,6 +17,7 @@
 	low_threshold_cleared = "<span class='info'>The last bouts of pain in your stomach have died out.</span>"
 
 /obj/item/organ/stomach/on_life()
+	..()
 	var/datum/reagent/consumable/nutriment/Nutri
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -211,6 +211,8 @@
 	phomeme_type = pick(phomeme_types)
 
 /obj/item/organ/tongue/bone/applyOrganDamage(var/d, var/maximum = maxHealth)
+	if(d < 0)
+		return
 	if(!owner)
 		return
 	var/target = owner.get_bodypart(BODY_ZONE_HEAD)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -23,6 +23,8 @@
 		/datum/language/aphasia,
 		/datum/language/slime,
 	))
+	healing_factor = STANDARD_ORGAN_HEALING*5 //Fast!!
+	decay_factor = STANDARD_ORGAN_DECAY
 
 /obj/item/organ/tongue/Initialize(mapload)
 	. = ..()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -24,7 +24,7 @@
 		/datum/language/slime,
 	))
 	healing_factor = STANDARD_ORGAN_HEALING*5 //Fast!!
-	decay_factor = STANDARD_ORGAN_DECAY
+	decay_factor = STANDARD_ORGAN_DECAY/2
 
 /obj/item/organ/tongue/Initialize(mapload)
 	. = ..()

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -100,7 +100,7 @@
 	id = "synthtissue"
 	description = "Synthetic tissue used for grafting onto damaged organs during surgery, or for treating limb damage. Has a very tight growth window between 305-320, any higher and the temperature will cause the cells to die. Additionally, growth time is considerably long, so chemists are encouraged to leave beakers with said reaction ongoing, while they tend to their other duties."
 	pH = 7.6
-	metabolization_rate = 0.1
+	metabolization_rate = 0.05 //Give them time to graft
 	data = list("grown_volume" = 0, "injected_vol" = 0)
 
 /datum/reagent/synthtissue/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -104,7 +104,6 @@
 	data = list("grown_volume" = 0, "injected_vol" = 0)
 
 /datum/reagent/synthtissue/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
-	message_admins("mob: data: [data["injected_vol"]] passed: [reac_volume]")
 	if(iscarbon(M))
 		var/target = M.zone_selected
 		if (M.stat == DEAD)
@@ -137,7 +136,6 @@
 		return ..()
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
-	message_admins("merge: data: [data["injected_vol"]] passed: [passed_data["injected_vol"]]")
 	if(iscarbon(holder.my_atom))
 		data["injected_vol"] = data["injected_vol"] + passed_data["injected_vol"]
 		passed_data["injected_vol"] = 0

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -104,6 +104,7 @@
 	data = list("grown_volume" = 0, "injected_vol" = 0)
 
 /datum/reagent/synthtissue/reaction_mob(mob/living/M, method=TOUCH, reac_volume,show_message = 1)
+	message_admins("mob: data: [data["injected_vol"]] passed: [reac_volume]")
 	if(iscarbon(M))
 		var/target = M.zone_selected
 		if (M.stat == DEAD)
@@ -115,7 +116,7 @@
 				to_chat(M, "<span class='danger'>You feel your [target] heal! It stings like hell!</span>")
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
 	if(method==INJECT)
-		data["injected_vol"] = data["injected_vol"] + reac_volume
+		data["injected_vol"] = reac_volume
 	..()
 
 /datum/reagent/synthtissue/on_mob_life(mob/living/carbon/C)
@@ -136,6 +137,10 @@
 		return ..()
 	if(passed_data["grown_volume"] > data["grown_volume"])
 		data["grown_volume"] = passed_data["grown_volume"]
+	message_admins("merge: data: [data["injected_vol"]] passed: [passed_data["injected_vol"]]")
+	if(iscarbon(holder.my_atom))
+		data["injected_vol"] = data["injected_vol"] + passed_data["injected_vol"]
+		passed_data["injected_vol"] = 0
 	..()
 
 /datum/reagent/synthtissue/on_new(passed_data)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Fixes; Heart, Tongue and stomach regen.
Fixes lung damage threshholds.
Tweaks heart decay time.
Fixes graft synthtissue which does damage instead of healing it (oops), and fixes the data tracking of injected vol (tracking volume added to a mob across multiple instances is a huge pain)
Also makes synthtissue keep track of how much is grown via it's name.
Tweaks how organs are frozen, if they're on a cold tile (less than 150K) they'll freeze and won't decay. Equally, if a mob is frozen, their organs won't decay. You can still freeze mobs/organs in blood coolers, freezers, fridges and morgue units too. Held and floor organs rely on the turf, internal relies on mob temperature. (So you can bung a corpse in cyro to stop decay!)
Fixes skeletons from being too much like ghost rider, and will only become ghost rider for a short time when drinking strong acids/bases.
Fixes autosurgeons' organs decaying.
Enables slow, passive brain healing.
Prevents organ regeneration when frozen.

## Why It's Good For The Game

From recent people pointing out bugs and feedback.
Overhall coming fairly soon, but this should help things for now.
Also fixes a lot of things I assumed worked because tg had it. I can't tell if it's a difference in our codebases or oversights existent in tg too.

## Changelog
:cl: Fermis
Fix: Heart, Tongue and stomach regen.
Fix: lung damage threshholds.
Fix: Graft synthtissue
Fix: Skeleton's burning for no reason
Fix: Organ freezing handling.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
