### PR TITLE
Adds dynamic antag injection to config

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -376,6 +376,22 @@
 	config_entry_value = 6
 	min_val = 1
 
+/datum/config_entry/number/dynamic_midround_delay_min
+	config_entry_value = 15
+	min_val = 1
+
+/datum/config_entry/number/dynamic_midround_delay_max
+	config_entry_value = 35
+	min_val = 1
+
+/datum/config_entry/number/dynamic_latejoin_delay_min
+	config_entry_value = 5
+	min_val = 1
+
+/datum/config_entry/number/dynamic_latejoin_delay_min
+	config_entry_value = 25
+	min_val = 1
+
 /datum/config_entry/keyed_list/dynamic_cost
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -388,7 +388,7 @@
 	config_entry_value = 5
 	min_val = 1
 
-/datum/config_entry/number/dynamic_latejoin_delay_min
+/datum/config_entry/number/dynamic_latejoin_delay_max
 	config_entry_value = 25
 	min_val = 1
 

--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -111,6 +111,10 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 	..()
 	pop_per_requirement = CONFIG_GET(number/dynamic_pop_per_requirement)
 	GLOB.dynamic_high_pop_limit = CONFIG_GET(number/dynamic_high_pop_limit)
+	GLOB.dynamic_latejoin_delay_min = CONFIG_GET(number/dynamic_latejoin_delay_min)*600
+	GLOB.dynamic_latejoin_delay_max = CONFIG_GET(number/dynamic_latejoin_delay_max)*600
+	GLOB.dynamic_midround_delay_min = CONFIG_GET(number/dynamic_midround_delay_min)*600
+	GLOB.dynamic_midround_delay_max = CONFIG_GET(number/dynamic_midround_delay_max)*600
 
 /datum/game_mode/dynamic/admin_panel()
 	var/list/dat = list("<html><head><title>Game Mode Panel</title></head><body><h1><B>Game Mode Panel</B></h1>")

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -258,6 +258,12 @@ EVENTS_MIN_PLAYERS_MUL 1
 
 ### DYNAMIC MODE ###
 
+## Injection delays: how long (in minutes) will pass before a midround or latejoin antag is injected.
+DYNAMIC_MIDROUND_DELAY_MIN 15
+DYNAMIC_MIDROUND_DELAY_MAX 35
+DYNAMIC_LATEJOIN_DELAY_MIN 5
+DYNAMIC_LATEJOIN_DELAY_MAX 25
+
 ## How many roundstart players required for high population override to take effect.
 DYNAMIC_HIGH_POP_LIMIT 55
 


### PR DESCRIPTION
## About The Pull Request

Adds dynamic midround antag/latejoin antag injection timers to the config.

## Why It's Good For The Game

I completely omitted them last time, silly me. They could be highly useful for further configuring dynamic not to be miserable.

## Changelog
:cl:
config: Added dynamic midround/latejoin antag injection to the config.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
