### PR TITLE
Makes pod people not constantly slightly fat

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/podpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/podpeople.dm
@@ -36,8 +36,8 @@
 		var/turf/T = H.loc
 		light_amount = min(1,T.get_lumcount()) - 0.5
 		H.nutrition += light_amount * light_nutrition_gain_factor
-		if(H.nutrition > NUTRITION_LEVEL_FULL)
-			H.nutrition = NUTRITION_LEVEL_FULL
+		if(H.nutrition >= NUTRITION_LEVEL_FULL)
+			H.nutrition = NUTRITION_LEVEL_FULL - 1
 		if(light_amount > 0.2) //if there's enough light, heal
 			H.heal_overall_damage(light_bruteheal, light_burnheal)
 			H.adjustToxLoss(-light_toxheal)


### PR DESCRIPTION
## About The Pull Request

Pod people would be set to NUTRITION_LEVEL_FULL if above it. Unfortunately, fatness starts *at* NUTRITION_LEVEL_FULL, not above it. This makes it so that they never quite reach fatness.

## Why It's Good For The Game

Pod people shouldn't get a negative moodlet for existing.

## Changelog
:cl:
tweak: Pod people can no longer get fat from standing in the light
/:cl: