### PR TITLE
The True Cosmic Winter Coat

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -187,6 +187,7 @@
 	var/datum/gas_mixture/temp_air_contents
 	var/obj/item/tank/internals/tank = null
 	var/mob/living/carbon/human/cur_user
+	var/suit_type = /obj/item/clothing/suit/space/hardsuit
 
 /obj/item/tank/jetpack/suit/New()
 	..()
@@ -197,7 +198,7 @@
 	return
 
 /obj/item/tank/jetpack/suit/cycle(mob/user)
-	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit))
+	if(!istype(loc, suit_type))
 		to_chat(user, "<span class='warning'>\The [src] must be connected to a hardsuit!</span>")
 		return
 
@@ -208,7 +209,7 @@
 	..()
 
 /obj/item/tank/jetpack/suit/turn_on(mob/user)
-	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit) || !ishuman(loc.loc) || loc.loc != user)
+	if(!istype(loc, suit_type) || !ishuman(loc.loc) || loc.loc != user)
 		return
 	var/mob/living/carbon/human/H = user
 	tank = H.s_store
@@ -225,7 +226,7 @@
 	..()
 
 /obj/item/tank/jetpack/suit/process()
-	if(!istype(loc, /obj/item/clothing/suit/space/hardsuit) || !ishuman(loc.loc))
+	if(!istype(loc, suit_type) || !ishuman(loc.loc))
 		turn_off(cur_user)
 		return
 	var/mob/living/carbon/human/H = loc.loc
@@ -248,7 +249,7 @@
 
 /mob/living/carbon/human/get_jetpack()
 	var/obj/item/tank/jetpack/J = ..()
-	if(!istype(J) && istype(wear_suit, /obj/item/clothing/suit/space/hardsuit))
+	if(!istype(J) && (istype(wear_suit, /obj/item/clothing/suit/space/hardsuit) || istype(wear_suit, /obj/item/clothing/suit/hooded/wintercoat/cosmic/true)))
 		var/obj/item/clothing/suit/space/hardsuit/C = wear_suit
 		J = C.jetpack
 	return J

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -691,9 +691,19 @@
 	item_state = "coatcosmic"
 	allowed = list(/obj/item/flashlight)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/cosmic
+	light_power = 2
+	light_range = 1.4
 
 /obj/item/clothing/head/hooded/winterhood/cosmic
 	icon_state = "winterhood_cosmic"
+
+/obj/item/clothing/suit/hooded/wintercoat/cosmic/attackby(obj/item/I, mob/user, params)
+	if (istype(I,/obj/item/assembly/signaler/anomaly))
+		new /obj/item/clothing/suit/hooded/wintercoat/cosmic/true(get_turf(src))
+		user.visible_message("<span class='notice'>[src] flashes brightly, the stars on it's design flaring as [user] pushes the [I] into it!</span>")
+		qdel(I)
+		qdel(src)
+
 
 /obj/item/clothing/suit/hooded/wintercoat/janitor
 	name = "janitors winter coat"
@@ -733,6 +743,58 @@
 
 /obj/item/clothing/head/hooded/winterhood/miner
 	icon_state = "winterhood_miner"
+
+/obj/item/clothing/suit/hooded/wintercoat/cosmic/true
+	name = "true cosmic winter coat"
+	icon_state = "coatcosmic"
+	item_state = "coatcosmic"
+	desc = "A true cosmic winter coat, it protects even from the rigors of space and comes with an inbuilt invisible jetpack."
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals)
+	hoodtype = /obj/item/clothing/head/hooded/winterhood/cosmic/true
+	var/obj/item/tank/jetpack/suit/jetpack = /obj/item/tank/jetpack/suit/cosmiccoat
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
+	cold_protection = CHEST | GROIN | LEGS | FEET | ARMS | HANDS
+	min_cold_protection_temperature = SPACE_SUIT_MIN_TEMP_PROTECT
+	heat_protection = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	max_heat_protection_temperature = SPACE_SUIT_MAX_TEMP_PROTECT
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL
+	body_parts_covered = CHEST|GROIN|LEGS|FEET|ARMS|HANDS
+	light_power = 4
+	light_range = 3
+
+/obj/item/clothing/head/hooded/winterhood/cosmic/true
+	icon_state = "winterhood_cosmic"
+	clothing_flags = STOPSPRESSUREDAMAGE | THICKMATERIAL | BLOCK_GAS_SMOKE_EFFECT | SNUG_FIT
+	cold_protection = HEAD
+	min_cold_protection_temperature = SPACE_HELM_MIN_TEMP_PROTECT
+	heat_protection = HEAD
+	max_heat_protection_temperature = SPACE_HELM_MAX_TEMP_PROTECT
+
+/obj/item/clothing/suit/hooded/wintercoat/cosmic/true/Initialize()
+	if(jetpack && ispath(jetpack))
+		jetpack = new jetpack(src)
+	. = ..()
+
+/obj/item/clothing/suit/hooded/wintercoat/cosmic/true/equipped(mob/user, slot)
+	..()
+	if(jetpack)
+		if(slot == SLOT_WEAR_SUIT)
+			for(var/X in jetpack.actions)
+				var/datum/action/A = X
+				A.Grant(user)
+
+/obj/item/clothing/suit/hooded/wintercoat/cosmic/true/dropped(mob/user)
+	..()
+	if(jetpack)
+		for(var/X in jetpack.actions)
+			var/datum/action/A = X
+			A.Remove(user)
+
+/obj/item/tank/jetpack/suit/cosmiccoat
+	desc = "You really shouldn't see this."
+	name = "cosmic jetpack"
+	suit_type = /obj/item/clothing/suit/hooded/wintercoat/cosmic/true
+	full_speed = TRUE //MAGIC
 
 /obj/item/clothing/suit/spookyghost
 	name = "spooky ghost"


### PR DESCRIPTION
## About The Pull Request

To be quite honest, this isn't a serious PR and I don't expect it to get merged, but it would be fun if it was.
This adds the true cosmic winter coat, which can be gotten by tapping a cosmic winter coat with an anomaly core. The true cosmic winter coat is space proof and comes with an inbuilt fast jetpack.

## Why It's Good For The Game

It really wouldn't add anything to the game except a bit of fun. It wouldn't be powergames very easily since it's hard enough to collect the 20 winter coats to make the cosmic winter coat anyway, adding an anomaly would make it a very very rare occurence.

## Changelog
:cl:
add: added the true cosmic winter coat + suit jetpack
tweak: made it easier to add suit jetpacks to things that aren't hardsuits if need be (not ingame, just in code)
/:cl:
