### PR TITLE
Riding component fix and hacky mood runtimes workaround.

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -21,7 +21,6 @@
 	RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT, .proc/add_event)
 	RegisterSignal(parent, COMSIG_CLEAR_MOOD_EVENT, .proc/clear_event)
 	RegisterSignal(parent, COMSIG_MODIFY_SANITY, .proc/modify_sanity)
-	RegisterSignal(parent, COMSIG_PARENT_QDELETED, .proc/work_around) // hacky work around to an obnoxious runtime issue we haven't found the source of yet.
 
 	RegisterSignal(parent, COMSIG_MOB_HUD_CREATED, .proc/modify_hud)
 	var/mob/living/owner = parent
@@ -34,9 +33,6 @@
 	STOP_PROCESSING(SSmood, src)
 	unmodify_hud()
 	return ..()
-
-/datum/component/mood/proc/work_around(datum/source) // I'm sorry and tired.
-	qdel(src)
 
 /datum/component/mood/proc/print_mood(mob/user)
 	var/msg = "<span class='info'>*---------*\n<EM>Your current mood</EM>\n"
@@ -129,6 +125,9 @@
 			screen_obj.icon_state = "mood[mood_level]"
 
 /datum/component/mood/process() //Called on SSmood process
+	if(QDELETED(parent)) // workaround to an obnoxious sneaky periodical runtime.
+		qdel(src)
+		return
 	var/mob/living/owner = parent
 
 	switch(mood_level)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -21,6 +21,7 @@
 	RegisterSignal(parent, COMSIG_ADD_MOOD_EVENT, .proc/add_event)
 	RegisterSignal(parent, COMSIG_CLEAR_MOOD_EVENT, .proc/clear_event)
 	RegisterSignal(parent, COMSIG_MODIFY_SANITY, .proc/modify_sanity)
+	RegisterSignal(parent, COMSIG_PARENT_QDELETED, .proc/work_around) // hacky work around to an obnoxious runtime issue we haven't found the source of yet.
 
 	RegisterSignal(parent, COMSIG_MOB_HUD_CREATED, .proc/modify_hud)
 	var/mob/living/owner = parent
@@ -33,6 +34,9 @@
 	STOP_PROCESSING(SSmood, src)
 	unmodify_hud()
 	return ..()
+
+/datum/component/mood/proc/work_around(datum/source) // I'm sorry and tired.
+	qdel(src)
 
 /datum/component/mood/proc/print_mood(mob/user)
 	var/msg = "<span class='info'>*---------*\n<EM>Your current mood</EM>\n"
@@ -249,7 +253,7 @@
 	RegisterSignal(screen_obj, COMSIG_CLICK, .proc/hud_click)
 
 /datum/component/mood/proc/unmodify_hud(datum/source)
-	if(!screen_obj)
+	if(!screen_obj || !parent)
 		return
 	var/mob/living/owner = parent
 	var/datum/hud/hud = owner.hud_used

--- a/code/datums/components/riding.dm
+++ b/code/datums/components/riding.dm
@@ -310,10 +310,10 @@
 		if(!user.put_in_hands(inhand, TRUE))
 			qdel(inhand) // it isn't going to be added to offhands anyway
 			break
-		LAZYADD(equipped, src)
+		LAZYADD(equipped, inhand)
 	var/amount_equipped = LAZYLEN(equipped)
 	if(amount_equipped)
-		LAZYADD(offhands[L], amount_equipped)
+		LAZYADD(offhands[L], equipped)
 	if(amount_equipped >= amount_required)
 		return TRUE
 	unequip_buckle_inhands(L)


### PR DESCRIPTION
## About The Pull Request
First, fixing the riding component, apparently re-re-reviewing what I wrote on the file personally didn't help.
Second, a hacky fix to mood components with no owner throwing gazillions runtimes. I have checked the garbage subsystem (similar to tg's save for some unrelated lines), the base datums/atoms/movables/mob Destroy(), _component.dm (similar to tg's minus spacedmm hooks and documentation), mood.dm itself yet couldn't find trace of why is this happening yet.

## Why It's Good For The Game
Welp, yea sorry for not putting the riding component fix on another PR.

## Changelog
:cl:
fix: Riding component fix
/:cl:
