### PR TITLE
Fixes implant pads and updates them a little (WHY THE HELL DO WE STILL HAVE THIS OLDCODE CRAP LINGERING AROUND?)

### DIFF
--- a/code/game/objects/items/implants/implant.dm
+++ b/code/game/objects/items/implants/implant.dm
@@ -107,7 +107,7 @@
 	return ..()
 
 /obj/item/implant/proc/get_data()
-	return "No information available"
+	return "No information available about this implant."
 
 /obj/item/implant/dropped(mob/user)
 	. = 1

--- a/code/game/objects/items/implants/implantpad.dm
+++ b/code/game/objects/items/implants/implantpad.dm
@@ -13,34 +13,31 @@
 	var/broadcasting = null
 	var/listening = 1
 
+/obj/item/implantpad/examine(mob/user)
+	. = ..()
+	if(case)
+		. += "<span class='notice'>Alt-click [src] to remove the inserted implant case.</span>"
 
 /obj/item/implantpad/update_icon()
-	if(case)
-		icon_state = "implantpad-1"
-	else
-		icon_state = "implantpad-0"
+	icon_state = "implantpad-[case ? TRUE : FALSE]"
 
-
-/obj/item/implantpad/attack_hand(mob/user)
+/obj/item/implantpad/AltClick(mob/user)
 	. = ..()
-	if(.)
-		return
-	if(case && user.is_holding(src))
-		user.put_in_active_hand(case)
+	if(case && user.can_hold_items() && user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
+		user.put_in_hands(case)
 
 		case.add_fingerprint(user)
 		case = null
 
 		add_fingerprint(user)
 		update_icon()
+		return TRUE
 
 /obj/item/implantpad/attackby(obj/item/implantcase/C, mob/user, params)
-	if(istype(C, /obj/item/implantcase))
-		if(!case)
-			if(!user.transferItemToLoc(C, src))
-				return
+	if(istype(C))
+		if(!case && user.transferItemToLoc(C, src))
 			case = C
-		update_icon()
+			update_icon()
 	else
 		return ..()
 

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -10,7 +10,7 @@
 //So we're treating each "pair" of limbs as a team, so "both" refers to them
 /mob/proc/get_inactive_held_item()
 	return get_item_for_held_index(get_inactive_hand_index())
-
+put_in_active_hand
 
 //Finds the opposite index for the active one (eg: upper left arm will find the item in upper right arm)
 //So we're treating each "pair" of limbs as a team, so "both" refers to them

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -10,7 +10,7 @@
 //So we're treating each "pair" of limbs as a team, so "both" refers to them
 /mob/proc/get_inactive_held_item()
 	return get_item_for_held_index(get_inactive_hand_index())
-put_in_active_hand
+
 
 //Finds the opposite index for the active one (eg: upper left arm will find the item in upper right arm)
 //So we're treating each "pair" of limbs as a team, so "both" refers to them


### PR DESCRIPTION
## About The Pull Request
Fixing implant pads cases being unremovable, because apparently put_in_hands() calls are safer than put_in_active_hand(). Moved the case ejection from attack_hand() to AltClick(), added examine infos about it.
Also made the default implant get_data() a little more explicit.

## Why It's Good For The Game
This will close #10009, I guess.

## Changelog
:cl:
fix: Fixing implant cases being lost inside implant pads when trying to eject them with your active hand full.
tweak: Moved the implant pad's case ejection from attack_hand() to AltClick(), added examination infos about it.
/:cl:
