### PR TITLE
Fixes free real estate paraplegic trait and bolas.

### DIFF
--- a/code/modules/surgery/bodyparts/helpers.dm
+++ b/code/modules/surgery/bodyparts/helpers.dm
@@ -112,13 +112,13 @@
 /mob/proc/get_leg_ignore()
 	return FALSE
 
-/mob/living/carbon/alien/larva/get_leg_ignore()
-	return TRUE
-
-/mob/living/carbon/human/get_leg_ignore()
-	if(movement_type & FLYING|FLOATING)
+/mob/living/carbon/get_leg_ignore()
+	if(movement_type & (FLYING|FLOATING))
 		return TRUE
 	return FALSE
+
+/mob/living/carbon/alien/larva/get_leg_ignore()
+	return TRUE
 
 /mob/living/proc/get_missing_limbs()
 	return list()


### PR DESCRIPTION
## About The Pull Request
This will close #9673 (also legcuffs not working). Also making the now fixed floating/flying check carbon level because monkeys.

## Why It's Good For The Game
Fixing some issues. And yes, it's my fault.

## Changelog
:cl:
fix: Fixed free real estate paraplegic trait and bolas.
/:cl: