### PR TITLE
Makes from-ghosts rulesets cancel if fewer than required candidates

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -107,11 +107,11 @@
 
 	candidates = pollGhostCandidates("The mode is looking for volunteers to become a [name]", antag_flag, SSticker.mode, antag_flag, poll_time = 300)
 
-	if(!candidates || candidates.len <= 0)
-		message_admins("The ruleset [name] received no applications.")
-		log_game("DYNAMIC: The ruleset [name] received no applications.")
+	if(!candidates || candidates.len <= required_candidates)
+		message_admins("The ruleset [name] did not receive enough applications.")
+		log_game("DYNAMIC: The ruleset [name] did not receive enough applications.")
 		mode.refund_threat(cost)
-		mode.log_threat("Rule [name] refunded [cost] (no applications)",verbose=TRUE)
+		mode.log_threat("Rule [name] refunded [cost] (not receive enough applications)",verbose=TRUE)
 		mode.executed_rules -= src
 		return
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Abductors wants 2 candidates. So, it checks if there's at least one candidate, then from 1 to 2 assigns a role to all the candidates who signed up... without ever checking if there's at least 2, only checking if there's more than 0. Whoops.

## Why It's Good For The Game

Single abductor isn't precisely playable, is it?

## Changelog
:cl: Putnam
fix: From-ghosts dynamic rulesets now actually listen to "required candidates"
/:cl:
