### PR TITLE
Mousedrop fixes - Adds return value to item mousedrop and fixes bugs with the few things that override it

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -385,13 +385,14 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return
 	if(over == src)
 		return usr.client.Click(src, src_location, src_control, params)
-	var/list/directaccess = usr.DirectAccess()
+	var/list/directaccess = usr.DirectAccess()	//This, specifically, is what requires the copypaste. If this were after the adjacency check, then it'd be impossible to use items in your inventory, among other things.
+												//If this were before the above checks, then trying to click on items would act a little funky and signal overrides wouldn't work.
 	if((usr.CanReach(src) || (src in directaccess)) && (usr.CanReach(over) || (over in directaccess)))
 		if(!usr.get_active_held_item())
 			usr.UnarmedAttack(src, TRUE)
 			if(usr.get_active_held_item() == src)
 				melee_attack_chain(usr, over)
-			return
+			return TRUE //returning TRUE as a "is this overridden?" flag
 	if(!Adjacent(usr) || !over.Adjacent(usr))
 		return // should stop you from dragging through windows
 

--- a/code/game/objects/items/defib.dm
+++ b/code/game/objects/items/defib.dm
@@ -104,7 +104,7 @@
 
 /obj/item/defibrillator/MouseDrop(obj/over_object)
 	. = ..()
-	if(ismob(loc))
+	if(!. && ismob(loc) && loc == usr)
 		var/mob/M = loc
 		if(!M.incapacitated() && istype(over_object, /obj/screen/inventory/hand))
 			var/obj/screen/inventory/hand/H = over_object

--- a/code/game/objects/items/pet_carrier.dm
+++ b/code/game/objects/items/pet_carrier.dm
@@ -151,12 +151,13 @@
 		add_overlay("[locked ? "" : "un"]locked")
 
 /obj/item/pet_carrier/MouseDrop(atom/over_atom)
-	. = ..()
 	if(isopenturf(over_atom) && usr.canUseTopic(src, BE_CLOSE, ismonkey(usr)) && usr.Adjacent(over_atom) && open && occupants.len)
 		usr.visible_message("<span class='notice'>[usr] unloads [src].</span>", \
 		"<span class='notice'>You unload [src] onto [over_atom].</span>")
 		for(var/V in occupants)
 			remove_occupant(V, over_atom)
+	else
+		return ..()
 
 /obj/item/pet_carrier/proc/load_occupant(mob/living/user, mob/living/target)
 	if(pet_carrier_full(src))

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -740,10 +740,9 @@
 		return ..()
 
 /obj/item/toy/cards/deck/MouseDrop(atom/over_object)
-	. = ..()
 	var/mob/living/M = usr
 	if(!istype(M) || usr.incapacitated() || usr.lying)
-		return
+		return ..()
 	if(Adjacent(usr))
 		if(over_object == M && loc != M)
 			M.put_in_hands(src)
@@ -755,7 +754,9 @@
 				to_chat(usr, "<span class='notice'>You pick up the deck.</span>")
 
 	else
-		to_chat(usr, "<span class='warning'>You can't reach it from here!</span>")
+		. = ..()
+		if(!.)
+			to_chat(usr, "<span class='warning'>You can't reach it from here!</span>")
 
 
 

--- a/code/modules/clothing/clothing.dm
+++ b/code/modules/clothing/clothing.dm
@@ -62,7 +62,7 @@
 	if(ismecha(M.loc)) // stops inventory actions in a mech
 		return
 
-	if(!M.incapacitated() && loc == M && istype(over_object, /obj/screen/inventory/hand))
+	if(!. && !M.incapacitated() && loc == M && istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
 		if(M.putItemFromInventoryInHandIfPossible(src, H.held_index))
 			add_fingerprint(usr)

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -92,6 +92,8 @@
 
 /obj/item/papercutter/MouseDrop(atom/over_object)
 	. = ..()
+	if(.)
+		return
 	var/mob/M = usr
 	if(M.incapacitated() || !Adjacent(M))
 		return

--- a/code/modules/paperwork/paper_cutter.dm
+++ b/code/modules/paperwork/paper_cutter.dm
@@ -91,9 +91,6 @@
 		update_icon()
 
 /obj/item/papercutter/MouseDrop(atom/over_object)
-	. = ..()
-	if(.)
-		return
 	var/mob/M = usr
 	if(M.incapacitated() || !Adjacent(M))
 		return
@@ -104,6 +101,10 @@
 	else if(istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
 		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
+
+	else
+	 . = ..()
+
 	add_fingerprint(M)
 
 /obj/item/paperslip

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -41,9 +41,6 @@
 	..()
 
 /obj/item/paper_bin/MouseDrop(atom/over_object)
-	. = ..()
-	if(.)
-		return
 	var/mob/living/M = usr
 	if(!istype(M) || M.incapacitated() || !Adjacent(M))
 		return
@@ -54,6 +51,9 @@
 	else if(istype(over_object, /obj/screen/inventory/hand))
 		var/obj/screen/inventory/hand/H = over_object
 		M.putItemFromInventoryInHandIfPossible(src, H.held_index)
+		
+	else
+		. = ..()
 
 	add_fingerprint(M)
 

--- a/code/modules/paperwork/paperbin.dm
+++ b/code/modules/paperwork/paperbin.dm
@@ -42,6 +42,8 @@
 
 /obj/item/paper_bin/MouseDrop(atom/over_object)
 	. = ..()
+	if(.)
+		return
 	var/mob/living/M = usr
 	if(!istype(M) || M.incapacitated() || !Adjacent(M))
 		return

--- a/modular_citadel/code/modules/reagents/objects/clothes.dm
+++ b/modular_citadel/code/modules/reagents/objects/clothes.dm
@@ -34,7 +34,6 @@
 		if(src == C.head)
 			C.emote("me",1,"tips their hat.",TRUE)
 			return
-	..()
 
 /obj/item/clothing/head/hattip/equipped(mob/M, slot)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Closes #10014 (That PR was made with the primary motivation of "ITS BUGGED!!!!! REVERT!!!!" and made no attempt to contact me or any of the maintainers at all prior)
This PR adds a return value to the item-level mousedrop() proc and fixes various bugs with the few things that currently override item mousedrop(). Details in the changelog


## Changelog
:cl: Bhijn
code: Item mousedrop() now provides a return value indicating whether or not behavior has been overridden somehow.
fix: Defibs now properly check that their loc is the same as the user for mousedrop() calls, meaning ghosts can no longer make you equip defibs. Plus extra sanity checks.
fix: Pet carriers no longer attack turfs while trying to unload their contents.
fix: Decks of cards now function as they originally intended when attempting to use their drag and drop behavior.
fix: Paper bins and papercutters no longer act wonky when you're trying to pull a piece of paper from them.
fix: Adds clothing drag n drop sanity checks.
fix: Sythetic hats now have extra sanity checks
/:cl:
