### PR TITLE
Barricade girder walls no longer runtime each tick.

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -74,7 +74,8 @@
 			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
 			if(do_after(user, 50, target=src))
 				W.use(5)
-				new /turf/closed/wall/mineral/wood/nonmetal(get_turf(src))
+				var/turf/T = get_turf(src)
+				T.PlaceOnTop(/turf/closed/wall/mineral/wood/nonmetal)
 				qdel(src)
 				return
 	return ..()


### PR DESCRIPTION
Credit goes to Ghommie to finding the solution.

## About The Pull Request

Barricade girder walls would break dynamic lighting, and runtime every single tick they processed with atmos.
As a result of mishandling the turf below them, new has been replaced with PlaceOnTop.

## Why It's Good For The Game

Bugfix

## Changelog
:cl:
fix: barricade girder walls use PlaceOnTop instead of new
/:cl: