### PR TITLE
Fixing nuke ops / adminspawn combat mechs having tracking beacons.

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -267,6 +267,7 @@
 	operation_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/honker/dark
 	max_equip = 3
+	spawn_tracked = FALSE
 
 /obj/mecha/combat/honker/dark/GrantActions(mob/living/user, human_occupant = 0)
 	..()

--- a/code/game/mecha/combat/combat.dm
+++ b/code/game/mecha/combat/combat.dm
@@ -3,3 +3,9 @@
 	internal_damage_threshold = 50
 	armor = list("melee" = 30, "bullet" = 30, "laser" = 15, "energy" = 20, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	mouse_pointer = 'icons/mecha/mecha_mouse.dmi'
+	var/spawn_tracked = TRUE
+
+/obj/mecha/combat/Initialize()
+	. = ..()
+	if(spawn_tracked)
+		trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/durand.dm
+++ b/code/game/mecha/combat/durand.dm
@@ -19,7 +19,3 @@
 /obj/mecha/combat/durand/RemoveActions(mob/living/user, human_occupant = 0)
 	..()
 	defense_action.Remove(user)
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -29,6 +29,7 @@
 	operation_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
 	max_equip = 4
+	spawn_tracked = FALSE
 
 /obj/mecha/combat/gygax/dark/loaded/Initialize()
 	. = ..()
@@ -48,7 +49,6 @@
 		return
 	cell = new /obj/item/stock_parts/cell/hyper(src)
 
-
 /obj/mecha/combat/gygax/GrantActions(mob/living/user, human_occupant = 0)
 	..()
 	overload_action.Grant(user, src)
@@ -65,7 +65,3 @@
 /obj/mecha/combat/gygax/dark/RemoveActions(mob/living/user, human_occupant = 0)
 	..()
 	thrusters_action.Remove(user)
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -153,7 +153,3 @@
 	for (var/i=0;i<6;i++)
 		color = color+pick(colors)
 	return color
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -16,6 +16,7 @@
 	force = 45
 	max_equip = 4
 	bumpsmash = 1
+	spawn_tracked = FALSE
 
 /obj/mecha/combat/marauder/GrantActions(mob/living/user, human_occupant = 0)
 	..()

--- a/code/game/mecha/combat/neovgre.dm
+++ b/code/game/mecha/combat/neovgre.dm
@@ -13,6 +13,7 @@
 	breach_time = 100 //ten seconds till all goes to shit
 	recharge_rate = 100
 	wreckage = /obj/structure/mecha_wreckage/durand/neovgre
+	spawn_tracked = FALSE
 
 /obj/mecha/combat/neovgre/GrantActions(mob/living/user, human_occupant = 0) //No Eject action for you sonny jim, your life for Ratvar!
 	internals_action.Grant(user, src)

--- a/code/game/mecha/combat/phazon.dm
+++ b/code/game/mecha/combat/phazon.dm
@@ -27,7 +27,3 @@
 	..()
 	switch_damtype_action.Remove(user)
 	phasing_action.Remove(user)
-
-/obj/mecha/combat/Initialize()
-	. = ..()
-	trackers += new /obj/item/mecha_parts/mecha_tracking(src)

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -18,6 +18,7 @@
 	stepsound = null
 	turnsound = null
 	opacity = 0
+	spawn_tracked = FALSE
 
 /obj/mecha/combat/reticence/loaded/Initialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Basically #9555 but decent.

## Why It's Good For The Game
This will close #9553.

## Changelog
:cl:
fix: Nuke ops / adminbus combat mechs will no longer spawn with tracking beacons.
/:cl:
