### PR TITLE
Porting "Moves machine/computer frames and structures below object layer." and lowering trays layer.

### DIFF
--- a/code/__DEFINES/layers.dm
+++ b/code/__DEFINES/layers.dm
@@ -39,6 +39,7 @@
 #define DOOR_HELPER_LAYER 2.71 //keep this above OPEN_DOOR_LAYER
 #define PROJECTILE_HIT_THRESHHOLD_LAYER 2.75 //projectiles won't hit objects at or below this layer if possible
 #define TABLE_LAYER 2.8
+#define TRAY_LAYER 2.85
 #define BELOW_OBJ_LAYER 2.9
 #define LOW_ITEM_LAYER 2.95
 //#define OBJ_LAYER 3 //For easy recordkeeping; this is a byond define

--- a/code/game/objects/structures.dm
+++ b/code/game/objects/structures.dm
@@ -8,6 +8,7 @@
 	var/climbable = FALSE
 	var/mob/living/structureclimber
 	var/broken = 0 //similar to machinery's stat BROKEN
+	layer = BELOW_OBJ_LAYER
 
 /obj/structure/Initialize()
 	if (!armor)

--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -4,7 +4,6 @@
 	icon = 'icons/obj/closet.dmi'
 	icon_state = "generic"
 	density = TRUE
-	layer = BELOW_OBJ_LAYER
 	var/icon_door = null
 	var/icon_door_override = FALSE //override to have open overlay use icon different to its base's
 	var/secure = FALSE //secure locker or not, also used if overriding a non-secure locker with a secure door overlay to add fancy lights

--- a/code/game/objects/structures/girders.dm
+++ b/code/game/objects/structures/girders.dm
@@ -4,7 +4,6 @@
 	desc = "A large structural assembly made out of metal; It requires a layer of metal before it can be considered a wall."
 	anchored = TRUE
 	density = TRUE
-	layer = BELOW_OBJ_LAYER
 	var/state = GIRDER_NORMAL
 	var/girderpasschance = 20 // percentage chance that a projectile passes through the girder.
 	var/can_displace = TRUE //If the girder can be moved around by wrenching it

--- a/code/game/objects/structures/mineral_doors.dm
+++ b/code/game/objects/structures/mineral_doors.dm
@@ -6,6 +6,7 @@
 	density = TRUE
 	anchored = TRUE
 	opacity = TRUE
+	layer = CLOSED_DOOR_LAYER
 
 	icon = 'icons/obj/doors/mineral_doors.dmi'
 	icon_state = "metal"
@@ -90,6 +91,7 @@
 	flick("[initial_state]opening",src)
 	sleep(10)
 	density = FALSE
+	layer = OPEN_DOOR_LAYER
 	state = 1
 	air_update_turf(1)
 	update_icon()
@@ -111,6 +113,7 @@
 	density = TRUE
 	set_opacity(TRUE)
 	state = 0
+	layer = initial(layer)
 	air_update_turf(1)
 	update_icon()
 	isSwitchingStates = 0

--- a/code/game/objects/structures/morgue.dm
+++ b/code/game/objects/structures/morgue.dm
@@ -305,7 +305,7 @@ GLOBAL_LIST_EMPTY(crematoriums)
 /obj/structure/tray
 	icon = 'icons/obj/stationobjs.dmi'
 	density = TRUE
-	layer = BELOW_OBJ_LAYER
+	layer = TRAY_LAYER
 	var/obj/structure/bodycontainer/connected = null
 	anchored = TRUE
 	pass_flags = LETPASSTHROW

--- a/code/game/objects/structures/reflector.dm
+++ b/code/game/objects/structures/reflector.dm
@@ -5,7 +5,6 @@
 	desc = "A base for reflector assemblies."
 	anchored = FALSE
 	density = FALSE
-	layer = BELOW_OBJ_LAYER
 	var/deflector_icon_state
 	var/image/deflector_overlay
 	var/finished = FALSE

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -4,7 +4,6 @@
 	animate_movement = FORWARD_STEPS
 	anchored = TRUE
 	density = TRUE
-	layer = BELOW_OBJ_LAYER
 	var/moving = 0
 	var/datum/gas_mixture/air_contents = new()
 

--- a/code/modules/antagonists/clockcult/clock_structures/traps/steam_vent.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/traps/steam_vent.dm
@@ -7,7 +7,6 @@
 	break_message = "<span class='warning'>The vent snaps and collapses!</span>"
 	max_integrity = 100
 	density = FALSE
-	layer = BELOW_OBJ_LAYER
 
 /obj/structure/destructible/clockwork/trap/steam_vent/activate()
 	opacity = !opacity

--- a/code/modules/antagonists/clockcult/clock_structures/wall_gear.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/wall_gear.dm
@@ -5,7 +5,6 @@
 	unanchored_icon = "wall_gear"
 	climbable = TRUE
 	max_integrity = 100
-	layer = BELOW_OBJ_LAYER
 	construction_value = 3
 	desc = "A massive brass gear. You could probably secure or unsecure it with a wrench, or just climb over it."
 	break_message = "<span class='warning'>The gear breaks apart into shards of alloy!</span>"


### PR DESCRIPTION
## About The Pull Request
Ports /tg/station PR #44165 (where appliable), and will close #9512.

## Why It's Good For The Game
Fixing some layering issues.

## Changelog
:cl: Ghommie (original PR by Skoglol)
tweak: Moved machine and computer frames below objects, parts are now always on top.
tweak: Moved structures (chairs, closets, windows, cult altars etc etc) below objects.
tweak: Moves mineral doors to airlock layers
tweak: morgue/crematorium trays' layers shouldn't overlap bodybags' anymore.
/:cl: