### PR TITLE
Fixing anti-meta hidden random event reports.

### DIFF
--- a/code/modules/events/anomaly_bluespace.dm
+++ b/code/modules/events/anomaly_bluespace.dm
@@ -13,13 +13,7 @@
 	if(prob(90))
 		priority_announce("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Unstable bluespace anomaly"
-				P.info = "Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name]."
-				P.update_icon()
+		print_command_report("Unstable bluespace anomaly detected on long range scanners. Expected location: [impact_area.name].", "Unstable bluespace anomaly")
 
 /datum/round_event/anomaly/anomaly_bluespace/start()
 	var/turf/T = safepick(get_area_turfs(impact_area))

--- a/code/modules/events/anomaly_flux.dm
+++ b/code/modules/events/anomaly_flux.dm
@@ -14,13 +14,7 @@
 	if(prob(90))
 		priority_announce("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Localized hyper-energetic flux wave"
-				P.info = "Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name]."
-				P.update_icon()
+		print_command_report("Localized hyper-energetic flux wave detected on long range scanners. Expected location: [impact_area.name].","Localized hyper-energetic flux wave")
 
 /datum/round_event/anomaly/anomaly_flux/start()
 	var/turf/T = safepick(get_area_turfs(impact_area))

--- a/code/modules/events/anomaly_grav.dm
+++ b/code/modules/events/anomaly_grav.dm
@@ -12,13 +12,7 @@
 	if(prob(90))
 		priority_announce("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Gravitational anomaly"
-				P.info = "Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name]."
-				P.update_icon()
+		print_command_report("Gravitational anomaly detected on long range scanners. Expected location: [impact_area.name].", "Gravitational anomaly")
 
 /datum/round_event/anomaly/anomaly_grav/start()
 	var/turf/T = safepick(get_area_turfs(impact_area))

--- a/code/modules/events/anomaly_pyro.dm
+++ b/code/modules/events/anomaly_pyro.dm
@@ -12,13 +12,7 @@
 	if(prob(90))
 		priority_announce("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Anomaly Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Pyroclastic anomaly"
-				P.info = "Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name]."
-				P.update_icon()
+		print_command_report("Pyroclastic anomaly detected on long range scanners. Expected location: [impact_area.name].", "Pyroclastic anomaly")
 
 /datum/round_event/anomaly/anomaly_pyro/start()
 	var/turf/T = safepick(get_area_turfs(impact_area))

--- a/code/modules/events/anomaly_vortex.dm
+++ b/code/modules/events/anomaly_vortex.dm
@@ -14,13 +14,7 @@
 	if(prob(90))
 		priority_announce("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]", "Anomaly Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Vortex anomaly"
-				P.info = "Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name]."
-				P.update_icon()
+		print_command_report("Localized high-intensity vortex anomaly detected on long range scanners. Expected location: [impact_area.name].","Vortex anomaly")
 
 /datum/round_event/anomaly/anomaly_vortex/start()
 	var/turf/T = safepick(get_area_turfs(impact_area))

--- a/code/modules/events/blob.dm
+++ b/code/modules/events/blob.dm
@@ -18,13 +18,7 @@
 	if(prob(75))
 		priority_announce("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "Biohazard Alert", "outbreak5")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "level 5 biohazard"
-				P.info = "Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak."
-				P.update_icon()
+		print_command_report("Confirmed outbreak of level 5 biohazard aboard [station_name()]. All personnel must contain the outbreak.", "level 5 biohazard")
 
 /datum/round_event/ghost_role/blob/spawn_role()
 	if(!GLOB.blobstart.len)

--- a/code/modules/events/brand_intelligence.dm
+++ b/code/modules/events/brand_intelligence.dm
@@ -38,13 +38,8 @@
 	if(prob(50))
 		priority_announce("Rampant brand intelligence has been detected aboard [station_name()]. Please stand by. The origin is believed to be \a [source].", "Machine Learning Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Rampant brand intelligence"
-				P.info = "Rampant brand intelligence has been detected aboard [station_name()]. Please stand by. The origin is believed to be \a [source]."
-				P.update_icon()
+		print_command_report("Rampant brand intelligence has been detected aboard [station_name()]. Please stand by. The origin is believed to be \a [source].", "Rampant brand intelligence")
+
 /datum/round_event/brand_intelligence/start()
 	for(var/obj/machinery/vending/V in GLOB.machines)
 		if(!is_station_level(V.z))

--- a/code/modules/events/carp_migration.dm
+++ b/code/modules/events/carp_migration.dm
@@ -17,13 +17,7 @@
 	if(prob(50))
 		priority_announce("Unknown biological entities have been detected near [station_name()], please stand-by.", "Lifesign Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Biological entities"
-				P.info = "Unknown biological entities have been detected near [station_name()], you may wish to break out arms."
-				P.update_icon()
+		print_command_report("Unknown biological entities have been detected near [station_name()], you may wish to break out arms.", "Biological entities")
 
 
 /datum/round_event/carp_migration/start()

--- a/code/modules/events/electrical_storm.dm
+++ b/code/modules/events/electrical_storm.dm
@@ -15,13 +15,7 @@
 	if(prob(50))
 		priority_announce("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Electrical Storm"
-				P.info = "An electrical storm has been detected in your area, please repair potential electronic overloads."
-				P.update_icon()
+		print_command_report("An electrical storm has been detected in your area, please repair potential electronic overloads.", "Electrical Storm")
 
 /datum/round_event/electrical_storm/start()
 	var/list/epicentreList = list()

--- a/code/modules/events/major_dust.dm
+++ b/code/modules/events/major_dust.dm
@@ -19,10 +19,4 @@
 	if(prob(50))
 		priority_announce(pick(reason), "Collision Alert")
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Collision Alert"
-				P.info = "[pick(reason)]"
-				P.update_icon()
+		print_command_report("[pick(reason)]", "Collision Alert")

--- a/code/modules/events/mice_migration.dm
+++ b/code/modules/events/mice_migration.dm
@@ -23,13 +23,7 @@
 		into the [location].", "Migration Alert",
 		'sound/effects/mousesqueek.ogg')
 	else
-		priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-		for(var/obj/machinery/computer/communications/C in GLOB.machines)
-			if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-				var/obj/item/paper/P = new(C.loc)
-				P.name = "Rodent Migration"
-				P.info = "Due to [cause], [plural] [name] have [movement] into the [location]."
-				P.update_icon()
+		print_command_report("Due to [cause], [plural] [name] have [movement] into the [location].", "Rodent Migration")
 
 /datum/round_event/mice_migration/start()
 	SSminor_mapping.trigger_migration(rand(minimum_mice, maximum_mice))

--- a/code/modules/events/prison_break.dm
+++ b/code/modules/events/prison_break.dm
@@ -33,13 +33,7 @@
 		if(prob(50))
 			priority_announce("Gr3y.T1d3 virus detected in [station_name()] door subroutines. Severity level of [severity]. Recommend station AI involvement.", "Security Alert")
 		else
-			priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-			for(var/obj/machinery/computer/communications/C in GLOB.machines)
-				if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-					var/obj/item/paper/P = new(C.loc)
-					P.name = "Gr3y.T1d3 virus"
-					P.info = "Gr3y.T1d3 virus detected in [station_name()] door subroutines. Severity level of [severity]. Recommend station AI involvement."
-					P.update_icon()
+			print_command_report("Gr3y.T1d3 virus detected in [station_name()] door subroutines. Severity level of [severity]. Recommend station AI involvement.", "Gr3y.T1d3 virus")
 	else
 		log_world("ERROR: Could not initate grey-tide. No areas in the list!")
 		kill()

--- a/code/modules/events/shuttle_loan.dm
+++ b/code/modules/events/shuttle_loan.dm
@@ -27,109 +27,43 @@
 
 /datum/round_event/shuttle_loan/announce(fake)
 	SSshuttle.shuttle_loan = src
+	var/message = "Cargo: I just wanna tell you techs good luck, we are all counting on you."
+	var/title = "CentCom Free Real Estate"
 	switch(dispatch_type)
 		if(HIJACK_SYNDIE)
-			if(prob(50))
-				priority_announce("Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache.","CentCom Counter Intelligence")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache."
-						P.update_icon()
+			message = "Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache."
+			title = "CentCom Counter Intelligence"
 		if(RUSKY_PARTY)
-			if(prob(50))
-				priority_announce("Cargo: A group of angry Russians want to have a party. Can you send them your cargo shuttle then make them disappear?","CentCom Russian Outreach Program")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: The syndicate are trying to infiltrate your station. If you let them hijack your cargo shuttle, you'll save us a headache."
-						P.update_icon()
+			message = "Cargo: A group of angry Russians want to have a party. Can you send them your cargo shuttle then make them disappear?"
+			title = "CentCom Russian Outreach Program"
 		if(SPIDER_GIFT)
-			if(prob(50))
-				priority_announce("Cargo: The Spider Clan has sent us a mysterious gift. Can we ship it to you to see what's inside?","CentCom Diplomatic Corps")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: The Spider Clan has sent us a mysterious gift. Can we ship it to you to see what's inside?"
-						P.update_icon()
+			message = "Cargo: The Spider Clan has sent us a mysterious gift. Can we ship it to you to see what's inside?"
+			title = "CentCom Diplomatic Corps"
 		if(DEPARTMENT_RESUPPLY)
-			if(prob(50))
-				priority_announce("Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?","CentCom Supply Department")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?"
-						P.update_icon()
+			message = "Cargo: Seems we've ordered doubles of our department resupply packages this month. Can we send them to you?"
+			title = "CentCom Supply Department"
 		if(ANTIDOTE_NEEDED)
-			if(prob(50))
-				priority_announce("Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples.", "CentCom Research Initiatives")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples."
-						P.update_icon()
+			message = "Cargo: Your station has been chosen for an epidemiological research project. Send us your cargo shuttle to receive your research samples."
+			title = "CentCom Research Initiatives"
 		if (PIZZA_DELIVERY)
-			if(prob(50))
-				priority_announce("Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead.", "CentCom Spacepizza Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead."
-						P.update_icon()
+			message = "Cargo: It looks like a neighbouring station accidentally delivered their pizza to you instead."
+			title = "CentCom Spacepizza Division"
 		if(ITS_HIP_TO)
-			if(prob(50))
-				priority_announce("Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?", "CentCom Janitorial Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?."
-						P.update_icon()
+			message = "Cargo: One of our freighters carrying a bee shipment has been attacked by eco-terrorists. Can you clean up the mess for us?"
+			title = "CentCom Janitorial Division"
 			bonus_points = 20000 //Toxin bees can be unbeelievably lethal
 		if(MY_GOD_JC)
-			if(prob(50))
-				priority_announce("Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it.", "CentCom Security Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it."
-						P.update_icon()
+			message = "Cargo: We have discovered an active Syndicate bomb near our VIP shuttle's fuel lines. If you feel up to the task, we will pay you for defusing it."
+			title = "CentCom Security Division"
 			bonus_points = 45000 //If you mess up, people die and the shuttle gets turned into swiss cheese
 		if(DELTA_CRATES)
-			if(prob(50))
-				priority_announce("Cargo: We have discovered a warehouse of DELTA locked crates, we cant store any more of them at CC can you take them for us?.", "CentCom Security Division")
-			else
-				priority_announce("A report has been downloaded and printed out at all communications consoles.", "Incoming Classified Message", "commandreport") // CITADEL EDIT metabreak
-				for(var/obj/machinery/computer/communications/C in GLOB.machines)
-					if(!(C.stat & (BROKEN|NOPOWER)) && is_station_level(C.z))
-						var/obj/item/paper/P = new(C.loc)
-						P.name = "Cargo Report"
-						P.info = "Cargo: We have discovered a warehouse of DELTA locked crates, we cant store any more of them at CC can you take them for us?."
-						P.update_icon()
+			message = "Cargo: We have discovered a warehouse of DELTA locked crates, we cant store any more of them at CC can you take them for us?."
+			title = "CentCom Security Division"
 			bonus_points = 25000 //If you mess up, people die and the shuttle gets turned into swiss cheese
+	if(prob(50))
+		priority_announce(message, title)
+	else
+		print_command_report(message, "Cargo report")
 
 /datum/round_event/shuttle_loan/proc/loan_shuttle()
 	priority_announce(thanks_msg, "Cargo shuttle commandeered by CentCom.")


### PR DESCRIPTION
## About The Pull Request
Fixing "meta-break" event announcements only priting a paper message without sending the message to the consoles' message list. That was one shittty copypasta.

## Why It's Good For The Game
This PR will close #9794.

## Changelog
:cl:
fix: Fixed hidden random event reports only priting a paper message without sending the message to the consoles' message list.
/:cl:
