### PR TITLE
Porting some return type annotations and bad keyword fixes.

### DIFF
--- a/code/datums/components/_component.dm
+++ b/code/datums/components/_component.dm
@@ -184,6 +184,7 @@
 
 // The type arg is casted so initial works, you shouldn't be passing a real instance into this
 /datum/proc/GetComponent(datum/component/c_type)
+	RETURN_TYPE(c_type)
 	if(initial(c_type.dupe_mode) == COMPONENT_DUPE_ALLOWED)
 		stack_trace("GetComponent was called to get a component of which multiple copies could be on an object. This can easily break and should be changed. Type: \[[c_type]\]")
 	var/list/dc = datum_components

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -689,15 +689,16 @@ Code:
 				active_bot = null
 
 			if("summon") //Args are in the correct order, they are stated here just as an easy reminder.
-				active_bot.bot_control(command= "summon", user_turf= get_turf(usr), user_access= host_pda.GetAccess())
+				active_bot.bot_control("summon", usr, host_pda.GetAccess())
 
 			else //Forward all other bot commands to the bot itself!
-				active_bot.bot_control(command= href_list["op"], user= usr)
+				active_bot.bot_control(href_list["op"], usr)
 		playsound(src, 'sound/machines/terminal_select.ogg', 50, 1)
 
 	if(href_list["mule"]) //MULEbots are special snowflakes, and need different args due to how they work.
-
-		active_bot.bot_control(href_list["mule"], usr, TRUE)
+		var/mob/living/simple_animal/bot/mulebot/mule = active_bot
+		if (istype(mule))
+			active_bot.bot_control(href_list["mule"], usr, TRUE)
 
 	if(!host_pda)
 		return

--- a/code/modules/antagonists/blob/blob/theblob.dm
+++ b/code/modules/antagonists/blob/blob/theblob.dm
@@ -244,6 +244,7 @@
 		return ..()
 
 /obj/structure/blob/proc/chemeffectreport()
+	RETURN_TYPE(/list)
 	. = list()
 	if(overmind)
 		. += "<b>Material: <font color=\"[overmind.blob_reagent_datum.color]\">[overmind.blob_reagent_datum.name]</font><span class='notice'>.</span></b>"
@@ -253,6 +254,7 @@
 		. += "<b>No Material Detected!</b><br>"
 
 /obj/structure/blob/proc/typereport()
+	RETURN_TYPE(/list)
 	. = list("<b>Blob Type:</b> <span class='notice'>[uppertext(initial(name))]</span>")
 	. += "<b>Health:</b> <span class='notice'>[obj_integrity]/[max_integrity]</span>"
 	. += "<b>Effects:</b> <span class='notice'>[scannerreport()]</span>"

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -72,11 +72,13 @@
 		air.copy_from(copy)
 
 /turf/return_air()
+	RETURN_TYPE(/datum/gas_mixture)
 	var/datum/gas_mixture/GM = new
 	GM.copy_from_turf(src)
 	return GM
 
 /turf/open/return_air()
+	RETURN_TYPE(/datum/gas_mixture)
 	return air
 
 /turf/temperature_expose()

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -53,7 +53,6 @@
 		return
 
 	var/turf/open/T = get_turf(parent)
-	var/
 	if(abs(ONE_ATMOSPHERE - T.return_air().return_pressure()) > (potency/10 + 10)) // clouds can begin showing at around 50-60 potency in standard atmos
 		return
 

--- a/code/modules/hydroponics/grown/misc.dm
+++ b/code/modules/hydroponics/grown/misc.dm
@@ -53,6 +53,7 @@
 		return
 
 	var/turf/open/T = get_turf(parent)
+	var/
 	if(abs(ONE_ATMOSPHERE - T.return_air().return_pressure()) > (potency/10 + 10)) // clouds can begin showing at around 50-60 potency in standard atmos
 		return
 

--- a/code/modules/mob/living/carbon/alien/damage_procs.dm
+++ b/code/modules/mob/living/carbon/alien/damage_procs.dm
@@ -7,9 +7,9 @@
 
 /* CIT CHANGE - Pffffffffffffhahahahahhaha-- No.
 //aliens are immune to stamina damage.
-/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_stamina = 1)
+/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_health = 1)
 	return
 
-/mob/living/carbon/alien/setStaminaLoss(amount, updating_stamina = 1)
+/mob/living/carbon/alien/setStaminaLoss(amount, updating_health = 1)
 	return
 */

--- a/code/modules/mob/living/carbon/inventory.dm
+++ b/code/modules/mob/living/carbon/inventory.dm
@@ -85,7 +85,7 @@
 
 	return not_handled
 
-/mob/living/carbon/doUnEquip(obj/item/I)
+/mob/living/carbon/doUnEquip(obj/item/I, force, newloc, no_move, invdrop = TRUE)
 	. = ..() //Sets the default return value to what the parent returns.
 	if(!. || !I) //We don't want to set anything to null if the parent returned 0.
 		return

--- a/code/modules/mob/living/damage_procs.dm
+++ b/code/modules/mob/living/damage_procs.dm
@@ -225,10 +225,10 @@
 /mob/living/proc/getStaminaLoss()
 	return staminaloss
 
-/mob/living/proc/adjustStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE)
+/mob/living/proc/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	return
 
-/mob/living/proc/setStaminaLoss(amount, updating_stamina = TRUE, forced = FALSE)
+/mob/living/proc/setStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	return
 
 // heal ONE external organ, organ gets randomly selected from damaged ones.

--- a/code/modules/mob/living/silicon/damage_procs.dm
+++ b/code/modules/mob/living/silicon/damage_procs.dm
@@ -30,10 +30,10 @@
 /mob/living/silicon/setCloneLoss(amount, updating_health = TRUE, forced = FALSE)
 	return FALSE
 
-/mob/living/silicon/adjustStaminaLoss(amount, updating_stamina = 1, forced = FALSE)//immune to stamina damage.
+/mob/living/silicon/adjustStaminaLoss(amount, updating_health = 1, forced = FALSE)//immune to stamina damage.
 	return FALSE
 
-/mob/living/silicon/setStaminaLoss(amount, updating_stamina = 1)
+/mob/living/silicon/setStaminaLoss(amount, updating_health = 1)
 	return FALSE
 
 /mob/living/silicon/adjustOrganLoss(slot, amount, maximum = 500)

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1295,6 +1295,6 @@
 			bellyup = 1
 	update_icons()
 
-/mob/living/silicon/robot/adjustStaminaLossBuffered(amount, updating_stamina = 1)
+/mob/living/silicon/robot/adjustStaminaLossBuffered(amount, updating_health = 1)
 	if(istype(cell))
 		cell.charge -= amount*5

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -674,11 +674,11 @@ Pass a positive integer as an argument to override a bot's default speed.
 	destination = nearest_beacon
 
 //PDA control. Some bots, especially MULEs, may have more parameters.
-/mob/living/simple_animal/bot/proc/bot_control(command, mob/user, turf/user_turf, list/user_access = list())
+/mob/living/simple_animal/bot/proc/bot_control(command, mob/user, list/user_access = list())
 	if(!on || emagged == 2 || remote_disabled) //Emagged bots do not respect anyone's authority! Bots with their remote controls off cannot get commands.
 		return TRUE //ACCESS DENIED
 	if(client)
-		bot_control_message(command,user,user_turf,user_access)
+		bot_control_message(command, user)
 	// process control input
 	switch(command)
 		if("patroloff")
@@ -690,7 +690,7 @@ Pass a positive integer as an argument to override a bot's default speed.
 
 		if("summon")
 			bot_reset()
-			summon_target = user_turf
+			summon_target = get_turf(user)
 			if(user_access.len != 0)
 				access_card.access = user_access + prev_access //Adds the user's access, if any.
 			mode = BOT_SUMMON
@@ -702,15 +702,14 @@ Pass a positive integer as an argument to override a bot's default speed.
 	return
 
 //
-/mob/living/simple_animal/bot/proc/bot_control_message(command,user,user_turf,user_access)
+/mob/living/simple_animal/bot/proc/bot_control_message(command, user)
 	switch(command)
 		if("patroloff")
 			to_chat(src, "<span class='warning big'>STOP PATROL</span>")
 		if("patrolon")
 			to_chat(src, "<span class='warning big'>START PATROL</span>")
 		if("summon")
-			var/area/a = get_area(user_turf)
-			to_chat(src, "<span class='warning big'>PRIORITY ALERT:[user] in [a.name]!</span>")
+			to_chat(src, "<span class='warning big'>PRIORITY ALERT:[user] in [get_area_name(user)]!</span>")
 		if("stop")
 			to_chat(src, "<span class='warning big'>STOP!</span>")
 

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -218,7 +218,7 @@
 			bot_control(action, usr) // Kill this later.
 			. = TRUE
 
-/mob/living/simple_animal/bot/mulebot/bot_control(command, mob/user, pda = 0, turf/user_turf, list/user_access = list())
+/mob/living/simple_animal/bot/mulebot/bot_control(command, mob/user, pda = FALSE)
 	if(pda && wires.is_cut(WIRE_RX)) // MULE wireless is controlled by wires.
 		return
 

--- a/code/modules/vehicles/_vehicle.dm
+++ b/code/modules/vehicles/_vehicle.dm
@@ -60,6 +60,7 @@
 			.++
 
 /obj/vehicle/proc/return_controllers_with_flag(flag)
+	RETURN_TYPE(/list/mob)
 	. = list()
 	for(var/i in occupants)
 		if(occupants[i] & flag)

--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -1,4 +1,4 @@
-/mob/living/carbon/adjustStaminaLossBuffered(amount, updating_stamina = 1)
+/mob/living/carbon/adjustStaminaLossBuffered(amount, updating_health = 1)
 	if(status_flags & GODMODE)
 		return 0
 	if(CONFIG_GET(flag/disable_stambuffer))
@@ -8,7 +8,7 @@
 		adjustStaminaLoss(directstamloss)
 	bufferedstam = CLAMP(bufferedstam + amount, 0, stambuffer)
 	stambufferregentime = world.time + 10
-	if(updating_stamina)
+	if(updating_health)
 		update_health_hud()
 
 /mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE, affected_zone = BODY_ZONE_CHEST)

--- a/modular_citadel/code/modules/mob/living/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/damage_procs.dm
@@ -1,4 +1,4 @@
-/mob/living/proc/adjustStaminaLossBuffered(amount, updating_stamina = TRUE, forced = FALSE)
+/mob/living/proc/adjustStaminaLossBuffered(amount, updating_health = TRUE, forced = FALSE)
 	return
 
 /mob/living/proc/doSprintLossTiles(amount)


### PR DESCRIPTION
## About The Pull Request
Ergo tgstation's #44825 and #43076 by SpaceManiac, well, what's left to do, chops of both PRs have been sporiadically ported last month already.

## Why It's Good For The Game
Linter stuff sanity for #9757. So it doesn't throw warnings for that return_air() on grown/misc.dm, line 56.

## Changelog
None.