### PR TITLE
Fixing suit store overlays

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -336,7 +336,7 @@ There are several things that need to be remembered:
 		if(!t_state)
 			t_state = s_store.icon_state
 		overlays_standing[SUIT_STORE_LAYER]	= mutable_appearance(((s_store.alternate_worn_icon) ? s_store.alternate_worn_icon : 'icons/mob/belt_mirror.dmi'), t_state, -SUIT_STORE_LAYER)
-		var/mutable_appearance/s_store_overlay = overlays_standing[SUIT_LAYER]
+		var/mutable_appearance/s_store_overlay = overlays_standing[SUIT_STORE_LAYER]
 		if(OFFSET_S_STORE in dna.species.offset_features)
 			s_store_overlay.pixel_x += dna.species.offset_features[OFFSET_S_STORE][1]
 			s_store_overlay.pixel_y += dna.species.offset_features[OFFSET_S_STORE][2]


### PR DESCRIPTION
## About The Pull Request
This wouldn't have happened if tgstation PR #39685 from august of the last year wasn't skipped somehow by the dying sync.

## Why It's Good For The Game
Fixing some issues with suit mob overlays (such shielded hardsuit/robes or hooded clothes) not updating if there is an item in the suit storage.

## Changelog
I don't feel like writing changelogs right now.