### PR TITLE
Ports "Removes phantom gas effects on space tiles"

### DIFF
--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -27,6 +27,8 @@
 /turf/open/space/Initialize()
 	icon_state = SPACE_ICON_STATE
 	air = space_gas
+	vis_contents.Cut() //removes inherited overlays
+	visibilityChanged()
 
 	if(flags_1 & INITIALIZED_1)
 		stack_trace("Warning: [src]([type]) initialized multiple times!")


### PR DESCRIPTION
## About The Pull Request
Tgstation PR #44787 by TetraK1/Tetr4

## Why It's Good For The Game
A little atmos visual overlays fix accidentally skipped here last year.

## Changelog
:cl: Tetr4
fix: Turning a tile with gas effects into space now gets rid of the effects.
/:cl:
