### PR TITLE
Makes summon (X) spells interact with dynamic's threat system, when applicable

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -411,3 +411,27 @@
 /datum/config_entry/keyed_list/dynamic_high_population_requirement
 	key_mode = KEY_MODE_TEXT
 	value_mode = VALUE_MODE_NUM
+
+/datum/config_entry/number/dynamic_summon_guns_requirement
+	config_entry_value = 10
+	min_val = 0
+
+/datum/config_entry/number/dynamic_summon_guns_cost
+	config_entry_value = 5
+	min_val = 0
+
+/datum/config_entry/number/dynamic_summon_magic_requirement
+	config_entry_value = 10
+	min_val = 0
+
+/datum/config_entry/number/dynamic_summon_magic_cost
+	config_entry_value = 5
+	min_val = 0
+
+/datum/config_entry/number/dynamic_summon_events_requirement
+	config_entry_value = 20
+	min_val = 0
+
+/datum/config_entry/number/dynamic_summon_events_cost
+	config_entry_value = 10
+	min_val = 0

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -484,7 +484,7 @@
 		return 0
 	if(istype(SSticker.mode,/datum/game_mode/dynamic))
 		var/datum/game_mode/dynamic/mode = SSticker.mode
-		if(mode.threat < CONFIG_GET(number/summon_guns_requirement))
+		if(mode.threat < CONFIG_GET(number/dynamic_summon_guns_requirement))
 			return 0
 	return !CONFIG_GET(flag/no_summon_guns)
 
@@ -496,7 +496,7 @@
 	to_chat(user, "<span class='notice'>You have cast summon guns!</span>")
 	if(istype(SSticker.mode,/datum/game_mode/dynamic))
 		var/datum/game_mode/dynamic/mode = SSticker.mode
-		mode.spend_threat(CONFIG_GET(number/summon_guns_cost))
+		mode.spend_threat(CONFIG_GET(number/dynamic_summon_guns_cost))
 	return 1
 
 /datum/spellbook_entry/summon/magic
@@ -508,7 +508,7 @@
 		return 0
 	if(istype(SSticker.mode,/datum/game_mode/dynamic))
 		var/datum/game_mode/dynamic/mode = SSticker.mode
-		if(mode.threat < CONFIG_GET(number/summon_magic_requirement))
+		if(mode.threat < CONFIG_GET(number/dynamic_summon_magic_requirement))
 			return 0
 	return !CONFIG_GET(flag/no_summon_magic)
 
@@ -520,7 +520,7 @@
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")
 	if(istype(SSticker.mode,/datum/game_mode/dynamic))
 		var/datum/game_mode/dynamic/mode = SSticker.mode
-		mode.spend_threat(CONFIG_GET(number/summon_magic_cost))
+		mode.spend_threat(CONFIG_GET(number/dynamic_summon_magic_cost))
 	return 1
 
 /datum/spellbook_entry/summon/events
@@ -533,7 +533,7 @@
 		return 0
 	if(istype(SSticker.mode,/datum/game_mode/dynamic) && times == 0)
 		var/datum/game_mode/dynamic/mode = SSticker.mode
-		if(mode.threat < CONFIG_GET(number/summon_events_requirement))
+		if(mode.threat < CONFIG_GET(number/dynamic_summon_events_requirement))
 			return 0
 	return !CONFIG_GET(flag/no_summon_events)
 
@@ -545,7 +545,7 @@
 	to_chat(user, "<span class='notice'>You have cast summon events.</span>")
 	if(istype(SSticker.mode,/datum/game_mode/dynamic) && times == 0)
 		var/datum/game_mode/dynamic/mode = SSticker.mode
-		mode.spend_threat(CONFIG_GET(number/summon_events_cost))
+		mode.spend_threat(CONFIG_GET(number/dynamic_summon_events_cost))
 	return 1
 
 /datum/spellbook_entry/summon/events/GetInfo()

--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -482,6 +482,10 @@
 /datum/spellbook_entry/summon/guns/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
 		return 0
+	if(istype(SSticker.mode,/datum/game_mode/dynamic))
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		if(mode.threat < CONFIG_GET(number/summon_guns_requirement))
+			return 0
 	return !CONFIG_GET(flag/no_summon_guns)
 
 /datum/spellbook_entry/summon/guns/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
@@ -490,6 +494,9 @@
 	active = 1
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon guns!</span>")
+	if(istype(SSticker.mode,/datum/game_mode/dynamic))
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		mode.spend_threat(CONFIG_GET(number/summon_guns_cost))
 	return 1
 
 /datum/spellbook_entry/summon/magic
@@ -499,6 +506,10 @@
 /datum/spellbook_entry/summon/magic/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
 		return 0
+	if(istype(SSticker.mode,/datum/game_mode/dynamic))
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		if(mode.threat < CONFIG_GET(number/summon_magic_requirement))
+			return 0
 	return !CONFIG_GET(flag/no_summon_magic)
 
 /datum/spellbook_entry/summon/magic/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
@@ -507,6 +518,9 @@
 	active = 1
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon magic!</span>")
+	if(istype(SSticker.mode,/datum/game_mode/dynamic))
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		mode.spend_threat(CONFIG_GET(number/summon_magic_cost))
 	return 1
 
 /datum/spellbook_entry/summon/events
@@ -517,6 +531,10 @@
 /datum/spellbook_entry/summon/events/IsAvailible()
 	if(!SSticker.mode) // In case spellbook is placed on map
 		return 0
+	if(istype(SSticker.mode,/datum/game_mode/dynamic) && times == 0)
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		if(mode.threat < CONFIG_GET(number/summon_events_requirement))
+			return 0
 	return !CONFIG_GET(flag/no_summon_events)
 
 /datum/spellbook_entry/summon/events/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
@@ -525,6 +543,9 @@
 	times++
 	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
 	to_chat(user, "<span class='notice'>You have cast summon events.</span>")
+	if(istype(SSticker.mode,/datum/game_mode/dynamic) && times == 0)
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		mode.spend_threat(CONFIG_GET(number/summon_events_cost))
 	return 1
 
 /datum/spellbook_entry/summon/events/GetInfo()

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -396,6 +396,22 @@ DYNAMIC_HIGH_POPULATION_REQUIREMENT NIGHTMARE 50
 DYNAMIC_HIGH_POPULATION_REQUIREMENT LATEJOIN_TRAITOR 10
 DYNAMIC_HIGH_POPULATION_REQUIREMENT LATEJOIN_REVOLUTION 50
 
+## Dynamic wizard stuff
+
+## How much threat level is required to buy summon guns. Setting to 0 makes it always available.
+DYNAMIC_SUMMON_GUNS_REQUIREMENT 10
+
+## How much summon guns reduces the round's remaining threat. Setting to 0 makes it cost none.
+DYNAMIC_SUMMON_GUNS_COST 5
+
+## As above, but for summon magic
+DYNAMIC_SUMMON_MAGIC_REQUIREMENT 10
+DYNAMIC_SUMMON_MAGIC_COST 5
+
+## As above, but for summon events
+DYNAMIC_SUMMON_EVENTS_REQUIREMENT 20
+DYNAMIC_SUMMON_EVENTS_COST 10
+
 ## AI ###
 
 ## Allow the AI job to be picked.


### PR DESCRIPTION
## About The Pull Request

A wizard who uses summon events has caused far more chaos, so reflect that if dynamic mode is being played. There's options in game_options that reflect these values, which can be changed as seen fit.

Could add stuff for s/laughter demons too, but I'm unsure, since those are somewhat more localized while this is a global event. Course, that's just post hoc justification for me having forgotten about 'em.

## Why It's Good For The Game

Honestly more things should use dynamic's threat system *in general*, when dynamic is being played, and it's all customizable anyway.

## Changelog
:cl:
balance: In dynamic mode, summon events/guns/magic now count as, essentially, minor antags in their own way.
config: Added configuration that adjusts how much the summon spells adjust dynamic threat.
/:cl: