### PR TITLE
modkit uninstall() calling forceMove() calling loc.Exited() calling modkit uninstall()

### DIFF
--- a/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
+++ b/code/modules/projectiles/guns/energy/kinetic_accelerator.dm
@@ -331,9 +331,9 @@
 			uninstall(KA)
 
 /obj/item/borg/upgrade/modkit/proc/uninstall(obj/item/gun/energy/kinetic_accelerator/KA, forcemove = TRUE)
+	KA.modkits -= src
 	if(forcemove)
 		forceMove(get_turf(KA))
-	KA.modkits -= src
 
 /obj/item/borg/upgrade/modkit/proc/modify_projectile(obj/item/projectile/kinetic/K)
 


### PR DESCRIPTION
## About The Pull Request
Not an endless loop as I first screamed about because the latter uninstall() call has the forcemove arg disabled, but it's still an issue because proper modkit uninstallation calls uninstall() twice.

## Why It's Good For The Game
Fixing a little issue.

## Changelog
None.