### PR TITLE
Fixing sniper rifles scope datum action oddity.

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -408,12 +408,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
 	for(var/X in actions)
 		var/datum/action/A = X
-		if(item_action_slot_check(slot, user)) //some items only give their actions buttons when in a specific slot.
+		if(item_action_slot_check(slot, user, A)) //some items only give their actions buttons when in a specific slot.
 			A.Grant(user)
 	item_flags |= IN_INVENTORY
 
 //sometimes we only want to grant the item's action if it's equipped in a specific slot.
-/obj/item/proc/item_action_slot_check(slot, mob/user)
+/obj/item/proc/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_IN_BACKPACK || slot == SLOT_LEGCUFFED) //these aren't true slots, so avoid granting actions there
 		return FALSE
 	return TRUE

--- a/code/game/objects/items/chrono_eraser.dm
+++ b/code/game/objects/items/chrono_eraser.dm
@@ -37,7 +37,7 @@
 				PA = new(src)
 				user.put_in_hands(PA)
 
-/obj/item/chrono_eraser/item_action_slot_check(slot, mob/user)
+/obj/item/chrono_eraser/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_BACK)
 		return 1
 

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -193,7 +193,7 @@
 		remove_paddles(user)
 		update_icon()
 
-/obj/item/defibrillator/item_action_slot_check(slot, mob/user)
+/obj/item/defibrillator/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == user.getBackSlot())
 		return 1
 
@@ -244,7 +244,7 @@
 	w_class = WEIGHT_CLASS_NORMAL
 	slot_flags = ITEM_SLOT_BELT
 
-/obj/item/defibrillator/compact/item_action_slot_check(slot, mob/user)
+/obj/item/defibrillator/compact/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == user.getBeltSlot())
 		return TRUE
 

--- a/code/game/objects/items/devices/traitordevices.dm
+++ b/code/game/objects/items/devices/traitordevices.dm
@@ -195,7 +195,7 @@ effective or pretty fucking useless.
 			Deactivate()
 	return
 
-/obj/item/shadowcloak/item_action_slot_check(slot, mob/user)
+/obj/item/shadowcloak/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_BELT)
 		return 1
 

--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -24,7 +24,7 @@
 /obj/item/watertank/ui_action_click(mob/user)
 	toggle_mister(user)
 
-/obj/item/watertank/item_action_slot_check(slot, mob/user)
+/obj/item/watertank/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == user.getBackSlot())
 		return 1
 
@@ -341,7 +341,7 @@
 /obj/item/reagent_containers/chemtank/ui_action_click()
 	toggle_injection()
 
-/obj/item/reagent_containers/chemtank/item_action_slot_check(slot, mob/user)
+/obj/item/reagent_containers/chemtank/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_BACK)
 		return 1
 

--- a/code/modules/antagonists/abductor/equipment/abduction_gear.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_gear.dm
@@ -55,7 +55,7 @@
 		var/datum/action/A = X
 		A.UpdateButtonIcon()
 
-/obj/item/clothing/suit/armor/abductor/vest/item_action_slot_check(slot, mob/user)
+/obj/item/clothing/suit/armor/abductor/vest/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_WEAR_SUIT) //we only give the mob the ability to activate the vest if he's actually wearing it.
 		return 1
 

--- a/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
+++ b/code/modules/antagonists/clockcult/clock_items/judicial_visor.dm
@@ -27,7 +27,7 @@
 	qdel(blaster)
 	return ..()
 
-/obj/item/clothing/glasses/judicial_visor/item_action_slot_check(slot, mob/user)
+/obj/item/clothing/glasses/judicial_visor/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot != SLOT_GLASSES)
 		return 0
 	return ..()

--- a/code/modules/clothing/glasses/_glasses.dm
+++ b/code/modules/clothing/glasses/_glasses.dm
@@ -104,7 +104,7 @@
 	resistance_flags = ACID_PROOF
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
 
-/obj/item/clothing/glasses/science/item_action_slot_check(slot)
+/obj/item/clothing/glasses/science/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_GLASSES)
 		return 1
 
@@ -307,7 +307,7 @@
 		M.appearance_flags |= RESET_COLOR
 		M.color = "#[H.eye_color]"
 		. += M
-	
+
 /obj/item/clothing/glasses/sunglasses/big
 	desc = "Strangely ancient technology used to help provide rudimentary eye cover. Larger than average enhanced shielding blocks flashes."
 	icon_state = "bigsunglasses"

--- a/code/modules/clothing/spacesuits/flightsuit.dm
+++ b/code/modules/clothing/spacesuits/flightsuit.dm
@@ -547,7 +547,7 @@
 	changeWearer()
 	..()
 
-/obj/item/flightpack/item_action_slot_check(slot)
+/obj/item/flightpack/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == ITEM_SLOT_BACK)
 		return TRUE
 
@@ -574,7 +574,7 @@
 		momentum_speed_y = 0
 	momentum_speed = max(momentum_speed_x, momentum_speed_y)
 
-/obj/item/flightpack/item_action_slot_check(slot)
+/obj/item/flightpack/item_action_slot_check(slot, mob/user, datum/action/A)
 	return slot == SLOT_BACK
 
 /obj/item/flightpack/proc/enable_stabilizers()
@@ -730,7 +730,7 @@
 		if(!active)
 			clothing_flags &= ~NOSLIP
 
-/obj/item/clothing/shoes/flightshoes/item_action_slot_check(slot)
+/obj/item/clothing/shoes/flightshoes/item_action_slot_check(slot, mob/user, datum/action/A)
 	return slot == SLOT_SHOES
 
 /obj/item/clothing/shoes/flightshoes/proc/delink_suit()

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -47,7 +47,7 @@
 		suit.RemoveHelmet()
 		soundloop.stop(user)
 
-/obj/item/clothing/head/helmet/space/hardsuit/item_action_slot_check(slot)
+/obj/item/clothing/head/helmet/space/hardsuit/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_HEAD)
 		return 1
 
@@ -158,7 +158,7 @@
 			var/datum/action/A = X
 			A.Remove(user)
 
-/obj/item/clothing/suit/space/hardsuit/item_action_slot_check(slot)
+/obj/item/clothing/suit/space/hardsuit/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_WEAR_SUIT) //we only give the mob the ability to toggle the helmet if he's wearing the hardsuit.
 		return 1
 

--- a/code/modules/clothing/suits/toggles.dm
+++ b/code/modules/clothing/suits/toggles.dm
@@ -23,7 +23,7 @@
 /obj/item/clothing/suit/hooded/ui_action_click()
 	ToggleHood()
 
-/obj/item/clothing/suit/hooded/item_action_slot_check(slot, mob/user)
+/obj/item/clothing/suit/hooded/item_action_slot_check(slot, mob/user, datum/action/A)
 	if(slot == SLOT_WEAR_SUIT || slot == SLOT_NECK)
 		return 1
 

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -205,7 +205,7 @@
 	resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	var/mob/living/carbon/human/active_owner
 
-/obj/item/clothing/neck/necklace/memento_mori/item_action_slot_check(slot)
+/obj/item/clothing/neck/necklace/memento_mori/item_action_slot_check(slot, mob/user, datum/action/A)
 	return slot == SLOT_NECK
 
 /obj/item/clothing/neck/necklace/memento_mori/dropped(mob/user)
@@ -796,21 +796,21 @@
 
 /obj/item/melee/ghost_sword/proc/ghost_check()
 	var/list/mob/dead/observer/current_spirits = list()
-	
+
 	recursive_orbit_collect(src, current_spirits)
 	recursive_orbit_collect(loc, current_spirits)		//anything holding us
-	
+
 	for(var/i in spirits - current_spirits)
 		var/mob/dead/observer/G = i
 		G.invisibility = GLOB.observer_default_invisibility
- 	
+
 	for(var/i in current_spirits)
 		var/mob/dead/observer/G = i
 		G.invisibility = 0
-	
+
 	spirits = current_spirits
 	return length(spirits)
- 
+
 /obj/item/melee/ghost_sword/attack(mob/living/target, mob/living/carbon/human/user)
 	force = 0
 	var/ghost_counter = ghost_check()

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -377,7 +377,6 @@
 		zoom(user)
 	else if(istype(action, alight))
 		toggle_gunlight()
-	return ..()
 
 /obj/item/gun/proc/toggle_gunlight()
 	if(!gun_light)
@@ -469,10 +468,6 @@
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "sniper_zoom"
 
-/datum/action/item_action/toggle_scope_zoom/Trigger()
-	var/obj/item/gun/G = target
-	G.zoom(owner)
-
 /datum/action/item_action/toggle_scope_zoom/IsAvailable()
 	. = ..()
 	if(!.)
@@ -485,16 +480,15 @@
 	return ..()
 
 /obj/item/gun/proc/zoom(mob/living/user, forced_zoom)
-	if(!user || !user.client)
+	if(!(user?.client))
 		return
 
-	switch(forced_zoom)
-		if(FALSE)
-			zoomed = FALSE
-		if(TRUE)
-			zoomed = TRUE
-		else
-			zoomed = !zoomed
+	if(!isnull(forced_zoom))
+		if(zoomed == forced_zoom)
+			return
+		zoomed = forced_zoom
+	else
+		zoomed = !zoomed
 
 	if(zoomed)
 		var/_x = 0
@@ -516,7 +510,6 @@
 		user.client.change_view(CONFIG_GET(string/default_view))
 		user.client.pixel_x = 0
 		user.client.pixel_y = 0
-	return zoomed
 
 /obj/item/gun/handle_atom_del(atom/A)
 	if(A == chambered)

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -51,8 +51,10 @@
 			else
 				to_chat(user, "<span class='warning'>You cannot seem to get \the [src] out of your hands!</span>")
 
-/obj/item/gun/ballistic/automatic/ui_action_click()
-	burst_select()
+/obj/item/gun/ballistic/automatic/ui_action_click(mob/user, action)
+	. = ..()
+	if(istype(action, /datum/action/item_action/toggle_firemode))
+		burst_select()
 
 /obj/item/gun/ballistic/automatic/proc/burst_select()
 	var/mob/living/carbon/human/user = usr

--- a/code/modules/projectiles/guns/ballistic/automatic.dm
+++ b/code/modules/projectiles/guns/ballistic/automatic.dm
@@ -52,9 +52,10 @@
 				to_chat(user, "<span class='warning'>You cannot seem to get \the [src] out of your hands!</span>")
 
 /obj/item/gun/ballistic/automatic/ui_action_click(mob/user, action)
-	. = ..()
 	if(istype(action, /datum/action/item_action/toggle_firemode))
 		burst_select()
+	else
+		return ..()
 
 /obj/item/gun/ballistic/automatic/proc/burst_select()
 	var/mob/living/carbon/human/user = usr

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -174,9 +174,6 @@
 		itemState += "[ratio]"
 		item_state = itemState
 
-/obj/item/gun/energy/ui_action_click()
-	toggle_gunlight()
-
 /obj/item/gun/energy/suicide_act(mob/living/user)
 	if (istype(user) && can_shoot() && can_trigger_gun(user) && user.get_bodypart(BODY_ZONE_HEAD))
 		user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to commit suicide!</span>")

--- a/code/modules/projectiles/guns/misc/beam_rifle.dm
+++ b/code/modules/projectiles/guns/misc/beam_rifle.dm
@@ -45,7 +45,7 @@
 	var/aiming_lastangle = 0
 	var/mob/current_user = null
 	var/list/obj/effect/projectile/tracer/current_tracers
-	
+
 	var/structure_piercing = 1
 	var/structure_bleed_coeff = 0.7
 	var/wall_pierce_amount = 0
@@ -111,7 +111,9 @@
 				to_chat(owner, "<span class='boldnotice'>You switch [src]'s zooming processor to center mode.</span>")
 			if(ZOOM_LOCK_OFF)
 				to_chat(owner, "<span class='boldnotice'>You disable [src]'s zooming system.</span>")
-	reset_zooming()
+		reset_zooming()
+	else
+		return ..()
 
 /obj/item/gun/energy/beam_rifle/proc/set_autozoom_pixel_offsets_immediate(current_angle)
 	if(zoom_lock == ZOOM_LOCK_CENTER_VIEW || zoom_lock == ZOOM_LOCK_OFF)


### PR DESCRIPTION
## About The Pull Request
Fixed those weird "sniper rifle falling out on the floor as I try to take it the bag" occurences caused, most certainly, by an unexplainable interaction between `/obj/item/gun/proc/zoom()` and the citadel widescreen preferences tied to `/client/proc/change_view()`.

Simply said, I added early returns to stop change_view() from being called whenever the zoomed boolean equalled forced_zoom already.

Also rewrote the scope action into an item_action subtype because it was quite rubbish, and removed some redunant lines.

## Why It's Good For The Game
Fixing an issue. We don't know why that happened, but it did. Was tested.

## Changelog
:cl:
fix: Gorlex Marauders are pleased to announce non-slip grooves were given to their .50 sniper rifles, and thus shouldn't accidentally flop on the floor like pocket spaghettis whenever taken out of a bag anymore.
/:cl:

