### PR TITLE
Able to use Legion Cores in-hand

### DIFF
--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -59,6 +59,7 @@
 		to_chat(owner, "<span class='notice'>[src] breaks down as it tries to activate.</span>")
 	else
 		owner.revive(full_heal = 1)
+		owner.log_message("[owner] used an implanted [src] to heal themselves! Keep fighting, it's just a flesh wound!", LOG_ATTACK, color="green") //Logging for implanted legion core use
 	qdel(src)
 
 /obj/item/organ/regenerative_core/on_life()
@@ -85,6 +86,7 @@
 				SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
 			H.revive(full_heal = 1)
 			qdel(src)
+			user.log_message("[user] used [src] to heal [H]! Wake the fuck up, Samurai!", LOG_ATTACK, color="green") //Logging for 'old' style legion core use, when clicking on a sprite of yourself or another.
 
 /obj/item/organ/regenerative_core/attack_self(mob/user) //Knouli's first hack! Allows for the use of the core in hand rather than needing to click on the target, yourself, to selfheal. Its a rip of the proc just above - but skips on distance check and only uses 'user' rather than 'target'
 	if(ishuman(user)) //Check if user is human, no need for distance check as it's self heal
@@ -97,6 +99,8 @@
 			SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
 		H.revive(full_heal = 1)
 		qdel(src)
+		H.log_message("[H] used [src] to heal themselves! Making use of Knouli's sexy and intelligent use-in-hand proc!", LOG_ATTACK, color="green") //Logging for 'new' style legion core use, when using the core in-hand.
+
 
 /obj/item/organ/regenerative_core/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	. = ..()

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -86,6 +86,18 @@
 			H.revive(full_heal = 1)
 			qdel(src)
 
+/obj/item/organ/regenerative_core/attack_self(mob/user) //Knouli's first hack! Allows for the use of the core in hand rather than needing to click on the target, yourself, to selfheal. Its a rip of the proc just above - but skips on distance check and only uses 'user' rather than 'target'
+	if(ishuman(user)) //Check if user is human, no need for distance check as it's self heal
+		var/mob/living/carbon/human/H = user //Set H to user rather than target
+		if(inert) //Inert cores are useless
+			to_chat(user, "<span class='notice'>[src] has decayed and can no longer be used to heal.</span>")
+			return
+		else //Skip on check if the target to be healed is dead as, if you are dead, you're not going to be able to use it on yourself!
+			to_chat(user, "<span class='notice'>You start to smear [src] on yourself. It feels and smells disgusting, but you feel amazingly refreshed in mere moments.</span>")
+			SSblackbox.record_feedback("nested tally", "hivelord_core", 1, list("[type]", "used", "self"))
+		H.revive(full_heal = 1)
+		qdel(src)
+
 /obj/item/organ/regenerative_core/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	. = ..()
 	if(!preserved && !inert)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hacks in a new proc for if the player uses a legion core in their hand rather than clicking on themselves. This is equivalent to clicking on the self, with nearly all the same checks as the original, skipping out on the user's death and distance - as the player would not be able to activate the legion core in-hand in the first place if they were dead, and if self healing, the distance would be null anyhow.

This is also my first hack for SS13. Yell at me and tell me how I messed it up.

Edit: Logging is now incorporated in the scope of this PR. With unique logs for all three use cases of legion core healing to be saved via LOG_ATTACK.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
The lavalands megafuana sprites are huge, big-huge, enough to swallow up and block the character if they are just above them. This creates a frustrating scenario where you want to heal with a core but cannot access your own sprite as it is overlapped by the mega. This circumvents that issue as you can now instead use the legion core in hand for the same effect as if clicking on yourself.

Edit: Logging will improve round reconstruction and provide better insight for administrators performing after-action reviews.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: attack_self proc for the legion core which triggers a self-heal al la the previous 'afterattack' proc, as if clicking on the character's own sprite to self-heal
add: admin logging for all three use cases of legion core healing - afterattack, attack_self, and implanted ui_action_click
/:cl:
<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
