### PR TITLE
Removes Shufflenames from the game.

### DIFF
--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -37,40 +37,6 @@
 
 //---//
 
-/datum/round_event_control/wizard/shufflenames //Face/off joke
-	name = "Change Faces!"
-	weight = 4
-	typepath = /datum/round_event/wizard/shufflenames
-	max_occurrences = 5
-	earliest_start = 0 MINUTES
-
-/datum/round_event/wizard/shufflenames/start()
-	var/list/mobnames = list()
-	var/list/mobs	 = list()
-
-	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		mobnames += H.real_name
-		mobs += H
-
-	if(!mobs)
-		return
-
-	shuffle_inplace(mobnames)
-	shuffle_inplace(mobs)
-
-	for(var/mob/living/carbon/human/H in mobs)
-		if(!mobnames)
-			break
-		H.real_name = mobnames[mobnames.len]
-		mobnames.len -= 1
-
-	for(var/mob/living/carbon/human/H in GLOB.alive_mob_list)
-		var/datum/effect_system/smoke_spread/smoke = new
-		smoke.set_up(0, H.loc)
-		smoke.start()
-
-//---//
-
 /datum/round_event_control/wizard/shuffleminds //Basically Mass Ranged Mindswap
 	name = "Change Minds!"
 	weight = 1


### PR DESCRIPTION

## About The Pull Request

Removes shufflenames from the game entirely.

## Why It's Good For The Game

I don't believe it belongs in the game. It disrupts ERP and leads to a lot of suicides and cryos. It's clearly not fun for anyone.

## Changelog
:cl:
del: Removed the wizard shufflenames event from the game.
/:cl:
