### PR TITLE
Fixing gibspawner runtimes and improving them, how gruesome...

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -354,7 +354,8 @@
 				O.organ_flags &= ~ORGAN_FROZEN
 		unattached_flesh.Cut()
 		mess = FALSE
-		new /obj/effect/gibspawner/generic(get_turf(src))
+		if(mob_occupant)
+			mob_occupant.spawn_gibs()
 		audible_message("<span class='italics'>You hear a splat.</span>")
 		update_icon()
 		return

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -32,7 +32,8 @@
 	var/list/dna_to_add //find the dna to pass to the spawned gibs. do note this can be null if the mob doesn't have blood. add_blood_DNA() has built in null handling.
 	var/body_coloring = ""
 	if(source_mob)
-		dna_to_add = source_mob.get_blood_dna_list() //ez pz
+		if(!issilicon(source_mob))
+			dna_to_add = source_mob.get_blood_dna_list() //ez pz
 		if(ishuman(source_mob))
 			var/mob/living/carbon/human/H = source_mob
 			if(H.dna.species.use_skintones)
@@ -54,12 +55,9 @@
 				qdel(H)
 			else
 				dna_to_add = temp_mob.get_blood_dna_list()
-				qdel(temp_mob)
 		else if(!issilicon(temp_mob))
 			dna_to_add = temp_mob.get_blood_dna_list()
-			qdel(temp_mob)
-		else
-			qdel(temp_mob)
+		qdel(temp_mob)
 	else
 		dna_to_add = list("Non-human DNA" = random_blood_type()) //else, generate a random bloodtype for it.
 

--- a/code/game/objects/effects/spawners/gibspawner.dm
+++ b/code/game/objects/effects/spawners/gibspawner.dm
@@ -52,7 +52,6 @@
 					body_coloring = "#[skintone2hex(H.skin_tone)]"
 				else
 					body_coloring = "#[H.dna.features["mcolor"]]"
-				qdel(H)
 			else
 				dna_to_add = temp_mob.get_blood_dna_list()
 		else if(!issilicon(temp_mob))

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -265,7 +265,7 @@
 		if (B && !QDELETED(B))
 			H.internal_organs -= B
 			qdel(B)
-		new /obj/effect/gibspawner/generic(get_turf(H), H.dna)
+		H.spawn_gibs()
 		return (BRUTELOSS)
 
 /obj/item/melee/classic_baton/telescopic/attack_self(mob/user)

--- a/code/modules/mob/living/carbon/alien/death.dm
+++ b/code/modules/mob/living/carbon/alien/death.dm
@@ -1,8 +1,9 @@
-/mob/living/carbon/alien/spawn_gibs(with_bodyparts)
+/mob/living/carbon/alien/spawn_gibs(with_bodyparts, atom/loc_override)
+	var/location = loc_override ? loc_override.drop_location() : drop_location()
 	if(with_bodyparts)
-		new /obj/effect/gibspawner/xeno(drop_location())
+		new /obj/effect/gibspawner/xeno(location, src)
 	else
-		new /obj/effect/gibspawner/xeno/bodypartless(drop_location())
+		new /obj/effect/gibspawner/xeno/bodypartless(location, src)
 
 /mob/living/carbon/alien/gib_animation()
 	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-a")

--- a/code/modules/mob/living/carbon/alien/larva/death.dm
+++ b/code/modules/mob/living/carbon/alien/larva/death.dm
@@ -6,11 +6,12 @@
 
 	update_icons()
 
-/mob/living/carbon/alien/larva/spawn_gibs(with_bodyparts)
+/mob/living/carbon/alien/larva/spawn_gibs(with_bodyparts, atom/loc_override)
+	var/location = loc_override ? loc_override.drop_location() : drop_location()
 	if(with_bodyparts)
-		new /obj/effect/gibspawner/larva(drop_location())
+		new /obj/effect/gibspawner/larva(location, src)
 	else
-		new /obj/effect/gibspawner/larva/bodypartless(drop_location())
+		new /obj/effect/gibspawner/larva/bodypartless(location, src)
 
 /mob/living/carbon/alien/larva/gib_animation()
 	new /obj/effect/temp_visual/gib_animation(loc, "gibbed-l")

--- a/code/modules/mob/living/carbon/human/death.dm
+++ b/code/modules/mob/living/carbon/human/death.dm
@@ -4,36 +4,21 @@
 /mob/living/carbon/human/dust_animation()
 	new /obj/effect/temp_visual/dust_animation(loc, "dust-h")
 
-/mob/living/carbon/human/spawn_gibs(with_bodyparts)
-	if(isjellyperson(src))
-		if(with_bodyparts)
-			new /obj/effect/gibspawner/slime(drop_location(), dna, get_static_viruses())
+/mob/living/carbon/human/spawn_gibs(with_bodyparts, atom/loc_override)
+	var/location = loc_override ? loc_override.drop_location() : drop_location()
+	if(dna?.species?.gib_types)
+		var/datum/species/S = dna.species
+		var/length = length(S.gib_types)
+		if(length)
+			var/path = (with_bodyparts && length > 1) ? S.gib_types[2] : S.gib_types[1]
+			new path(location, src, get_static_viruses())
 		else
-			new /obj/effect/gibspawner/slime/bodypartless(drop_location(), dna, get_static_viruses())
-
-	if(isipcperson(src))
-		if(with_bodyparts)
-			new /obj/effect/gibspawner/ipc(drop_location(), dna, get_static_viruses())
-		else
-			new /obj/effect/gibspawner/ipc/bodypartless(drop_location(), dna, get_static_viruses())
-
-	if(isxenoperson(src))
-		if(with_bodyparts)
-			new /obj/effect/gibspawner/xeno/xenoperson(drop_location(), dna, get_static_viruses())
-		else
-			new /obj/effect/gibspawner/xeno/xenoperson/bodypartless(drop_location(), dna, get_static_viruses())
-
-	if(islizard(src))
-		if(with_bodyparts)
-			new /obj/effect/gibspawner/lizard(drop_location(), dna, get_static_viruses())
-		else
-			new /obj/effect/gibspawner/lizard/bodypartless(drop_location(), dna, get_static_viruses())
-
+			new S.gib_types(location, src, get_static_viruses())
 	else
 		if(with_bodyparts)
-			new /obj/effect/gibspawner/human(drop_location(), dna, get_static_viruses())
+			new /obj/effect/gibspawner/human(location, src, get_static_viruses())
 		else
-			new /obj/effect/gibspawner/human/bodypartless(drop_location(), dna, get_static_viruses())
+			new /obj/effect/gibspawner/human/bodypartless(location, src, get_static_viruses())
 
 /mob/living/carbon/human/spawn_dust(just_ash = FALSE)
 	if(just_ash)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -43,6 +43,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	var/exotic_blood = ""	// If your race wants to bleed something other than bog standard blood, change this to reagent id.
 	var/exotic_bloodtype = "" //If your race uses a non standard bloodtype (A+, O-, AB-, etc)
 	var/meat = /obj/item/reagent_containers/food/snacks/meat/slab/human //What the species drops on gibbing
+	var/list/gib_types = list(/obj/effect/gibspawner/human, /obj/effect/gibspawner/human/bodypartless)
 	var/skinned_type
 	var/liked_food = NONE
 	var/disliked_food = GROSS

--- a/code/modules/mob/living/carbon/human/species_types/android.dm
+++ b/code/modules/mob/living/carbon/human/species_types/android.dm
@@ -6,6 +6,7 @@
 	inherent_traits = list(TRAIT_RESISTHEAT,TRAIT_NOBREATH,TRAIT_RESISTCOLD,TRAIT_RESISTHIGHPRESSURE,TRAIT_RESISTLOWPRESSURE,TRAIT_RADIMMUNE,TRAIT_NOFIRE,TRAIT_PIERCEIMMUNE,TRAIT_NOHUNGER,TRAIT_LIMBATTACHMENT)
 	inherent_biotypes = list(MOB_ROBOTIC, MOB_HUMANOID)
 	meat = null
+	gib_types = /obj/effect/gibspawner/robot
 	damage_overlay_type = "synth"
 	mutanttongue = /obj/item/organ/tongue/robot
 	limbs_id = "synth"

--- a/code/modules/mob/living/carbon/human/species_types/corporate.dm
+++ b/code/modules/mob/living/carbon/human/species_types/corporate.dm
@@ -18,3 +18,4 @@
 	species_traits = list(NOBLOOD,EYECOLOR,NOGENITALS)
 	inherent_traits = list(TRAIT_RADIMMUNE,TRAIT_VIRUSIMMUNE,TRAIT_PIERCEIMMUNE,TRAIT_NODISMEMBER,TRAIT_NOLIMBDISABLE,TRAIT_NOHUNGER)
 	sexes = 0
+	gib_types = /obj/effect/gibspawner/robot

--- a/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -64,6 +64,7 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
+	gib_types = list(/obj/effect/gibspawner/xeno/xenoperson, /obj/effect/gibspawner/xeno/xenoperson/bodypartless)
 	skinned_type = /obj/item/stack/sheet/animalhide/xeno
 	exotic_bloodtype = "X*"
 	damage_overlay_type = "xeno"

--- a/code/modules/mob/living/carbon/human/species_types/ipc.dm
+++ b/code/modules/mob/living/carbon/human/species_types/ipc.dm
@@ -11,6 +11,7 @@
 	mutant_bodyparts = list("ipc_screen", "ipc_antenna")
 	default_features = list("ipc_screen" = "Blank", "ipc_antenna" = "None")
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/ipc
+	gib_types = list(/obj/effect/gibspawner/ipc, /obj/effect/gibspawner/ipc/bodypartless)
 	mutanttongue = /obj/item/organ/tongue/robot/ipc
 	mutant_heart = /obj/item/organ/heart/ipc
 	exotic_bloodtype = "HF"

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -11,6 +11,7 @@
 	default_features = list("mcolor" = "FFF", "mam_tail" = "None", "mam_ears" = "None", "mam_snouts" = "None", "taur" = "None", "deco_wings" = "None") //CIT CHANGE
 	inherent_traits = list(TRAIT_TOXINLOVER)
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime
+	gib_types = list(/obj/effect/gibspawner/slime, /obj/effect/gibspawner/slime/bodypartless)
 	exotic_blood = "jellyblood"
 	exotic_bloodtype = "GEL"
 	damage_overlay_type = ""

--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -18,6 +18,7 @@
 	attack_sound = 'sound/weapons/slash.ogg'
 	miss_sound = 'sound/weapons/slashmiss.ogg'
 	meat = /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard
+	gib_types = list(/obj/effect/gibspawner/lizard, /obj/effect/gibspawner/lizard/bodypartless)
 	skinned_type = /obj/item/stack/sheet/animalhide/lizard
 	exotic_bloodtype = "L"
 	disliked_food = GRAIN | DAIRY

--- a/code/modules/mob/living/carbon/human/species_types/synths.dm
+++ b/code/modules/mob/living/carbon/human/species_types/synths.dm
@@ -9,6 +9,7 @@
 	dangerous_existence = 1
 	blacklisted = 1
 	meat = null
+	gib_types = /obj/effect/gibspawner/robot
 	damage_overlay_type = "synth"
 	limbs_id = "synth"
 	var/list/initial_species_traits = list(NOTRANSSTING) //for getting these values back for assume_disguise()

--- a/code/modules/mob/living/death.dm
+++ b/code/modules/mob/living/death.dm
@@ -23,8 +23,12 @@
 /mob/living/proc/gib_animation()
 	return
 
-/mob/living/proc/spawn_gibs()
-	new /obj/effect/gibspawner/generic(drop_location(), null, get_static_viruses())
+/mob/living/proc/spawn_gibs(with_bodyparts, atom/loc_override)
+	var/location = loc_override ? loc_override.drop_location() : drop_location()
+	if(MOB_ROBOTIC in mob_biotypes)
+		new /obj/effect/gibspawner/robot(location, src, get_static_viruses())
+	else
+		new /obj/effect/gibspawner/generic(location, src, get_static_viruses())
 
 /mob/living/proc/spill_organs()
 	return

--- a/code/modules/mob/living/silicon/death.dm
+++ b/code/modules/mob/living/silicon/death.dm
@@ -1,5 +1,5 @@
-/mob/living/silicon/spawn_gibs()
-	new /obj/effect/gibspawner/robot(drop_location())
+/mob/living/silicon/spawn_gibs(with_bodyparts, atom/loc_override)
+	new /obj/effect/gibspawner/robot(loc_override ? loc_override.drop_location() : drop_location(), src)
 
 /mob/living/silicon/spawn_dust()
 	new /obj/effect/decal/remains/robot(loc)

--- a/code/modules/mob/living/simple_animal/hostile/netherworld.dm
+++ b/code/modules/mob/living/simple_animal/hostile/netherworld.dm
@@ -95,7 +95,7 @@
 		if(M)
 			playsound(src, 'sound/magic/demon_consume.ogg', 50, 1)
 			M.adjustBruteLoss(60)
-			new /obj/effect/gibspawner/generic(get_turf(M))
+			M.spawn_gibs()
 			if(M.stat == DEAD)
 				var/mob/living/simple_animal/hostile/netherworld/blankbody/blank
 				blank = new(loc)

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -86,10 +86,9 @@
 		var/mob/living/carbon/C = user
 		log_game("[key_name(C)] has been disintegrated by attempting to telekenetically grab a singularity.</span>")
 		C.visible_message("<span class='danger'>[C]'s head begins to collapse in on itself!</span>", "<span class='userdanger'>Your head feels like it's collapsing in on itself! This was really not a good idea!</span>", "<span class='italics'>You hear something crack and explode in gore.</span>")
-		var/turf/T = get_turf(C)
 		for(var/i in 1 to 3)
 			C.apply_damage(30, BRUTE, BODY_ZONE_HEAD)
-			new /obj/effect/gibspawner/generic(T)
+			C.spawn_gibs()
 			sleep(1)
 		var/obj/item/bodypart/head/rip_u = C.get_bodypart(BODY_ZONE_HEAD)
 		rip_u.dismember(BURN) //nice try jedi

--- a/code/modules/projectiles/guns/ballistic.dm
+++ b/code/modules/projectiles/guns/ballistic.dm
@@ -152,7 +152,7 @@
 
 #define BRAINS_BLOWN_THROW_RANGE 3
 #define BRAINS_BLOWN_THROW_SPEED 1
-/obj/item/gun/ballistic/suicide_act(mob/user)
+/obj/item/gun/ballistic/suicide_act(mob/living/user)
 	var/obj/item/organ/brain/B = user.getorganslot(ORGAN_SLOT_BRAIN)
 	if (B && chambered && chambered.BB && can_trigger_gun(user) && !chambered.BB.nodamage)
 		user.visible_message("<span class='suicide'>[user] is putting the barrel of [src] in [user.p_their()] mouth.  It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -165,12 +165,10 @@
 			var/turf/target = get_ranged_target_turf(user, turn(user.dir, 180), BRAINS_BLOWN_THROW_RANGE)
 			B.Remove(user)
 			B.forceMove(T)
-			var/datum/dna/user_dna
 			if(iscarbon(user))
 				var/mob/living/carbon/C = user
-				user_dna = C.dna
-				B.add_blood_DNA(user_dna, C.diseases)
-			var/datum/callback/gibspawner = CALLBACK(GLOBAL_PROC, /proc/spawn_atom_to_turf, /obj/effect/gibspawner/generic, B, 1, FALSE, list(user_dna))
+				B.add_blood_DNA(C.dna, C.diseases)
+			var/datum/callback/gibspawner = CALLBACK(user, /mob/living/proc/spawn_gibs, FALSE, B)
 			B.throw_at(target, BRAINS_BLOWN_THROW_RANGE, BRAINS_BLOWN_THROW_SPEED, callback=gibspawner)
 			return(BRUTELOSS)
 		else


### PR DESCRIPTION
## About The Pull Request
Fixing some gibspawner runtimes caused by the mobs' dna being passed down as argument while it should be the mob itself now, thanks to Poojawa's blood refactor.

While I was at it I also replaced several new generic gibs spawners with the mob's spawn_gibs() proc, for consistency, reorganized human's spawn_gibs() to check the new species gib_types var, made synths (not to be confused with IPCs), androids and corporate agent species as well as simple mobs with the MOB_ROBOTIC mob biotype drop robotic gibs on death instead.

## Why It's Good For The Game
Fixing runtimes and improving bloody hells.

## Changelog
:cl:
fix: humans should now drop gibs when gibbed again.
add: synths (not to be confused with IPCs), android and corporate species, as well as robotic simple mobs, will now spawn robotic giblets instead of organic ones.
/:cl:
