### PR TITLE
Ports "UTTERLY CATASTROPHIC pumpkin meteors will now only happen when it's catastrophic meteor wave, instead of 100% ending the round every time any kind of dust appears"

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -32,8 +32,6 @@
 		determine_wave_type()
 
 /datum/round_event/meteor_wave/proc/determine_wave_type()
-	if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
-		wave_name = "halloween"
 	if(!wave_name)
 		wave_name = pickweight(list(
 			"normal" = 50,
@@ -45,7 +43,10 @@
 		if("threatening")
 			wave_type = GLOB.meteors_threatening
 		if("catastrophic")
-			wave_type = GLOB.meteors_catastrophic
+			if(SSevents.holidays && SSevents.holidays[HALLOWEEN])
+				wave_type = GLOB.meteorsSPOOKY
+			else
+				wave_type = GLOB.meteors_catastrophic
 		if("meaty")
 			wave_type = GLOB.meteorsB
 		if("space dust")


### PR DESCRIPTION
## About The Pull Request
Ports tgstation PR  #41203. :jack_o_lantern: :ok_hand: 

## Why It's Good For The Game
One year later... close #9543. 

## Changelog
:cl: Ghommie (original PR by Barhandar
fix: Pumpkin meteors on Halloween now replace catastrophic meteor waves, instead of ALL OF THEM.
/:cl: