### PR TITLE
Nerfing move speed buffs and correcting reagent descriptions

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1378,14 +1378,14 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 	if(gravity && !flight)	//Check for chemicals and innate speedups and slowdowns if we're on the ground
 		if(HAS_TRAIT(H, TRAIT_GOTTAGOFAST))
-			. -= 1
+			. -= 0.5
 		if(HAS_TRAIT(H, TRAIT_GOTTAGOREALLYFAST))
-			. -= 2
+			. -= 1
 		. += speedmod
 		. += H.physiology.speed_mod
 
 	if (H.m_intent == MOVE_INTENT_WALK && HAS_TRAIT(H, TRAIT_SPEEDY_STEP))
-		. -= 1.5
+		. -= 0.75
 
 	if(HAS_TRAIT(H, TRAIT_IGNORESLOWDOWN))
 		ignoreslow = 1

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1385,7 +1385,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		. += H.physiology.speed_mod
 
 	if (H.m_intent == MOVE_INTENT_WALK && HAS_TRAIT(H, TRAIT_SPEEDY_STEP))
-		. -= 0.75
+		. -= 1.5
 
 	if(HAS_TRAIT(H, TRAIT_IGNORESLOWDOWN))
 		ignoreslow = 1

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -162,7 +162,7 @@
 /datum/reagent/drug/methamphetamine
 	name = "Methamphetamine"
 	id = "methamphetamine"
-	description = "Reduces stun times by about 300%, speeds the user up, and allows the user to quickly recover stamina while dealing a small amount of Brain damage. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage."
+	description = "Reduces stun times by about 300%, and allows the user to quickly recover stamina while dealing a small amount of Brain damage. If overdosed the subject will move randomly, laugh randomly, drop items and suffer from Toxin and Brain damage. If addicted the subject will constantly jitter and drool, before becoming dizzy and losing motor control and eventually suffer heavy toxin damage."
 	reagent_state = LIQUID
 	color = "#FAFAFA"
 	overdose_threshold = 20

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -629,7 +629,7 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 /datum/reagent/medicine/ephedrine
 	name = "Ephedrine"
 	id = "ephedrine"
-	description = "Increases stun resistance and movement speed. Overdose deals toxin damage and inhibits breathing."
+	description = "Increases stun resistance. Overdose deals toxin damage and inhibits breathing."
 	reagent_state = LIQUID
 	color = "#D2FFFA"
 	metabolization_rate = 0.5 * REAGENTS_METABOLISM


### PR DESCRIPTION
## About The Pull Request
Reduces the move speed bonus provided by GOTTAGOFAST, GOTTAGOREALLYFAST, and SPEEDY_STEP to half of their original values.

Also corrects the descriptions of Meth and Ephedrine to reflect that they had GOTTAGOFAST removed from them in the past and no longer provide move speed bonuses.

## Why It's Good For The Game
With the remove of tazers' hardstun, adrenals are now more dominant and even less fun to deal with.
Kevinz has expressed his distaste for adrenals and all GOTTAGOFAST effects several times on Discord and gave the go ahead to nerf the speed buff from "20 tiles per second to around 13 per second at best, if people really want the move speed to stay"

Additionally, the correction of Meth and Ephedrine's descriptions will reduce confusion for new or inexperienced players who, reasonably, expect item descriptions to be accurate. Fermi also informed me that our wiki pulls item descriptions for its own use, meaning the wiki will also now be displaying more accurate information.

## Changelog
:cl:
balance: Reduces GOTTAGOFAST from a bonus of 1 to 0.5
Reduces GOTTAGOREALLYFAST from a bonus of 2 to 1
Reduces SPEEDY_STEP from a bonus of 1.5 to 0.75

fix: Fixes the descriptions of Methamphetamine and Ephedrine to reflect that they previously lost their move speed buffs altogether.
/:cl: