### PR TITLE
Reduces stamloss of melee weapons by 20%

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -82,7 +82,7 @@
 	log_combat(user, M, "attacked", src.name, "(INTENT: [uppertext(user.a_intent)]) (DAMTYPE: [uppertext(damtype)])")
 	add_fingerprint(user)
 
-	user.adjustStaminaLossBuffered(getweight())//CIT CHANGE - makes attacking things cause stamina loss
+	user.adjustStaminaLossBuffered(getweight()*0.8)//CIT CHANGE - makes attacking things cause stamina loss
 
 //the equivalent of the standard version of attack() but for object targets.
 /obj/item/proc/attack_obj(obj/O, mob/living/user)


### PR DESCRIPTION
## About The Pull Request

This melee buff will make it so it's not so hard to put yourself in stamcrit from attacking someone. Note, this doesn't effect the stamloss of hitting an object, just against other mobs.

## Why It's Good For The Game

It helps ashwalkers actually fight mobs, as well as reducing the feel bad of attacking people who have stamina tools, and then they use them against you.

## Changelog
:cl:
balance: rebalance melee stamloss
/:cl: