### PR TITLE
Lowers ghosts and insain clowns hp to 120 from 1e6

### DIFF
--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -176,7 +176,7 @@
 		return
 
 /mob/living/simple_animal/shade/howling_ghost/adjustHealth()
-	. = 0
+	. = ..() 
 
 /mob/living/simple_animal/shade/howling_ghost/CanPass(atom/movable/mover, turf/target)
 	return 1
@@ -203,7 +203,6 @@
 /mob/living/simple_animal/hostile/retaliate/clown/insane/Initialize()
 	. = ..()
 	timer = rand(5,15)
-	return
 
 /mob/living/simple_animal/hostile/retaliate/clown/insane/Retaliate()
 	return
@@ -235,7 +234,7 @@
 	return
 
 /mob/living/simple_animal/hostile/retaliate/clown/insane/adjustHealth()
-	. = 0
+	. = ..() 
 	if(prob(5))
 		playsound(loc, 'sound/spookoween/insane_low_laugh.ogg', 300, 1)
 

--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -127,8 +127,8 @@
 	name = "ghost"
 	real_name = "ghost"
 	icon = 'icons/mob/mob.dmi'
-	maxHealth = 1e6
-	health = 1e6
+	maxHealth = 120
+	health = 120
 	speak_emote = list("howls")
 	emote_hear = list("wails","screeches")
 	density = FALSE
@@ -195,8 +195,8 @@
 	icon_dead = "scary_clown"
 	icon_gib = "scary_clown"
 	speak = list("...", ". . .")
-	maxHealth = 1e6
-	health = 1e6
+	maxHealth = 120
+	health = 120
 	emote_see = list("silently stares")
 	unsuitable_atmos_damage = 0
 	var/timer

--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -141,7 +141,6 @@
 	. = ..()
 	icon_state = pick("ghost","ghostian","ghostian2","ghostking","ghost1","ghost2")
 	icon_living = icon_state
-	status_flags |= GODMODE
 	timer = rand(1,15)
 
 /mob/living/simple_animal/shade/howling_ghost/Life()
@@ -204,7 +203,6 @@
 /mob/living/simple_animal/hostile/retaliate/clown/insane/Initialize()
 	. = ..()
 	timer = rand(5,15)
-	status_flags = (status_flags | GODMODE)
 	return
 
 /mob/living/simple_animal/hostile/retaliate/clown/insane/Retaliate()

--- a/code/modules/holiday/halloween/halloween.dm
+++ b/code/modules/holiday/halloween/halloween.dm
@@ -175,12 +175,8 @@
 			step(I,direction)
 		return
 
-/mob/living/simple_animal/shade/howling_ghost/adjustHealth()
-	. = ..() 
-
 /mob/living/simple_animal/shade/howling_ghost/CanPass(atom/movable/mover, turf/target)
 	return 1
-
 
 ///////////////////////////
 //Spookoween Insane Clown//


### PR DESCRIPTION

## About The Pull Request

Lowers the npc shade ghost things that spawn in lockers to 120 as well as insain clowns

## Why It's Good For The Game

They cant really be killed and theirs not reason for that, they can float onto cargo shuttle and stop it from going

## Changelog
:cl:
tweak: shades and clowns HP
/:cl:
