### PR TITLE
Glitchfix. Prevents storage bags from changing the order of their numbered contents when items are removed.

### DIFF
--- a/code/__HELPERS/cmp.dm
+++ b/code/__HELPERS/cmp.dm
@@ -84,3 +84,9 @@ GLOBAL_VAR_INIT(cmp_field, "name")
 
 /proc/cmp_job_display_asc(datum/job/A, datum/job/B)
 	return A.display_order - B.display_order
+
+/proc/cmp_numbered_displays_name_asc(datum/numbered_display/A, datum/numbered_display/B)
+	return sorttext(A.sample_object.name, B.sample_object.name)
+
+/proc/cmp_numbered_displays_name_dsc(datum/numbered_display/A, datum/numbered_display/B)
+	return sorttext(B.sample_object.name, A.sample_object.name)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -309,6 +309,7 @@
 		else
 			var/datum/numbered_display/ND = .[I.type]
 			ND.number++
+	. = sortTim(., /proc/cmp_numbered_displays_name_asc, associative = TRUE)
 
 //This proc determines the size of the inventory to be displayed. Please touch it only if you know what you're doing.
 /datum/component/storage/proc/orient2hud(mob/user, maxcolumns)


### PR DESCRIPTION
## About The Pull Request

As much as it's not a full-blown bug, it's definitely an inconvenience.
Coded on request of a certain botanist who has made **_mistakes_** due to stuff changing places unexpectedly in their bag, while planting glowshrooms.

To explain it in a bit more clear way, as an example,
you've got `pumpkin, carrot, carrot, apple, apple, apple, pumpkin` in the contents of a plant bag,
resulting in `pumpkin(2), carrot(2), apple(3)` being displayed to you in the bag
however, removing one pumpkin from the bag will remove the first one from the list, causing the 
pumpkin stack to jump to the last spot, as the algorithm looks for the first occurence of an item in the contents, when deciding the ordering,resulting in `carrot(2), apple(3), pumpkin(1)`

As sorting the entire contents list is not going to be efficient in any way, especially with existence of things like ore bags of holding, my proposed solution is to simply sort the stacks alphabetically and call it a day.

## Changelog
:cl:
fix: numbered storages now are sorted in a consistent way, instead of depending on ordering of their contents var
/:cl:
