### PR TITLE
Fixing radio emotes conflict with drunk memes.

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -23,6 +23,8 @@
 #define MODE_WHISPER "whisper"
 #define MODE_WHISPER_CRIT "whispercrit"
 
+#define MODE_CUSTOM_SAY "custom_say"
+
 #define MODE_DEPARTMENT "department"
 #define MODE_KEY_DEPARTMENT "h"
 #define MODE_TOKEN_DEPARTMENT ":h"

--- a/code/modules/mob/living/carbon/human/say.dm
+++ b/code/modules/mob/living/carbon/human/say.dm
@@ -1,14 +1,14 @@
 /mob/living/carbon/human/say_mod(input, message_mode)
 	verb_say = dna.species.say_mod
-	switch(slurring)
-		if(10 to 25)
-			return "jumbles"
-		if(25 to 50)
-			return "slurs"
-		if(50 to INFINITY)
-			return "garbles"
-		else
-			. = ..()
+	. = ..()
+	if(message_mode != MODE_CUSTOM_SAY && message_mode != MODE_WHISPER_CRIT)
+		switch(slurring)
+			if(10 to 25)
+				return "jumbles"
+			if(25 to 50)
+				return "slurs"
+			if(50 to INFINITY)
+				return "garbles"
 
 /mob/living/carbon/human/GetVoice()
 	if(istype(wear_mask, /obj/item/clothing/mask/chameleon))

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -391,16 +391,16 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 	return 0
 
 /mob/living/say_mod(input, message_mode)
-	if(message_mode == MODE_WHISPER)
-		. = verb_whisper
-	else if(message_mode == MODE_WHISPER_CRIT)
+	. = ..()
+	if(message_mode == MODE_WHISPER_CRIT)
 		. = "[verb_whisper] in [p_their()] last breath"
-	else if(stuttering)
-		. = "stammers"
-	else if(derpspeech)
-		. = "gibbers"
-	else
-		. = ..()
+	else if(message_mode != MODE_CUSTOM_SAY)
+		if(message_mode == MODE_WHISPER)
+			. = verb_whisper
+		else if(stuttering)
+			. = "stammers"
+		else if(derpspeech)
+			. = "gibbers"
 
 /mob/living/whisper(message, bubble_type, list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	say("#[message]", bubble_type, spans, sanitize, language, ignore_spam, forced)

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -88,7 +88,7 @@
 			if(newletter==" ")
 				newletter="...huuuhhh..."
 			if(newletter==".")
-				newletter=" *BURP*."
+				newletter=" BURP!"
 		if(rand(1,100) <= strength*0.5)
 			if(rand(1,5) == 1)
 				newletter+="'"

--- a/modular_citadel/code/modules/mob/mob.dm
+++ b/modular_citadel/code/modules/mob/mob.dm
@@ -3,9 +3,11 @@
 
 /mob/say_mod(input, message_mode)
 	var/customsayverb = findtext(input, "*")
-	if(customsayverb)
+	if(customsayverb && message_mode != MODE_WHISPER_CRIT)
+		message_mode = MODE_CUSTOM_SAY
 		return lowertext(copytext(input, 1, customsayverb))
-	. = ..()
+	else
+		return ..()
 
 /atom/movable/proc/attach_spans(input, list/spans)
 	var/customsayverb = findtext(input, "*")


### PR DESCRIPTION
## About The Pull Request
Fixing an issue as old as the custom say spans emotes feature itself, #7423.
Stopping drunk say mods from overriding custom ones and removing those couple asterisks from `slur()`'s *BURP*.

## Why It's Good For The Game
I would love to remove the feature altogheter due to more complicate issue #9232. Because speech hook modifiers are performed long before this step and how needlessly intricate the code is already.

## Changelog
:cl:
fix: Fixed custom say emotes conflict with drunk memes.
/:cl: