### PR TITLE
Allows extended voting on dynamic if recent rounds too chaotic

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -12,6 +12,7 @@ SUBSYSTEM_DEF(persistence)
 	var/list/obj/structure/chisel_message/chisel_messages = list()
 	var/list/saved_messages = list()
 	var/list/saved_modes = list(1,2,3)
+	var/list/saved_threat_levels = list(1,1,1)
 	var/list/saved_maps
 	var/list/saved_trophies = list()
 	var/list/spawned_objects = list()
@@ -27,6 +28,7 @@ SUBSYSTEM_DEF(persistence)
 	LoadChiselMessages()
 	LoadTrophies()
 	LoadRecentModes()
+	LoadRecentThreats()
 	LoadRecentMaps()
 	LoadPhotoPersistence()
 	if(CONFIG_GET(flag/use_antag_rep))
@@ -166,6 +168,15 @@ SUBSYSTEM_DEF(persistence)
 		return
 	saved_modes = json["data"]
 
+/datum/controller/subsystem/persistence/proc/LoadRecentThreats()
+	var/json_file = file("data/RecentThreatLevels.json")
+	if(!fexists(json_file))
+		return
+	var/list/json = json_decode(file2text(json_file))
+	if(!json)
+		return
+	saved_threat_levels = json["data"]
+
 /datum/controller/subsystem/persistence/proc/LoadRecentMaps()
 	var/json_file = file("data/RecentMaps.json")
 	if(!fexists(json_file))
@@ -216,6 +227,7 @@ SUBSYSTEM_DEF(persistence)
 	CollectSecretSatchels()
 	CollectTrophies()
 	CollectRoundtype()
+	CollectThreatLevel()
 	RecordMaps()
 	SavePhotoPersistence()						//THIS IS PERSISTENCE, NOT THE LOGGING PORTION.
 	if(CONFIG_GET(flag/use_antag_rep))
@@ -371,6 +383,18 @@ SUBSYSTEM_DEF(persistence)
 	file_data["data"] = saved_modes
 	fdel(json_file)
 	WRITE_FILE(json_file, json_encode(file_data))
+
+/datum/controller/subsystem/persistence/proc/CollectThreatLevel()
+	if(istype(SSticker.mode, /datum/game_mode/dynamic))
+		var/datum/game_mode/dynamic/mode = SSticker.mode
+		saved_threat_levels[3] = saved_threat_levels[2]
+		saved_threat_levels[2] = saved_threat_levels [1]
+		saved_threat_levels[1] = mode.threat_level
+		var/json_file = file("data/RecentThreatLevels.json")
+		var/list/file_data = list()
+		file_data["data"] = saved_threat_levels
+		fdel(json_file)
+		WRITE_FILE(json_file, json_encode(file_data))
 
 /datum/controller/subsystem/persistence/proc/RecordMaps()
 	saved_maps = saved_maps?.len ? list("[SSmapping.config.map_name]") | saved_maps : list("[SSmapping.config.map_name]")

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -153,6 +153,10 @@ SUBSYSTEM_DEF(vote)
 				if(SSticker.current_state > GAME_STATE_PREGAME)//Don't change the mode if the round already started.
 					return message_admins("A vote has tried to change the gamemode, but the game has already started. Aborting.")
 				GLOB.master_mode = "dynamic"
+				if("extended" in choices)
+					if(. == "extended")
+						GLOB.dynamic_forced_extended = TRUE // we still do the rest of the stuff
+					choices[PEACE] += choices["extended"]
 				var/mean = 0
 				var/voters = 0
 				for(var/client/c in GLOB.clients)
@@ -253,7 +257,11 @@ SUBSYSTEM_DEF(vote)
 			if("roundtype") //CIT CHANGE - adds the roundstart secret/extended vote
 				choices.Add("secret", "extended")
 			if("dynamic")
-				choices.Add(PEACE,CHAOS)
+				var/saved_threats = SSpersistence.saved_threat_levels
+				if((saved_threats[1]+saved_threats[2]+saved_threats[3])>150)
+					choices.Add("extended",PEACE,CHAOS)
+				else
+					choices.Add(PEACE,CHAOS)
 			if("custom")
 				question = stripped_input(usr,"What is the vote for?")
 				if(!question)


### PR DESCRIPTION
## About The Pull Request

As title. Keeps track of last three rounds and if the average of the three is at least 50 it'll let people vote for extended too.

## Why It's Good For The Game

A major complaint about dynamic is that it no longer allows extended; this alleviates that complaint by adding an actual, real way to get extended, at times when people are probably most annoyed by the lack of it. **It's a bit of a stopgap solution to the preferred one, which is to just get people to vote for calm if they want calm**, but I think it's fine to have.

## Changelog
:cl: Putnam
add: Dynamic voting now features extended, if recent rounds have been chaotic.
/:cl: