### PR TITLE
Ports Closet & Crate Initialization Fixes

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -44,7 +44,7 @@
 	update_icon()
 	PopulateContents()
 	if(mapload && !opened)		// if closed, any item at the crate's loc is put in the contents
-		take_contents()
+		addtimer(CALLBACK(src, .proc/take_contents), 0)
 	if(secure)
 		lockerelectronics = new(src)
 		lockerelectronics.accesses = req_access

--- a/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets/utility_closets.dm
@@ -26,7 +26,7 @@
 	if (prob(40))
 		new /obj/item/storage/toolbox/emergency(src)
 
-	switch (pickweight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10, "nothing" = 4, "delete" = 1)))
+	switch (pickweight(list("small" = 40, "aid" = 25, "tank" = 20, "both" = 10, "nothing" = 5)))
 		if ("small")
 			new /obj/item/tank/internals/emergency_oxygen(src)
 			new /obj/item/tank/internals/emergency_oxygen(src)
@@ -49,9 +49,7 @@
 		if ("nothing")
 			// doot
 
-		// teehee
-		if ("delete")
-			qdel(src)
+			return
 
 /*
  * Fire Closet


### PR DESCRIPTION
## About The Pull Request

Ports a similarly named [pull request](https://github.com/KeplerStation/KeplerStation/pull/860) (thank you Cool Cat, you saved Citadel).

## Why It's Good For The Game

Stuff hanging out on top of lockers is not hot.

## Changelog
:cl:
fix: fixed closet initialisation being broken
del: emergency closets no longer have a 1% chance to delete themselves
/:cl: