### PR TITLE
Shameless late game crew nerf

### DIFF
--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -4,8 +4,8 @@
 	weight = 10
 	max_occurrences = 1
 
-	earliest_start = 60 MINUTES
-	min_players = 40
+	earliest_start = 40 MINUTES
+	min_players = 35
 
 	gamemode_blacklist = list("blob") //Just in case a blob survives that long
 


### PR DESCRIPTION
## About The Pull Request
Also called "Proud midgame blob buff".
Lowered the earliest start from 1 hour to 40 minutes (ergo one third), and the required player population from 40 to 35.

## Why It's Good For The Game
Blobs get curbstomped by crews powered by lategame gear and yote antags loot.
There are always a few times where the blob is actually good and the crew is idiotic, or crippled by other antagonists, but it's quite a rare sight.

If you come up with a beautiful suggestion, just tell. I'm lazy, not salty.

## Changelog
:cl:
balance: Lowered blob event earliest start from 1 hour to 40 minutes (ergo one third), and the required player population from 40 to 35.
/:cl:

