### PR TITLE
Adds Beanbag Slugs to Seclathe

### DIFF
--- a/code/modules/research/designs/weapon_designs.dm
+++ b/code/modules/research/designs/weapon_designs.dm
@@ -67,6 +67,12 @@
 //Ammo Shells/
 //////////////
 
+/datum/design/beanbag_slug/sec
+	id = "sec_beanbag"
+	build_type = PROTOLATHE
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
 /datum/design/rubbershot/sec
 	id = "sec_rshot"
 	build_type = PROTOLATHE

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -10,7 +10,7 @@
 	// Default research tech, prevents bricking
 	design_ids = list("basic_matter_bin", "basic_cell", "basic_scanning", "basic_capacitor", "basic_micro_laser", "micro_mani",
 	"destructive_analyzer", "circuit_imprinter", "experimentor", "rdconsole", "design_disk", "tech_disk", "rdserver", "rdservercontrol", "mechfab",
-	"space_heater", "xlarge_beaker", "sec_rshot", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "sec_38lethal",
+	"space_heater", "xlarge_beaker", "sec_beanbag", "sec_rshot", "sec_bshot", "sec_slug", "sec_Islug", "sec_dart", "sec_38", "sec_38lethal",
 	"rglass","plasteel","plastitanium","plasmaglass","plasmareinforcedglass","titaniumglass","plastitaniumglass")
 
 /datum/techweb_node/mmi


### PR DESCRIPTION
I couldn't stick it to redtail so I decided to fix it instead

## About The Pull Request

Adds Beanbag Shotgun Slugs to the Security Protolathe. Wow I wonder who forgot to add those?

## Why It's Good For The Game

Consistency.

## Changelog
:cl:
add: Adds beanbag slugs to the sec protolathe at round start
fix: Brings shotgun ammo availability back in like between seclathe and autolathe.
/:cl:
