### PR TITLE
Adds posibrains to the spawners menu for ghosts.

### DIFF
--- a/_maps/RandomRuins/SpaceRuins/augmentationfacility.dmm
+++ b/_maps/RandomRuins/SpaceRuins/augmentationfacility.dmm
@@ -90,6 +90,9 @@
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
 /obj/item/organ/cyberimp/chest/reviver,
+/obj/item/stack/sheet/mineral/gold{
+	amount = 3
+	},
 /turf/open/floor/plasteel,
 /area/ruin/powered)
 "s" = (
@@ -145,9 +148,6 @@
 "A" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/item/mmi/posibrain{
-	pixel_y = 9
-	},
 /obj/item/mmi,
 /turf/open/floor/plasteel,
 /area/ruin/powered)

--- a/code/modules/mob/dead/new_player/new_player.dm
+++ b/code/modules/mob/dead/new_player/new_player.dm
@@ -151,7 +151,7 @@
 			message_admins(msg)
 			to_chat(usr, "<span class='danger'>The round is either not ready, or has already finished...</span>")
 			return
-			
+
 		if(!GLOB.enter_allowed)
 			to_chat(usr, "<span class='notice'>There is an administrative lock on entering the game!</span>")
 			return

--- a/code/modules/mob/living/brain/posibrain.dm
+++ b/code/modules/mob/living/brain/posibrain.dm
@@ -92,6 +92,17 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	if(posi_ask == "No" || QDELETED(src))
 		return
 	transfer_personality(user)
+	latejoin_remove()
+
+/obj/item/mmi/posibrain/Destroy()
+	latejoin_remove()
+	return ..()
+
+/obj/item/mmi/posibrain/proc/latejoin_remove()
+	GLOB.poi_list -= src
+	LAZYREMOVE(GLOB.mob_spawners[name], src)
+	if(!LAZYLEN(GLOB.mob_spawners[name]))
+		GLOB.mob_spawners -= name
 
 /obj/item/mmi/posibrain/transfer_identity(mob/living/carbon/C)
 	name = "[initial(name)] ([C])"
@@ -163,6 +174,8 @@ GLOBAL_VAR(posibrain_notify_cooldown)
 	brainmob.container = src
 	if(autoping)
 		ping_ghosts("created", TRUE)
+	GLOB.poi_list |= src
+	LAZYADD(GLOB.mob_spawners[name], src)
 
 /obj/item/mmi/posibrain/attackby(obj/item/O, mob/user)
 	return


### PR DESCRIPTION
It aint perfect but it gets the job done.

This PR does the following.

-Adds posibrains and their subtypes to the spawners menu for ghosts
-Adds posibrains to the orbit list
-Removes the posibrain from augmentationfacility.dmm and replaces it with three sheets of gold

Why?
Nothin' like late joining a round and trying to find a posibrain to click on and being unable to.