### PR TITLE
adds an easy way for admins to force enable halloween races without the rest of halloween's code

### DIFF
--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -536,3 +536,10 @@ Since Ramadan is an entire month that lasts 29.5 days on average, the start and 
 
 /datum/holiday/easter/getStationPrefix()
 	return pick("Fluffy","Bunny","Easter","Egg")
+
+//Random citadel thing for halloween species
+/proc/force_enable_halloween_species()
+	var/list/oldlist = SSevents.holidays
+	SSevents.holidays = list(HALLOWEEN = new /datum/holiday/halloween)
+	generate_selectable_species(FALSE)
+	SSevents.holidays = oldlist

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -116,11 +116,14 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	..()
 
 
-/proc/generate_selectable_species()
+/proc/generate_selectable_species(clear = FALSE)
+	if(clear)
+		GLOB.roundstart_races = list()
+		GLOB.roundstart_race_names = list()
 	for(var/I in subtypesof(/datum/species))
 		var/datum/species/S = new I
 		if(S.check_roundstart_eligible())
-			GLOB.roundstart_races += S.id
+			GLOB.roundstart_races |= S.id
 			GLOB.roundstart_race_names["[S.name]"] = S.id
 			qdel(S)
 	if(!GLOB.roundstart_races.len)


### PR DESCRIPTION
proccall force_enable_halloween_species