### PR TITLE
Buff stechkin fire rate

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -9,6 +9,10 @@
 	fire_delay = 0
 	actions_types = list()
 
+/obj/item/gun/ballistic/automatic/pistol/shoot_live_shot(mob/living/user as mob|obj, pointblank = 0, mob/pbtarget = null, message = 1)
+	user.changeNext_move(3.5) //deciseconds delay after click, default is 4
+	. = ..()
+	
 /obj/item/gun/ballistic/automatic/pistol/no_mag
 	spawnwithmagazine = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
I asked kevin about buffing the stechkin, he replied eh. So here it is. Increases stechkin fire rate from 4 deciseconds PER shot to 3.25 deciseconds PER shot. Meaning it takes 3.25 deciseconds to fire the next one instead of 4.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
No one uses the stechkin ever because of various reasons: magazines cant be printed, low shot count, revolver is just better etc. This should make it easier to use the stechkin for intented use, burst down  an unsuspecting target fast and silently.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: tweaked stechkin fire rate
balance: rebalanced stechkin use as assasination tool
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
