### PR TITLE
Fixes and nerfs VTEC upgrades

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -680,7 +680,7 @@
 	action_icon_state = "Chevron_State_0"
 
 	var/currentState = 0
-	var/maxReduction = 2
+	var/maxReduction = 1
 
 
 /obj/effect/proc_holder/silicon/cyborg/vtecControl/Click(mob/living/silicon/robot/user)
@@ -688,14 +688,14 @@
 
 	currentState = (currentState + 1) % 3
 
-	if(usr)
+	if(istype(self))
 		switch(currentState)
 			if (0)
-				self.speed = maxReduction
+				self.speed = initial(self.speed)
 			if (1)
-				self.speed -= maxReduction*0.5
+				self.speed = initial(self.speed) - maxReduction * 0.5
 			if (2)
-				self.speed -= maxReduction*1.25
+				self.speed = initial(self.speed) - maxReduction * 1
 
 	action.button_icon_state = "Chevron_State_[currentState]"
 	action.UpdateButtonIcon()

--- a/modular_citadel/code/modules/mob/living/silicon/robot/robot_movement.dm
+++ b/modular_citadel/code/modules/mob/living/silicon/robot/robot_movement.dm
@@ -11,6 +11,7 @@
 	. = ..()
 	if(!resting && !sprinting)
 		. += 1
+	. += speed
 
 /mob/living/silicon/robot/proc/togglesprint(shutdown = FALSE) //Basically a copypaste of the proc from /mob/living/carbon/human
 	if(!shutdown && (!cell || cell.charge < 25))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

VTECs actually work but can only make you normal sprint speed, and to sprint faster you need to use charge

## Why It's Good For The Game

20 tiles per second combat is cancer, and having it for free is worse.

## Changelog
:cl:
balance: Nerfed VTEC modules.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
