### PR TITLE
Fixes summon events not spending threat (it still required it)

### DIFF
--- a/code/modules/antagonists/wizard/equipment/spellbook.dm
+++ b/code/modules/antagonists/wizard/equipment/spellbook.dm
@@ -600,14 +600,14 @@
 /datum/spellbook_entry/summon/events/Buy(mob/living/carbon/human/user,obj/item/spellbook/book)
 	SSblackbox.record_feedback("tally", "wizard_spell_learned", 1, name)
 	summonevents()
-	times++
-	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
-	to_chat(user, "<span class='notice'>You have cast summon events.</span>")
 	if(istype(SSticker.mode,/datum/game_mode/dynamic) && times == 0)
 		var/datum/game_mode/dynamic/mode = SSticker.mode
 		var/threat_spent = CONFIG_GET(number/dynamic_summon_events_cost)
 		mode.spend_threat(threat_spent)
 		mode.log_threat("Wizard spent [threat_spent] on summon events.")
+	times++
+	playsound(get_turf(user), 'sound/magic/castsummon.ogg', 50, 1)
+	to_chat(user, "<span class='notice'>You have cast summon events.</span>")
 	return 1
 
 /datum/spellbook_entry/summon/events/GetInfo()


### PR DESCRIPTION
## About The Pull Request

I had it checking "times == 0" after it had already done times++ so it wasn't spending anything whoops. This makes it spend it.

## Why It's Good For The Game

I'd rather not have dynamic be spawning more antags than it should after a summon events.

## Changelog
:cl:
fix: summon events now subtracts threat properly
/:cl:

