### PR TITLE
Adds Fun to the Kitchen's stacking skills

### DIFF
--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -33,7 +33,7 @@
 		size = "big"
 	if(ingredients.len>8)
 		size = "huge"
-	if(ingrenients.len>16)
+	if(ingredients.len>16)
 		size = "monster"
 	. += "It contains [ingredients.len?"[ingredients_listed]":"no ingredient, "]making a [size]-sized [initial(name)]."
 

--- a/code/modules/food_and_drinks/food/customizables.dm
+++ b/code/modules/food_and_drinks/food/customizables.dm
@@ -16,7 +16,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	volume = 80
 
-	var/ingMax = 12
+	var/ingMax = 32
 	var/list/ingredients = list()
 	var/ingredients_placement = INGREDIENTS_FILL
 	var/customname = "custom"
@@ -32,6 +32,8 @@
 	if(ingredients.len>5)
 		size = "big"
 	if(ingredients.len>8)
+		size = "huge"
+	if(ingrenients.len>16)
 		size = "monster"
 	. += "It contains [ingredients.len?"[ingredients_listed]":"no ingredient, "]making a [size]-sized [initial(name)]."
 

--- a/code/modules/food_and_drinks/food/snacks_pastry.dm
+++ b/code/modules/food_and_drinks/food/snacks_pastry.dm
@@ -386,7 +386,7 @@
 	tastes = list("pastry" = 1, "sweetness" = 1)
 	foodtype = GRAIN
 
-#define PANCAKE_MAX_STACK 10
+#define PANCAKE_MAX_STACK 30
 
 /obj/item/reagent_containers/food/snacks/pancakes
 	name = "pancake"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Pancakes, Burgers and Sandwiches can now be stacked up pretty high. This doesn't affect other customizable foods such as cakes, pizzas, breads, etc. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I think it'd be hilarious to see more sandwiches, burgers, and pancakes that are stacked taller than 3 tiles.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: 
tweak: tweaked the number of ingredients/pancakes you can stack.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
