### PR TITLE
Dynamic summon events tweaks

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -283,6 +283,7 @@
 /datum/dynamic_ruleset/midround/from_ghosts/wizard
 	name = "Wizard"
 	config_tag = "midround_wizard"
+	persistent = TRUE
 	antag_datum = /datum/antagonist/wizard
 	antag_flag = ROLE_WIZARD
 	enemy_roles = list("Security Officer","Detective","Head of Security", "Captain")
@@ -293,6 +294,7 @@
 	requirements = list(90,90,70,50,50,50,50,40,30,30)
 	high_population_requirement = 30
 	repeatable = TRUE
+	var/datum/mind/wizard
 
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/ready(forced = FALSE)
 	if (required_candidates > (dead_players.len + list_observers.len))
@@ -306,6 +308,20 @@
 /datum/dynamic_ruleset/midround/from_ghosts/wizard/finish_setup(mob/new_character, index)
 	..()
 	new_character.forceMove(pick(GLOB.wizardstart))
+
+/datum/dynamic_ruleset/midround/from_ghosts/wizard/rule_process() // i can literally copy this from are_special_antags_dead it's great
+	if(isliving(wizard.current) && wizard.current.stat!=DEAD)
+		return FALSE
+
+	for(var/obj/item/phylactery/P in GLOB.poi_list) //TODO : IsProperlyDead()
+		if(P.mind && P.mind.has_antag_datum(/datum/antagonist/wizard))
+			return FALSE
+
+	if(SSevents.wizardmode) //If summon events was active, turn it off
+		SSevents.toggleWizardmode()
+		SSevents.resetFrequency()
+
+	return RULESET_STOP_PROCESSING
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -149,6 +149,7 @@
 /datum/dynamic_ruleset/roundstart/wizard
 	name = "Wizard"
 	config_tag = "wizard"
+	persistent = TRUE
 	antag_flag = ROLE_WIZARD
 	antag_datum = /datum/antagonist/wizard
 	minimum_required_age = 14
@@ -183,7 +184,24 @@
 	for(var/datum/mind/M in assigned)
 		M.current.forceMove(pick(GLOB.wizardstart))
 		M.add_antag_datum(new antag_datum())
+		roundstart_wizards += M
 	return TRUE
+
+/datum/dynamic_ruleset/roundstart/wizard/rule_process() // i can literally copy this from are_special_antags_dead it's great
+	for(var/datum/mind/wizard in roundstart_wizards)
+		if(isliving(wizard.current) && wizard.current.stat!=DEAD)
+			return FALSE
+
+	for(var/obj/item/phylactery/P in GLOB.poi_list) //TODO : IsProperlyDead()
+		if(P.mind && P.mind.has_antag_datum(/datum/antagonist/wizard))
+			return FALSE
+
+	if(SSevents.wizardmode) //If summon events was active, turn it off
+		SSevents.toggleWizardmode()
+		SSevents.resetFrequency()
+
+	return RULESET_STOP_PROCESSING
+
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/modules/events/_event.dm
+++ b/code/modules/events/_event.dm
@@ -34,6 +34,7 @@
 
 /datum/round_event_control/wizard
 	wizardevent = 1
+	var/can_be_midround_wizard = TRUE
 
 // Checks if the event can be spawned. Used by event controller and "false alarm" event.
 // Admin-created events override this.
@@ -53,6 +54,13 @@
 	if(holidayID && (!SSevents.holidays || !SSevents.holidays[holidayID]))
 		return FALSE
 	return TRUE
+
+/datum/round_event_control/wizard/canSpawnEvent(var/players_amt, var/gamemode)
+	if(istype(SSticker.mode, /datum/game_mode/dynamic))
+		var/var/datum/game_mode/dynamic/mode = SSticker.mode
+		if (locate(/datum/dynamic_ruleset/midround/from_ghosts/wizard) in mode.executed_rules)
+			return can_be_midround_wizard && ..()
+	return ..()
 
 /datum/round_event_control/proc/preRunEvent()
 	if(!ispath(typepath, /datum/round_event))

--- a/code/modules/events/wizard/curseditems.dm
+++ b/code/modules/events/wizard/curseditems.dm
@@ -4,6 +4,7 @@
 	typepath = /datum/round_event/wizard/cursed_items
 	max_occurrences = 3
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE
 
 //Note about adding items to this: Because of how NODROP_1 works if an item spawned to the hands can also be equiped to a slot
 //it will be able to be put into that slot from the hand, but then get stuck there. To avoid this make a new subtype of any

--- a/code/modules/events/wizard/departmentrevolt.dm
+++ b/code/modules/events/wizard/departmentrevolt.dm
@@ -4,6 +4,7 @@
 	typepath = /datum/round_event/wizard/deprevolt
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE // not removing it completely yet
 
 /datum/round_event/wizard/deprevolt/start()
 

--- a/code/modules/events/wizard/race.dm
+++ b/code/modules/events/wizard/race.dm
@@ -4,6 +4,7 @@
 	typepath = /datum/round_event/wizard/race
 	max_occurrences = 5
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE
 
 /datum/round_event/wizard/race
 	var/list/stored_name

--- a/code/modules/events/wizard/shuffle.dm
+++ b/code/modules/events/wizard/shuffle.dm
@@ -7,6 +7,7 @@
 	typepath = /datum/round_event/wizard/shuffleloc
 	max_occurrences = 5
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE // not removing it completely yet
 
 /datum/round_event/wizard/shuffleloc/start()
 	var/list/moblocs = list()
@@ -43,6 +44,7 @@
 	typepath = /datum/round_event/wizard/shufflenames
 	max_occurrences = 5
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE // not removing it completely yet
 
 /datum/round_event/wizard/shufflenames/start()
 	var/list/mobnames = list()
@@ -77,6 +79,7 @@
 	typepath = /datum/round_event/wizard/shuffleminds
 	max_occurrences = 3
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE // not removing it completely yet
 
 /datum/round_event/wizard/shuffleminds/start()
 	var/list/mobs	 = list()

--- a/code/modules/events/wizard/summons.dm
+++ b/code/modules/events/wizard/summons.dm
@@ -4,6 +4,7 @@
 	typepath = /datum/round_event/wizard/summonguns
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE // not removing it completely yet
 
 /datum/round_event_control/wizard/summonguns/New()
 	if(CONFIG_GET(flag/no_summon_guns))
@@ -19,6 +20,7 @@
 	typepath = /datum/round_event/wizard/summonmagic
 	max_occurrences = 1
 	earliest_start = 0 MINUTES
+	can_be_midround_wizard = FALSE // not removing it completely yet
 
 /datum/round_event_control/wizard/summonmagic/New()
 	if(CONFIG_GET(flag/no_summon_magic))


### PR DESCRIPTION
## About The Pull Request

Makes some of the griefier "CALL SHUTTLE NOW" events simply not occur if done by a midround wizard and makes summon events end as soon as the wizard dies.

## Why It's Good For The Game

Trying to mitigate the "round with wizard is now a wizard round" issue, since dynamic really doesn't want that.

## Changelog
:cl: Putnam
fix: summon events now ends when the wizard dies in dynamic
tweak: cursed items, changes races, change faces, change places, change minds, summon guns (random), summon magic (random) are all limited to roundstart wizards only
/:cl:
