### PR TITLE
Personal closets can use PDAs/tablets now

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -9,11 +9,22 @@
 	if(registered_name)
 		to_chat(user, "<span class='notice'>The display reads, \"Owned by [registered_name]\".</span>")
 
-/obj/structure/closet/secure_closet/personal/check_access(obj/item/card/id/I)
+/obj/structure/closet/secure_closet/personal/check_access(obj/item/I)
 	. = ..()
 	if(!I || !istype(I))
 		return
-	if(registered_name == I.registered_name)
+	if(istype(I,/obj/item/modular_computer/tablet))
+		var/obj/item/modular_computer/tablet/ourTablet = I
+		var/obj/item/computer_hardware/card_slot/card_slot = ourTablet.all_components[MC_CARD]
+		if(card_slot)
+			return registered_name == card_slot.stored_card.registered_name || registered_name == card_slot.stored_card2.registered_name
+	var/obj/item/card/id/ID
+	if(istype(I,/obj/item/pda))
+		var/obj/item/pda/ourPDA = I
+		ID = ourPDA.id
+	else if(istype(I,/obj/item/card/id))
+		ID = I
+	if(registered_name == ID.registered_name)
 		return TRUE
 
 /obj/structure/closet/secure_closet/personal/PopulateContents()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -18,7 +18,7 @@
 		var/obj/item/computer_hardware/card_slot/card_slot = ourTablet.all_components[MC_CARD]
 		if(card_slot)
 			return registered_name == card_slot.stored_card.registered_name || registered_name == card_slot.stored_card2.registered_name
-	var/obj/item/card/id/ID = I.getID()
+	var/obj/item/card/id/ID = I.GetID()
 	if(ID && registered_name == ID.registered_name)
 		return TRUE
 	return FALSE

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -18,14 +18,10 @@
 		var/obj/item/computer_hardware/card_slot/card_slot = ourTablet.all_components[MC_CARD]
 		if(card_slot)
 			return registered_name == card_slot.stored_card.registered_name || registered_name == card_slot.stored_card2.registered_name
-	var/obj/item/card/id/ID
-	if(istype(I,/obj/item/pda))
-		var/obj/item/pda/ourPDA = I
-		ID = ourPDA.id
-	else if(istype(I,/obj/item/card/id))
-		ID = I
-	if(registered_name == ID.registered_name)
+	var/obj/item/card/id/ID = I.getID()
+	if(ID && registered_name == ID.registered_name)
 		return TRUE
+	return FALSE
 
 /obj/structure/closet/secure_closet/personal/PopulateContents()
 	..()


### PR DESCRIPTION
## About The Pull Request

Fixes #9929

## Why It's Good For The Game

A bit of consistency can't hurt. It's not the only thing that can't use PDAs, only ID cards, and there's *lots* of stuff that can't use tablets, but whatever, one step at a time.

## Changelog
:cl: Putnam
fix: Personal closets can use anything that holds an ID card now.
/:cl: