### PR TITLE
makes gps show location on examine

### DIFF
--- a/code/game/objects/items/devices/gps.dm
+++ b/code/game/objects/items/devices/gps.dm
@@ -15,6 +15,8 @@ GLOBAL_LIST_EMPTY(GPS_list)
 
 /obj/item/gps/examine(mob/user)
 	..()
+	var/turf/curr = get_turf(src)
+	to_chat(user, "The screen says: [get_area_name(curr, TRUE)] ([curr.x], [curr.y], [curr.z])")
 	to_chat(user, "<span class='notice'>Alt-click to switch it [tracking ? "off":"on"].</span>")
 
 /obj/item/gps/Initialize()


### PR DESCRIPTION

## About The Pull Request

Adds the gps's location to the description of it.

## Why It's Good For The Game

Because it seems like a good idea. On devices where people play SS13 with really really shitty computers, they can barely use the GPS menu.

## Changelog
:cl:
add: GPS location on examine
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
