### PR TITLE
Gives ways for various slime-killing healing viruses not to do that.

### DIFF
--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -368,7 +368,6 @@
 	level = 8
 	passive_message = "<span class='notice'>You feel an odd attraction to plasma.</span>"
 	var/temp_rate = 1
-	var/heals_slimes = FALSE
 	threshold_desc = "<b>Transmission 6:</b> Increases temperature adjustment rate and heals toxin lovers.<br>\
 					  <b>Stage Speed 7:</b> Increases healing speed."
 

--- a/code/datums/diseases/advance/symptoms/heal.dm
+++ b/code/datums/diseases/advance/symptoms/heal.dm
@@ -79,7 +79,7 @@
 	if(M.getToxLoss() && prob(5))
 		to_chat(M, "<span class='notice'>Your skin tingles as the starlight seems to heal you.</span>")
 
-	M.adjustToxLoss(-(4 * heal_amt)) //most effective on toxins
+	M.adjustToxLoss(-(4 * heal_amt), forced = TRUE) //most effective on toxins
 
 	var/list/parts = M.get_damaged_bodyparts(1,1)
 
@@ -368,7 +368,8 @@
 	level = 8
 	passive_message = "<span class='notice'>You feel an odd attraction to plasma.</span>"
 	var/temp_rate = 1
-	threshold_desc = "<b>Transmission 6:</b> Increases temperature adjustment rate.<br>\
+	var/heals_slimes = FALSE
+	threshold_desc = "<b>Transmission 6:</b> Increases temperature adjustment rate and heals toxin lovers.<br>\
 					  <b>Stage Speed 7:</b> Increases healing speed."
 
 /datum/symptom/heal/plasma/Start(datum/disease/advance/A)
@@ -410,7 +411,7 @@
 		if(prob(5))
 			to_chat(M, "<span class='notice'>You feel warmer.</span>")
 
-	M.adjustToxLoss(-heal_amt)
+	M.adjustToxLoss(-heal_amt, forced = (temp_rate == 4))
 
 	var/list/parts = M.get_damaged_bodyparts(1,1)
 	if(!parts.len)
@@ -435,7 +436,7 @@
 	symptom_delay_max = 1
 	passive_message = "<span class='notice'>Your skin glows faintly for a moment.</span>"
 	var/cellular_damage = FALSE
-	threshold_desc = "<b>Transmission 6:</b> Additionally heals cellular damage.<br>\
+	threshold_desc = "<b>Transmission 6:</b> Additionally heals cellular damage and toxin lovers.<br>\
 					  <b>Resistance 7:</b> Increases healing speed."
 
 /datum/symptom/heal/radiation/Start(datum/disease/advance/A)
@@ -468,7 +469,7 @@
 	if(cellular_damage)
 		M.adjustCloneLoss(-heal_amt * 0.5)
 
-	M.adjustToxLoss(-(2 * heal_amt))
+	M.adjustToxLoss(-(2 * heal_amt), forced = cellular_damage)
 
 	var/list/parts = M.get_damaged_bodyparts(1,1)
 


### PR DESCRIPTION
## About The Pull Request

Makes starlight condensation not hurt toxin lovers and allows the transmission thresholds of plasma fixation and radioactive resonance to do the same.

## Why It's Good For The Game

starlight condensation made every slime player immediately call for the viro's head for the pill labeled "healing disease" killing them and the other two it's nice to have more reasons to reach thresholds, plus see above

## Changelog
:cl:
balance: Made starlight condensation not kill slime people.
balance: Added not-killing-slime-people to the transmission threshold of plasma fixation and radioactive resonance.
/:cl: