### PR TITLE
Little stunbaton nerf (split off from #9500)

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -1,4 +1,5 @@
 #define STUNBATON_CHARGE_LENIENCY 0.3
+#define STUNBATON_DEPLETION_RATE 0.006
 
 /obj/item/melee/baton
 	name = "stunbaton"
@@ -76,7 +77,7 @@
 	update_icon()
 
 /obj/item/melee/baton/process()
-	deductcharge(hitcost * 0.004, FALSE, FALSE)
+	deductcharge(round(hitcost * STUNBATON_DEPLETION_RATE), FALSE, FALSE)
 
 /obj/item/melee/baton/update_icon()
 	if(status)
@@ -251,3 +252,4 @@
 	. = ..()
 
 #undef STUNBATON_CHARGE_LENIENCY
+#undef STUNBATON_DEPLETION_RATE


### PR DESCRIPTION
## About The Pull Request
Kev told me to put the mild nerf in a separate PR.
Incremented the stunbaton power cell depletion rate per tick when the left on from 0.4% of its hitcost to 0.6%, ergo taking about 6 minutes to deplete one "stun charge" down from 8-9 minutes.

## Why It's Good For The Game
making their power depletion rate less of a joke (it still is, just a little more evil toward the smart people who just leave it on all time).

## Changelog
:cl:
balance: Increased stunbatons power cell depletion rate when left on by 50%.
/:cl:
