### PR TITLE
Adds two cotten seeds to ash walker home

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_ash_walker1.dmm
@@ -475,6 +475,8 @@
 	dir = 4
 	},
 /obj/item/storage/bag/plants/portaseeder,
+/obj/item/seeds/cotton,
+/obj/item/seeds/cotton,
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
 "bk" = (


### PR DESCRIPTION
## About The Pull Request
Adds two seed packets to ash walker base so they can get more cloth for bags/and rags

## Why It's Good For The Game

Ash walkers tend to get harmed a lot and go through rags a lot or one person makes it all into a bag or two, this should allow them to get more without needing to cut up bed cloths from rng leagon golems

## Changelog
:cl:
add: Added two seed packets of cotten to ash walkers base
/:cl: