### PR TITLE
Fixes holodeck sleepers leaving sleeper buffers behind when deleted.

### DIFF
--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -36,7 +36,7 @@
 	RefreshParts()
 	add_inital_chems()
 
-/obj/machinery/sleeper/on_deconstruction(disassembled = TRUE)
+/obj/machinery/sleeper/on_deconstruction()
 	var/obj/item/reagent_containers/sleeper_buffer/buffer = new (loc)
 	buffer.volume = reagents.maximum_volume
 	buffer.reagents.maximum_volume = reagents.maximum_volume

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -36,13 +36,11 @@
 	RefreshParts()
 	add_inital_chems()
 
-/obj/machinery/sleeper/deconstruct(disassembled = TRUE)
-	if(!CHECK_BITFIELD(flags_1, NODECONSTRUCT_1 | HOLOGRAM_1))
-		var/obj/item/reagent_containers/sleeper_buffer/buffer = new (loc)
-		buffer.volume = reagents.maximum_volume
-		buffer.reagents.maximum_volume = reagents.maximum_volume
-		reagents.trans_to(buffer.reagents, reagents.total_volume)
-	return ..()
+/obj/machinery/sleeper/on_deconstruction(disassembled = TRUE)
+	var/obj/item/reagent_containers/sleeper_buffer/buffer = new (loc)
+	buffer.volume = reagents.maximum_volume
+	buffer.reagents.maximum_volume = reagents.maximum_volume
+	reagents.trans_to(buffer.reagents, reagents.total_volume)
 
 /obj/machinery/sleeper/proc/add_inital_chems()
 	for(var/i in available_chems)

--- a/code/game/machinery/Sleeper.dm
+++ b/code/game/machinery/Sleeper.dm
@@ -36,12 +36,13 @@
 	RefreshParts()
 	add_inital_chems()
 
-/obj/machinery/sleeper/Destroy()
-	var/obj/item/reagent_containers/sleeper_buffer/buffer = new /obj/item/reagent_containers/sleeper_buffer(loc)
-	buffer.volume = reagents.maximum_volume
-	buffer.reagents.maximum_volume = reagents.maximum_volume
-	reagents.trans_to(buffer.reagents, reagents.total_volume)
-	..()
+/obj/machinery/sleeper/deconstruct(disassembled = TRUE)
+	if(!CHECK_BITFIELD(flags_1, NODECONSTRUCT_1 | HOLOGRAM_1))
+		var/obj/item/reagent_containers/sleeper_buffer/buffer = new (loc)
+		buffer.volume = reagents.maximum_volume
+		buffer.reagents.maximum_volume = reagents.maximum_volume
+		reagents.trans_to(buffer.reagents, reagents.total_volume)
+	return ..()
 
 /obj/machinery/sleeper/proc/add_inital_chems()
 	for(var/i in available_chems)


### PR DESCRIPTION
## About The Pull Request
Moves sleeper buffer spawning from Destroy() to on_deconstruction(), which is not called by machineries with the `nodeconstruct_1` flag enabled (like holodeck's).
Also Fermis forgot to add `return` / `. =` before the parent call on Destroy. But that doesn't matter anymore now.

## Why It's Good For The Game
This will close #10028.

## Changelog
:cl:
fix: Fixed holodeck sleepers leaving sleeper buffers behind when deleted.
/:cl:
