### PR TITLE
Adds two VR sleepers to all current maps' perma.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -616,6 +616,9 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-24"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abB" = (
@@ -57136,9 +57139,7 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "hwu" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-24"
-	},
+/obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "hEm" = (
@@ -57158,6 +57159,13 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"ihn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/vr_sleeper,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "iiW" = (
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -85235,7 +85243,7 @@ aav
 aaL
 aaQ
 aaY
-aav
+ihn
 abE
 acg
 acJ

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -16541,16 +16541,10 @@
 /area/security/prison)
 "aId" = (
 /obj/machinery/seed_extractor,
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aIe" = (
-/obj/structure/cable/white{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -16567,9 +16561,6 @@
 "aIf" = (
 /obj/structure/cable/white{
 	icon_state = "2-4"
-	},
-/obj/structure/cable/white{
-	icon_state = "2-8"
 	},
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -18952,25 +18943,11 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aMd" = (
-/obj/structure/table,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/structure/sign/warning/electricshock{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
-	},
-/area/security/prison)
 "aMe" = (
-/obj/structure/table,
-/obj/machinery/computer/libraryconsole/bookmanagement,
 /obj/structure/cable/white{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
+/turf/open/floor/plasteel,
 /area/security/prison)
 "aMf" = (
 /obj/structure/easel,
@@ -126743,6 +126720,10 @@
 	dir = 1
 	},
 /area/science/circuit)
+"gUV" = (
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gVS" = (
 /obj/item/clothing/head/kitty,
 /obj/item/clothing/under/maid,
@@ -126780,6 +126761,9 @@
 	dir = 10
 	},
 /area/science/circuit)
+"hlc" = (
+/turf/open/floor/plasteel,
+/area/security/prison)
 "hrP" = (
 /obj/structure/cable/white{
 	icon_state = "1-2"
@@ -127397,6 +127381,17 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"mvf" = (
+/obj/structure/table,
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/cable/white{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/white{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -127418,6 +127413,16 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/circuit/green,
 /area/science/research/abandoned)
+"mEy" = (
+/obj/structure/table,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "mIi" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
@@ -127607,6 +127612,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
+"oNW" = (
+/obj/machinery/vr_sleeper,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "oOb" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -127710,6 +127722,18 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"pEq" = (
+/obj/structure/sign/warning/electricshock{
+	pixel_y = 32
+	},
+/obj/machinery/vr_sleeper,
+/obj/structure/cable/white{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/security/prison)
 "pHf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -127852,6 +127876,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
+"tmZ" = (
+/obj/machinery/light/small,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "twt" = (
 /obj/machinery/vr_sleeper,
 /obj/effect/turf_decal/tile/neutral{
@@ -179430,10 +179458,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-ajr
-aad
-aad
+aeH
+aFm
+aIc
+aFm
 aFm
 aFm
 aFm
@@ -179687,10 +179715,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-ajr
-aaa
-aad
+aeH
+aFm
+mEy
+bbt
 aFm
 aMc
 aNx
@@ -179944,10 +179972,10 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aad
-aaa
-aad
+aeH
+aFm
+oNW
+tmZ
 aFm
 aKV
 aNy
@@ -180202,11 +180230,11 @@ aaa
 ajr
 ajr
 aad
-aad
-aaa
-aad
 aFm
-aMd
+pEq
+hlc
+gUV
+hlc
 aNz
 aPh
 aQZ
@@ -180459,10 +180487,10 @@ aaa
 ajr
 aad
 aad
-aad
-aad
-aad
 aFn
+mvf
+aJA
+aJA
 aMe
 aNA
 aPi
@@ -180717,7 +180745,7 @@ ajr
 aad
 aFm
 aFm
-aIc
+aFm
 aFm
 aFm
 aMf

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -213,17 +213,11 @@
 "aaG" = (
 /obj/machinery/hydroponics/constructable,
 /obj/item/seeds/ambrosia,
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
-	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aaH" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "2-4"
@@ -394,30 +388,16 @@
 /obj/item/canvas/twentythreeXtwentythree,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"abk" = (
-/obj/structure/table,
-/obj/item/folder,
-/obj/item/paper/guides/jobs/hydroponics,
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/item/pen,
-/obj/item/storage/crayons,
-/obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "abl" = (
 /obj/structure/table,
 /obj/machinery/computer/libraryconsole/bookmanagement,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abm" = (
-/obj/machinery/computer/arcade,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 32
 	},
+/obj/machinery/vr_sleeper,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "abn" = (
@@ -83303,6 +83283,13 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/cryopod)
+"ghT" = (
+/obj/machinery/computer/arcade{
+	icon_state = "arcade";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "gnZ" = (
 /obj/item/radio/intercom{
 	pixel_y = -30
@@ -83417,6 +83404,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
+"hYs" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ioI" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -83528,6 +83524,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"jVj" = (
+/obj/machinery/vr_sleeper,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "kfu" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/white,
@@ -83819,6 +83819,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
+"odR" = (
+/obj/structure/table,
+/obj/item/folder,
+/obj/item/paper/guides/jobs/hydroponics,
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/item/pen,
+/obj/item/storage/crayons,
+/turf/open/floor/plasteel,
+/area/security/prison)
 "ohj" = (
 /obj/item/integrated_electronics/analyzer,
 /obj/item/integrated_electronics/debugger,
@@ -83924,6 +83935,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
+"pzu" = (
+/obj/structure/chair/stool,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "pCV" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -84241,6 +84259,16 @@
 /obj/machinery/vending/assist,
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"uEa" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/public/glass{
+	id_tag = "permahydro";
+	name = "Recreation Module"
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
 "uGW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -106416,10 +106444,10 @@ aaa
 aaa
 aaf
 aaa
-aaa
-aaa
-aaf
-aaa
+aax
+aax
+aaF
+aax
 aax
 abj
 aaR
@@ -106673,12 +106701,12 @@ aaa
 aaa
 aaf
 aaf
-aaf
-aaf
-aaf
-aaf
 aay
-abk
+odR
+hYs
+abC
+uEa
+hYs
 abC
 abC
 acr
@@ -106930,13 +106958,13 @@ aaa
 aaa
 aaf
 aaa
-aaa
-aaf
-aaa
-aaa
 aax
 abl
-abD
+pzu
+ghT
+aax
+jVj
+aaR
 aaR
 aaI
 acF
@@ -107189,7 +107217,7 @@ aaa
 aaa
 aax
 aax
-aaF
+aax
 aax
 aax
 abm

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -1181,19 +1181,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"aeI" = (
-/obj/machinery/seed_extractor,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aeJ" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 8
@@ -1508,24 +1495,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "afr" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
 /obj/machinery/light/small,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/security/prison)
-"afs" = (
-/obj/structure/table,
-/obj/structure/bedsheetbin,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/security/prison)
 "aft" = (
@@ -52882,6 +52858,19 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/department/security/brig)
+"cJd" = (
+/obj/machinery/seed_extractor,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "cJo" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
@@ -53223,6 +53212,21 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"dqi" = (
+/obj/structure/table,
+/obj/structure/bedsheetbin,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/window/reinforced,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "dqw" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "0";
@@ -55028,6 +55032,15 @@
 /obj/item/clothing/glasses/regular,
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"hyl" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "hzc" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -58617,6 +58630,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/explab)
+"pED" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "pEL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -60956,6 +60975,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
+"vtz" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
 "vtT" = (
 /turf/open/floor/plating,
 /area/maintenance/solars/port)
@@ -62168,6 +62193,19 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
+"yff" = (
+/obj/machinery/vr_sleeper{
+	icon_state = "sleeper";
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "yfO" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/tile/yellow,
@@ -62184,6 +62222,15 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
+"yhs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/security/prison)
 "yjy" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/light{
@@ -81546,8 +81593,8 @@ aaa
 aaa
 adR
 aaa
-abI
-aaa
+aem
+aem
 aem
 aem
 aem
@@ -81804,8 +81851,8 @@ aaa
 adR
 aaa
 aem
-aem
-aem
+aeo
+aeC
 aeT
 afn
 agy
@@ -82060,9 +82107,9 @@ aaa
 aaa
 adR
 abI
-aem
-aeo
-aeC
+aen
+aep
+aeD
 aeU
 aeU
 afC
@@ -82317,9 +82364,9 @@ aaa
 aaa
 adR
 aaa
-aen
-aep
-aeD
+aem
+aeq
+aeE
 aeU
 afo
 afD
@@ -82574,9 +82621,9 @@ aaa
 aaa
 adR
 abI
-aem
-aeq
-aeE
+aen
+aer
+aeF
 aeU
 afp
 afE
@@ -82831,9 +82878,9 @@ aaa
 aaa
 adR
 aaa
-aen
-aer
-aeF
+aem
+aes
+aeG
 aeV
 afq
 afF
@@ -83088,10 +83135,10 @@ aaa
 aaa
 adR
 abI
-aem
-aes
-aeG
-aeU
+aen
+aet
+aeH
+vtz
 afo
 afG
 aeU
@@ -83345,10 +83392,10 @@ aaa
 aaa
 adR
 aaa
-aen
-aet
-aeH
-aeH
+aem
+aeu
+cJd
+pED
 aeH
 afH
 aeH
@@ -83603,8 +83650,8 @@ aaa
 adR
 abI
 aem
-aeu
-aeI
+agy
+agy
 lGp
 aeU
 aae
@@ -83860,9 +83907,9 @@ aaa
 adR
 aaa
 aem
-aem
-aem
 aeW
+yhs
+hyl
 afr
 agy
 agc
@@ -84116,11 +84163,11 @@ aaa
 aaa
 adR
 aaa
-abI
-aaa
 aem
 aeX
-afs
+dqi
+yff
+yff
 agy
 agd
 agp
@@ -84372,9 +84419,9 @@ aaa
 aaa
 aaa
 aaa
-aed
-adR
 abI
+aem
+aem
 aem
 aem
 aem
@@ -84630,9 +84677,9 @@ aaa
 aaa
 aaa
 aaa
-aaa
-aaa
-aaa
+aed
+adR
+abI
 aaa
 aaa
 aaa


### PR DESCRIPTION
## About The Pull Request

Adds a pair of VR sleepers to Box, Delta, Pubby, and Meta.
https://i.imgur.com/mR8uuKr.png

## Why It's Good For The Game

Gives perma prisoners more to do, and allows non-perma crew to have some interaction with perma prisoners safely (or not so safely if emags have been in play...).

## Changelog
:cl:
add: Adds a pair of VR sleepers to Box Station's permabrig
add: Adds a pair of VR sleepers to Delta Station's permabrig
add: Adds a pair of VR sleepers to Pubby Station's permabrig
add: Adds a pair of VR sleepers to Meta Station's permabrig
/:cl: