### PR TITLE
Ports "You can now click on objects and mobs below flaps and signs"

### DIFF
--- a/code/controllers/subsystem/vis_overlays.dm
+++ b/code/controllers/subsystem/vis_overlays.dm
@@ -31,8 +31,8 @@ SUBSYSTEM_DEF(vis_overlays)
 			return
 
 //the "thing" var can be anything with vis_contents which includes images
-/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha=255)
-	. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]"
+/datum/controller/subsystem/vis_overlays/proc/add_vis_overlay(atom/movable/thing, icon, iconstate, layer, plane, dir, alpha = 255, add_appearance_flags = NONE)
+	. = "[icon]|[iconstate]|[layer]|[plane]|[dir]|[alpha]|[add_appearance_flags]"
 	var/obj/effect/overlay/vis/overlay = vis_overlay_cache[.]
 	if(!overlay)
 		overlay = new
@@ -42,6 +42,7 @@ SUBSYSTEM_DEF(vis_overlays)
 		overlay.plane = plane
 		overlay.dir = dir
 		overlay.alpha = alpha
+		overlay.appearance_flags |= add_appearance_flags
 		vis_overlay_cache[.] = overlay
 	else
 		overlay.unused = 0
@@ -66,10 +67,12 @@ SUBSYSTEM_DEF(vis_overlays)
 		UnregisterSignal(thing, COMSIG_ATOM_DIR_CHANGE)
 
 /datum/controller/subsystem/vis_overlays/proc/rotate_vis_overlay(atom/thing, old_dir, new_dir)
+	if(old_dir == new_dir)
+		return
 	var/rotation = dir2angle(old_dir) - dir2angle(new_dir)
 	var/list/overlays_to_remove = list()
 	for(var/i in thing.managed_vis_overlays)
 		var/obj/effect/overlay/vis/overlay = i
-		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation))
+		add_vis_overlay(thing, overlay.icon, overlay.icon_state, overlay.layer, overlay.plane, turn(overlay.dir, rotation), overlay.alpha, overlay.appearance_flags)
 		overlays_to_remove += overlay
 	remove_vis_overlay(thing, overlays_to_remove)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -7,7 +7,6 @@
 	anchored = TRUE
 	max_integrity = 1
 	armor = list("melee" = 0, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
-	layer = BELOW_OBJ_LAYER
 	var/obj/item/holosign_creator/projector
 
 /obj/structure/holosign/Initialize(mapload, source_projector)

--- a/code/game/objects/structures/holosign.dm
+++ b/code/game/objects/structures/holosign.dm
@@ -7,13 +7,16 @@
 	anchored = TRUE
 	max_integrity = 1
 	armor = list("melee" = 0, "bullet" = 50, "laser" = 50, "energy" = 50, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 20, "acid" = 20)
+	layer = BELOW_OBJ_LAYER
 	var/obj/item/holosign_creator/projector
 
-/obj/structure/holosign/New(loc, source_projector)
+/obj/structure/holosign/Initialize(mapload, source_projector)
+	. = ..()
 	if(source_projector)
 		projector = source_projector
 		projector.signs += src
-	..()
+	alpha = 0
+	SSvis_overlays.add_vis_overlay(src, icon, icon_state, ABOVE_MOB_LAYER, plane, dir, add_appearance_flags = RESET_ALPHA) //you see mobs under it, but you hit them like they are above it
 
 /obj/structure/holosign/Destroy()
 	if(projector)
@@ -71,10 +74,8 @@
 	desc = "A holographic barrier resembling a firelock. Though it does not prevent solid objects from passing through, gas is kept out."
 	icon_state = "holo_firelock"
 	density = FALSE
-	layer = ABOVE_MOB_LAYER
 	anchored = TRUE
 	CanAtmosPass = ATMOS_PASS_NO
-	layer = ABOVE_MOB_LAYER
 	alpha = 150
 
 /obj/structure/holosign/barrier/atmos/Initialize()
@@ -100,7 +101,6 @@
 	desc = "A holobarrier that uses biometrics to detect human viruses. Denies passing to personnel with easily-detected, malicious viruses. Good for quarantines."
 	icon_state = "holo_medical"
 	alpha = 125 //lazy :)
-	layer = ABOVE_MOB_LAYER
 	var/force_allaccess = FALSE
 	var/buzzcd = 0
 

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -6,7 +6,6 @@
 	armor = list("melee" = 100, "bullet" = 80, "laser" = 80, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 50, "acid" = 50)
 	density = FALSE
 	anchored = TRUE
-	layer = BELOW_OBJ_LAYER
 	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/plasticflaps/opaque

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -12,6 +12,11 @@
 /obj/structure/plasticflaps/opaque
 	opacity = TRUE
 
+/obj/structure/plasticflaps/Initialize()
+	. = ..()
+	alpha = 0
+	SSvis_overlays.add_vis_overlay(src, icon, icon_state, ABOVE_MOB_LAYER, plane, dir, add_appearance_flags = RESET_ALPHA) //you see mobs under it, but you hit them like they are above it
+
 /obj/structure/plasticflaps/examine(mob/user)
 	. = ..()
 	if(anchored)

--- a/code/game/objects/structures/plasticflaps.dm
+++ b/code/game/objects/structures/plasticflaps.dm
@@ -6,7 +6,7 @@
 	armor = list("melee" = 100, "bullet" = 80, "laser" = 80, "energy" = 100, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 50, "acid" = 50)
 	density = FALSE
 	anchored = TRUE
-	layer = ABOVE_MOB_LAYER
+	layer = BELOW_OBJ_LAYER
 	CanAtmosPass = ATMOS_PASS_NO
 
 /obj/structure/plasticflaps/opaque


### PR DESCRIPTION
## About The Pull Request
Ports /tg/station PR #41866, also the #42652 fix.

## Why It's Good For The Game
Just remembered that this still had to be ported. Don't merge it and #9515 at the same time since these added `layer = BELOW_OBJ_LAYER` lines will become redunant. No real merge conflict however.

## Changelog
:cl: Ghommie (original PR by nicbn and Menshin)
fix: You can click on things that are under flaps or holo barriers.
/:cl: