### PR TITLE
Random plush spawner tweaks and fixes.

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -1,8 +1,7 @@
 #define ARCADE_WEIGHT_TRICK 4
 #define ARCADE_WEIGHT_USELESS 2
 #define ARCADE_WEIGHT_RARE 1
-#define ARCADE_WEIGHT_PLUSH 65
-
+#define ARCADE_RATIO_PLUSH 0.20 // average 1 out of 6 wins is a plush.
 
 /obj/machinery/computer/arcade
 	name = "random arcade"
@@ -27,7 +26,6 @@
 		/obj/item/toy/katana = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/minimeteor = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/nuke = ARCADE_WEIGHT_TRICK,
-		/obj/item/toy/plush/random = ARCADE_WEIGHT_PLUSH,
 		/obj/item/toy/redbutton = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/spinningtoy = ARCADE_WEIGHT_TRICK,
 		/obj/item/toy/sword = ARCADE_WEIGHT_TRICK,
@@ -90,6 +88,9 @@
 		var/obj/item/circuitboard/CB = new thegame()
 		new CB.build_path(loc, CB)
 		return INITIALIZE_HINT_QDEL
+	//The below object acts as a spawner with a wide array of possible picks, most being uninspired references to past/current player characters.
+	//Nevertheless, this keeps its ratio constant with the sum of all the others prizes.
+	prizes[/obj/item/toy/plush/random] = counterlist_sum(prizes) * ARCADE_RATIO_PLUSH
 	Reset()
 
 /obj/machinery/computer/arcade/proc/prizevend(mob/user, list/rarity_classes)

--- a/code/game/objects/items/plushes.dm
+++ b/code/game/objects/items/plushes.dm
@@ -366,10 +366,10 @@
 /obj/item/toy/plush/random
 	name = "Illegal plushie"
 	desc = "Something fucked up"
+	var/blacklisted_plushes = list(/obj/item/toy/plush/carpplushie/dehy_carp, /obj/item/toy/plush/awakenedplushie, /obj/item/toy/plush/random)
 
 /obj/item/toy/plush/random/Initialize()
-	..()
-	var/newtype = pick(subtypesof(/obj/item/toy/plush))
+	var/newtype = pick(subtypesof(/obj/item/toy/plush) - typecacheof(blacklisted_plushes))
 	new newtype(loc)
 	return INITIALIZE_HINT_QDEL
 


### PR DESCRIPTION
## About The Pull Request
Blacklisted dehydratated carps (duh), the awakened plushie and the spawner itself (duh) from being spawned.
Replaced the hardcoded plush weight of 65 (average prize weight being 2 or 3) with a set value equal to the sum of all other weights multiplied by a define, currently set to 0.2.
Lowered the plush / other prize ratio from 1 : 2.5 circa to 1 : 5,

## Why It's Good For The Game
The awakened supposed to be a silly unique example for global component signals found on the bus ruin. It bitters me seeing it diluted amongst other crap. Same can't be said for Nar'sie, Ratvar and otherwise unachievable megafauna plushes.

See my commentary on line 91-92 for the rest.

## Changelog
:cl:
tweak: lowered the arcade's random plush / other prizes ratio from 1 : 2.5 circa to 1 : 5. Dehydratated carps and the awakened plush can not be achieved this way anymore.
/:cl: