### PR TITLE
Refactoring how Jacqueen teleportation destination is selected. 

### DIFF
--- a/code/game/machinery/hologram.dm
+++ b/code/game/machinery/hologram.dm
@@ -24,6 +24,8 @@ Possible to do for anyone motivated enough:
  * Holopad
  */
 
+GLOBAL_LIST_EMPTY(network_holopads)
+
 #define HOLOPAD_PASSIVE_POWER_USAGE 1
 #define HOLOGRAM_POWER_USAGE 2
 
@@ -55,7 +57,6 @@ Possible to do for anyone motivated enough:
 	var/record_user			//user that inititiated the recording
 	var/obj/effect/overlay/holo_pad_hologram/replay_holo	//replay hologram
 	var/static/force_answer_call = FALSE	//Calls will be automatically answered after a couple rings, here for debugging
-	var/static/list/holopads = list()
 	var/obj/effect/overlay/holoray/ray
 	var/ringing = FALSE
 	var/offset = FALSE
@@ -96,7 +97,7 @@ Possible to do for anyone motivated enough:
 /obj/machinery/holopad/Initialize()
 	. = ..()
 	if(on_network)
-		holopads += src
+		GLOB.network_holopads += src
 
 /obj/machinery/holopad/Destroy()
 	if(outgoing_call)
@@ -116,7 +117,7 @@ Possible to do for anyone motivated enough:
 
 	QDEL_NULL(disk)
 
-	holopads -= src
+	GLOB.network_holopads -= src
 	return ..()
 
 /obj/machinery/holopad/power_change()
@@ -260,7 +261,7 @@ Possible to do for anyone motivated enough:
 		temp += "<A href='?src=[REF(src)];mainmenu=1'>Main Menu</A>"
 		if(usr.loc == loc)
 			var/list/callnames = list()
-			for(var/I in holopads)
+			for(var/I in GLOB.network_holopads)
 				var/area/A = get_area(I)
 				if(A)
 					LAZYADD(callnames[A], I)
@@ -474,7 +475,7 @@ For the other part of the code, check silicon say.dm. Particularly robot talk.*/
 	var/obj/effect/overlay/holo_pad_hologram/h = masters[holo_owner]
 	if(!h || h.HC) //Holocalls can't change source.
 		return FALSE
-	for(var/pad in holopads)
+	for(var/pad in GLOB.network_holopads)
 		var/obj/machinery/holopad/another = pad
 		if(another == src)
 			continue

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -104,8 +104,8 @@
 
 	//Try to go to populated areas
 	var/list/pop_areas = list()
-	for(var/M in GLOB.player_list)
-		var/area/A = get_area(M)
+	for(var/mob/living/L in GLOB.player_list)
+		var/area/A = get_area(L)
 		pop_areas += A
 
 	var/list/targets = list()

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -121,15 +121,16 @@
 
 	for(var/i in 1 to 6) //Attempts a jump up to 6 times.
 		var/area/A = pick(cool_places)
-		var/list/L = list()
+		var/list/area_turfs = list(get_area_turfs(A.type))
 
 		if(i != 6) // We need to teleport away, no matter what.
-			for(var/turf/T in get_area_turfs(A.type))
+			for(var/t in area_turfs)
+				var/turf/T = t
 				if(!is_blocked_turf(T))
-					L += T
-			if(!L.len)
-				cool_places -= A
-				continue
+					L -= T
+				if(!L.len)
+					cool_places -= A
+					continue
 
 		if(!do_teleport(src, pick(L), channel = TELEPORT_CHANNEL_MAGIC))
 			return TRUE

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -102,39 +102,27 @@
 	canmove = TRUE
 	health = 25
 
-	var/list/areas = list()
-	for(var/A in GLOB.teleportlocs)
-		if(findtextEx(A, "AI"))
-			continue
-		areas += GLOB.teleportlocs[A]
-
 	//Try to go to populated areas
 	var/list/pop_areas = list()
 	for(var/M in GLOB.player_list)
 		var/area/A = get_area(M)
 		pop_areas += A
 
-	var/list/cool_places = uniquemergelist(areas, pop_areas)
+	var/list/targets = list()
+	for(var/H in GLOB.network_holopads)
+		var/area/A = get_area(H)
+		if(findtextEx(A, "AI") || !(A in pop_areas) || !is_station_level(H))
+			continue
+		targets += H
 
-	if(!cool_places.len)
-		cool_places = areas
+	if(!targets)
+		targets = GLOB.generic_event_spawns
 
 	for(var/i in 1 to 6) //Attempts a jump up to 6 times.
-		var/area/A = pick(cool_places)
-		var/list/area_turfs = list(get_area_turfs(A.type))
-
-		if(i != 6) // We need to teleport away, no matter what.
-			for(var/t in area_turfs)
-				var/turf/T = t
-				if(!is_blocked_turf(T))
-					L -= T
-				if(!L.len)
-					cool_places -= A
-					continue
-
-		if(!do_teleport(src, pick(L), channel = TELEPORT_CHANNEL_MAGIC))
+		var/atom/A = pick(targets)
+		if(!do_teleport(src, A, channel = TELEPORT_CHANNEL_MAGIC))
 			return TRUE
-		cool_places -= A
+		targets -= A
 	return FALSE
 
 /mob/living/simple_animal/jacq/proc/gender_check(mob/living/carbon/C)

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -120,7 +120,7 @@
 
 	for(var/i in 1 to 6) //Attempts a jump up to 6 times.
 		var/atom/A = pick(targets)
-		if(!do_teleport(src, A, channel = TELEPORT_CHANNEL_MAGIC))
+		if(do_teleport(src, A, channel = TELEPORT_CHANNEL_MAGIC))
 			return TRUE
 		targets -= A
 	return FALSE

--- a/code/modules/holiday/halloween/jacqueen.dm
+++ b/code/modules/holiday/halloween/jacqueen.dm
@@ -104,7 +104,7 @@
 
 	var/list/areas = list()
 	for(var/A in GLOB.teleportlocs)
-		if(findtextEx(A, "AI")
+		if(findtextEx(A, "AI"))
 			continue
 		areas += GLOB.teleportlocs[A]
 
@@ -116,7 +116,7 @@
 
 	var/list/cool_places = uniquemergelist(areas, pop_areas)
 
-	if(!cool_places)
+	if(!cool_places.len)
 		cool_places = areas
 
 	for(var/i in 1 to 6) //Attempts a jump up to 6 times.


### PR DESCRIPTION
## About The Pull Request
Preventing the Jacqueen mob from teleporting where they shouldn't in a slighty more "fashionable" way. I couldn't care less about making findtextEx()'s needle a regex atm as I don't see a reason too until we blacklist more areas.

## Why It's Good For The Game
Improving and simplifying this mob's teleportation code, fixing some oddities.

## Changelog
:cl:
fix: Refactored how Jacqueen teleportation destination is selected, preventing them from teleporting on off-station holopads.
/:cl: