### PR TITLE
Ports "restores legacy sends to SSChat"

### DIFF
--- a/code/controllers/subsystem/chat.dm
+++ b/code/controllers/subsystem/chat.dm
@@ -29,6 +29,7 @@ SUBSYSTEM_DEF(chat)
 		target = GLOB.clients
 
 	//Some macros remain in the string even after parsing and fuck up the eventual output
+	var/original_message = message
 	message = replacetext(message, "\improper", "")
 	message = replacetext(message, "\proper", "")
 	if(handle_whitespace)
@@ -45,6 +46,12 @@ SUBSYSTEM_DEF(chat)
 		for(var/I in target)
 			var/client/C = CLIENT_FROM_VAR(I) //Grab us a client if possible
 
+			if(!C)
+				return
+
+			//Send it to the old style output window.
+			SEND_TEXT(C, original_message)
+
 			if(!C?.chatOutput || C.chatOutput.broken) //A player who hasn't updated his skin file.
 				continue
 
@@ -56,6 +63,12 @@ SUBSYSTEM_DEF(chat)
 
 	else
 		var/client/C = CLIENT_FROM_VAR(target) //Grab us a client if possible
+
+		if(!C)
+			return
+
+		//Send it to the old style output window.
+		SEND_TEXT(C, original_message)
 
 		if(!C?.chatOutput || C.chatOutput.broken) //A player who hasn't updated his skin file.
 			return


### PR DESCRIPTION
## About The Pull Request
TG pr #47709 by actioninja.

## Why It's Good For The Game
> A couple of users are having issues with goonchat failing to load so this is a fallback in the immediate send proc in the mean time.

The issue still lingers around, but at least the game should be playable again for those unfortunate fellows suffering from it.

## Changelog
:cl: actioninja
fix: Chat is properly sent to legacy window if goonchat fails to load again.
/:cl:
