### PR TITLE
buffs bluespace apprentice (targeted teleport --> blink)

### DIFF
--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -165,7 +165,7 @@
 			owner.AddSpell(new /obj/effect/proc_holder/spell/aimed/fireball(null))
 			to_chat(owner, "<B>Your service has not gone unrewarded, however. Studying under [master.current.real_name], you have learned powerful, destructive spells. You are able to cast magic missile and fireball.")
 		if(APPRENTICE_BLUESPACE)
-			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/area_teleport/teleport(null))
+			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/turf_teleport/blink(null))
 			owner.AddSpell(new /obj/effect/proc_holder/spell/targeted/ethereal_jaunt(null))
 			to_chat(owner, "<B>Your service has not gone unrewarded, however. Studying under [master.current.real_name], you have learned reality bending mobility spells. You are able to cast teleport and ethereal jaunt.")
 		if(APPRENTICE_HEALING)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

gives bluespace apprentice blink instead of targeted area teleport

## Why It's Good For The Game

bluespace is unironically weaker than all of the other three sets, this should make them harder to steamroll and de-incentivize hiding for long periods of time. also without teleport they can blink but it's harder for them to cover a huge amount of ground quickly/also less incentivize to locker hide until it's charged.
the point of wizards is to fight, not to run forever.

## Changelog
:cl:
balance: bluespace wizard apprentice now has blink instead of targeted area teleportation
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
