### PR TITLE
Removes tracking beacons on Synda/CC mechs

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -285,7 +285,6 @@
 	cell = new /obj/item/stock_parts/cell/hyper(src)
 
 /obj/mecha/combat/honker/dark/loaded/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/honker()
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/banana_mortar/bombanana()//Needed more offensive weapons.

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -3,3 +3,7 @@
 	internal_damage_threshold = 50
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 15, "energy" = 20, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
+
+/obj/mecha/combat/Initialize()
+	. = ..()
+	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -19,7 +19,3 @@
 /obj/mecha/combat/durand/RemoveActions(mob/living/user, human_occupant = 0)
 	..()
 	defense_action.Remove(user)
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -40,6 +40,7 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	ME.attach(src)
+	trackers -= /obj/item/mecha_parts/mecha_tracking(src)
 
 /obj/mecha/combat/gygax/dark/add_cell(obj/item/stock_parts/cell/C=null)
 	if(C)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -40,7 +40,6 @@
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/tesla_energy_relay
 	ME.attach(src)
-	trackers -= /obj/item/mecha_parts/mecha_tracking(src)
 
 /obj/mecha/combat/gygax/dark/add_cell(obj/item/stock_parts/cell/C=null)
 	if(C)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -31,7 +31,6 @@
 	max_equip = 4
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/carbine
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/launcher/flashbang

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -109,7 +109,6 @@
 	output += ..()
 	return output
 
-
 /obj/mecha/combat/honker/get_equipment_list()
 	if(!equipment.len)
 		return
@@ -118,8 +117,6 @@
 		output += "<div id='[REF(MT)]'>[MT.get_equip_info()]</div>"
 	output += "</div>"
 	return output
-
-
 
 /obj/mecha/combat/honker/mechstep(direction)
 	var/result = step(src,direction)
@@ -153,7 +150,3 @@
 	for (var/i=0;i<6;i++)
 		color = color+pick(colors)
 	return color
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -30,7 +30,6 @@
 	zoom_action.Remove(user)
 
 /obj/mecha/combat/marauder/loaded/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/energy/pulse(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/missile_rack(src)
@@ -53,7 +52,6 @@
 	max_equip = 5
 
 /obj/mecha/combat/marauder/seraph/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)
 	ME.attach(src)
@@ -75,7 +73,6 @@
 	max_equip = 5
 
 /obj/mecha/combat/marauder/mauler/loaded/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/lmg(src)
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/scattershot(src)

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -27,7 +27,3 @@
 	..()
 	switch_damtype_action.Remove(user)
 	phasing_action.Remove(user)
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -20,7 +20,6 @@
 	opacity = 0
 
 /obj/mecha/combat/reticence/loaded/Initialize()
-	. = ..()
 	var/obj/item/mecha_parts/mecha_equipment/ME = new /obj/item/mecha_parts/mecha_equipment/weapon/ballistic/silenced
 	ME.attach(src)
 	ME = new /obj/item/mecha_parts/mecha_equipment/rcd //HAHA IT MAKES WALLS GET IT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Removes the tracking/emp beacon from all synda/CC combat mechs

## Why It's Good For The Game

Stealth ops and such with mech (Dont laugh) become viable again and stops EMPing the baddies well they are in their base setting up

closes #9553 

## Changelog
:cl:
fix: beacon on CC and Synda mechs
/:cl: