### PR TITLE
Taser rework - Gives electrodes a debilitating status effect, makes disabler the default taser mode, and more

### DIFF
--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -34,3 +34,5 @@
 
 #define MOVESPEED_ID_PRONE_DRAGGING                     "PRONE_DRAG"
 #define MOVESPEED_ID_HUMAN_CARRYING                     "HUMAN_CARRY"
+
+#define MOVESPEED_ID_TASED_STATUS						"TASED"

--- a/code/__DEFINES/status_effects.dm
+++ b/code/__DEFINES/status_effects.dm
@@ -44,6 +44,8 @@
 
 #define STATUS_EFFECT_SLEEPING /datum/status_effect/incapacitating/sleeping //the affected is asleep
 
+#define STATUS_EFFECT_TASED /datum/status_effect/electrode //the affected has been tased, preventing fine muscle control
+
 #define STATUS_EFFECT_PACIFY /datum/status_effect/pacify //the affected is pacified, preventing direct hostile actions
 
 #define STATUS_EFFECT_BELLIGERENT /datum/status_effect/belligerent //forces the affected to walk, doing damage if they try to run

--- a/code/__HELPERS/mobs.dm
+++ b/code/__HELPERS/mobs.dm
@@ -400,6 +400,12 @@ GLOBAL_LIST_EMPTY(species_list)
 			. = 0
 			break
 
+		if(isliving(user))
+			var/mob/living/L = user
+			if(L.recoveringstam)
+				. = 0
+				break
+
 		if(!QDELETED(Tloc) && (QDELETED(target) || Tloc != target.loc))
 			if((Uloc != Tloc || Tloc != user) && !drifting)
 				. = 0

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -105,7 +105,7 @@
 
 /datum/status_effect/electrode/tick()
 	if(owner)
-		owner.adjustStaminaLoss(10) //if you really want to try to stamcrit someone with a taser alone, you can, but it'll take time and good timing.
+		owner.adjustStaminaLoss(5) //if you really want to try to stamcrit someone with a taser alone, you can, but it'll take time and good timing.
 
 /datum/status_effect/electrode/nextmove_modifier() //why is this a proc. its no big deal since this doesnt get called often at all but literally w h y
 	return 2

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -80,6 +80,36 @@
 	desc = "You've fallen asleep. Wait a bit and you should wake up. Unless you don't, considering how helpless you are."
 	icon_state = "asleep"
 
+//TASER
+/datum/status_effect/electrode
+	id = "tased"
+	blocks_combatmode = TRUE
+	status_type = STATUS_EFFECT_REPLACE
+	alert_type = null
+
+/datum/status_effect/electrode/on_creation(mob/living/new_owner, set_duration)
+	if(isnum(set_duration))
+		duration = set_duration
+	. = ..()
+	if(iscarbon(owner))
+		var/mob/living/carbon/C = owner
+		if(C.combatmode)
+			C.toggle_combat_mode(TRUE)
+		C.add_movespeed_modifier(MOVESPEED_ID_TASED_STATUS, TRUE, override = TRUE, multiplicative_slowdown = 8)
+
+/datum/status_effect/electrode/on_remove()
+	if(iscarbon(owner))
+		var/mob/living/carbon/C = owner
+		C.remove_movespeed_modifier(MOVESPEED_ID_TASED_STATUS)
+	. = ..()
+
+/datum/status_effect/electrode/tick()
+	if(owner)
+		owner.adjustStaminaLoss(10) //if you really want to try to stamcrit someone with a taser alone, you can, but it'll take time and good timing.
+
+/datum/status_effect/electrode/nextmove_modifier() //why is this a proc. its no big deal since this doesnt get called often at all but literally w h y
+	return 2
+
 //OTHER DEBUFFS
 /datum/status_effect/his_wrath //does minor damage over time unless holding His Grace
 	id = "his_wrath"

--- a/code/datums/status_effects/status_effect.dm
+++ b/code/datums/status_effects/status_effect.dm
@@ -11,6 +11,7 @@
 	var/on_remove_on_mob_delete = FALSE //if we call on_remove() when the mob is deleted
 	var/examine_text //If defined, this text will appear when the mob is examined - to use he, she etc. use "SUBJECTPRONOUN" and replace it in the examines themselves
 	var/alert_type = /obj/screen/alert/status_effect //the alert thrown by the status effect, contains name and description
+	var/blocks_combatmode //Does this status effect prevent the user from toggling combat mode?
 	var/obj/screen/alert/status_effect/linked_alert = null //the alert itself, if it exists
 
 /datum/status_effect/New(list/arguments)

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -40,6 +40,8 @@
 
 	var/stun_projectile = null		//stun mode projectile type
 	var/stun_projectile_sound
+	var/nonlethal_projectile		//projectile to use in stun mode when the target is resting, if any
+	var/nonlethal_projectile_sound
 	var/lethal_projectile = null	//lethal mode projectile type
 	var/lethal_projectile_sound
 
@@ -535,13 +537,22 @@
 					T = closer
 					break
 
+	var/mob/living/carbon/C
+	if(iscarbon(target))
+		C = target
+
 	update_icon()
 	var/obj/item/projectile/A
 	//any emagged turrets drains 2x power and uses a different projectile?
 	if(mode == TURRET_STUN)
-		use_power(reqpower)
-		A = new stun_projectile(T)
-		playsound(loc, stun_projectile_sound, 75, 1)
+		if(nonlethal_projectile && C && C.resting)
+			use_power(reqpower*0.5)
+			A = new nonlethal_projectile(T)
+			playsound(loc, nonlethal_projectile_sound, 75, 1)
+		else
+			use_power(reqpower)
+			A = new stun_projectile(T)
+			playsound(loc, stun_projectile_sound, 75, 1)
 	else
 		use_power(reqpower * 2)
 		A = new lethal_projectile(T)
@@ -653,6 +664,8 @@
 	base_icon_state = "standard"
 	stun_projectile = /obj/item/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
+	nonlethal_projectile = /obj/item/projectile/beam/disabler
+	nonlethal_projectile_sound = 'sound/weapons/taser2.ogg'
 	lethal_projectile = /obj/item/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	desc = "An energy blaster auto-turret."
@@ -662,6 +675,8 @@
 	base_icon_state = "standard"
 	stun_projectile = /obj/item/projectile/energy/electrode
 	stun_projectile_sound = 'sound/weapons/taser.ogg'
+	nonlethal_projectile = /obj/item/projectile/beam/disabler
+	nonlethal_projectile_sound = 'sound/weapons/taser2.ogg'
 	lethal_projectile = /obj/item/projectile/beam/laser/heavylaser
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	desc = "An energy blaster auto-turret."
@@ -681,6 +696,8 @@
 
 /obj/machinery/porta_turret/ai
 	faction = list("silicon")
+	nonlethal_projectile = /obj/item/projectile/beam/disabler
+	nonlethal_projectile_sound = 'sound/weapons/taser2.ogg'
 
 /obj/machinery/porta_turret/ai/assess_perp(mob/living/carbon/human/perp)
 	return 10 //AI turrets shoot at everything not in their faction

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -79,7 +79,7 @@
 
 
 
-/mob/living/proc/apply_effect(effect = 0,effecttype = EFFECT_STUN, blocked = FALSE)
+/mob/living/proc/apply_effect(effect = 0,effecttype = EFFECT_STUN, blocked = FALSE, knockdown_stamoverride, knockdown_stammax)
 	var/hit_percent = (100-blocked)/100
 	if(!effect || (hit_percent <= 0))
 		return 0
@@ -87,7 +87,7 @@
 		if(EFFECT_STUN)
 			Stun(effect * hit_percent)
 		if(EFFECT_KNOCKDOWN)
-			Knockdown(effect * hit_percent)
+			Knockdown(effect * hit_percent, override_stamdmg = knockdown_stammax ? CLAMP(knockdown_stamoverride, 0, knockdown_stammax-getStaminaLoss()) : knockdown_stamoverride)
 		if(EFFECT_UNCONSCIOUS)
 			Unconscious(effect * hit_percent)
 		if(EFFECT_IRRADIATE)
@@ -107,13 +107,13 @@
 	return 1
 
 
-/mob/living/proc/apply_effects(stun = 0, knockdown = 0, unconscious = 0, irradiate = 0, slur = 0, stutter = 0, eyeblur = 0, drowsy = 0, blocked = FALSE, stamina = 0, jitter = 0)
+/mob/living/proc/apply_effects(stun = 0, knockdown = 0, unconscious = 0, irradiate = 0, slur = 0, stutter = 0, eyeblur = 0, drowsy = 0, blocked = FALSE, stamina = 0, jitter = 0, kd_stamoverride, kd_stammax)
 	if(blocked >= 100)
 		return 0
 	if(stun)
 		apply_effect(stun, EFFECT_STUN, blocked)
 	if(knockdown)
-		apply_effect(knockdown, EFFECT_KNOCKDOWN, blocked)
+		apply_effect(knockdown, EFFECT_KNOCKDOWN, blocked, kd_stamoverride, kd_stammax)
 	if(unconscious)
 		apply_effect(unconscious, EFFECT_UNCONSCIOUS, blocked)
 	if(irradiate)

--- a/code/modules/projectiles/guns/energy/stun.dm
+++ b/code/modules/projectiles/guns/energy/stun.dm
@@ -20,7 +20,7 @@
 	name = "hybrid taser"
 	desc = "A dual-mode taser designed to fire both short-range high-power electrodes and long-range disabler beams."
 	icon_state = "advtaser"
-	ammo_type = list(/obj/item/ammo_casing/energy/electrode, /obj/item/ammo_casing/energy/disabler)
+	ammo_type = list(/obj/item/ammo_casing/energy/disabler, /obj/item/ammo_casing/energy/electrode)
 	ammo_x_offset = 2
 
 /obj/item/gun/energy/e_gun/advtaser/cyborg

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -88,6 +88,8 @@
 		//Effects
 	var/stun = 0
 	var/knockdown = 0
+	var/knockdown_stamoverride
+	var/knockdown_stam_max
 	var/unconscious = 0
 	var/irradiate = 0
 	var/stutter = 0
@@ -202,7 +204,7 @@
 	else
 		L.log_message("has been shot by [firer] with [src]", LOG_ATTACK, color="orange")
 
-	return L.apply_effects(stun, knockdown, unconscious, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter)
+	return L.apply_effects(stun, knockdown, unconscious, irradiate, slur, stutter, eyeblur, drowsy, blocked, stamina, jitter, knockdown_stamoverride, knockdown_stam_max)
 
 /obj/item/projectile/proc/vol_by_damage()
 	if(src.damage)

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -3,7 +3,9 @@
 	icon_state = "spark"
 	color = "#FFFF00"
 	nodamage = 1
-	knockdown = 100
+	knockdown = 60
+	knockdown_stamoverride = 36
+	knockdown_stam_max = 50
 	stutter = 5
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
@@ -11,6 +13,7 @@
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun
+	var/tase_duration = 50
 
 /obj/item/projectile/energy/electrode/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -23,6 +26,7 @@
 		if(C.dna && C.dna.check_mutation(HULK))
 			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
 		else if((C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE))
+			C.apply_status_effect(STATUS_EFFECT_TASED, tase_duration)
 			addtimer(CALLBACK(C, /mob/living/carbon.proc/do_jitter_animation, jitter), 5)
 
 /obj/item/projectile/energy/electrode/on_range() //to ensure the bolt sparks when it reaches the end of its range if it didn't hit a target yet

--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -18,9 +18,13 @@
 					return FALSE
 	return .
 
-/mob/living/carbon/proc/toggle_combat_mode()
+/mob/living/carbon/proc/toggle_combat_mode(forced)
 	if(recoveringstam)
 		return TRUE
+	if(!forced)
+		for(var/datum/status_effect/S in status_effects)
+			if(S.blocks_combatmode)
+				return TRUE
 	combatmode = !combatmode
 	if(voremode)
 		toggle_vore_mode()

--- a/modular_citadel/code/modules/mob/living/living.dm
+++ b/modular_citadel/code/modules/mob/living/living.dm
@@ -116,7 +116,7 @@
 			to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")
 			resting = TRUE
 			if(combatmode)
-				toggle_combat_mode()
+				toggle_combat_mode(TRUE)
 			recoveringstam = TRUE
 			filters += CIT_FILTER_STAMINACRIT
 			update_canmove()

--- a/modular_citadel/code/modules/projectiles/projectile/energy.dm
+++ b/modular_citadel/code/modules/projectiles/projectile/energy.dm
@@ -1,2 +1,0 @@
-/obj/item/projectile/energy/electrode
-	stamina = 36

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -3086,7 +3086,6 @@
 #include "modular_citadel\code\modules\projectiles\guns\ballistic\spinfusor.dm"
 #include "modular_citadel\code\modules\projectiles\guns\energy\energy_gun.dm"
 #include "modular_citadel\code\modules\projectiles\guns\energy\laser.dm"
-#include "modular_citadel\code\modules\projectiles\projectile\energy.dm"
 #include "modular_citadel\code\modules\projectiles\projectiles\reusable.dm"
 #include "modular_citadel\code\modules\reagents\chemistry\reagents\astrogen.dm"
 #include "modular_citadel\code\modules\reagents\chemistry\reagents\eigentstasium.dm"


### PR DESCRIPTION
## About The Pull Request
This PR shakes up the current meta quite a bit by completely reworking how electrodes work. This is primarily a stopgap to address the majority of concerns regarding security's current gameplay prior to the upcoming stamina rework. As of right now, there are a lot of complaints regarding the golden bolt being way too good as the end-all-be-all solution to every problem, instead of sitting in its intended role of quickly reducing a target's combat ability from a range.

So instead of the golden bolt dealing 61 stamloss and performing a strong knockdown, the golden bolt now instead performs a weak knockdown (does not interrupt timers or knock items out of hands), applies the new tased status effect for 5 seconds, and deals 35 stamloss on hit, but only up to a maximum of 50 direct stamloss.

The new tased status effect is a fun one. It disables the target's combat mode for its duration, doubles click delay, applies a heavy movement speed penalty, and deals 5 staminaloss every second. This greatly reduces a target's combat ability, and makes it far easier for sec to close the gap or follow up with a few disabler shots, but still gives the target some room for counterplay, since the golden bolt no longer forces item drops.

The disabler is untouched, but it is now the default mode for hybrid tasers. This should give security players a tiny nudge that says "hey, the disabler might be useful", and allows players who have no idea that the taser's a hybrid taser to still be meaningfully useful as security.

All of this combined makes the taser fairly useful for weakening a target, but overthrows them from the throne of being the king of stamloss sources; the most efficient way for sec to take out a target with this PR is to fire one electrode, then follow up with multiple disabler shots, rather than to simply spam electrodes and hope for the best. This should lead to far more interesting gameplay for both sec and antags, as sec's primary stamloss source is no longer one that's strong enough to stop someone from being able to play the game.

This also allows roundstart turrets to specify a nonlethal projectile type. If the turret's mode is set to stun and its target is resting, the nonlethal projectile type will be used in place of the stun projectile type. For the AI turrets and syndicate energy turrets, the nonlethal projectile is the disabler beam. This makes it possible for turrets to actually perform their jobs of incapacitating intruders when set to stun, as otherwise, turrets would be spamming electrodes into targets blindly.

## Changelog
:cl:
balance: The taser's electrode has been reworked. Instead of being a strong knockdown that deals a heavy amount of stamloss, it now causes a weak knockdown, applies a debilitating status effect for 5 seconds, and deals 35 stamloss on hit up to a maximum 50 total stamloss.
balance: Roundstart turrets now have a nonlethal projectile that gets used when they're set to stun and the target is resting
tweak: Hybrid tasers now have disablers set as their default mode.
/:cl:
