### PR TITLE
Fix not being able to read paper stuck to airlocks, lets AI view paper but with obfuscated text

### DIFF
--- a/code/modules/oracle_ui/hookup_procs.dm
+++ b/code/modules/oracle_ui/hookup_procs.dm
@@ -23,6 +23,8 @@
 		return TRUE
 	if(user.incapacitated())
 		return FALSE
+	if(isobj(src.loc) && get_dist(src, user) < 2)
+		return TRUE
 	if(isturf(src.loc) && Adjacent(user))
 		return TRUE
 	return FALSE

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -59,7 +59,7 @@
 	updateinfolinks()
 
 /obj/item/paper/oui_getcontent(mob/target)
-	if(!target.is_literate())
+	if(!target.is_literate() || isAI(target))
 		return "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)]<HR>[stamps]</BODY></HTML>"
 	else if(istype(target.get_active_held_item(), /obj/item/pen) | istype(target.get_active_held_item(), /obj/item/toy/crayon))
 		return "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info_links]<HR>[stamps]</BODY><div align='right'style='position:fixed;bottom:0;font-style:bold;'><A href='?src=[REF(src)];help=1'>\[?\]</A></div></HTML>"
@@ -70,8 +70,7 @@
 	if(check_rights_for(target.client, R_FUN)) //Allows admins to view faxes
 		return TRUE
 	if(isAI(target))
-		var/mob/living/silicon/ai/ai = target
-		return get_dist(src, ai.current) < 2
+		return TRUE
 	if(iscyborg(target))
 		return get_dist(src, target) < 2
 	return ..()
@@ -133,18 +132,8 @@
 			playsound(loc, 'sound/items/bikehorn.ogg', 50, 1)
 			addtimer(CALLBACK(src, .proc/reset_spamflag), 20)
 
-
 /obj/item/paper/attack_ai(mob/living/silicon/ai/user)
-	var/dist
-	if(istype(user) && user.current) //is AI
-		dist = get_dist(src, user.current)
-	else //cyborg or AI not seeing through a camera
-		dist = get_dist(src, user)
-	if(dist < 2)
-		show_content(user)
-	else
-		to_chat(user, "<span class='notice'>You can't quite see it.</span>")
-
+	show_content(user)
 
 /obj/item/paper/proc/addtofield(id, text, links = 0)
 	var/locid = 0

--- a/code/modules/paperwork/paper.dm
+++ b/code/modules/paperwork/paper.dm
@@ -32,6 +32,7 @@
 	var/contact_poison // Reagent ID to transfer on contact
 	var/contact_poison_volume = 0
 	var/datum/oracle_ui/ui = null
+	var/force_stars = FALSE // If we should force the text to get obfuscated with asterisks
 
 
 /obj/item/paper/pickup(user)
@@ -59,7 +60,8 @@
 	updateinfolinks()
 
 /obj/item/paper/oui_getcontent(mob/target)
-	if(!target.is_literate() || isAI(target))
+	if(!target.is_literate() || force_stars)
+		force_stars = FALSE
 		return "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[stars(info)]<HR>[stamps]</BODY></HTML>"
 	else if(istype(target.get_active_held_item(), /obj/item/pen) | istype(target.get_active_held_item(), /obj/item/toy/crayon))
 		return "<HTML><HEAD><TITLE>[name]</TITLE></HEAD><BODY>[info_links]<HR>[stamps]</BODY><div align='right'style='position:fixed;bottom:0;font-style:bold;'><A href='?src=[REF(src)];help=1'>\[?\]</A></div></HTML>"
@@ -70,6 +72,7 @@
 	if(check_rights_for(target.client, R_FUN)) //Allows admins to view faxes
 		return TRUE
 	if(isAI(target))
+		force_stars = TRUE
 		return TRUE
 	if(iscyborg(target))
 		return get_dist(src, target) < 2


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Title. Alternative to https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9546 that isn't just a bandaid fix and fixes the underlying issue. The AI can just see paper with the stars text, I couldn't get it to check if the paper was close to a camera to be able to read it fully.

## Changelog
:cl:
fix: unable to read paper on airlocks
tweak: ai can see paper (still just shows stars)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
