### PR TITLE
A more "fun" nerf to trashbags (and some FUCK-tier code refactoring for storage components to make it happen)

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -146,6 +146,9 @@
 	var/datum/component/storage/concrete/master = master()
 	return master? master.real_location() : null
 
+/datum/component/storage/proc/accessible_items()
+	return contents()
+
 /datum/component/storage/proc/canreach_react(datum/source, list/next)
 	var/datum/component/storage/concrete/master = master()
 	if(!master)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -156,8 +156,8 @@
 	var/list/contents = contents()
 	if(contents)
 		if(limited_random_access && random_access)
-			if(limited_radnom_access_stack_position && (length(contents) > limited_random_access_stack_position))
-				if(limited_random_acccess_stack_bottom_up)
+			if(limited_random_access_stack_position && (length(contents) > limited_random_access_stack_position))
+				if(limited_random_access_stack_bottom_up)
 					contents.Cut(1, limited_random_access_stack_position + 1)
 				else
 					contents.Cut(1, length(contents) - limited_random_access_stack_position + 1)
@@ -301,7 +301,6 @@
 
 /datum/component/storage/proc/_process_numerical_display()
 	. = list()
-	var/atom/real_location = real_location()
 	for(var/obj/item/I in accessible_items())
 		if(QDELETED(I))
 			continue
@@ -313,9 +312,8 @@
 
 //This proc determines the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /datum/component/storage/proc/orient2hud(mob/user, maxcolumns)
-	var/atom/real_location = real_location()
-	var/accessible_contents = accessible_items()
-	var/adjusted_contents = accessible_contents.len
+	var/list/accessible_contents = accessible_items()
+	var/adjusted_contents = length(accessible_contents)
 
 	//Numbered contents display
 	var/list/datum/numbered_display/numbered_contents
@@ -347,7 +345,6 @@
 				if(cy - screen_start_y >= rows)
 					break
 	else
-		var/atom/real_location = real_location()
 		for(var/obj/O in accessible_items())
 			if(QDELETED(O))
 				continue
@@ -369,7 +366,6 @@
 		return FALSE
 	var/list/cview = getviewsize(M.client.view)
 	var/maxallowedscreensize = cview[1]-8
-	var/atom/real_location = real_location()
 	if(M.active_storage != src && (M.stat == CONSCIOUS))
 		for(var/obj/item/I in accessible_items())
 			if(I.on_found(M))

--- a/code/game/objects/items/storage/bags.dm
+++ b/code/game/objects/items/storage/bags.dm
@@ -49,6 +49,8 @@
 	STR.max_combined_w_class = 30
 	STR.max_items = 30
 	STR.cant_hold = typecacheof(list(/obj/item/disk/nuclear))
+	STR.limited_random_access = TRUE
+	STR.limited_random_access_stack_position = 3
 
 /obj/item/storage/bag/trash/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] puts [src] over [user.p_their()] head and starts chomping at the insides! Disgusting!</span>")
@@ -88,6 +90,7 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_combined_w_class = 60
 	STR.max_items = 60
+	STR.limited_random_access_stack_position = 5
 
 /obj/item/storage/bag/trash/bluespace/cyborg
 	insertable = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Trashbags now only allow accessing the top 3 items in there (stack datastructure style)
bluespace ones are 5.

Refactors storage(!!) a bit to allow for this.

## Why It's Good For The Game

trashbags shouldn't be better toolbelts but the other nerf makes them pretty useless

## Changelog
:cl:
balance: Trashbags now only allow accessing the first 3 items. 5 for bluespace ones.
experimental: Storage now allows for limiting of random access
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
