### PR TITLE
makes meteor hallucinations have an ETA now

### DIFF
--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -894,7 +894,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			SEND_SOUND(target, get_announcer_sound("aimalf"))
 		if("meteors") //Meteors inbound!
 			to_chat(target, "<h1 class='alert'>Meteor Alert</h1>")
-			to_chat(target, "<br><br><span class='alert'>Meteors have been detected on collision course with the station.</span><br><br>")
+			to_chat(target, "<br><br><span class='alert'>Meteors have been detected on collision course with the station. Estimated time until impact: [round(rand(300,600)/60)] minutes.</span><br><br>")
 			SEND_SOUND(target, get_announcer_sound("meteors"))
 		if("supermatter")
 			SEND_SOUND(target, 'sound/magic/charge.ogg')


### PR DESCRIPTION
## About The Pull Request

Gives meteor hallucinations an ETA.

## Why It's Good For The Game

SO PEOPLE STOP FUCKIN SAYING "OH IT'S JUST A HALLUCINATION" AND ACTUALLY GET WORRIED AGAIN.

## Changelog
:cl:
fix: fixed the meteor hallucination
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
