### PR TITLE
Rags are no longer transparent reagent containers. Also allows squeezing their reagents into another container.

### DIFF
--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -91,6 +91,8 @@
 			var/obj/item/target
 			if(Adjacent(user)) //Allows the user to drain the reagents into a beaker if adjacent (no telepathy).
 				for(var/obj/item/I in user.held_items)
+					if(I == src)
+						continue
 					if(I.is_open_container() && !I.reagents.holder_full())
 						target = I
 						break

--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -23,7 +23,7 @@
 /obj/item/reagent_containers/rag/examine(mob/user)
 	. = ..()
 	if(reagents.total_volume)
-		. += "<span class='notice'>It's soaked. Alt-Click to squeeze it dry.</span>"
+		. += "<span class='notice'>It's soaked. Alt-Click to squeeze it dry, and perhaps gather the liquids into another held open container.</span>"
 
 /obj/item/reagent_containers/rag/afterattack(atom/A as obj|turf|area, mob/user,proximity)
 	. = ..()
@@ -85,13 +85,24 @@
 /obj/item/reagent_containers/rag/AltClick(mob/user)
 	. = ..()
 	if(reagents.total_volume && user.canUseTopic(src, BE_CLOSE))
-		to_chat(user, "<span class='notice'>You start squeezing the liquids out of \the [src]...</span>")
+		to_chat(user, "<span class='notice'>You start squeezing \the [src] dry...</span>")
 		if(do_after(user, action_speed, TRUE, src))
-			to_chat(user, "<span class='notice'>You squeeze \the [src] dry.</span>")
-			var/atom/react_loc = get_turf(src)
-			if(react_loc)
-				reagents.reaction(react_loc, TOUCH)
-			reagents.clear_reagents()
+			var/msg = "You squeeze \the [src]"
+			var/obj/item/target
+			if(Adjacent(user)) //Allows the user to drain the reagents into a beaker if adjacent (no telepathy).
+				for(var/obj/item/I in user.held_items)
+					if(I.is_open_container() && !I.reagents.holder_full())
+						target = I
+						break
+			if(!target)
+				msg += " dry"
+				reagents.reaction(get_turf(src), TOUCH)
+				reagents.clear_reagents()
+			else
+				msg += "'s liquids into \the [target]"
+				reagents.trans_to(target, reagents.total_volume)
+			to_chat(user, "<span class='notice'>[msg].</span>")
+
 
 /obj/item/reagent_containers/rag/towel
 	name = "towel"

--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -5,7 +5,7 @@
 	icon = 'icons/obj/toy.dmi'
 	icon_state = "rag"
 	item_flags = NOBLUDGEON
-	reagent_flags = OPENCONTAINER
+	reagent_flags = REFILLABLE | DRAINABLE
 	amount_per_transfer_from_this = 5
 	possible_transfer_amounts = list()
 	volume = 5
@@ -23,7 +23,7 @@
 /obj/item/reagent_containers/rag/examine(mob/user)
 	. = ..()
 	if(reagents.total_volume)
-		. += "<span class='notice'>Alt-Click to squeeze the liquids out of it.</span>"
+		. += "<span class='notice'>It's soaked. Alt-Click to squeeze it dry.</span>"
 
 /obj/item/reagent_containers/rag/afterattack(atom/A as obj|turf|area, mob/user,proximity)
 	. = ..()
@@ -89,8 +89,6 @@
 		if(do_after(user, action_speed, TRUE, src))
 			to_chat(user, "<span class='notice'>You squeeze \the [src] dry.</span>")
 			var/atom/react_loc = get_turf(src)
-			if(ismob(react_loc))
-				react_loc = react_loc.loc
 			if(react_loc)
 				reagents.reaction(react_loc, TOUCH)
 			reagents.clear_reagents()


### PR DESCRIPTION
## About The Pull Request
Common sense, rags are not marked with measurement lines threshold unlike beakers (neither do drinking glasses, but those are not the point of this PR, yet I can ez pz make them like baycode with estimated amounts later).
Also yea, improving this thing a little.

## Why It's Good For The Game
Fixing an oversight. QoL for this useless things.

## Changelog
:cl:
tweak: You can no longer estimate the amount of reagents found inside a damp rag.
tweak: You can now squeeze a rag's reagents into another open container, as long as the other one is not full.
/:cl:

