### PR TITLE
[Fix]Make Cells not a viable replacement for the Stock Part Cheese

### DIFF
--- a/code/modules/power/cell.dm
+++ b/code/modules/power/cell.dm
@@ -20,6 +20,7 @@
 	var/self_recharge = 0 //does it self recharge, over time, or not?
 	var/ratingdesc = TRUE
 	var/grown_battery = FALSE // If it's a grown that acts as a battery, add a wire overlay to it.
+	rad_flags = RAD_NO_CONTAMINATE // Prevent the same cheese as with the stock parts
 
 /obj/item/stock_parts/cell/get_cell()
 	return src


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Poojawa took the time to put the stock parts unable to be irradiated, but forgot to do it for the batteries too.

## Why It's Good For The Game

Make cheesing the SM more costly.

## Changelog
:cl:
fix: Batteries are now Rad-Proof like the other stock parts
/:cl: