### PR TITLE
A few clock cult improvements.

### DIFF
--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -167,6 +167,7 @@ Credit where due:
 		number_players -= 30
 		starter_servants += round(number_players / 10)
 	starter_servants = min(starter_servants, 8) //max 8 servants (that sould only happen with a ton of players)
+	GLOB.clockwork_vitality += 60 * starter_servants //Add some starter vitality based on
 	while(starter_servants)
 		var/datum/mind/servant = antag_pick(antag_candidates)
 		servants_to_serve += servant
@@ -342,6 +343,8 @@ Credit where due:
 	or splashed onto metal sheets to make brass. This chemical can be found in minimal quantities by grinding brass sheets.\
 	<li><b>Brass Flasks:</b>Intended to store Zelus Oil in, but can also be used as fragile single use throwing weapons in a pinch! \
 	These are crafted with a single sheet of brass and fit in the Clockwork Cuirass' suit storage.\
+	<hr>\
+	<li><b>Extra Vitality Matrix:</b> You start your quest with some spare Vitality charge to help recover from any initial foul up. \
 	<b>Good luck!</b>"
 
 /obj/item/paper/servant_primer/Initialize()

--- a/code/game/gamemodes/clock_cult/clock_cult.dm
+++ b/code/game/gamemodes/clock_cult/clock_cult.dm
@@ -167,7 +167,7 @@ Credit where due:
 		number_players -= 30
 		starter_servants += round(number_players / 10)
 	starter_servants = min(starter_servants, 8) //max 8 servants (that sould only happen with a ton of players)
-	GLOB.clockwork_vitality += 60 * starter_servants //Add some starter vitality based on
+	GLOB.clockwork_vitality += 50 * starter_servants //some starter Vitality to help recover from initial fuck ups
 	while(starter_servants)
 		var/datum/mind/servant = antag_pick(antag_candidates)
 		servants_to_serve += servant
@@ -343,8 +343,6 @@ Credit where due:
 	or splashed onto metal sheets to make brass. This chemical can be found in minimal quantities by grinding brass sheets.\
 	<li><b>Brass Flasks:</b>Intended to store Zelus Oil in, but can also be used as fragile single use throwing weapons in a pinch! \
 	These are crafted with a single sheet of brass and fit in the Clockwork Cuirass' suit storage.\
-	<hr>\
-	<li><b>Extra Vitality Matrix:</b> You start your quest with some spare Vitality charge to help recover from any initial foul up. \
 	<b>Good luck!</b>"
 
 /obj/item/paper/servant_primer/Initialize()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -126,7 +126,7 @@
 
 /datum/dynamic_ruleset/roundstart/changeling/execute()
 	var/team_mode = FALSE
-	if(prob(team_mode_probability)) 
+	if(prob(team_mode_probability))
 		team_mode = TRUE
 		var/list/team_objectives = subtypesof(/datum/objective/changeling_team_objective)
 		var/list/possible_team_objectives = list()
@@ -174,14 +174,14 @@
 /datum/dynamic_ruleset/roundstart/wizard/pre_execute()
 	if(GLOB.wizardstart.len == 0)
 		return FALSE
-	
+
 	var/mob/M = pick(candidates)
 	if (M)
 		candidates -= M
 		assigned += M.mind
 		M.mind.assigned_role = ROLE_WIZARD
 		M.mind.special_role = ROLE_WIZARD
-	
+
 	return TRUE
 
 /datum/dynamic_ruleset/roundstart/wizard/execute()
@@ -189,7 +189,7 @@
 		M.current.forceMove(pick(GLOB.wizardstart))
 		M.add_antag_datum(new antag_datum())
 	return TRUE
-	
+
 //////////////////////////////////////////////
 //                                          //
 //                BLOOD CULT                //
@@ -238,7 +238,7 @@
 		var/datum/antagonist/cult/new_cultist = new antag_datum()
 		new_cultist.cult_team = main_cult
 		new_cultist.give_equipment = TRUE
-		M.add_antag_datum(new_cultist)	
+		M.add_antag_datum(new_cultist)
 	main_cult.setup_objectives()
 	return TRUE
 
@@ -390,7 +390,7 @@
 	SSshuttle.registerHostileEnvironment(src)
 
 	return TRUE
-	
+
 /datum/dynamic_ruleset/roundstart/delayed/revs/rule_process()
 	if(check_rev_victory())
 		finished = 1
@@ -492,6 +492,7 @@
 		number_players -= 30
 		starter_servants += round(number_players / 10)
 	starter_servants = min(starter_servants, 8)
+	GLOB.clockwork_vitality += 50 * starter_servants //some starter Vitality to help recover from initial fuck ups
 	for (var/i in 1 to starter_servants)
 		var/mob/servant = pick(candidates)
 		candidates -= servant
@@ -605,7 +606,7 @@
 	high_population_requirement = 101
 	var/devil_limit = 4 // Hard limit on devils if scaling is turned off
 
-/datum/dynamic_ruleset/roundstart/devil/pre_execute()	
+/datum/dynamic_ruleset/roundstart/devil/pre_execute()
 	var/tsc = CONFIG_GET(number/traitor_scaling_coeff)
 	var/num_devils = 1
 

--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -147,6 +147,16 @@
 		if(iscarbon(L))
 			var/mob/living/carbon/M = L
 			M.uncuff()
+		var/brutedamage = L.getBruteLoss()
+		var/burndamage = L.getFireLoss()
+		if(brutedamage || burndamage)
+			var/efficiency = 0.75
+			var/vitality_cost = FLOOR((brutedamage + burndamage * efficienty) / 10, 1)
+			if(GLOB.clockwork_vitality < vitality_cost)
+				efficiency = efficienty * round(GLOB.clockwork_vitality / vitality_cost, 0.1)
+			L.adjustBruteLoss(-(brutedamage * efficiency))
+			L.adjustFireLoss(-(burndamage * efficiency))
+			GLOB.clockwork_vitality = min(GLOB.clockwork_vitality - vitality_cost, 0)
 	L.Knockdown(50) //Completely defenseless for five seconds - mainly to give them time to read over the information they've just been presented with
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L
@@ -262,7 +272,7 @@
 	clockwork_desc = "A sigil that will drain non-Servants that remain on it. Servants that remain on it will be healed if it has any vitality drained."
 	icon_state = "sigilvitality"
 	layer = SIGIL_LAYER
-	alpha = 75
+	alpha = 125
 	color = "#123456"
 	affects_servants = TRUE
 	stat_affected = DEAD

--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -150,13 +150,8 @@
 		var/brutedamage = L.getBruteLoss()
 		var/burndamage = L.getFireLoss()
 		if(brutedamage || burndamage)
-			var/efficiency = 0.75
-			var/vitality_cost = FLOOR((brutedamage + burndamage * efficiency) / 10, 1)
-			if(GLOB.clockwork_vitality < vitality_cost)
-				efficiency = efficiency * round(GLOB.clockwork_vitality / vitality_cost, 0.1)
-			L.adjustBruteLoss(-(brutedamage * efficiency))
-			L.adjustFireLoss(-(burndamage * efficiency))
-			GLOB.clockwork_vitality = min(GLOB.clockwork_vitality - vitality_cost, 0)
+			L.adjustBruteLoss(-(brutedamage * 0.25))
+			L.adjustFireLoss(-(burndamage * 0.25))
 	L.Knockdown(50) //Completely defenseless for five seconds - mainly to give them time to read over the information they've just been presented with
 	if(iscarbon(L))
 		var/mob/living/carbon/C = L

--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -151,9 +151,9 @@
 		var/burndamage = L.getFireLoss()
 		if(brutedamage || burndamage)
 			var/efficiency = 0.75
-			var/vitality_cost = FLOOR((brutedamage + burndamage * efficienty) / 10, 1)
+			var/vitality_cost = FLOOR((brutedamage + burndamage * efficiency) / 10, 1)
 			if(GLOB.clockwork_vitality < vitality_cost)
-				efficiency = efficienty * round(GLOB.clockwork_vitality / vitality_cost, 0.1)
+				efficiency = efficiency * round(GLOB.clockwork_vitality / vitality_cost, 0.1)
 			L.adjustBruteLoss(-(brutedamage * efficiency))
 			L.adjustFireLoss(-(burndamage * efficiency))
 			GLOB.clockwork_vitality = min(GLOB.clockwork_vitality - vitality_cost, 0)

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -80,8 +80,8 @@
 	power_cost = 125
 	whispered = TRUE
 	object_path = /obj/effect/clockwork/sigil/submission
-	creator_message = "<span class='brass'>A luminous sigil appears below you. Any non-Servants to cross it will be converted after 8 seconds if they do not move.</span>"
-	usage_tip = "This is the primary conversion method, though it will not penetrate mindshield implants."
+	creator_message = "<span class='brass'>A luminous sigil appears below you. Any non-Servants to cross it will be converted after 8 seconds if they do not move and are healed of most of their traumas at a vitality matrix cost.</span>"
+	usage_tip = "This is the primary conversion method, though it will not penetrate mindshield implants. Convertees "
 	tier = SCRIPTURE_DRIVER
 	one_per_tile = TRUE
 	primary_component = HIEROPHANT_ANSIBLE

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -80,8 +80,8 @@
 	power_cost = 125
 	whispered = TRUE
 	object_path = /obj/effect/clockwork/sigil/submission
-	creator_message = "<span class='brass'>A luminous sigil appears below you. Any non-Servants to cross it will be converted after 8 seconds if they do not move and are healed of most of their traumas at a vitality matrix cost.</span>"
-	usage_tip = "This is the primary conversion method, though it will not penetrate mindshield implants. Convertees "
+	creator_message = "<span class='brass'>A luminous sigil appears below you. Any non-Servants to cross it will be converted and healed of some of their wounds after 8 seconds if they do not move.</span>"
+	usage_tip = "This is the primary conversion method, though it will not penetrate mindshield implants."
 	tier = SCRIPTURE_DRIVER
 	one_per_tile = TRUE
 	primary_component = HIEROPHANT_ANSIBLE

--- a/code/modules/antagonists/clockcult/clock_structures/_trap_object.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/_trap_object.dm
@@ -71,6 +71,7 @@
 	return TRUE
 
 /obj/structure/destructible/clockwork/trap/proc/activate()
+	return
 
 //These objects send signals to normal traps to activate
 /obj/structure/destructible/clockwork/trap/trigger
@@ -78,6 +79,14 @@
 	max_integrity = 5
 	break_message = "<span class='warning'>The trigger breaks apart!</span>"
 	density = FALSE
+
+/obj/structure/destructible/clockwork/trap/trigger/Initialize()
+	. = ..()
+	for(var/obj/structure/destructible/clockwork/trap/T in get_turf(src))
+		if(!istype(T, /obj/structure/destructible/clockwork/trap/trigger))
+			wired_to += T
+			T.wired_to += src
+			to_chat(usr, "<span class='alloy'>[src] automatically links with [T] beneath it.</span>")
 
 /obj/structure/destructible/clockwork/trap/trigger/activate()
 	for(var/obj/structure/destructible/clockwork/trap/T in wired_to)

--- a/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/ocular_warden.dm
@@ -110,9 +110,7 @@
 				if(!(BI.resistance_flags & ON_FIRE))
 					BI.fire_act()
 			continue
-		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE))
-			continue
-		if(L.stat || L.lying)
+		if(is_servant_of_ratvar(L) || (HAS_TRAIT(L, TRAIT_BLIND)) || L.anti_magic_check(TRUE, TRUE) || L.incapacitated(TRUE))
 			continue
 		if (iscarbon(L))
 			var/mob/living/carbon/c = L

--- a/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/trap_triggers/pressure_sensor.dm
@@ -7,18 +7,10 @@
 	icon_state = "pressure_sensor"
 	alpha = 50
 
-/obj/structure/destructible/clockwork/trap/trigger/Initialize()
-	. = ..()
-	for(var/obj/structure/destructible/clockwork/trap/T in get_turf(src))
-		if(!istype(T, /obj/structure/destructible/clockwork/trap/trigger))
-			wired_to += T
-			T.wired_to += src
-			to_chat(usr, "<span class='alloy'>[src] automatically links with [T] beneath it.</span>")
-
 /obj/structure/destructible/clockwork/trap/trigger/pressure_sensor/Crossed(atom/movable/AM)
 	if(isliving(AM) && !is_servant_of_ratvar(AM))
 		var/mob/living/L = AM
-		if(L.stat || L.m_intent == MOVE_INTENT_WALK || L.lying)
+		if(L.stat || L.m_intent == MOVE_INTENT_WALK || L.movement_type & (FLYING|FLOATING))
 			return
 		audible_message("<i>*click*</i>")
 		playsound(src, 'sound/items/screwdriver2.ogg', 50, TRUE)


### PR DESCRIPTION
## About The Pull Request
Giving clock cult some initial vitality matrix charge scaled with the number of starter servants.
Allowing conversion runes to heal wounds at a vitality matrix cost.
Vitality Matrix sigil made slighty more visible cause it's barely noticeable when inactive.
Made ocular wardens and pressure sensors not skip crawling people anymore, but made pressure sensors skip flying/floating mobs as per common sense.

## Why It's Good For The Game
This will close #9759. Also balancing a few underpowered aspect of clock cult.

## Changelog
:cl:
add: Clock cult starts with some spare vitality matrix charge scaled of the number of starter servants.
balance: Made the vitality matrix sigil slighty more visible, also allowed conversion runes to heal fresh converts at the cost of some vitality charge.
fix: Crawling won't save you from the wrath of ocular wardens and pressure sensors anymore, heretics. fix: Pressure sensors are no more triggered by floating/flying mobs.
/:cl:
