### PR TITLE
Reduces meteor sheilds to just one screen as a radius

### DIFF
--- a/code/modules/station_goals/shield.dm
+++ b/code/modules/station_goals/shield.dm
@@ -132,7 +132,7 @@
 	desc = "A meteor point-defense satellite."
 	mode = "M-SHIELD"
 	speed_process = TRUE
-	var/kill_range = 14
+	var/kill_range = 11
 
 /obj/machinery/satellite/meteor_shield/sci
 	name = "\improper Meteor Shield Satellite"
@@ -146,7 +146,7 @@
 /obj/machinery/satellite/meteor_shield/attackby(obj/item/I, mob/user, params)
 	if(istype(I, /obj/item/disk/meteor))
 		to_chat(user, "<span class='notice'>The disk uploads better tracking and rang modification software.</span>")
-		kill_range = 17
+		kill_range = 14
 	else
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

Subtracting 3 from the the range of the of the regular meteor shield, and the extended range upgrade. So from 14 range to 11, and 17 to 14.

## Why It's Good For The Game

Meteor shields can be spammed by engineering at the moment, with just glass and metal. So the second that they're needed, with the delay, they can be easily made by any engineer that wants to. 
The range is already **huge**, so this is just making it at least able to be described, in easier words, how huge it is.

## Changelog
:cl:
tweak: tweaked a few things
/:cl:
