### PR TITLE
Disables halloween meteor override

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -32,8 +32,10 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
+	/* Disabled until someone balances this. It's too powerful.
 	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
 		wave_name = "halloween"
+	*/
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

So who thought making every meteor wave catastrophic was a good idea?

## Why It's Good For The Game

/obj/effect/meteor/pumpkin is too OP. No one likes every wave being a catastrohpic wave for "festivity".

## Changelog
:cl:
balance: Disabled halloween meteor waves.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
