### PR TITLE
Black powder fix. Alternative to #9861

### DIFF
--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -156,9 +156,12 @@
 /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/prime()
 	icon_state = "cherry_bomb_lit"
 	playsound(src, 'sound/effects/fuse.ogg', seed.potency, 0)
+	addtimer(CALLBACK(src, /obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/detonate), rand(50, 100))
+
+/obj/item/reagent_containers/food/snacks/grown/cherry_bomb/proc/detonate()
 	reagents.chem_temp = 1000 //Sets off the black powder
 	reagents.handle_reactions()
-
+	
 // Lavaland cactus
 
 /obj/item/seeds/lavaland/cactus

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -99,7 +99,6 @@
 
 /datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
 	var/turf/T = get_turf(holder.my_atom)
-	sleep(rand(50,100))
 	..(holder, created_volume, T)
 
 /datum/chemical_reaction/thermite


### PR DESCRIPTION
## About The Pull Request

Alternative to https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9861

Makes blackpowder explode instantly, instead of after a delay.
Imo, it's not imbalanced. The explosion is comparable to a meth explosion, which is instantaneous.

## Changelog
:cl:
fix: resolves the issues revolving around blackpowder exploding where the reaction happened, instead of where it actually is through making it explode instantly
tweak: the explosion delay moved from blackpowder directly into bomb cherries, to keep them functioning as intended
/:cl: