### PR TITLE
medibots are now TOXINLOVER (so slimes) friendly

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -51,6 +51,7 @@
 	var/treatment_fire = "kelotane"
 	var/treatment_tox_avoid = "tricordrazine"
 	var/treatment_tox = "charcoal"
+	var/treatment_tox_toxlover = "toxin"
 	var/treatment_virus_avoid = null
 	var/treatment_virus = "spaceacillin"
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
@@ -381,8 +382,8 @@
 
 	if((!C.reagents.has_reagent(treatment_fire_avoid)) && (C.getFireLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_fire)))
 		return TRUE
-
-	if((!C.reagents.has_reagent(treatment_tox_avoid)) && (C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(treatment_tox)))
+	var/treatment_toxavoid = get_avoidchem_toxin(C)
+	if(((treatment_toxavoid && !C.reagents.has_reagent(treatment_toxavoid))) && (C.getToxLoss() >= heal_threshold) && (!C.reagents.has_reagent(get_healchem_toxin(C))))
 		return TRUE
 
 	if(treat_virus && !C.reagents.has_reagent(treatment_virus_avoid) && !C.reagents.has_reagent(treatment_virus))
@@ -395,6 +396,15 @@
 				return TRUE //STOP DISEASE FOREVER
 
 	return FALSE
+
+/mob/living/simple_animal/bot/medbot/proc/get_avoidchem_toxin(mob/M)
+	return toxlover_check(M)? null : treatment_tox_avoid
+
+/mob/living/simple_animal/bot/medbot/proc/get_healchem_toxin(mob/M)
+	return toxlover_check(M)? treatment_tox_toxlover : treatment_tox
+
+/mob/living/simple_animal/bot/medbot/proc/toxlover_check(mob/M)
+	return HAS_TRAIT(M, TRAIT_TOXINLOVER)
 
 /mob/living/simple_animal/bot/medbot/UnarmedAttack(atom/A)
 	if(iscarbon(A))
@@ -463,8 +473,10 @@
 				reagent_id = treatment_fire
 
 		if(!reagent_id && (C.getToxLoss() >= heal_threshold))
-			if(!C.reagents.has_reagent(treatment_tox) && !C.reagents.has_reagent(treatment_tox_avoid))
-				reagent_id = treatment_tox
+			var/toxin_heal_avoid = get_avoidchem_toxin(C)
+			var/toxin_healchem = get_healchem_toxin(C)
+			if(!C.reagents.has_reagent(toxin_healchem) && (toxin_heal_avoid && !C.reagents.has_reagent(toxin_heal_avoid)))
+				reagent_id = toxin_healchem
 
 		//If the patient is injured but doesn't have our special reagent in them then we should give it to them first
 		if(reagent_id && use_beaker && reagent_glass && reagent_glass.reagents.total_volume)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -398,13 +398,10 @@
 	return FALSE
 
 /mob/living/simple_animal/bot/medbot/proc/get_avoidchem_toxin(mob/M)
-	return toxlover_check(M)? null : treatment_tox_avoid
+	return HAS_TRAIT(M, TRAIT_TOXINLOVER)? null : treatment_tox_avoid
 
 /mob/living/simple_animal/bot/medbot/proc/get_healchem_toxin(mob/M)
-	return toxlover_check(M)? treatment_tox_toxlover : treatment_tox
-
-/mob/living/simple_animal/bot/medbot/proc/toxlover_check(mob/M)
-	return HAS_TRAIT(M, TRAIT_TOXINLOVER)
+	return HAS_TRAIT(M, TRAIT_TOXINLOVER)? treatment_tox_toxlover : treatment_tox
 
 /mob/living/simple_animal/bot/medbot/UnarmedAttack(atom/A)
 	if(iscarbon(A))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes medibots slime friendly

## Why It's Good For The Game

Medibots murdering slimes is hilarious but slimes deserve some love and now that they can actually bleed I don't think it's an issue to let them not die to medibots like they usually would.

## Changelog
:cl:
balance: Medibots no longer kill slimes when trying to heal their toxins.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
