### PR TITLE
Fixed double whitespace gap in human, ai and carbon examine.

### DIFF
--- a/code/modules/mob/living/carbon/examine.dm
+++ b/code/modules/mob/living/carbon/examine.dm
@@ -38,7 +38,7 @@
 			continue
 		. += "<span class='warning'><B>[t_His] [parse_zone(t)] is missing!</B></span>"
 
-	var/list/msg = list("<span class='warning'>")
+	var/list/msg = list()
 	var/temp = getBruteLoss()
 	if(!(user == src && src.hal_screwyhud == SCREWYHUD_HEALTHY)) //fake healthy
 		if(temp)
@@ -78,9 +78,8 @@
 	if(pulledby && pulledby.grab_state)
 		msg += "[t_He] [t_is] restrained by [pulledby]'s grip.\n"
 
-	msg += "</span>"
-
-	. += msg.Join("")
+	if(msg.len)
+		. += "<span class='warning'>[msg.Join("")]</span>"
 
 	if(!appears_dead)
 		if(stat == UNCONSCIOUS)

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -113,7 +113,7 @@
 				. += "[dicc.desc]"
 
 	var/cursed_stuff = attempt_vr(src,"examine_bellies",args) //vore Code
-	if(!isnull(cursed_stuff))
+	if(cursed_stuff)
 		. += cursed_stuff
 //END OF CIT CHANGES
 
@@ -169,7 +169,7 @@
 	var/r_limbs_missing = 0
 	for(var/t in missing)
 		if(t==BODY_ZONE_HEAD)
-			msg += "<span class='deadsay'><B>[t_His] [parse_zone(t)] is missing!</B><span class='warning'>\n"
+			msg += "<span class='deadsay'><B>[t_His] [parse_zone(t)] is missing!</B></span>\n"
 			continue
 		if(t == BODY_ZONE_L_ARM || t == BODY_ZONE_L_LEG)
 			l_limbs_missing++
@@ -272,11 +272,10 @@
 				msg += "[t_He] [t_is] a shitfaced, slobbering wreck.\n"
 
 	if(reagents.has_reagent("astral"))
-		msg += "[t_He] has wild, spacey eyes"
 		if(mind)
-			msg += " and they have a strange, abnormal look to them.\n"
+			msg += "[t_He] has wild, spacey eyes and they have a strange, abnormal look to them.\n"
 		else
-			msg += " and they don't look like they're all there.\n"
+			msg += "[t_He] has wild, spacey eyes and they don't look like they're all there.\n"
 
 	if(isliving(user))
 		var/mob/living/L = user
@@ -287,7 +286,7 @@
 				msg += "[t_He] seem[p_s()] winded.\n"
 			if (getToxLoss() >= 10)
 				msg += "[t_He] seem[p_s()] sickly.\n"
-			var/datum/component/mood/mood = src.GetComponent(/datum/component/mood)
+			var/datum/component/mood/mood = GetComponent(/datum/component/mood)
 			if(mood.sanity <= SANITY_DISTURBED)
 				msg += "[t_He] seem[p_s()] distressed.\n"
 				SEND_SIGNAL(user, COMSIG_ADD_MOOD_EVENT, "empath", /datum/mood_event/sad_empath, src)
@@ -298,8 +297,6 @@
 				msg += "[t_He] appear[p_s()] to be staring off into space.\n"
 			if (HAS_TRAIT(src, TRAIT_DEAF))
 				msg += "[t_He] appear[p_s()] to not be responding to noises.\n"
-
-	msg += "</span>"
 
 	var/obj/item/organ/vocal_cords/Vc = user.getorganslot(ORGAN_SLOT_VOICE)
 	if(Vc)
@@ -360,7 +357,7 @@
 					if(R)
 						. += "<a href='?src=[REF(src)];hud=m;evaluation=1'>\[Medical evaluation\]</a>"
 					if(traitstring)
-						. += "<span class='info'>Detected physiological traits:\n[traitstring]"
+						. += "<span class='info'>Detected physiological traits:\n[traitstring]</span>"
 
 
 

--- a/code/modules/mob/living/silicon/ai/examine.dm
+++ b/code/modules/mob/living/silicon/ai/examine.dm
@@ -3,18 +3,16 @@
 	if (stat == DEAD)
 		. += "<span class='deadsay'>It appears to be powered-down.</span>"
 	else
-		. += "<span class='warning'>"
 		if (getBruteLoss())
 			if (getBruteLoss() < 30)
-				. += "It looks slightly dented."
+				. += "<span class='warning'>It looks slightly dented.</span>"
 			else
-				. += "<B>It looks severely dented!</B>"
+				. += "<span class='danger'>It looks severely dented!</span>"
 		if (getFireLoss())
 			if (getFireLoss() < 30)
-				. += "It looks slightly charred."
+				. += "<span class='warning'>It looks slightly charred.</span>"
 			else
-				. += "<B>Its casing is melted and heat-warped!</B>"
-		. += "</span>"
+				. += "<span class='danger'>Its casing is melted and heat-warped!</span>"
 		if(deployed_shell)
 			. += "The wireless networking light is blinking."
 		else if (!shunted && !client)


### PR DESCRIPTION
## About The Pull Request
human's examine is so baaaaaaaaaaaaaaadly full of stuff.
This should remove one gap found in line 302, and another one from examine_bellies() returning "", which is distinct from null. (damn I hate attempt_vr call procs stuff)
Also some extra lines, a liiiittle unrelated to the problem but still ok cause `src.` is already implied and redundant.
Edit: also carbons and AI.

## Why It's Good For The Game
Deletes annoying whitespaces. My bad.

## Changelog
:cl:
fix: Fixed double whitespace gap in human and AI examine. Fixed single whitespace in carbon examine.
/:cl:
