### PR TITLE
can we not tell all the nonantags that antagonist ooc is enabled please 

### DIFF
--- a/code/modules/client/verbs/aooc.dm
+++ b/code/modules/client/verbs/aooc.dm
@@ -116,10 +116,10 @@ GLOBAL_VAR_INIT(normal_aooc_colour, "#ce254f")
 		antaglisting |= M.current.client
 
 	for(var/mob/M in GLOB.player_list)
-		if(M.client && (M.stat == DEAD || M.client.holder))
+		if(M.client && (M.stat == DEAD || M.client.holder || is_special_character(M)))
 			antaglisting |= M.client
 
 	for(var/client/C in antaglisting)
-		if(!C || !istype(C) || !is_special_character(C.mob))
+		if(!C || !istype(C))
 			continue
 		to_chat(C, "<B>The Antagonist OOC channel has been [GLOB.aooc_allowed ? "enabled. If you're an antagonist, you can access it through the \"AOOC\" verb." : "disabled"].</B>")

--- a/code/modules/client/verbs/aooc.dm
+++ b/code/modules/client/verbs/aooc.dm
@@ -120,6 +120,6 @@ GLOBAL_VAR_INIT(normal_aooc_colour, "#ce254f")
 			antaglisting |= M.client
 
 	for(var/client/C in antaglisting)
-		if(!C || !istype(C))
+		if(!C || !istype(C) || !is_special_character(C.mob))
 			continue
 		to_chat(C, "<B>The Antagonist OOC channel has been [GLOB.aooc_allowed ? "enabled. If you're an antagonist, you can access it through the \"AOOC\" verb." : "disabled"].</B>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

aooc toggle now only broadcasts to antagonists

## Why It's Good For The Game

meta

## Changelog
:cl:
fix: aooc toggling now only broadcasts to antagonists
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
