### PR TITLE
Fixing some ayy overlays and client images oddities.

### DIFF
--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -45,8 +45,8 @@
 	RemoveInfectionImages()
 	AddInfectionImages()
 
-/obj/item/organ/body_egg/proc/AddInfectionImages()
+/obj/item/organ/body_egg/proc/AddInfectionImages(mob/living/carbon/C)
 	return
 
-/obj/item/organ/body_egg/proc/RemoveInfectionImages()
+/obj/item/organ/body_egg/proc/RemoveInfectionImages(mob/living/carbon/C)
 	return

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -111,7 +111,7 @@
 	else //When it is removed via surgery at a late stage, rather than forced.
 		new_xeno.visible_message("<span class='danger'>[new_xeno] wriggles out of [owner]!</span>", "<span class='userdanger'>You exit [owner], your previous host.</span>")
 		owner.adjustBruteLoss(40)
-		owner.cut_overlay(overlay)
+	owner.cut_overlay(overlay)
 	qdel(src)
 
 
@@ -119,19 +119,19 @@
 Proc: AddInfectionImages(C)
 Des: Adds the infection image to all aliens for this embryo
 ----------------------------------------*/
-/obj/item/organ/body_egg/alien_embryo/AddInfectionImages()
+/obj/item/organ/body_egg/alien_embryo/AddInfectionImages(mob/living/carbon/C)
 	for(var/mob/living/carbon/alien/alien in GLOB.player_list)
 		if(alien.client)
-			var/I = image('icons/mob/alien.dmi', loc = owner, icon_state = "infected[stage]")
+			var/I = image('icons/mob/alien.dmi', loc = C, icon_state = "infected[stage]")
 			alien.client.images += I
 
 /*----------------------------------------
 Proc: RemoveInfectionImage(C)
 Des: Removes all images from the mob infected by this embryo
 ----------------------------------------*/
-/obj/item/organ/body_egg/alien_embryo/RemoveInfectionImages()
+/obj/item/organ/body_egg/alien_embryo/RemoveInfectionImages(mob/living/carbon/C)
 	for(var/mob/living/carbon/alien/alien in GLOB.player_list)
 		if(alien.client)
 			for(var/image/I in alien.client.images)
-				if(dd_hasprefix_case(I.icon_state, "infected") && I.loc == owner)
+				if(dd_hasprefix_case(I.icon_state, "infected") && I.loc == C)
 					qdel(I)


### PR DESCRIPTION
## About The Pull Request
The alien-bursting-from-your-thorax and the xeno "hud" embryo stage images will now properly delete them once it's over.
(I'm not sure about the latter, but since `RemoveInfectionImages()` is asynced from the main `Remove()` proc, I can assume it failed as soon as owner went null and the client images just stuck around)

## Why It's Good For The Game
Fixing some issues.

## Changelog
:cl:
fix: The alien-bursting-from-your-thorax and the xeno "hud" embryo stage images will now properly delete them once the embryo egg lifecycle is complete.
/:cl:
