### PR TITLE
[DYNAMIC] Prevents VR mobs from being midround antags.

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -41,6 +41,9 @@
 		if (!istype(M, required_type))
 			trimmed_list.Remove(M)
 			continue
+		if (M.GetComponent(/datum/component/virtual_reality))
+			trimmed_list.Remove(M)
+			continue
 		if (!M.client) // Are they connected?
 			trimmed_list.Remove(M)
 			continue


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It wasn't checking at all if a mob was in VR. This fixes that.

## Why It's Good For The Game

We're all here to have fun, so a feature that calls out the user for being a tough guy only in a virtual world seems a little too mean-spirited and on-the-nose.

## Changelog
:cl: Putnam
fix: VR mobs can no longer be dynamic midround antags.
/:cl: