### PR TITLE
Dynamic rulesets that have fired in recent rounds have lower weight

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -80,8 +80,8 @@
 	/// Delay for when execute will get called from the time of post_setup (roundstart) or process (midround/latejoin).
 	/// Make sure your ruleset works with execute being called during the game when using this, and that the clean_up proc reverts it properly in case of faliure.
 	var/delay = 0
-	/// Whether or not previous-round weight values are taken into account for this ruleset.
-	/// Uses the same values as secret's rulesets.
+	/// Whether or not recent-round weight values are taken into account for this ruleset.
+	/// Weight reduction uses the same values as secret's recent-round mode weight reduction.
 	var/always_max_weight = FALSE
 
 /datum/dynamic_ruleset/New()

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -98,7 +98,7 @@
 	if(config_tag in weights)
 		var/weight_mult = 1
 		if(!always_max_weight && SSpersistence.saved_dynamic_rules.len == 3 && repeated_mode_adjust.len == 3)
-			var/saved_dynamic_rules = SSpersistence.saved_dynamic_rules.len
+			var/saved_dynamic_rules = SSpersistence.saved_dynamic_rules
 			for(var/i in 1 to 3)
 				if(config_tag in saved_dynamic_rules[i])
 					weight_mult -= (repeated_mode_adjust[i]/100)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -94,14 +94,14 @@
 	var/costs = CONFIG_GET(keyed_list/dynamic_cost)
 	var/requirementses = CONFIG_GET(keyed_list/dynamic_requirements) // can't damn well use requirements
 	var/high_population_requirements = CONFIG_GET(keyed_list/dynamic_high_population_requirement)
-	var/list/repeated_mode_adjust = Get(/datum/config_entry/number_list/repeated_mode_adjust)
+	var/list/repeated_mode_adjust = CONFIG_GET(number_list/repeated_mode_adjust)
 	if(config_tag in weights)
 		var/weight_mult = 1
 		if(!always_max_weight && SSpersistence.saved_dynamic_rules.len == 3 && repeated_mode_adjust.len == 3)
 			var/saved_dynamic_rules = SSpersistence.saved_dynamic_rules.len
 			for(var/i in 1 to 3)
 				if(config_tag in saved_dynamic_rules[i])
-					weight_mult -= (adjustment/100)
+					weight_mult -= (repeated_mode_adjust[i]/100)
 		weight = weights[config_tag] * weight_mult
 	if(config_tag in costs)
 		cost = costs[config_tag]

--- a/code/game/gamemodes/dynamic/dynamic_rulesets.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets.dm
@@ -80,6 +80,9 @@
 	/// Delay for when execute will get called from the time of post_setup (roundstart) or process (midround/latejoin).
 	/// Make sure your ruleset works with execute being called during the game when using this, and that the clean_up proc reverts it properly in case of faliure.
 	var/delay = 0
+	/// Whether or not previous-round weight values are taken into account for this ruleset.
+	/// Uses the same values as secret's rulesets.
+	var/always_max_weight = FALSE
 
 /datum/dynamic_ruleset/New()
 	..()
@@ -91,8 +94,15 @@
 	var/costs = CONFIG_GET(keyed_list/dynamic_cost)
 	var/requirementses = CONFIG_GET(keyed_list/dynamic_requirements) // can't damn well use requirements
 	var/high_population_requirements = CONFIG_GET(keyed_list/dynamic_high_population_requirement)
+	var/list/repeated_mode_adjust = Get(/datum/config_entry/number_list/repeated_mode_adjust)
 	if(config_tag in weights)
-		weight = weights[config_tag]
+		var/weight_mult = 1
+		if(!always_max_weight && SSpersistence.saved_dynamic_rules.len == 3 && repeated_mode_adjust.len == 3)
+			var/saved_dynamic_rules = SSpersistence.saved_dynamic_rules.len
+			for(var/i in 1 to 3)
+				if(config_tag in saved_dynamic_rules[i])
+					weight_mult -= (adjustment/100)
+		weight = weights[config_tag] * weight_mult
 	if(config_tag in costs)
 		cost = costs[config_tag]
 	if(config_tag in requirementses)

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -125,6 +125,7 @@
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	high_population_requirement = 5
 	repeatable = TRUE
+	always_max_weight = TRUE
 
 //////////////////////////////////////////////
 //                                          //
@@ -280,6 +281,7 @@
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	high_population_requirement = 5
 	repeatable = TRUE
+	always_max_weight = TRUE
 
 /datum/dynamic_ruleset/event/space_dust
 	name = "Minor Space Dust"
@@ -293,6 +295,7 @@
 	requirements = list(5,5,5,5,5,5,5,5,5,5)
 	high_population_requirement = 5
 	repeatable = TRUE
+	always_max_weight = TRUE
 
 /datum/dynamic_ruleset/event/major_dust
 	name = "Major Space Dust"
@@ -332,6 +335,7 @@
 	requirements = list(101,101,101,5,5,5,5,5,5,5)
 	high_population_requirement = 5
 	repeatable = TRUE
+	always_max_weight = TRUE
 
 /datum/dynamic_ruleset/event/radiation_storm
 	name = "Radiation Storm"

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_latejoin.dm
@@ -69,6 +69,7 @@
 	high_population_requirement = 15
 	repeatable = TRUE
 	flags = TRAITOR_RULESET
+	always_max_weight = TRUE
 
 //////////////////////////////////////////////
 //                                          //

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -186,6 +186,7 @@
 	repeatable = TRUE
 	high_population_requirement = 15
 	flags = TRAITOR_RULESET
+	always_max_weight = TRUE
 
 /datum/dynamic_ruleset/midround/autotraitor/acceptable(population = 0, threat = 0)
 	var/player_count = mode.current_players[CURRENT_LIVING_PLAYERS].len

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_roundstart.dm
@@ -21,6 +21,7 @@
 	requirements = list(50,50,50,50,50,50,50,50,50,50)
 	high_population_requirement = 40
 	antag_cap = list(1,1,1,1,2,2,2,2,3,3)
+	always_max_weight = TRUE
 	var/autotraitor_cooldown = 450 // 15 minutes (ticks once per 2 sec)
 
 /datum/dynamic_ruleset/roundstart/traitor/pre_execute()


### PR DESCRIPTION
## About The Pull Request

As title: if a ruleset fires, it'll be lower in weight for next round, with some exceptions (traitor of all flavors, plus ion storm, space dust, processor overload, heart attack).

## Why It's Good For The Game

Adding because secret does it, mostly. Reduces monotony, makes rounds more "dynamic" in general. I'm kinda iffy on it personally, actually, but it seemed like an idea worth considering and it's actually pretty easy to code, so I here's a PR with all the required code for discussion.

## Changelog
:cl: Putnam
tweak: Dynamic rulesets have lower weight if a round recently featured them (except traitor).
/:cl:
