### PR TITLE
Makes glowsticks no longer radioactively contaminable.

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -431,6 +431,7 @@
 	icon_state = "glowstick"
 	item_state = "glowstick"
 	grind_results = list("phenol" = 15, "hydrogen" = 10, "oxygen" = 5) //Meth-in-a-stick
+	rad_flags = RAD_NO_CONTAMINATE
 	var/fuel = 0
 
 /obj/item/flashlight/glowstick/Initialize()


### PR DESCRIPTION
## About The Pull Request

As title. Glowsticks are no longer radioactively contaminable. 

## Why It's Good For The Game

Fixes supermatter ultrapower cheese using an RLD. This also tends to cause massive amounts of radioactive contamination, which is annoying as hell to clean up.

## Changelog
:cl:
tweak: Glowsticks can no longer be radioactively contaminated (one more supermatter contam exploit gone)
/:cl: