### PR TITLE
Removes transit tube density

### DIFF
--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -20,7 +20,7 @@
 	var/boarding_dir //from which direction you can board the tube
 
 	var/const/OPEN_DURATION = 6
-	var/const/CLOSE_DURATION = 
+	var/const/CLOSE_DURATION = 6
 
 /obj/structure/transit_tube/station/New()
 	..()

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -20,7 +20,7 @@
 	var/boarding_dir //from which direction you can board the tube
 
 	var/const/OPEN_DURATION = 6
-	var/const/CLOSE_DURATION = 6
+	var/const/CLOSE_DURATION = 
 
 /obj/structure/transit_tube/station/New()
 	..()
@@ -41,7 +41,6 @@
 				pod.update_icon()
 				return
 
-
 //pod insertion
 /obj/structure/transit_tube/station/MouseDrop_T(obj/structure/c_transit_tube_pod/R, mob/user)
 	if(!user.canmove || user.stat || user.restrained())
@@ -56,7 +55,6 @@
 	TP.setDir(turn(src.dir, -90))
 	user.visible_message("[user] inserts [R].", "<span class='notice'>You insert [R].</span>")
 	qdel(R)
-
 
 /obj/structure/transit_tube/station/attack_hand(mob/user)
 	. = ..()
@@ -126,6 +124,7 @@
 /obj/structure/transit_tube/station/proc/launch_pod()
 	if(launch_cooldown >= world.time)
 		return
+	density = FALSE
 	for(var/obj/structure/transit_tube_pod/pod in loc)
 		if(!pod.moving)
 			pod_moving = 1
@@ -148,6 +147,7 @@
 			pod.setDir(tube_dirs[1]) //turning the pod around for next launch.
 		launch_cooldown = world.time + cooldown_delay
 		open_animation()
+		density = TRUE
 		sleep(OPEN_DURATION + 2)
 		pod_moving = 0
 		if(!QDELETED(pod))

--- a/code/game/objects/structures/transit_tubes/transit_tube.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/atmospherics/pipes/transit_tube.dmi'
 	icon_state = "straight"
 	desc = "A transit tube for moving things around."
-	density = TRUE
+	density = FALSE
 	layer = LOW_ITEM_LAYER
 	anchored = TRUE
 	climbable = 1
@@ -16,7 +16,7 @@
 
 /obj/structure/transit_tube/CanPass(atom/movable/mover, turf/target)
 	if(istype(mover) && (mover.pass_flags & PASSGLASS))
-		return 1
+		return TRUE
 	return !density
 
 /obj/structure/transit_tube/New(loc, newdirection)
@@ -189,7 +189,6 @@
 	dir = WEST
 
 /obj/structure/transit_tube/diagonal/crossing
-	density = FALSE
 	icon_state = "diagonal_crossing"
 	tube_construction = /obj/structure/c_transit_tube/diagonal/crossing
 
@@ -263,7 +262,6 @@
 /obj/structure/transit_tube/crossing
 	icon_state = "crossing"
 	tube_construction = /obj/structure/c_transit_tube/crossing
-	density = FALSE
 
 //mostly for mapping use
 /obj/structure/transit_tube/crossing/horizontal

--- a/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_pod.dm
@@ -3,17 +3,15 @@
 	icon_state = "pod"
 	animate_movement = FORWARD_STEPS
 	anchored = TRUE
-	density = TRUE
+	density = FALSE
 	var/moving = 0
 	var/datum/gas_mixture/air_contents = new()
-
 
 /obj/structure/transit_tube_pod/Initialize()
 	. = ..()
 	air_contents.gases[/datum/gas/oxygen] = MOLES_O2STANDARD
 	air_contents.gases[/datum/gas/nitrogen] = MOLES_N2STANDARD
 	air_contents.temperature = T20C
-
 
 /obj/structure/transit_tube_pod/Destroy()
 	empty_pod()
@@ -135,13 +133,11 @@
 		sleep(last_delay)
 		setDir(next_dir)
 		forceMove(next_loc) // When moving from one tube to another, skip collision and such.
-		density = current_tube.density
-
+	
 		if(current_tube && current_tube.should_stop_pod(src, next_dir))
 			current_tube.pod_stopped(src, dir)
 			break
 
-	density = TRUE
 	moving = 0
 
 	var/obj/structure/transit_tube/TT = locate(/obj/structure/transit_tube) in loc


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Sick of transit tubes being spammed from RPDs and used as barricades. Since it isn't exactly a sane idea to require RPDs to use metal (both because it unnecessarily fucks over anyone making legitimate projects, and because metal is really easy to get) I'm just removing density from this.

## Changelog
:cl:
balance: Transit tubes no longer have density.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
