### PR TITLE
[TESTMERGE ONLY] Reverts bullets causing bleed

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -177,11 +177,7 @@
 				else
 					new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_loca, splatter_dir, bloodtype_to_color())
 
-			if(iscarbon(L))
-				var/mob/living/carbon/C = L
-				C.bleed(damage)
-			else
-				L.add_splatter_floor(target_loca)
+			L.add_splatter_floor(target_loca)
 
 		else if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)


### PR DESCRIPTION
This doesn't take into account armor and it's ridiculously, ridiculously annoying to have a near hard hitpoint bar you can only refill by going to medbay and draining a bloodpack that all bullets drain from without considering b u l l e t a r m o r

I get that this is meant to be part of making medical more complicated but on its own it's really not accomplishing anything other than making having heavy armor basically useless in an extended fight. There's better ways to balance gunfights than losing half your blood over 240 damage.

@deathride58 