### PR TITLE
Removes the night vision quirk

### DIFF
--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -101,21 +101,6 @@
 	H.equip_to_slot(musicaltuner, SLOT_IN_BACKPACK)
 	H.regenerate_icons()
 
-/datum/quirk/night_vision
-	name = "Night Vision"
-	desc = "You can see slightly more clearly in full darkness than most people."
-	value = 1
-	mob_trait = TRAIT_NIGHT_VISION
-	gain_text = "<span class='notice'>The shadows seem a little less dark.</span>"
-	lose_text = "<span class='danger'>Everything seems a little darker.</span>"
-
-/datum/quirk/night_vision/on_spawn()
-	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/organ/eyes/eyes = H.getorgan(/obj/item/organ/eyes)
-	if(!eyes || eyes.lighting_alpha)
-		return
-	eyes.Insert(H) //refresh their eyesight and vision
-
 /datum/quirk/photographer
 	name = "Photographer"
 	desc = "You know how to handle a camera, shortening the delay between each shot."


### PR DESCRIPTION
## About The Pull Request

Removes the night vision quirk, a 1 point quirk that grants the user perfect night vision as if using NVGs.

## Why It's Good For The Game

The night vision quirk is an extremely gamey and powerful quirk that doesn't really have a place on a server where gameplay mechanics matter. Night vision gives its users a demonstrable advantage over characters that do not select the perk, creating an environment that not only rewards but encourages powergaming, and does not exist for any other purpose.
(This also nerfs Kevinz's powergaming slightly, which he's said he's fine with, lol.)

## Changelog
:cl:
del: Removed night vision quirk
/:cl: