### PR TITLE
Fixes neurotoxin stunning non-carbons

### DIFF
--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -8,7 +8,7 @@
 	if(isalien(target))
 		knockdown = 0
 		nodamage = TRUE
-	else if(isliving(target))
+	else if(iscarbon(target))
 		var/mob/living/L = target
 		L.Knockdown(100, TRUE, FALSE, 30, 25)
 	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Neurotoxins no longer stun non carbon lifeforms, including silicons

## Why It's Good For The Game

Unintentional change by me when I buffed it.

## Changelog
:cl:
fix: Neurotoxin no longer stuns non-carbons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
