### PR TITLE
Fixes identity transfer not copying digi legs.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -42,8 +42,8 @@
 	destination.dna.unique_enzymes = unique_enzymes
 	destination.dna.uni_identity = uni_identity
 	destination.dna.blood_type = blood_type
-	destination.set_species(species.type, icon_update=0)
 	destination.dna.features = features.Copy()
+	destination.set_species(species.type, icon_update=0)
 	destination.dna.real_name = real_name
 	destination.dna.nameless = nameless
 	destination.dna.custom_species = custom_species


### PR DESCRIPTION
## About The Pull Request
This PR will close #9345. The furry species stuff rework bound digitigrade legs into dna features then checked by `on_species_gain()`, and since `transfer_identity()` only copies dna features after the species is set, you can guess why it broke.

## Why It's Good For The Game
Fixing issues.

## Changelog
:cl:
fix: Fixes identity transfer (envy knife, changeling transformation, making a vr avatar) not copying digitigrade legs.
/:cl:
