### PR TITLE
Magnetic Pistols Fit In Boots

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -56,7 +56,7 @@
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin
+		/obj/item/firing_pin, /obj/item/gun/ballistic/automatic/pistol/mag
 		))
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()


### PR DESCRIPTION
## About The Pull Request
The shoe pockets component can now hold the magpistol.
## Why It's Good For The Game
Literally nobody uses the magpistol, so here's a stupid idea for it being usable.
## Changelog
:cl:
add: Magnetic pistols now fit in boot pockets - jackboots, workboots, etc.
/:cl: