### PR TITLE
[TESTMERGE] Explosion/bomb armor rework

### DIFF
--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -386,43 +386,34 @@
 		return
 	var/b_loss = 0
 	var/f_loss = 0
-	var/bomb_armor = getarmor(null, "bomb")
+	var/bomb_armor = max(0,(100-getarmor(null, "bomb"))/100)
 
 	switch (severity)
 		if (1)
-			if(prob(bomb_armor))
-				b_loss = 500
+			if(bomb_armor)
+				b_loss = 500*bomb_armor
 				var/atom/throw_target = get_edge_target_turf(src, get_dir(src, get_step_away(src, src)))
 				throw_at(throw_target, 200, 4)
-				damage_clothes(400 - bomb_armor, BRUTE, "bomb")
+				damage_clothes(400*bomb_armor, BRUTE, "bomb")
 			else
-				for(var/I in contents)
-					var/atom/A = I
-					A.ex_act(severity)
+				damage_clothes(400,BRUTE,"bomb")
 				gib()
 				return
 
 		if (2)
-			b_loss = 60
-			f_loss = 60
-			if(bomb_armor)
-				b_loss = 30*(2 - round(bomb_armor*0.01, 0.05))
-				f_loss = b_loss
-			damage_clothes(200 - bomb_armor, BRUTE, "bomb")
+			b_loss = 60*bomb_armor
+			f_loss = 60*bomb_armor
+			damage_clothes(200*bomb_armor, BRUTE, "bomb")
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
 				adjustEarDamage(30, 120)
-			if (prob(max(70 - (bomb_armor * 0.5), 0)))
-				Unconscious(200)
+			Unconscious(200*bomb_armor)
 
 		if(3)
-			b_loss = 30
-			if(bomb_armor)
-				b_loss = 15*(2 - round(bomb_armor*0.01, 0.05))
+			b_loss = 30*bomb_armor
 			damage_clothes(max(50 - bomb_armor, 0), BRUTE, "bomb")
 			if (!istype(ears, /obj/item/clothing/ears/earmuffs))
 				adjustEarDamage(15,60)
-			if (prob(max(50 - (bomb_armor * 0.5), 0)))
-				Unconscious(160)
+			Unconscious(100*bomb_armor)
 
 	take_overall_damage(b_loss,f_loss)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Bomb armor now works like other armors, i.e. multiplies damage by a percentage of total bomb armor rather than a bunch of RNG dreck. This applies to damage from the explosion, damage to clothes and unconsciousness duration.
2. Makes even the strongest explosions only damage the things the user is wearing, rather than recursively destroying everything on them including in their packs.

This is a WiP and could use more changes. If anything more needs looking at, I'll incorporate it.

## Why It's Good For The Game

These changes were suggested to me by Kevinz, mostly. Predictable responses from bomb armor is good. Not shredding every single thing on someone in an explosion is good.

## Changelog
:cl:
balance: Bomb armor now acts like other armor types.
balance: Devastation-level explosions on armorless people no longer destroys everything in their bags.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
