### PR TITLE
Nerfs the Clockwork Marauder meta

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -384,5 +384,5 @@
 	config_entry_value = 1800
 	min_val = 0
 
-/datum/config_entry/flag/allow_clockwork_marauder
+/datum/config_entry/flag/allow_station_clockwork_marauder
 	config_entry_value = TRUE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -383,3 +383,6 @@
 /datum/config_entry/number/marauder_delay_non_reebe
 	config_entry_value = 1800
 	min_val = 0
+
+/datum/config_entry/flag/allow_clockwork_marauder
+	config_entry_value = TRUE

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -379,3 +379,7 @@
 /datum/config_entry/number/auto_transfer_delay
 	config_entry_value = 72000
 	min_val = 0
+
+/datum/config_entry/number/marauder_delay_non_reebe
+	config_entry_value = 1800
+	min_val = 0

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -384,5 +384,5 @@
 	config_entry_value = 1800
 	min_val = 0
 
-/datum/config_entry/flag/allow_station_clockwork_marauder
+/datum/config_entry/flag/allow_clockwork_marauder_on_station
 	config_entry_value = TRUE

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -1,6 +1,6 @@
 #define MARAUDER_SLOWDOWN_PERCENTAGE 0.40 //Below this percentage of health, marauders will become slower
 #define MARAUDER_SHIELD_REGEN_TIME 200 //In deciseconds, how long it takes for shields to regenerate after breaking
-#define MARAUDER_SPACE_DIRECT_DAMAGE 6		//amount of damage per life tick while inside space
+#define MARAUDER_SPACE_FULL_DAMAGE 6		//amount of damage per life tick while inside space
 #define MARAUDER_SPACE_NEAR_DAMAGE 4			//amount of damage taking per Life() tick from being next to space.
 
 //Clockwork marauder: A well-rounded frontline construct. Only one can exist for every two human servants.

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -1,5 +1,6 @@
 #define MARAUDER_SLOWDOWN_PERCENTAGE 0.40 //Below this percentage of health, marauders will become slower
 #define MARAUDER_SHIELD_REGEN_TIME 200 //In deciseconds, how long it takes for shields to regenerate after breaking
+#define MARAUDER_SPACE_DAMAGE 4			//amount of damage taking per Life() tick from space.
 
 //Clockwork marauder: A well-rounded frontline construct. Only one can exist for every two human servants.
 /mob/living/simple_animal/hostile/clockwork/marauder
@@ -20,12 +21,14 @@
 	movement_type = FLYING
 	a_intent = INTENT_HARM
 	loot = list(/obj/item/clockwork/component/geis_capacitor/fallen_armor)
-	light_range = 2
-	light_power = 1.1
+	light_range = 3
+	light_power = 1.7
 	playstyle_string = "<span class='big bold'><span class='neovgre'>You are a clockwork marauder,</span></span><b> a well-rounded frontline construct of Ratvar. Although you have no \
 	unique abilities, you're a fearsome fighter in one-on-one combat, and your shield protects from projectiles!<br><br>Obey the Servants and do as they \
-	tell you. Your primary goal is to defend the Ark from destruction; they are your allies in this, and should be protected from harm.</b>"
+	tell you. Your primary goal is to defend the Ark from destruction; they are your allies in this, and should be protected from harm.</b> \
+	<span class='danger big'>Be warned, however, that you will rapidly decay near the void of space.</span>"
 	empower_string = "<span class='neovgre'>The Anima Bulwark's power flows through you! Your weapon will strike harder, your armor is sturdier, and your shield is more durable.</span>"
+	var/default_speed = 0
 	var/max_shield_health = 3
 	var/shield_health = 3 //Amount of projectiles that can be deflected within
 	var/shield_health_regen = 0 //When world.time equals this, shield health will regenerate
@@ -36,10 +39,14 @@
 
 /mob/living/simple_animal/hostile/clockwork/marauder/Life()
 	..()
+	var/turf/open/space/S = locate() in view(1)
+	if(S)
+		to_chat(src, "<span class='userdanger'>The void of space drains Ratvar's Light from you! You feel yourself rapidly decaying. It would be wise to get back inside!</span>")
+		adjustBruteLoss(MARAUDER_SPACE_DAMAGE)
 	if(!GLOB.ratvar_awakens && health / maxHealth <= MARAUDER_SLOWDOWN_PERCENTAGE)
-		speed = initial(speed) + 1 //Yes, this slows them down
+		speed = default_speed + 1 //Yes, this slows them down
 	else
-		speed = initial(speed)
+		speed = default_speed
 	if(shield_health < max_shield_health && world.time >= shield_health_regen)
 		shield_health_regen = world.time + MARAUDER_SHIELD_REGEN_TIME
 		to_chat(src, "<span class='neovgre'>Your shield has recovered, <b>[shield_health]</b> blocks remaining!</span>")

--- a/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/clockwork_marauder.dm
@@ -1,6 +1,7 @@
 #define MARAUDER_SLOWDOWN_PERCENTAGE 0.40 //Below this percentage of health, marauders will become slower
 #define MARAUDER_SHIELD_REGEN_TIME 200 //In deciseconds, how long it takes for shields to regenerate after breaking
-#define MARAUDER_SPACE_DAMAGE 4			//amount of damage taking per Life() tick from space.
+#define MARAUDER_SPACE_DIRECT_DAMAGE 6		//amount of damage per life tick while inside space
+#define MARAUDER_SPACE_NEAR_DAMAGE 4			//amount of damage taking per Life() tick from being next to space.
 
 //Clockwork marauder: A well-rounded frontline construct. Only one can exist for every two human servants.
 /mob/living/simple_animal/hostile/clockwork/marauder
@@ -39,10 +40,17 @@
 
 /mob/living/simple_animal/hostile/clockwork/marauder/Life()
 	..()
-	var/turf/open/space/S = locate() in view(1)
+	var/turf/T = get_turf(src)
+	var/turf/open/space/S = isspaceturf(T)? T : null
+	var/less_space_damage
+	if(!istype(S))
+		var/turf/open/space/nearS = locate() in oview(1)
+		if(nearS)
+			S = nearS
+			less_space_damage = TRUE
 	if(S)
 		to_chat(src, "<span class='userdanger'>The void of space drains Ratvar's Light from you! You feel yourself rapidly decaying. It would be wise to get back inside!</span>")
-		adjustBruteLoss(MARAUDER_SPACE_DAMAGE)
+		adjustBruteLoss(less_space_damage? MARAUDER_SPACE_NEAR_DAMAGE : MARAUDER_SPACE_FULL_DAMAGE)
 	if(!GLOB.ratvar_awakens && health / maxHealth <= MARAUDER_SLOWDOWN_PERCENTAGE)
 		speed = default_speed + 1 //Yes, this slows them down
 	else

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
@@ -96,7 +96,7 @@
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
 	if(!is_reebe(invoker.z))
 		if(!CONFIG_GET(flag/allow_clockwork_marauder_on_station))
-			to_chat(invoker, "<span class='brass'>This particular station is too far from the influence of the Hierophant Network. You can not summon a marauder here.</span>)
+			to_chat(invoker, "<span class='brass'>This particular station is too far from the influence of the Hierophant Network. You can not summon a marauder here.</span>")
 			return FALSE
 		if(world.time < (last_marauder + CONFIG_GET(number/marauder_delay_non_reebe)))
 			to_chat(invoker, "<span class='brass'>The hierophant network is still strained from the last summoning of a marauder on a plane without the strong energy connection of Reebe to support it. \

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
@@ -96,8 +96,7 @@
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
 	if(!is_reebe(invoker.z))
 		if(!CONFIG_GET(flag/allow_clockwork_marauder_on_station))
-			to_chat(invoker, "<span class='brass'>This particular station is too far from the influence of the Hierophant Network. You can not summon a marauder here</span> \
-			<span class='danger'>((OOC NOTE: Station marauders are config-disabled.))</span>")
+			to_chat(invoker, "<span class='brass'>This particular station is too far from the influence of the Hierophant Network. You can not summon a marauder here.</span>)
 			return FALSE
 		if(world.time < (last_marauder + CONFIG_GET(number/marauder_delay_non_reebe)))
 			to_chat(invoker, "<span class='brass'>The hierophant network is still strained from the last summoning of a marauder on a plane without the strong energy connection of Reebe to support it. \

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
@@ -87,9 +87,18 @@
 	object_path = /obj/item/clockwork/construct_chassis/clockwork_marauder
 	construct_type = /mob/living/simple_animal/hostile/clockwork/marauder
 	combat_construct = TRUE
-	var/static/recent_marauders = 0
-	var/static/time_since_last_marauder = 0
-	var/static/scaled_recital_time = 0
+	var/static/last_marauder = 0
+
+/datum/clockwork_scripture/create_object/construct/clockwork_marauder/post_recital()
+	last_marauder = world.time
+	return ..()
+
+/datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
+	if(!is_reebe(invoker.z) && (world.time < (last_marauder + CONFIG_GET(number/marauder_delay_non_reebe))))
+		to_chat(invoker, "<span class='brass'>The hierophant network is still strained from the last summoning of a marauder on a plane without the strong energy connection of Reebe to support it. \
+		You must wait another [DisplayTimeText((last_marauder + CONFIG_GET(number/marauder_delay_non_reebe)) - world.time, TRUE)]!</span>")
+		return FALSE
+	return ..()
 
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/update_construct_limit()
 	var/human_servants = 0
@@ -98,27 +107,7 @@
 		var/mob/living/L = M.current
 		if(ishuman(L) && L.stat != DEAD)
 			human_servants++
-	construct_limit = round(CLAMP((human_servants / 4), 1, 3)) - recent_marauders //1 per 4 human servants, maximum of 3, reduced by recent marauder creation
-	if(recent_marauders)
-		to_chat(invoker, "<span class='warning'>The Hierophant Network is depleted by a summoning in the last [DisplayTimeText(MARAUDER_SCRIPTURE_SCALING_THRESHOLD, TRUE)] - limiting the number of available marauders by [recent_marauders]!</span>")
-
-/datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
-	channel_time = initial(channel_time)
-	if(recent_marauders)
-		scaled_recital_time = min(recent_marauders * MARAUDER_SCRIPTURE_SCALING_TIME, MARAUDER_SCRIPTURE_SCALING_MAX)
-		to_chat(invoker, "<span class='warning'>The Hierophant Network is under strain from repeated summoning, making this scripture [DisplayTimeText(scaled_recital_time)] slower!</span>")
-		channel_time += scaled_recital_time
-	return TRUE
-
-/datum/clockwork_scripture/create_object/construct/clockwork_marauder/scripture_effects()
-	. = ..()
-	recent_marauders++
-	addtimer(CALLBACK(GLOBAL_PROC, .proc/marauder_reset),MARAUDER_SCRIPTURE_SCALING_THRESHOLD)
-
-/proc/marauder_reset()
-	var/datum/clockwork_scripture/create_object/construct/clockwork_marauder/CM = new()
-	CM.recent_marauders--
-	qdel(CM)
+	construct_limit = round(CLAMP((human_servants / 4), 1, 3))	//1 per 4 human servants, maximum of 3
 
 //Summon Neovgre: Summon a very powerful combat mech that explodes when destroyed for massive damage.
 /datum/clockwork_scripture/create_object/summon_arbiter

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_applications.dm
@@ -94,10 +94,15 @@
 	return ..()
 
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/pre_recital()
-	if(!is_reebe(invoker.z) && (world.time < (last_marauder + CONFIG_GET(number/marauder_delay_non_reebe))))
-		to_chat(invoker, "<span class='brass'>The hierophant network is still strained from the last summoning of a marauder on a plane without the strong energy connection of Reebe to support it. \
-		You must wait another [DisplayTimeText((last_marauder + CONFIG_GET(number/marauder_delay_non_reebe)) - world.time, TRUE)]!</span>")
-		return FALSE
+	if(!is_reebe(invoker.z))
+		if(!CONFIG_GET(flag/allow_clockwork_marauder_on_station))
+			to_chat(invoker, "<span class='brass'>This particular station is too far from the influence of the Hierophant Network. You can not summon a marauder here</span> \
+			<span class='danger'>((OOC NOTE: Station marauders are config-disabled.))</span>")
+			return FALSE
+		if(world.time < (last_marauder + CONFIG_GET(number/marauder_delay_non_reebe)))
+			to_chat(invoker, "<span class='brass'>The hierophant network is still strained from the last summoning of a marauder on a plane without the strong energy connection of Reebe to support it. \
+			You must wait another [DisplayTimeText((last_marauder + CONFIG_GET(number/marauder_delay_non_reebe)) - world.time, TRUE)]!</span>")
+			return FALSE
 	return ..()
 
 /datum/clockwork_scripture/create_object/construct/clockwork_marauder/update_construct_limit()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Marauders are now on a 3 minute cooldown per summon unless summoned on Reebe.
Marauders now take 6 damage per second in space or 4 while next to visible space (out of their 120 health)

Marauders also glow a bit brighter because why not.

## Why It's Good For The Game

Station clockwork marauder spam is getting a too much. Frankly I want to just revert clockcult back to station clockcult rather than Reebe Greytiding Simulator but until we have better plans for how clockcult should be working we might as well do this.
10 tile per second mobs running around in space smashing every window they can is ridiculous. If you want to do that, have a cultist steal a space suit and fire axe. 
Marauders are still a powerful thing to unleash on station, just not spammable waves of death.


## Changelog
:cl:
balance: Clockwork marauders are now on a configured summon cooldown if being summoned on station. They also rapidly bleed health while in or next to space. And they glow brighter.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
