### PR TITLE
Makes SDGF transfer notes/memories.

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/SDGF.dm
@@ -94,6 +94,7 @@ IMPORTANT FACTORS TO CONSIDER WHILE BALANCING
 				if(!SM.mind) //Something went wrong, use alt mechanics
 					return ..()
 				SM.mind.enslave_mind_to_creator(M)
+				SM.mind.store_memory(M.mind.memory)
 
 				//If they're a zombie, they can try to negate it with this.
 				//I seriously wonder if anyone will ever use this function.


### PR DESCRIPTION
## About The Pull Request

Couldn't think of a good reason that manually-written memories aren't transferred to SDGF clones, especially since SDGF's flavor explicitly says that you have the same memory.

## Why It's Good For The Game

Bringing mechanics up to flavor, allows easier coordination with SDGF clones.

## Changelog
:cl:
tweak: SDGF now copies memories as well as antag data and factions.
/:cl: