### PR TITLE
Fixes silicons being unable to use the teleporter and records consoles from a distance

### DIFF
--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -575,7 +575,7 @@
 	if(user)
 		if(message)
 			if(authenticated)
-				if(user.canUseTopic(src, BE_CLOSE))
+				if(user.canUseTopic(src, !issilicon(user)))
 					if(!record1 || record1 == active1)
 						if(!record2 || record2 == active2)
 							return 1

--- a/code/game/machinery/computer/security.dm
+++ b/code/game/machinery/computer/security.dm
@@ -801,7 +801,7 @@ What a mess.*/
 /obj/machinery/computer/secure_data/proc/canUseSecurityRecordsConsole(mob/user, message1 = 0, record1, record2)
 	if(user)
 		if(authenticated)
-			if(user.canUseTopic(src, BE_CLOSE))
+			if(user.canUseTopic(src, !issilicon(user)))
 				if(!trim(message1))
 					return 0
 				if(!record1 || record1 == active1)

--- a/code/game/machinery/computer/teleporter.dm
+++ b/code/game/machinery/computer/teleporter.dm
@@ -139,7 +139,7 @@
 					L[avoid_assoc_duplicate_keys(M.real_name, areaindex)] = M
 
 		var/desc = input("Please select a location to lock in.", "Locking Computer") as null|anything in L
-		if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY)) //check if we are still around
+		if(!user.canUseTopic(src, !issilicon(user), NO_DEXTERY)) //check if we are still around
 			return
 		target = L[desc]
 		if(imp_t)
@@ -167,7 +167,7 @@
 			to_chat(user, "<span class='alert'>No active connected stations located.</span>")
 			return
 		var/desc = input("Please select a station to lock in.", "Locking Computer") as null|anything in L
-		if(!user.canUseTopic(src, BE_CLOSE, NO_DEXTERY)) //again, check if we are still around
+		if(!user.canUseTopic(src, !issilicon(user), NO_DEXTERY)) //again, check if we are still around
 			return
 		var/obj/machinery/teleport/station/target_station = L[desc]
 		if(!target_station || !target_station.teleporter_hub)


### PR DESCRIPTION
## About The Pull Request
exactly what's said on the tin

## Why It's Good For The Game
fixes

## Changelog
:cl:
fix: Silicons can now operate teleporter, medical and security records console from a distance again.
/:cl: