### PR TITLE
Fixing some wizard den teleportation issues.

### DIFF
--- a/code/modules/antagonists/wizard/equipment/artefact.dm
+++ b/code/modules/antagonists/wizard/equipment/artefact.dm
@@ -383,7 +383,9 @@
 	if(!istype(user) || on_cooldown)
 		return
 	var/turf/T = get_turf(user)
-	if(!T)
+	var/area/A = get_area(user)
+	if(!T || !A || A.noteleport)
+		to_chat(user, "<span class='warning'>You play \the [src], yet no sound comes out of it... Looks like it won't work here.</span>")
 		return
 	on_cooldown = TRUE
 	last_user = user

--- a/code/modules/spells/spell_types/area_teleport.dm
+++ b/code/modules/spells/spell_types/area_teleport.dm
@@ -20,8 +20,11 @@
 	after_cast(targets)
 
 /obj/effect/proc_holder/spell/targeted/area_teleport/before_cast(list/targets)
-	var/A = null
-
+	var/area/U = get_area(usr)
+	if(U.noteleport && !istype(U, /area/wizard_station)) // Wizard den special check for those complaining about being unable to tele on station.
+		to_chat(usr, "<span class='warning'>Unseen forces prevent you from casting this spell in this area</span>")
+		return
+	var/A
 	if(!randomise_selection)
 		A = input("Area to teleport to", "Teleport", A) as null|anything in GLOB.teleportlocs
 	else
@@ -53,12 +56,13 @@
 		if(target && target.buckled)
 			target.buckled.unbuckle_mob(target, force=1)
 
+		var/forcecheck = istype(get_area(target), /area/wizard_station)
 		var/list/tempL = L
 		var/attempt = null
 		var/success = 0
 		while(tempL.len)
 			attempt = pick(tempL)
-			do_teleport(target, attempt, channel = TELEPORT_CHANNEL_MAGIC)
+			do_teleport(target, attempt, channel = TELEPORT_CHANNEL_MAGIC, forced = forcecheck)
 			if(get_turf(target) == attempt)
 				success = 1
 				break
@@ -66,7 +70,7 @@
 				tempL.Remove(attempt)
 
 		if(!success)
-			do_teleport(target, L, forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC)
+			do_teleport(target, L, forceMove = TRUE, channel = TELEPORT_CHANNEL_MAGIC, forced = forcecheck)
 			playsound(get_turf(user), sound2, 50,1)
 
 	return


### PR DESCRIPTION
## About The Pull Request
This will close #9848. Some quality of life for clueless 30 years old wizards.

## Why It's Good For The Game
Fixing an issue with the game.

## Changelog
:cl:
fix: Wizards can use the teleport spell from their den once again.
tweak: Wizards will now receive feedback messages when attempting to cast teleport or use the warp whistle while in a no-teleport area.
/:cl:
