### PR TITLE
Change the SEVA suit & Exo-suit's descriptions

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -129,7 +129,7 @@
 
 /obj/item/clothing/suit/hooded/explorer/seva
 	name = "SEVA Suit"
-	desc = "A fire-proof suit for exploring hot environments."
+	desc = "A fire-proof suit for exploring hot environments. Its design and material make it easier for a Goliath to keep their grip on the wearer."
 	icon_state = "seva"
 	item_state = "seva"
 	w_class = WEIGHT_CLASS_BULKY
@@ -141,7 +141,7 @@
 
 /obj/item/clothing/head/hooded/explorer/seva
 	name = "SEVA Hood"
-	desc = "A fire-proof hood for exploring hot environments."
+	desc = "A fire-proof hood for exploring hot environments. Its design and material make it easier for a Goliath to keep their grip on the wearer."
 	icon_state = "seva"
 	item_state = "seva"
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
@@ -159,7 +159,7 @@
 
 /obj/item/clothing/suit/hooded/explorer/exo
 	name = "Exo-suit"
-	desc = "A robust suit for exploring dangerous environments."
+	desc = "A robust suit for fighting dangerous animals. Its design and material make it harder for a Goliath to keep their grip on the wearer."
 	icon_state = "exo"
 	item_state = "exo"
 	w_class = WEIGHT_CLASS_BULKY
@@ -170,7 +170,7 @@
 
 /obj/item/clothing/head/hooded/explorer/exo
 	name = "Exo-hood"
-	desc = "A robust helmet for exploring dangerous environments."
+	desc = "A robust helmet for fighting dangerous animals. Its design and material make it harder for a Goliath to keep their grip on the wearer."
 	icon_state = "exo"
 	item_state = "exo"
 	armor = list("melee" = 65, "bullet" = 5, "laser" = 5, "energy" = 5, "bomb" = 60, "bio" = 25, "rad" = 10, "fire" = 0, "acid" = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This change the SEVA suit and the Exo-suit's description to better reflect their special features.

## Why It's Good For The Game

No one use the Exo-suit because they think it is shit, while is some situation it is better than the SEVA suit.

The SEVA suit make goliaths grab you longer, while the Exo-suit does the opposite.

In the code, the goliath grab you for 75 unit of time (I will call them that because I have no idea of the mesure used)

Wearing the SEVA suit, with its flag GOLIATH_WEAKNESS, change that 75 to 115.
Meanwhile
Wearing the Exo-suit, with the flag GOLIATH_RESISTANCE, change the 75 to 25.

Also the Exo-suit has 65 melee protection and 60 bomb while the SEVA suit has 15 melee and 25 bomb.

## Changelog
:cl:
tweak: Change the SEVA suit & Exo-suit's descriptions
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
