### PR TITLE
teleprods works on non-carbons too now.

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -1,5 +1,4 @@
 #define STUNBATON_CHARGE_LENIENCY 0.3
-#define STUNBATON_DEPLETION_RATE 0.006
 
 /obj/item/melee/baton
 	name = "stunbaton"
@@ -77,7 +76,7 @@
 	update_icon()
 
 /obj/item/melee/baton/process()
-	deductcharge(round(hitcost * STUNBATON_DEPLETION_RATE), FALSE, FALSE)
+	deductcharge(hitcost * 0.004, FALSE, FALSE)
 
 /obj/item/melee/baton/update_icon()
 	if(status)
@@ -252,4 +251,3 @@
 	. = ..()
 
 #undef STUNBATON_CHARGE_LENIENCY
-#undef STUNBATON_DEPLETION_RATE

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -1,4 +1,5 @@
 #define STUNBATON_CHARGE_LENIENCY 0.3
+#define STUNBATON_DEPLETION_RATE 0.006
 
 /obj/item/melee/baton
 	name = "stunbaton"
@@ -76,7 +77,7 @@
 	update_icon()
 
 /obj/item/melee/baton/process()
-	deductcharge(hitcost * 0.004, FALSE, FALSE)
+	deductcharge(round(hitcost * STUNBATON_DEPLETION_RATE), FALSE, FALSE)
 
 /obj/item/melee/baton/update_icon()
 	if(status)
@@ -251,3 +252,4 @@
 	. = ..()
 
 #undef STUNBATON_CHARGE_LENIENCY
+#undef STUNBATON_DEPLETION_RATE

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -10,7 +10,7 @@
 	. = ..()
 	if(!. || L.anchored)
 		return
-	do_teleport(M, get_turf(L), 15, channel = TELEPORT_CHANNEL_BLUESPACE)
+	do_teleport(L, get_turf(L), 15, channel = TELEPORT_CHANNEL_BLUESPACE)
 
 /obj/item/melee/baton/cattleprod/teleprod/clowning_around(mob/living/user)
 	user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -6,11 +6,11 @@
 	item_state = "teleprod"
 	slot_flags = null
 
-/obj/item/melee/baton/cattleprod/teleprod/baton_stun(mob/living/carbon/M, mob/living/carbon/user)//handles making things teleport when hit
+/obj/item/melee/baton/cattleprod/teleprod/baton_stun(mob/living/L, mob/living/carbon/user)//handles making things teleport when hit
 	. = ..()
-	if(!. || !istype(M) || M.anchored)
+	if(!. || L.anchored)
 		return
-	do_teleport(M, get_turf(M), 15, channel = TELEPORT_CHANNEL_BLUESPACE)
+	do_teleport(M, get_turf(L), 15, channel = TELEPORT_CHANNEL_BLUESPACE)
 
 /obj/item/melee/baton/cattleprod/teleprod/clowning_around(mob/living/user)
 	user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \


### PR DESCRIPTION
## About The Pull Request
Exactly what's said on the tin.

## Why It's Good For The Game
Fixing a minor issue.

## Changelog
:cl:
fix: Teleprods work on non-carbons mobs now.
/:cl:
