### PR TITLE
Blackpowder bugfix. Alternative to #9884

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -99,8 +99,9 @@
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	sleep(rand(50,100))
-	var/turf/T = get_turf(holder.my_atom)
-	..(holder, created_volume, T)
+	if(!QDELETED(holder.my_atom)
+		var/turf/T = get_turf(holder.my_atom)
+		..(holder, created_volume, T)
 
 /datum/chemical_reaction/thermite
 	name = "Thermite"

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -99,7 +99,7 @@
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	sleep(rand(50,100))
-	if(!QDELETED(holder.my_atom)
+	if(!QDELETED(holder.my_atom))
 		var/turf/T = get_turf(holder.my_atom)
 		..(holder, created_volume, T)
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -98,9 +98,12 @@
 	mix_message = "<span class='boldannounce'>Sparks start flying around the black powder!</span>"
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
+	var/C = holder.my_atom.color
+	holder.my_atom.color =  "#FF4500"
 	sleep(rand(50,100))
 	if(!QDELETED(holder.my_atom))
 		var/turf/T = get_turf(holder.my_atom)
+		holder.my_atom.color = C
 		..(holder, created_volume, T)
 
 /datum/chemical_reaction/thermite

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -98,8 +98,8 @@
 	mix_message = "<span class='boldannounce'>Sparks start flying around the black powder!</span>"
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
-	var/turf/T = get_turf(holder.my_atom)
 	sleep(rand(50,100))
+	var/turf/T = get_turf(holder.my_atom)
 	..(holder, created_volume, T)
 
 /datum/chemical_reaction/thermite


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9884

Fixes the problem of blackpowder exploding where the explosion reaction _happened_, instead of exploding where it is after the explosion delay happens.

## Changelog
:cl:
fix: blackpowder now explodes where its actual location is, instead of where the reaction happened
tweak: containers that had blackpowder reacted in them have their colour changed (if that's not enough, I can make them blink like the hot potato)
/:cl:
