### PR TITLE
Perma cryo sleepers no longer disable midround antags

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -265,7 +265,8 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/cryopod{
+/obj/machinery/cryopod/perma{
+	icon_state = "cryopod-open";
 	dir = 8
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -266,7 +266,6 @@
 	dir = 4
 	},
 /obj/machinery/cryopod/perma{
-	icon_state = "cryopod-open";
 	dir = 8
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -19026,7 +19026,7 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/machinery/cryopod,
+/obj/machinery/cryopod/perma,
 /turf/open/floor/plasteel,
 /area/security/prison)
 "aMl" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -902,7 +902,8 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/cryopod{
+/obj/machinery/cryopod/perma{
+	icon_state = "cryopod-open";
 	dir = 8
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -903,7 +903,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/cryopod/perma{
-	icon_state = "cryopod-open";
 	dir = 8
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53466,7 +53466,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "dUk" = (
 /obj/machinery/cryopod/perma{
-	icon_state = "cryopod-open";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53465,7 +53465,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "dUk" = (
-/obj/machinery/cryopod{
+/obj/machinery/cryopod/perma{
+	icon_state = "cryopod-open";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -177,6 +177,7 @@
 	// 15 minutes-ish safe period before being despawned.
 	var/time_till_despawn = 15 * 600 // This is reduced by 90% if a player manually enters cryo
 	var/despawn_world_time = null          // Used to keep track of the safe period.
+	var/penalize_cryo = TRUE	// Makes it so that players who cryo are not eligible for midround antags.
 
 	var/obj/machinery/computer/cryopod/control_computer
 	var/last_no_computer_message = 0
@@ -408,7 +409,7 @@
 
 	// Ghost and delete the mob.
 	if(!mob_occupant.get_ghost(1))
-		mob_occupant.ghostize(FALSE, penalize = TRUE)
+		mob_occupant.ghostize(FALSE, penalize = penalize_cryo)	// Checks the sleeper to determine if the occupant should be eligible for midround antag roles.
 
 	QDEL_NULL(occupant)
 	open_machine()
@@ -492,3 +493,6 @@
 //Attacks/effects.
 /obj/machinery/cryopod/blob_act()
 	return //Sorta gamey, but we don't really want these to be destroyed.
+
+/obj/machinery/cryopod/perma
+	penalize_cryo = FALSE	// Makes it so players who cryo with this specific sleeper are still eligible for midround antags.


### PR DESCRIPTION
## About The Pull Request

Adds a unique cryo sleeper pod intended for the permabrig, reworks how the penalize variable works, and adds the new cryo sleeper to all maps' permabrig.

## Why It's Good For The Game

This enables someone who has been put in the permabrig, and therefore can be assumed to have made a good faith effort towards completing their objectives as an antag, or been framed by one to the point they've been removed from the round anyway, to cryo out and still re-enter the round through a midround antag role.
This does **NOT** allow someone using the standard cryo sleepers to roll a midround antag, they must use the permabrig's cryo sleeper.
This has been a frequently requested feature that I've finally bothered addressing.

## Changelog
:cl:
add: Added "perma cryo sleepers" to all maps' permabrigs
tweak: The penalize variable that determines if someone cryo'ing is eligible for midround antag roles or not now looks at the sleeper they used, rather than being hard set to TRUE
/:cl: