### PR TITLE
Brings the combat back in combat defibrillator (DOES NOT BUFF CMO DO NOT YELL AT ME)

### DIFF
--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -27,6 +27,8 @@
 	var/pullshocksafely = FALSE //Dose the unit have the healdisk upgrade?
 	var/primetime = 0 // is the defib faster
 	var/timedeath = 10
+	var/disarm_shock_time = 10
+	var/always_emagged = FALSE
 
 /obj/item/defibrillator/get_cell()
 	return cell
@@ -141,6 +143,7 @@
 
 /obj/item/defibrillator/emag_act(mob/user)
 	. = ..()
+	always_emagged = TRUE
 	safety = !safety
 	to_chat(user, "<span class='warning'>You silently [safety ? "enable" : "disable"] [src]'s safety protocols with the cryptographic sequencer.</span>")
 	return TRUE
@@ -155,7 +158,7 @@
 		safety = FALSE
 		visible_message("<span class='notice'>[src] beeps: Safety protocols disabled!</span>")
 		playsound(src, 'sound/machines/defib_saftyOff.ogg', 50, 0)
-	else
+	else if(!always_emagged)
 		safety = TRUE
 		visible_message("<span class='notice'>[src] beeps: Safety protocols enabled!</span>")
 		playsound(src, 'sound/machines/defib_saftyOn.ogg', 50, 0)
@@ -259,6 +262,8 @@
 	desc = "A belt-equipped blood-red defibrillator that can be rapidly deployed. Does not have the restrictions or safeties of conventional defibrillators and can revive through space suits."
 	combat = TRUE
 	safety = FALSE
+	always_emagged = TRUE
+	disarm_shock_time = 0
 
 /obj/item/defibrillator/compact/combat/loaded/Initialize()
 	. = ..()
@@ -473,7 +478,7 @@
 	M.visible_message("<span class='danger'>[user] hastily places [src] on [M]'s chest!</span>", \
 			"<span class='userdanger'>[user] hastily places [src] on [M]'s chest!</span>")
 	busy = TRUE
-	if(do_after(user, 10, target = M))
+	if(do_after(user, disarm_shock_time, target = M))
 		M.visible_message("<span class='danger'>[user] zaps [M] with [src]!</span>", \
 				"<span class='userdanger'>[user] zaps [M] with [src]!</span>")
 		M.adjustStaminaLoss(50)

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -301,6 +301,7 @@
 	var/combat = FALSE //If it penetrates armor and gives additional functionality
 	var/grab_ghost = FALSE
 	var/tlimit = DEFIB_TIME_LIMIT * 10
+	var/disarm_shock_time = 10
 
 	var/datum/component/mobhook
 
@@ -478,7 +479,7 @@
 	M.visible_message("<span class='danger'>[user] hastily places [src] on [M]'s chest!</span>", \
 			"<span class='userdanger'>[user] hastily places [src] on [M]'s chest!</span>")
 	busy = TRUE
-	if(do_after(user, disarm_shock_time, target = M))
+	if(do_after(user, isnull(defib?.disarm_shock_time)? disarm_shock_time : defib.disarm_shock_time, target = M))
 		M.visible_message("<span class='danger'>[user] zaps [M] with [src]!</span>", \
 				"<span class='userdanger'>[user] zaps [M] with [src]!</span>")
 		M.adjustStaminaLoss(50)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Combat defibs now instant stun on disarm
Emagging a defib permanently makes it safety-disabled.

## Why It's Good For The Game

ERT medics stunning with this + MOST OF ALL NUKEOPS STUNNING WITH THIS WAS LIT AND INTERESTING GAMEPLAY 
tl;dr it's fun.
Also being emp'd sucks when you put in the effort to emag something/get a combat version.

## Changelog
:cl:
balance: Combat defibs now instant stun on disarm rather than 1 second again
balance: Defibs are now always emagged when emagged with an emag rather than EMP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
