### PR TITLE
Fixes the incongruent bone satchel description.

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -253,7 +253,7 @@
 
 /obj/item/storage/backpack/satchel/bone
 	name = "bone satchel"
-	desc = "A bone satchel fashend with watcher wings and large bones from goliath. Can be worn on the belt."
+	desc = "A grotesque satchel made of sinews and bones."
 	icon = 'icons/obj/mining.dmi'
 	icon_state = "goliath_saddle"
 	slot_flags = ITEM_SLOT_BACK


### PR DESCRIPTION
## About The Pull Request
Rephrased the bone satchel description to be terse, removing the now incorrect "can be worn on belt" hint.

## Why It's Good For The Game
Someone pointed this out yesterday. Consistency, spellchecking. 

## Changelog
:cl:
spellcheck: Fixed the incongruent bone satchel description.
/:cl:
