### PR TITLE
various runtime fixes - plasmaman tongues no longer have a maxHealth of "alien" and more

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -829,7 +829,7 @@ Proc for attack log creation, because really why not
 		return filters[filter_data.Find(name)]
 
 /atom/movable/proc/remove_filter(name)
-	if(filter_data[name])
+	if(filter_data && filter_data[name])
 		filter_data -= name
 		update_filters()
 		return TRUE

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -164,7 +164,7 @@
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)
 			var/obj/item/bodypart/B = L.get_bodypart(def_zone)
-			if(B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
+			if(istype(B) && B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
 				do_sparks(2, FALSE, target.loc)
 				if(prob(25))
 					new /obj/effect/decal/cleanable/oil(target_loca)

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -164,7 +164,7 @@
 			if(starting)
 				splatter_dir = get_dir(starting, target_loca)
 			var/obj/item/bodypart/B = L.get_bodypart(def_zone)
-			if(istype(B) && B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
+			if(B && B.status == BODYPART_ROBOTIC) // So if you hit a robotic, it sparks instead of bloodspatters
 				do_sparks(2, FALSE, target.loc)
 				if(prob(25))
 					new /obj/effect/decal/cleanable/oil(target_loca)

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -233,7 +233,6 @@
 	name = "plasma bone \"tongue\""
 	desc = "Like animated skeletons, Plasmamen vibrate their teeth in order to produce speech."
 	icon_state = "tongueplasma"
-	maxHealth = "alien"
 	modifies_speech = FALSE
 
 /obj/item/organ/tongue/robot


### PR DESCRIPTION
Title. These are very small, minor things. They don't really cause much harm to the game's functionality, but it'd be nice to not have these clog up the view runtimes panel. Might add more fixes later.

## Changelog
:cl:
fix: Plasmaman tongues no longer have a maxHealth of "alien", and no longer cause the organ's on_life to always runtime.
fix: Shooting a simplemob no longer causes runtimes prior to the blood effect being created.
fix: Removing a filter from an object that lacks filters no longer causes runtimes.
/:cl:
