### PR TITLE
Tiny airlock paper note examine fix.

### DIFF
--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -72,7 +72,7 @@
 	if(isAI(target))
 		var/mob/living/silicon/ai/ai = target
 		return get_dist(src, ai.current) < 2
-	if(iscyborg(target))
+	if(iscyborg(target) || istype(loc, /obj/machinery/door/airlock))
 		return get_dist(src, target) < 2
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request
Little workaround fix for people being unable to examine paper notes on airlocks. Perhaps a more fleshed out method to prevent this kind of adjacency/distance issues will be made in the future by someone else.

## Why It's Good For The Game
Fixing an issue.

## Changelog
:cl:
fix: You can now read airlock paper notes again.
/:cl: