### PR TITLE
Makes clone scans lock while processing

### DIFF
--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -298,13 +298,14 @@
 		src.updateUsrDialog()
 		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 		say("Initiating scan...")
-
+		scanner.locked = TRUE
 		spawn(20)
 			src.scan_occupant(scanner.occupant)
 
 			loading = 0
 			src.updateUsrDialog()
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+			scanner.locked = FALSE
 
 
 		//No locking an open scanner.

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -296,13 +296,15 @@
 
 		loading = 1
 		src.updateUsrDialog()
+		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 		say("Initiating scan...")
 
-		src.scan_occupant(scanner.occupant)
-		
-		loading = 0
-		src.updateUsrDialog()
-		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+		spawn(20)
+			src.scan_occupant(scanner.occupant)
+
+			loading = 0
+			src.updateUsrDialog()
+			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 
 		//No locking an open scanner.

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -298,6 +298,7 @@
 		src.updateUsrDialog()
 		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 		say("Initiating scan...")
+		var/prev_locked = scanner.locked
 		scanner.locked = TRUE
 		spawn(20)
 			src.scan_occupant(scanner.occupant)
@@ -305,7 +306,7 @@
 			loading = 0
 			src.updateUsrDialog()
 			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
-			scanner.locked = FALSE
+			scanner.locked = prev_locked
 
 
 		//No locking an open scanner.

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -296,15 +296,13 @@
 
 		loading = 1
 		src.updateUsrDialog()
-		playsound(src, 'sound/machines/terminal_prompt.ogg', 50, 0)
 		say("Initiating scan...")
 
-		spawn(20)
-			src.scan_occupant(scanner.occupant)
-
-			loading = 0
-			src.updateUsrDialog()
-			playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
+		src.scan_occupant(scanner.occupant)
+		
+		loading = 0
+		src.updateUsrDialog()
+		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 
 		//No locking an open scanner.


### PR DESCRIPTION
##  About The Pull Request

As above, locks the cloner while scanning.

## Why It's Good For The Game

No self-scans by cheesing with a humanized monkey.

## Changelog
:cl:
tweak: Made the clone scanner lock while it's scanning.
/:cl: