### PR TITLE
patching some combat mode edge cases and issues.

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -91,7 +91,10 @@
 	if(current)	// remove ourself from our old body's mind variable
 		current.mind = null
 		SStgui.on_transfer(current, new_character)
-
+		if(iscarbon(current))
+			var/mob/living/carbon/C = current
+			if(C.combatmode)
+				C.toggle_combat_mode(TRUE, TRUE)
 	if(!language_holder)
 		var/datum/language_holder/mob_holder = new_character.get_language_holder(shadow = FALSE)
 		language_holder = mob_holder.copy(src)

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -38,6 +38,7 @@
 /datum/status_effect/incapacitating/unconscious
 	id = "unconscious"
 	needs_update_stat = TRUE
+	blocks_combatmode = TRUE
 
 /datum/status_effect/incapacitating/unconscious/tick()
 	if(owner.getStaminaLoss())
@@ -48,6 +49,7 @@
 	id = "sleeping"
 	alert_type = /obj/screen/alert/status_effect/asleep
 	needs_update_stat = TRUE
+	blocks_combatmode = TRUE
 	var/mob/living/carbon/carbon_owner
 	var/mob/living/carbon/human/human_owner
 

--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -38,7 +38,6 @@
 /datum/status_effect/incapacitating/unconscious
 	id = "unconscious"
 	needs_update_stat = TRUE
-	blocks_combatmode = TRUE
 
 /datum/status_effect/incapacitating/unconscious/tick()
 	if(owner.getStaminaLoss())
@@ -49,7 +48,6 @@
 	id = "sleeping"
 	alert_type = /obj/screen/alert/status_effect/asleep
 	needs_update_stat = TRUE
-	blocks_combatmode = TRUE
 	var/mob/living/carbon/carbon_owner
 	var/mob/living/carbon/human/human_owner
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -789,6 +789,8 @@
 		if(IsUnconscious() || IsSleeping() || getOxyLoss() > 50 || (HAS_TRAIT(src, TRAIT_DEATHCOMA)) || (health <= HEALTH_THRESHOLD_FULLCRIT && !HAS_TRAIT(src, TRAIT_NOHARDCRIT)))
 			stat = UNCONSCIOUS
 			blind_eyes(1)
+			if(combatmode)
+				toggle_combat_mode(TRUE, TRUE)
 		else
 			if(health <= crit_threshold && !HAS_TRAIT(src, TRAIT_NOSOFTCRIT))
 				stat = SOFT_CRIT

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -794,6 +794,8 @@
 		else
 			if(health <= crit_threshold && !HAS_TRAIT(src, TRAIT_NOSOFTCRIT))
 				stat = SOFT_CRIT
+				if(combatmode)
+					toggle_combat_mode(TRUE, TRUE)
 			else
 				stat = CONSCIOUS
 			adjust_blindness(-1)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -956,3 +956,8 @@
 	if(mood)
 		if(mood.sanity < SANITY_UNSTABLE)
 			return TRUE
+
+/mob/living/carbon/transfer_ckey(mob/new_mob, send_signal = TRUE)
+	if(combatmode)
+		toggle_combat_mode(TRUE, TRUE)
+	return ..()

--- a/code/modules/mob/living/carbon/death.dm
+++ b/code/modules/mob/living/carbon/death.dm
@@ -7,13 +7,15 @@
 
 	if(!gibbed)
 		emote("deathgasp")
+	if(combatmode)
+		toggle_combat_mode(TRUE, TRUE)
 
 	. = ..()
-	
+
 	for(var/T in get_traumas())
 		var/datum/brain_trauma/BT = T
 		BT.on_death()
-	
+
 	if(SSticker.mode)
 		SSticker.mode.check_win() //Calls the rounds wincheck, mainly for wizard, malf, and changeling now
 
@@ -63,3 +65,8 @@
 		var/obj/item/bodypart/BP = X
 		BP.drop_limb()
 		BP.throw_at(get_edge_target_turf(src,pick(GLOB.alldirs)),rand(1,3),5)
+
+/mob/living/carbon/ghostize(can_reenter_corpse = TRUE, special = FALSE, penalize = FALSE)
+	if(combatmode)
+		toggle_combat_mode(TRUE, TRUE)
+	return ..()

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/colossus.dm
@@ -651,7 +651,7 @@ Difficulty: Very Hard
 			L.heal_overall_damage(heal_power, heal_power)
 			new /obj/effect/temp_visual/heal(get_turf(target), "#80F5FF")
 
-/mob/living/simple_animal/hostile/lightgeist/ghostize(can_reenter_corpse = TRUE, special = FALSE)
+/mob/living/simple_animal/hostile/lightgeist/ghostize(can_reenter_corpse = TRUE, special = FALSE, penalize = FALSE)
 	. = ..()
 	if(.)
 		death()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -449,7 +449,8 @@
 	return
 
 /mob/proc/transfer_ckey(mob/new_mob, send_signal = TRUE)
-	if(!ckey)
+	if(!ckey || !new_mob)
+		CRASH("transfer_ckey() called [ckey ? "" : "on a ckey-less mob[new_mob ? "" : " and "]"][new_mob ? "" : "without a valid mob target"]!")
 		return FALSE
 	if(send_signal)
 		SEND_SIGNAL(src, COMSIG_MOB_KEY_CHANGE, new_mob, src)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -451,7 +451,6 @@
 /mob/proc/transfer_ckey(mob/new_mob, send_signal = TRUE)
 	if(!ckey || !new_mob)
 		CRASH("transfer_ckey() called [ckey ? "" : "on a ckey-less mob[new_mob ? "" : " and "]"][new_mob ? "" : "without a valid mob target"]!")
-		return FALSE
 	if(send_signal)
 		SEND_SIGNAL(src, COMSIG_MOB_KEY_CHANGE, new_mob, src)
 	new_mob.ckey = ckey

--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -19,10 +19,11 @@
 	return .
 
 /mob/living/carbon/proc/toggle_combat_mode(forced, silent)
-	if(recoveringstam)
-		return TRUE
 	if(!forced)
-		for(var/datum/status_effect/S in status_effects)
+		if(recoveringstam || stat != CONSCIOUS)
+			return TRUE
+		for(var/i in status_effects)
+			var/datum/status_effect/S = i
 			if(S.blocks_combatmode)
 				return TRUE
 	combatmode = !combatmode

--- a/modular_citadel/code/modules/mob/living/carbon/carbon.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/carbon.dm
@@ -18,7 +18,7 @@
 					return FALSE
 	return .
 
-/mob/living/carbon/proc/toggle_combat_mode(forced)
+/mob/living/carbon/proc/toggle_combat_mode(forced, silent)
 	if(recoveringstam)
 		return TRUE
 	if(!forced)
@@ -28,20 +28,21 @@
 	combatmode = !combatmode
 	if(voremode)
 		toggle_vore_mode()
-	if(combatmode)
-		playsound_local(src, 'sound/misc/ui_toggle.ogg', 50, FALSE, pressure_affected = FALSE) //Sound from interbay!
-	else
-		playsound_local(src, 'sound/misc/ui_toggleoff.ogg', 50, FALSE, pressure_affected = FALSE) //Slightly modified version of the above!
+	if(!silent)
+		if(combatmode)
+			if(world.time >= combatmessagecooldown)
+				if(a_intent != INTENT_HELP)
+					visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
+				else
+					visible_message("<span class='notice'>[src] [pick("looks","seems","goes")] [pick("alert","attentive","vigilant")].</span>")
+			playsound_local(src, 'sound/misc/ui_toggle.ogg', 50, FALSE, pressure_affected = FALSE) //Sound from interbay!
+		else
+			playsound_local(src, 'sound/misc/ui_toggleoff.ogg', 50, FALSE, pressure_affected = FALSE) //Slightly modified version of the above!
 	if(client)
 		client.show_popup_menus = !combatmode // So we can right-click for alternate actions and all that other good shit. Also moves examine to shift+rightclick to make it possible to attack while sprinting
 	if(hud_used && hud_used.static_inventory)
 		for(var/obj/screen/combattoggle/selector in hud_used.static_inventory)
 			selector.rebasetointerbay(src)
-	if(world.time >= combatmessagecooldown && combatmode)
-		if(a_intent != INTENT_HELP)
-			visible_message("<span class='warning'>[src] [resting ? "tenses up" : (prob(95)? "drops into a combative stance" : (prob(95)? "poses aggressively" : "asserts dominance with their pose"))].</span>")
-		else
-			visible_message("<span class='notice'>[src] [pick("looks","seems","goes")] [pick("alert","attentive","vigilant")].</span>")
 	combatmessagecooldown = 10 SECONDS + world.time //This is set 100% of the time to make sure squeezing regen out of process cycles doesn't result in the combat mode message getting spammed
 	SEND_SIGNAL(src, COMSIG_COMBAT_TOGGLED, src, combatmode)
 	return TRUE


### PR DESCRIPTION
## About The Pull Request
See title. Making combat mode automatically turn off in the following situations: Dying, ghosting, going soft crit, going unconscious, transferring mind or ckey to another mob. Quite patchy but I don't guess it'll be componentized or anything anytime soon.
Also added a missing sanity check to the transfer_ckey() proc and following crash logging.

## Why It's Good For The Game
This will close #9953, and probably help figuring out the spurious client crashing issues, since on top of runtiming, null.ckey = src.ckey can and will crash the src's client.

## Changelog
:cl:
fix: Dying, ghosting, having your mind / ckey transferred to another mob, going softcrit or otherwise unconscious now properly turn off combat mode.
fix: combat mode can't be toggled on while non fully conscious anymore.
/:cl:
