### PR TITLE
the one PR about making big red buttons detonate syndibombs faster

### DIFF
--- a/code/game/machinery/syndicatebomb.dm
+++ b/code/game/machinery/syndicatebomb.dm
@@ -1,5 +1,5 @@
 #define BUTTON_COOLDOWN 60 // cant delay the bomb forever
-#define BUTTON_DELAY	50 //five seconds
+#define BUTTON_DELAY	20 // two seconds
 
 /obj/machinery/syndicatebomb
 	icon = 'icons/obj/assemblies.dmi'
@@ -500,7 +500,7 @@
 
 /obj/item/syndicatedetonator
 	name = "big red button"
-	desc = "Your standard issue bomb synchronizing button. Five second safety delay to prevent 'accidents'."
+	desc = "Your standard issue bomb synchronizing button. Two second safety delay to prevent 'accidents'."
 	icon = 'icons/obj/assemblies.dmi'
 	icon_state = "bigred"
 	item_state = "electronic"


### PR DESCRIPTION
## About The Pull Request
if i haven't changed the PR title by the time you get here you've been fucking bamboozled and i'm sorry

but fr it makes bomb timers 2 seconds instead of 5 if you hit the BRB (get it from syndicate outpost)
## Why It's Good For The Game
fast bomb
## Changelog
:cl:
tweak: The Big Red Button now sets bomb timers to 2 seconds, instead of 5.
/:cl: