### PR TITLE
Fixes recycler deleting all clothing for mobs found inside items (e.g bluespace bodybags)

### DIFF
--- a/code/game/machinery/recycler.dm
+++ b/code/game/machinery/recycler.dm
@@ -99,7 +99,7 @@
 /obj/machinery/recycler/proc/eat(atom/AM0, sound=TRUE)
 	var/list/to_eat
 	if(isitem(AM0))
-		to_eat = AM0.GetAllContents()
+		to_eat = AM0.GetAllContentsIgnoring(GLOB.typecache_mob)
 	else
 		to_eat = list(AM0)
 


### PR DESCRIPTION
## About The Pull Request
This will close issue #9240.

## Why It's Good For The Game
Fixing an issue.

## Changelog
:cl:
fix: Fixed mobs folded inside bluespace bodybags getting their clothing and items deleted when passing through a recycler.
/:cl:
