### PR TITLE
Ports "Fixes transit tube barricade spam"

### DIFF
--- a/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
+++ b/code/game/objects/structures/transit_tubes/transit_tube_construction.dm
@@ -15,6 +15,15 @@
 	var/flipped_build_type
 	var/base_icon
 
+/obj/structure/c_transit_tube/proc/can_wrench_in_loc(mob/user)
+	var/turf/source_turf = get_turf(loc)
+	var/existing_tubes = 0
+	for(var/obj/structure/transit_tube/tube in source_turf)
+		existing_tubes++
+		if(existing_tubes >= 2)
+			to_chat(user, "<span class='warning'>You cannot wrench any more transit tubes!</span>")
+			return FALSE
+	return TRUE
 
 /obj/structure/c_transit_tube/ComponentInitialize()
 	. = ..()
@@ -32,9 +41,11 @@
 		icon_state = "[base_icon][flipped]"
 
 /obj/structure/c_transit_tube/wrench_act(mob/living/user, obj/item/I)
+	if(!can_wrench_in_loc(user))
+		return
 	to_chat(user, "<span class='notice'>You start attaching the [name]...</span>")
 	add_fingerprint(user)
-	if(I.use_tool(src, user, time_to_unwrench, volume=50))
+	if(I.use_tool(src, user, time_to_unwrench, volume=50, extra_checks=CALLBACK(src, .proc/can_wrench_in_loc, user)))
 		to_chat(user, "<span class='notice'>You attach the [name].</span>")
 		var/obj/structure/transit_tube/R = new build_type(loc, dir)
 		transfer_fingerprints_to(R)


### PR DESCRIPTION
## About The Pull Request
tgstation PR #42813 by Coconutwarrior97. Pondered about making it check the dir instead but it's just not worth the time.

Kevinz apparently didn't realized that wrenching a construction transit tube down deletes it and builds another type of structure. That's why his months old fix failed miserably (still keeping it around, since it does actually stop stacking unwrenched construction transit tubes).

## Why It's Good For The Game
This will close #9973, and fix an issue with the game.

## Changelog
:cl: Coconutwarrior97
fix: Can only wrench down two transit tubes per turf.
/:cl:
