### PR TITLE
Radiation storms no longer do random mutations in of itself, but are far more lethal

### DIFF
--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -23,7 +23,7 @@
 
 	immunity_type = "rad"
 	
-	var/radiation_intensity = 150
+	var/radiation_intensity = 100
 
 /datum/weather/rad_storm/telegraph()
 	..()
@@ -31,7 +31,8 @@
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
-	L.rad_act(radiation_intensity / resist)
+	var/ratio = 1 - (min(resist, 100) / 100)
+	L.rad_act(radiation_intensity * percent)
 
 /datum/weather/rad_storm/end()
 	if(..())

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -31,7 +31,7 @@
 
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
-	L.rad_act(150 / resist)
+	L.rad_act(radiation_intensity / resist)
 
 /datum/weather/rad_storm/end()
 	if(..())

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -22,27 +22,16 @@
 	target_trait = ZTRAIT_STATION
 
 	immunity_type = "rad"
+	
+	var/radiation_intensity = 150
 
 /datum/weather/rad_storm/telegraph()
 	..()
 	status_alarm(TRUE)
 
-
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
-	if(prob(40))
-		if(ishuman(L))
-			var/mob/living/carbon/human/H = L
-			if(H.dna && !HAS_TRAIT(H, TRAIT_RADIMMUNE))
-				if(prob(max(0,100-resist)))
-					H.randmuti()
-					if(prob(50))
-						if(prob(90))
-							H.randmutb()
-						else
-							H.randmutg()
-						H.domutcheck()
-		L.rad_act(20)
+	L.rad_act(150 / resist)
 
 /datum/weather/rad_storm/end()
 	if(..())

--- a/code/datums/weather/weather_types/radiation_storm.dm
+++ b/code/datums/weather/weather_types/radiation_storm.dm
@@ -32,7 +32,7 @@
 /datum/weather/rad_storm/weather_act(mob/living/L)
 	var/resist = L.getarmor(null, "rad")
 	var/ratio = 1 - (min(resist, 100) / 100)
-	L.rad_act(radiation_intensity * percent)
+	L.rad_act(radiation_intensity * ratio)
 
 /datum/weather/rad_storm/end()
 	if(..())


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Radstorms are boring, let's make 'em more fun because gorilla monkies are great right?

## Why It's Good For The Game

Random mutations are honestly just annoying as shit, this makes them more of a threat but not by just mutating the hell out of you. If it kills too many afkers lockernapping we can address that.

## Changelog
:cl:
Experimental: Radiation storms no longer do random mutations directly, but do far more direct radiation.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
