### PR TITLE
How many times I have encountered this sort of issue in the past and how much of a meme it was...

### DIFF
--- a/code/game/objects/items/storage/dakis.dm
+++ b/code/game/objects/items/storage/dakis.dm
@@ -7,7 +7,7 @@
 	desc = "A large pillow depicting a girl in a compromising position. Featuring as many dimensions as you."
 	icon = 'icons/obj/daki.dmi'
 	icon_state = "daki_base"
-	slot_flags = SLOT_BACK
+	slot_flags = ITEM_SLOT_BACK
 	var/cooldowntime = 20
 	var/static/list/dakimakura_options = list("Callie","Casca","Chaika","Elisabeth","Foxy Grandpa","Haruko","Holo","Ian","Jolyne","Kurisu","Marie","Mugi","Nar'Sie","Patchouli","Plutia","Rei","Reisen","Naga","Squid","Squigly","Tomoko","Toriel","Umaru","Yaranaika","Yoko") //Kurisu is the ideal girl." - Me, Logos.
 


### PR DESCRIPTION
## About The Pull Request
This brings me back to when laser rifles were first merged on TGMC shortly after I refactored inventory code flags and how it ended up with people being able to wear them over their eyes because the slot flags were left unmodified... "I have special eyes".

## Why It's Good For The Game
Fixing an issue.

## Changelog
:cl:
fix: You can't wear dakimakuras in any other inappropriate slots save for the back slot anymore, degenerates.
/:cl:

