### PR TITLE
commits out nazi vender restock unit

### DIFF
--- a/modular_citadel/code/game/machinery/vending.dm
+++ b/modular_citadel/code/game/machinery/vending.dm
@@ -136,10 +136,11 @@
 	machine_name 	= "KinkMate"
 	icon			= 'modular_citadel/icons/vending_restock.dmi'
 	icon_state 		= "refill_kink"
-
+/*
 /obj/item/vending_refill/nazi
 	machine_name 	= "nazivend"
 	icon_state 		= "refill_nazi"
+*/
 
 /obj/item/vending_refill/soviet
 	machine_name 	= "sovietvend"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nazi vender icons were removed as well as the main vender being commited out

## Why It's Good For The Game

Rng spawning items can spawn it meaning that you can get it in game and you shouldnt

## Changelog
:cl:
del: Commits out nazi restock unit
salt:
kneejerk:
/:cl:
