### PR TITLE
Removes hyperspeed from light pink stabilized for -4.5 stam/tick + free sprint

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -162,6 +162,7 @@
 #define TRAIT_FRIENDLY			"friendly"
 #define TRAIT_ASSBLASTUSA       "assblastusa"
 #define TRAIT_CULT_EYES 		"cult_eyes"
+#define TRAIT_FREESPRINT		"free_sprinting"
 
 
 // common trait sources

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -903,11 +903,8 @@ datum/status_effect/stabilized/blue/on_remove()
 	id = "stabilizedlightpink"
 	colour = "light pink"
 
-/datum/status_effect/stabilized/lightpink/on_apply()
-	owner.add_movespeed_modifier(MOVESPEED_ID_SLIME_STATUS, update=TRUE, priority=100, multiplicative_slowdown=-1, blacklisted_movetypes=(FLYING|FLOATING))
-	return ..()
-
 /datum/status_effect/stabilized/lightpink/tick()
+	owner.adjustStaminaLoss(-3)
 	for(var/mob/living/carbon/human/H in range(1, get_turf(owner)))
 		if(H != owner && H.stat != DEAD && H.health <= 0 && !H.reagents.has_reagent("epinephrine"))
 			to_chat(owner, "[linked_extract] pulses in sync with [H]'s heartbeat, trying to keep [H.p_them()] alive.")

--- a/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
+++ b/code/modules/research/xenobiology/crossbreeding/_status_effects.dm
@@ -903,8 +903,12 @@ datum/status_effect/stabilized/blue/on_remove()
 	id = "stabilizedlightpink"
 	colour = "light pink"
 
+/datum/status_effect/stabilized/lightpink/on_apply()
+	ADD_TRAIT(owner, TRAIT_FREESPRINT, "stabilized_slime")
+	return ..()
+
 /datum/status_effect/stabilized/lightpink/tick()
-	owner.adjustStaminaLoss(-3)
+	owner.adjustStaminaLoss(-4.5)
 	for(var/mob/living/carbon/human/H in range(1, get_turf(owner)))
 		if(H != owner && H.stat != DEAD && H.health <= 0 && !H.reagents.has_reagent("epinephrine"))
 			to_chat(owner, "[linked_extract] pulses in sync with [H]'s heartbeat, trying to keep [H.p_them()] alive.")
@@ -912,7 +916,8 @@ datum/status_effect/stabilized/blue/on_remove()
 	return ..()
 
 /datum/status_effect/stabilized/lightpink/on_remove()
-	owner.remove_movespeed_modifier(MOVESPEED_ID_SLIME_STATUS)
+	REMOVE_TRAIT(owner, TRAIT_FREESPRINT, "stabilized_slime")
+	return ..()
 
 /datum/status_effect/stabilized/adamantine
 	id = "stabilizedadamantine"

--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -5,7 +5,8 @@
 	var/oldpseudoheight = pseudo_z_axis
 	. = ..()
 	if(. && sprinting && !(movement_type & FLYING) && canmove && !resting && m_intent == MOVE_INTENT_RUN && has_gravity(loc) && !pulledby)
-		doSprintLossTiles(1)
+		if(!HAS_TRAIT(src, TRAIT_FREESPRINT))
+			doSprintLossTiles(1)
 		if((oldpseudoheight - pseudo_z_axis) >= 8)
 			to_chat(src, "<span class='warning'>You trip off of the elevated surface!</span>")
 			for(var/obj/item/I in held_items)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

We've for a while wanted stuff like ephedrine to not be free super speed.
Stamina regeneration is already powerful, hell ephedrine allows for *near* infinite sprinting without actually infinite sprinting.
Doesn't make sense to keep this in.
-4.5 stam/tick
free sprinting
Good enough.

I originally was going to code painkiller system for movespeed modifiers but since that's not done and we're having too much issues so be it, looks like we can't wait.

## Changelog
:cl:
balance: Light pink extracts no longer speed you up. Instead, they give stamina regeneration and free sprinting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
