### PR TITLE
Make organs no longer radiaoctively contaminable.

### DIFF
--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -28,6 +28,7 @@
 	var/now_fixed
 	var/high_threshold_cleared
 	var/low_threshold_cleared
+	rad_flags = RAD_NO_CONTAMINATE
 
 /obj/item/organ/proc/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	if(!iscarbon(M) || owner == M)


### PR DESCRIPTION
## About The Pull Request

People are claiming genitals are causing permacontamination. The fix is a single line, so I've made the fix. I don't know if it's the actual problem, but testing it is trivial, so here you go.

## Why It's Good For The Game

Permacontamination is bad.

## Changelog
:cl:
fix: Organs can no longer be radioactively contaminated.
/:cl: