### PR TITLE
Fixing storage implant transplant.

### DIFF
--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -41,7 +41,6 @@
 	desc = "A tiny yet spacious pocket, usually found implanted inside sneaky syndicate agents and nowhere else."
 	component_type = /datum/component/storage/concrete/implant
 	resistance_flags = INDESTRUCTIBLE //A bomb!
-	item_flags = DROPDEL
 
 /obj/item/implanter/storage
 	name = "implanter (storage)"

--- a/code/game/objects/items/implants/implant_storage.dm
+++ b/code/game/objects/items/implants/implant_storage.dm
@@ -12,7 +12,7 @@
 
 /obj/item/implant/storage/removed(source, silent = FALSE, special = 0)
 	if(!special)
-		qdel(pocket)
+		QDEL_NULL(pocket)
 	else
 		pocket?.moveToNullspace()
 	return ..()
@@ -29,7 +29,7 @@
 			return FALSE
 	. = ..()
 	if(.)
-		if(pocket)
+		if(!QDELETED(pocket))
 			pocket.forceMove(target)
 		else
 			pocket = new(target)


### PR DESCRIPTION
## About The Pull Request
This should close #9684.

## Why It's Good For The Game
Forgot that deleting a variable without setting it null may leave a reference. Also pocket's item/doMove calling dropped(), which in turn calls qdel(src) because DROPDEL...

## Changelog
:cl:
fix: Fixed storage implant transplant.
/:cl:
