### PR TITLE
Makes jukeboxes work again after 512.1459's changes to SOUND_UPDATE (and other small fixes/tweaks)

### DIFF
--- a/code/__DEFINES/sound.dm
+++ b/code/__DEFINES/sound.dm
@@ -3,12 +3,12 @@
 #define CHANNEL_ADMIN 1023
 #define CHANNEL_VOX 1022
 #define CHANNEL_JUKEBOX 1021
-#define CHANNEL_JUKEBOX_START 1020
-#define CHANNEL_JUSTICAR_ARK 1019
-#define CHANNEL_HEARTBEAT 1018 //sound channel for heartbeats
-#define CHANNEL_AMBIENCE 1017
-#define CHANNEL_BUZZ 1016
-#define CHANNEL_BICYCLE 1015
+#define CHANNEL_JUKEBOX_START 1016 //The gap between this and CHANNEL_JUKEBOX determines the amount of free jukebox channels. This currently allows 6 jukebox channels to exist.
+#define CHANNEL_JUSTICAR_ARK 1015
+#define CHANNEL_HEARTBEAT 1014 //sound channel for heartbeats
+#define CHANNEL_AMBIENCE 1013
+#define CHANNEL_BUZZ 1012
+#define CHANNEL_BICYCLE 1011
 
 //CIT CHANNELS - TRY NOT TO REGRESS
 #define CHANNEL_PRED 1010


### PR DESCRIPTION
## About The Pull Request
This PR does exactly as it says on the tin. This allows clients to hear jukeboxes again even after 512.1459 irreversibly destroyed SOUND_UPDATE's functionality for playing sounds, as the sound is now globally initialized when a jukebox is added to the jukebox list. This PR also makes the jukebox errors throw simple runtimes instead of spamming debug text in the world chat when unexpected behavior occurs. This also fixes the bug where multiple jukeboxes turning on/off can result in extremely ear-splittingly loud glitchy audio by making the jukebox subsystem keep track of what jukebox channels are free. This means Raiq's donor item will now be capable of coexisting with mapped-in jukeboxes and any other future jukebox sources that may be added.


## Changelog
:cl: Bhijn
tweak: Jukeboxes now have 6 audio channels available to them, up from the previous accidental 2 and previously intended 5 channels.
fix: Jukeboxes now work again on clients running versions higher than 512.1459.
fix: People will no longer have their ears consumed by an eldritch god if multiple jukeboxes are active and the first jukebox in the jukebox list stops playing, then tries to play again
tweak: Instead of the debug text for invalid jukebox behavior being printed to world, the debug text is now restricted to the runtime panel.
/:cl:
