### PR TITLE
Minor ninja tweaks and stealth nerf.

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -70,7 +70,7 @@
 #define COMSIG_ATOM_CANREACH "atom_can_reach"					//from internal loop in atom/movable/proc/CanReach(): (list/next)
 	#define COMPONENT_BLOCK_REACH 1
 #define COMSIG_ATOM_SCREWDRIVER_ACT "atom_screwdriver_act"		//from base of atom/screwdriver_act(): (mob/living/user, obj/item/I)
-#define COMSIG_ATOM_INTERCEPT_TELEPORT "intercept_teleport"		//called when teleporting into a protected turf: (channel, turf/origin)
+#define COMSIG_ATOM_INTERCEPT_TELEPORT "intercept_teleport"		//called when teleporting into a protected turf: (channel, turf/origin, turf/destination)
 	#define COMPONENT_BLOCK_TELEPORT 1
 /////////////////
 #define COMSIG_ATOM_ATTACK_GHOST "atom_attack_ghost"			//from base of atom/attack_ghost(): (mob/dead/observer/ghost)
@@ -117,6 +117,7 @@
 #define COMSIG_MOVABLE_Z_CHANGED "movable_ztransit" 			//from base of atom/movable/onTransitZ(): (old_z, new_z)
 #define COMSIG_MOVABLE_HEAR "movable_hear"						//from base of atom/movable/Hear(): (message, atom/movable/speaker, message_language, raw_message, radio_freq, list/spans, message_mode)
 #define COMSIG_MOVABLE_DISPOSING "movable_disposing"			//called when the movable is added to a disposal holder object for disposal movement: (obj/structure/disposalholder/holder, obj/machinery/disposal/source)
+#define COMSIG_MOVABLE_TELEPORTED "movable_teleported"			//from base of do_teleport(): (channel, turf/origin, turf/destination)
 
 // /mind signals
 #define  COMSIG_MIND_TRANSFER "mind_transfer"					//from base of mind/transfer_to(): (new_character, old_character)
@@ -153,6 +154,7 @@
 #define COMSIG_LIVING_EXTINGUISHED "living_extinguished"		//from base of mob/living/ExtinguishMob() (/mob/living)
 #define COMSIG_LIVING_ELECTROCUTE_ACT "living_electrocute_act"		//from base of mob/living/electrocute_act(): (shock_damage)
 #define COMSIG_LIVING_MINOR_SHOCK "living_minor_shock"			//sent by stuff like stunbatons and tasers: ()
+#define COMSIG_LIVING_GUN_PROCESS_FIRE "living_gun_process_fire"	//from base of /obj/item/gun/proc/process_fire(): (atom/target, params, zone_override)
 
 // /mob/living/carbon signals
 #define COMSIG_CARBON_SOUNDBANG "carbon_soundbang"					//from base of mob/living/carbon/soundbang_act(): (list(intensity))

--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -34,11 +34,10 @@
 	var/turf/T = get_turf(target)
 	if(target in view(user.client.view, user))
 		var/obj/spot1 = new phaseout(get_turf(user), user.dir)
-		user.forceMove(T)
-		playsound(T, dash_sound, 25, 1)
-		var/obj/spot2 = new phasein(get_turf(user), user.dir)
-		spot1.Beam(spot2,beam_effect,time=20)
-		current_charges--
+		if(do_teleport(user, T, null, TRUE, null, null, dash_sound, dash_sound, TRUE, TELEPORT_CHANNEL_FREE, TRUE))
+			var/obj/spot2 = new phasein(get_turf(user), user.dir)
+			spot1.Beam(spot2,beam_effect,time=20)
+			current_charges--
 		holder.update_action_buttons_icon()
 		addtimer(CALLBACK(src, .proc/charge), charge_rate)
 

--- a/code/datums/helper_datums/teleport.dm
+++ b/code/datums/helper_datums/teleport.dm
@@ -79,6 +79,7 @@
 		tele_play_specials(teleatom, destturf, effectout, asoundout)
 		if(ismegafauna(teleatom))
 			message_admins("[teleatom] [ADMIN_FLW(teleatom)] has teleported from [ADMIN_VERBOSEJMP(curturf)] to [ADMIN_VERBOSEJMP(destturf)].")
+		SEND_SIGNAL(teleatom, COMSIG_MOVABLE_TELEPORTED, channel, curturf, destturf)
 
 	if(ismob(teleatom))
 		var/mob/M = teleatom

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stealth.dm
@@ -8,7 +8,7 @@ Contents:
 
 
 /obj/item/clothing/suit/space/space_ninja/proc/toggle_stealth()
-	if(!affecting)
+	if(!affecting || stealth_cooldown > world.time)
 		return
 	if(stealth)
 		cancel_stealth()
@@ -16,26 +16,34 @@ Contents:
 		if(cell.charge <= 0)
 			to_chat(affecting, "<span class='warning'>You don't have enough power to enable Stealth!</span>")
 			return
-		stealth = !stealth
-		animate(affecting, alpha = 10,time = 15)
+		stealth = TRUE
+		stealth_cooldown = world.time + 5 SECONDS
+		animate(affecting, alpha = 15, time = 3 SECONDS)
 		affecting.visible_message("<span class='warning'>[affecting.name] vanishes into thin air!</span>", \
 						"<span class='notice'>You are now mostly invisible to normal detection.</span>")
-		RegisterSignal(affecting, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_PARENT_ATTACKBY), .proc/reduce_stealth)
-		RegisterSignal(affecting, COMSIG_MOVABLE_BUMP, .proc/bumping_stealth)
+		addtimer(CALLBACK(src, .proc/enable_signals), 3 SECONDS)
 
-/obj/item/clothing/suit/space/space_ninja/proc/reduce_stealth()
-	affecting.alpha = min(affecting.alpha + 30, 80)
+/obj/item/clothing/suit/space/space_ninja/proc/enable_signals()
+	if(!affecting)
+		return
+	RegisterSignal(affecting, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_PARENT_ATTACKBY, COMSIG_MOVABLE_TELEPORTED, COMSIG_LIVING_GUN_PROCESS_FIRE), .proc/reduce_stealth)
+	RegisterSignal(affecting, COMSIG_MOVABLE_BUMP, .proc/bumping_stealth)
+
+
+/obj/item/clothing/suit/space/space_ninja/proc/reduce_stealth(datum/source)
+	affecting.alpha = min(affecting.alpha + 40, 100)
 
 /obj/item/clothing/suit/space/space_ninja/proc/bumping_stealth(datum/source, atom/A)
 	if(isliving(A))
-		affecting.alpha = min(affecting.alpha + 15, 80)
+		affecting.alpha = min(affecting.alpha + 20, 100)
 
 /obj/item/clothing/suit/space/space_ninja/proc/cancel_stealth()
 	if(!affecting || !stealth)
 		return FALSE
 	stealth = !stealth
-	UnregisterSignal(affecting, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_PARENT_ATTACKBY, COMSIG_MOVABLE_BUMP))
-	animate(affecting, alpha = 255, time = 15)
+	stealth_cooldown = world.time + 5 SECONDS
+	UnregisterSignal(affecting, list(COMSIG_MOB_ITEM_ATTACK, COMSIG_MOB_ATTACK_RANGED, COMSIG_MOB_ATTACK_HAND, COMSIG_MOB_THROW, COMSIG_PARENT_ATTACKBY, COMSIG_MOVABLE_BUMP, COMSIG_MOVABLE_TELEPORTED, COMSIG_LIVING_GUN_PROCESS_FIRE))
+	animate(affecting, alpha = 255, time = 3 SECONDS)
 	affecting.visible_message("<span class='warning'>[affecting.name] appears from thin air!</span>", \
 					"<span class='notice'>You are now visible.</span>")
 	return TRUE

--- a/code/modules/ninja/suit/suit.dm
+++ b/code/modules/ninja/suit/suit.dm
@@ -49,6 +49,7 @@ Contents:
 
 		//Support function variables.
 	var/stealth = FALSE//Stealth off.
+	var/stealth_cooldown = 0
 	var/s_busy = FALSE//Is the suit busy with a process? Like AI hacking. Used for safety functions.
 
 		//Ability function variables.

--- a/code/modules/ninja/suit/suit_process.dm
+++ b/code/modules/ninja/suit/suit_process.dm
@@ -7,7 +7,7 @@
 			s_coold--//Checks for ability s_cooldown first.
 
 		cell.charge -= s_cost//s_cost is the default energy cost each tick, usually 5.
-		if(stealth)//If stealth is active.
+		if(stealth && stealth_cooldown <= world.time)//If stealth is active.
 			cell.charge -= s_acost
 			affecting.alpha = max(affecting.alpha - 10, 10)
 

--- a/code/modules/ninja/suit/suit_process.dm
+++ b/code/modules/ninja/suit/suit_process.dm
@@ -9,7 +9,7 @@
 		cell.charge -= s_cost//s_cost is the default energy cost each tick, usually 5.
 		if(stealth && stealth_cooldown <= world.time)//If stealth is active.
 			cell.charge -= s_acost
-			affecting.alpha = max(affecting.alpha - 10, 10)
+			affecting.alpha = max(affecting.alpha - 10, 15)
 
 	else
 		cell.charge = 0

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -298,6 +298,7 @@
 
 	if(user)
 		user.update_inv_hands()
+		SEND_SIGNAL(user, COMSIG_LIVING_GUN_PROCESS_FIRE, target, params, zone_override)
 	SSblackbox.record_feedback("tally", "gun_fired", 1, type)
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Kevinz told me ninja stealth is too buff now (salt), so here I am, nerfing its values a little, including two new signals (ergo teleportion and firing guns) to the list of things that reduce the owner's invisibility, raising the animation timers for stealthing in and out and adding a 5 seconds cooldown between toggling stealth on/off. Also converted ninja dash forceMove() into do_teleport().

## Why It's Good For The Game
Tweaking and nerfing neigh-hard-to-see ninjas.

## Changelog
:cl:
balance: Minor ninja tweaks and stealth nerfs. The stealth penalty for the many combat-related actions, bumping and now teleporting/dashing or firing guns has been increased a by a third. There is now a cooldown of 5 seconds on toggling stealth as well as a slighty slowed stealth in/out animation.
/:cl:
