### PR TITLE
Reducing meteor warning time

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -20,7 +20,7 @@
 
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
-	startWhen = rand(300, 600) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	startWhen = rand(180, 360) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
 	if(GLOB.singularity_counter)
 		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -894,7 +894,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			SEND_SOUND(target, get_announcer_sound("aimalf"))
 		if("meteors") //Meteors inbound!
 			to_chat(target, "<h1 class='alert'>Meteor Alert</h1>")
-			to_chat(target, "<br><br><span class='alert'>Meteors have been detected on collision course with the station. Estimated time until impact: [round(rand(300,600)/60)] minutes.</span><br><br>")
+			to_chat(target, "<br><br><span class='alert'>Meteors have been detected on collision course with the station. Estimated time until impact: [round(rand(180,360)/60)] minutes.</span><br><br>")
 			SEND_SOUND(target, get_announcer_sound("meteors"))
 		if("supermatter")
 			SEND_SOUND(target, 'sound/magic/charge.ogg')


### PR DESCRIPTION
## About The Pull Request

Lowers the warning time for meteors to 3-6 minutes from 5-10, also changes the meteor hallucination warning to match!

## Why It's Good For The Game

Having a minimum of five entire minutes to prepare for meteors means they almost never actually hit the station unless they bug out and ignore shields or the station straight up doesn't have the materials to print shields and Cargo sits on their asses.
Three to six minutes was the lower time period specified by Burger when they originally made this change, and so I figured that would be a fair number to shoot for.

## Changelog
:cl:
tweak: Reduces the grace period for meteors from a minimum of 5 and maximum of 10 to 3 and 6 minutes respectively.
/:cl: