### PR TITLE
[Testmerge] Comments out Tinfoil hat until it's fixed

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -177,10 +177,10 @@
 	build_path = /obj/item/kitchen/knife/butcher
 	category = list("hacked", "Dinnerware")
 
-/datum/design/foilhat
-	name = "Tinfoil Hat"
-	id = "tinfoil_hat"
-	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 5500)
-	build_path = /obj/item/clothing/head/foilhat
-	category = list("hacked", "Misc")
+//datum/design/foilhat
+	//name = "Tinfoil Hat"
+	//id = "tinfoil_hat"
+	//build_type = AUTOLATHE
+	//materials = list(MAT_METAL = 5500)
+	//build_path = /obj/item/clothing/head/foilhat
+	//category = list("hacked", "Misc")


### PR DESCRIPTION
## About The Pull Request
Makes you unable to print Tinfoil Hats from the autolathe

## Why It's Good For The Game

The new holymelon, Tinfoil hats are broken in such a way they give you a random brain disability instead of the intended one (Phobia of command) in exchange for anti-magic, something several people are abusing to become immune to cults and wizards (and abductors)