### PR TITLE
Makes sure every dynamic-triggered event isn't random on dynamic

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -270,7 +270,7 @@
 	repeatable = TRUE
 
 /datum/dynamic_ruleset/event/processor_overload
-	name = "Processer Overload"
+	name = "Processor Overload"
 	config_tag = "processor_overload"
 	typepath = /datum/round_event/processor_overload
 	cost = 4

--- a/code/modules/events/major_dust.dm
+++ b/code/modules/events/major_dust.dm
@@ -2,6 +2,7 @@
 	name = "Major Space Dust"
 	typepath = /datum/round_event/meteor_wave/major_dust
 	weight = 8
+	gamemode_blacklist = list("dynamic")
 
 /datum/round_event/meteor_wave/major_dust
 	wave_name = "space dust"

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -10,6 +10,7 @@
 	min_players = 15
 	max_occurrences = 3
 	earliest_start = 25 MINUTES
+	dynamic_blacklist = list("dynamic")
 
 /datum/round_event/meteor_wave
 	startWhen		= 6

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -10,7 +10,7 @@
 	min_players = 15
 	max_occurrences = 3
 	earliest_start = 25 MINUTES
-	dynamic_blacklist = list("dynamic")
+	gamemode_blacklist = list("dynamic")
 
 /datum/round_event/meteor_wave
 	startWhen		= 6

--- a/code/modules/events/processor_overload.dm
+++ b/code/modules/events/processor_overload.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/processor_overload
 	weight = 15
 	min_players = 20
+	gamemode_blacklist = list("dynamic")
 
 /datum/round_event/processor_overload
 	announceWhen	= 1


### PR DESCRIPTION
## About The Pull Request

Makes sure all the round events that dynamic can trigger aren't triggered randomly if they can be triggered by dynamic. It was a mistake that some of them could be.

## Why It's Good For The Game

no more triple meteor in one round because I forgot to blacklist it whoops

## Changelog
:cl: Putnam
fix: Every dynamic-triggered event is now blacklisted from being triggered by the random events system when dynamic can trigger them.
/:cl: