### PR TITLE
Allow Xenomorph to speak their language

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/furrypeople.dm
@@ -70,6 +70,7 @@
 	liked_food = MEAT
 
 /datum/species/xeno/on_species_gain(mob/living/carbon/human/C, datum/species/old_species)
+	C.grant_language(/datum/language/xenocommon)
 	if(("legs" in C.dna.species.mutant_bodyparts) && (C.dna.features["legs"] == "Digitigrade" || C.dna.features["legs"] == "Avian"))
 		species_traits += DIGITIGRADE
 	if(DIGITIGRADE in species_traits)
@@ -77,6 +78,7 @@
 	. = ..()
 
 /datum/species/xeno/on_species_loss(mob/living/carbon/human/C, datum/species/new_species)
+	C.remove_language(/datum/language/xenocommon)
 	if(("legs" in C.dna.species.mutant_bodyparts) && C.dna.features["legs"] == "Plantigrade")
 		species_traits -= DIGITIGRADE
 	if(DIGITIGRADE in species_traits)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This allow Xenomorph Crew members to speak the xeno language, like how Slimepersons can speak the slime language and the Lizards can speak Draconic

## Why It's Good For The Game

It was proposed in the suggestion chat, and I thought it would be an easy fix that also make sense at the same time.

## Changelog
:cl:
add: Added the ability to speak Xenocommon to Xenomorphs Crew Members
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
