### PR TITLE
Removes Clockie Surgical capabilities

### DIFF
--- a/_maps/map_files/generic/City_of_Cogs.dmm
+++ b/_maps/map_files/generic/City_of_Cogs.dmm
@@ -379,15 +379,6 @@
 /obj/item/camera,
 /turf/open/indestructible/clock_spawn_room,
 /area/reebe/city_of_cogs)
-"Nz" = (
-/obj/structure/table/bronze,
-/obj/item/implantcase,
-/obj/item/implantcase,
-/obj/item/implantcase,
-/obj/item/implanter,
-/obj/item/storage/backpack/duffelbag/sec/surgery,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 "NH" = (
 /obj/structure/table/bronze,
 /obj/item/taperecorder,
@@ -409,10 +400,6 @@
 "WT" = (
 /turf/closed/wall/clockwork,
 /area/reebe)
-"Yy" = (
-/obj/structure/table/optable,
-/turf/open/floor/clockwork/reebe,
-/area/reebe/city_of_cogs)
 
 (1,1,1) = {"
 zb
@@ -33918,7 +33905,7 @@ ab
 ai
 bE
 aj
-Yy
+aj
 aj
 aj
 aA
@@ -34175,7 +34162,7 @@ ab
 ah
 al
 aj
-Nz
+aj
 aj
 aC
 ah


### PR DESCRIPTION
## About The Pull Request

Removes the surgery table, surgery duffle, implanter, and implant cases from Reebe. Also removes the now useless brass table.

## Why It's Good For The Game

Having roundstart access to surgery in a secure, clockie only location means there is functionally 0 risk to kidnapping heads and converting them early. On top of that, the surgery area means that mindshields are essentially useless. No matter how many you have, the Clockies can just kidnap mindshielded crew and remove it.

Edit @ 1:40 PM EST 11/26/2019:

Its come to my attention that the existence of the implanter and cases I deleted meant that not only could clockies convert Sec and heads, but then also re-implant them to make it seem like they were never de-implanted. One more reason to give this the big remove.

## Changelog
:cl:
del: Removed Clockwork Cult Surgical facility from Reebe
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
