### PR TITLE
Makes meteor not repeatable in dynamic.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -143,7 +143,6 @@
 	repeatable_weight_decrease = 2
 	requirements = list(60,50,40,30,30,30,30,30,30,30)
 	high_population_requirement = 30
-	repeatable = TRUE
 
 /datum/dynamic_ruleset/event/meteor_wave/ready()
 	if(mode.threat_level > 40 && mode.threat >= 25 && prob(20))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As above.

## Why It's Good For The Game

It's a huge drain on threat level for basically no actual added threat.

## Changelog
:cl:
tweak: Meteor wave is no longer repeatable in dynamic.
/:cl:
