### PR TITLE
Makes beaker spawn on pandemic instead of on user when hands full

### DIFF
--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -244,9 +244,9 @@
 
 /obj/machinery/computer/pandemic/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
 	if(beaker)
-		beaker.forceMove(drop_location())
 		if(user && Adjacent(user) && !issiliconoradminghost(user))
-			user.put_in_hands(beaker)
+			if(!user.put_in_hands(beaker))
+				beaker.forceMove(drop_location())
 	if(new_beaker)
 		beaker = new_beaker
 	else


### PR DESCRIPTION
## About The Pull Request

As a follow-up to #9432, emulates old behavior when hands are full, instead of putting it under the player and causing confusion.

## Why It's Good For The Game

It's more quality of life, old behavior was better in this particular circumstance

## Changelog
:cl:
tweak: PanD.E.M.I.C 2200 now ejects onto itself instead of onto user if user's hands are full
/:cl:

