### PR TITLE
[Balance Pass] - Supermatter Mega Delam (Tesla)

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -29,7 +29,7 @@
 #define MOLE_HEAT_PENALTY 350                 //Heat damage scales around this. Too hot setups with this amount of moles do regular damage, anything above and below is scaled
 #define POWER_PENALTY_THRESHOLD 5000          //Higher == Engine can generate more power before triggering the high power penalties.
 #define SEVERE_POWER_PENALTY_THRESHOLD 7000   //Same as above, but causes more dangerous effects
-#define CRITICAL_POWER_PENALTY_THRESHOLD 9000 //Even more dangerous effects, threshold for tesla delamination
+#define CRITICAL_POWER_PENALTY_THRESHOLD 12000 //Even more dangerous effects, threshold for tesla delamination
 #define HEAT_PENALTY_THRESHOLD 40             //Higher == Crystal safe operational temperature is higher.
 #define DAMAGE_HARDCAP 0.002
 #define DAMAGE_INCREASE_MULTIPLIER 0.25


### PR DESCRIPTION
All I'm doing here is raising the power_penalty_thresholds to a higher number so that it takes more time and effort to force the mega delamination.

Also by leaving a wider gap between Severe and Critical stages, it gives more warning to AI and Engineers that Tesla delamination is happening soon.

As some of us know by now, it's /very/ easy to force Tesla delams and that uhh... it's aids to deal with due to all the effects happening so quickly as it powers through all the stages from just 3 simple switches.

It takes effort and time for Singulo delam to start happening due to the high amount of moles needed on. that. tile. 

Does not take much for Tesla. Fixing that now.