### PR TITLE
Doubles locomotion circuit ext cooldown. Nerfs gun & pneumatic cannons circuits with sanity checks.

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -615,6 +615,11 @@
 		return
 	..()
 
+/obj/item/electronic_assembly/can_trigger_gun(mob/living/user) //sanity checks against pocket death weapon circuits
+	if(!can_fire_equipped || !user.is_holding(src))
+		return FALSE
+	return ..()
+
 /obj/item/electronic_assembly/default //The /default electronic_assemblys are to allow the introduction of the new naming scheme without breaking old saves.
 	name = "type-a electronic assembly"
 

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -402,3 +402,8 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		return TRUE
 
 	return FALSE
+
+/obj/item/integrated_circuit/can_trigger_gun(mob/living/user)
+	if(!user.is_holding(src))
+		return FALSE
+	return ..()

--- a/code/modules/integrated_electronics/subtypes/manipulation.dm
+++ b/code/modules/integrated_electronics/subtypes/manipulation.dm
@@ -11,7 +11,7 @@
 	w_class = WEIGHT_CLASS_SMALL
 	complexity = 10
 	cooldown_per_use = 1
-	ext_cooldown = 2
+	ext_cooldown = 4
 	inputs = list("direction" = IC_PINTYPE_DIR)
 	outputs = list("obstacle" = IC_PINTYPE_REF)
 	activators = list("step towards dir" = IC_PINTYPE_PULSE_IN,"on step"=IC_PINTYPE_PULSE_OUT,"blocked"=IC_PINTYPE_PULSE_OUT)

--- a/code/modules/integrated_electronics/subtypes/weaponized.dm
+++ b/code/modules/integrated_electronics/subtypes/weaponized.dm
@@ -81,9 +81,13 @@
 		to_chat(user, "<span class='notice'>There's no weapon to remove from the mechanism.</span>")
 
 /obj/item/integrated_circuit/weaponized/weapon_firing/do_work()
-	if(!installed_gun || !installed_gun.handle_pins())
+	if(!assembly || !installed_gun)
 		return
-	if(!isturf(assembly.loc) && !(assembly.can_fire_equipped && ishuman(assembly.loc)))
+	if(isliving(assembly.loc))
+		var/mob/living/L = assembly.loc
+		if(!assembly.can_fire_equipped || !L.is_holding(assembly) || !installed_gun.can_trigger_gun(L)) //includes pins, hulk and other chunky fingers checks.
+			return
+	else if(!isturf(assembly.loc) || !installed_gun.handle_pins())
 		return
 	set_pin_data(IC_OUTPUT, 1, WEAKREF(installed_gun))
 	push_data()
@@ -92,18 +96,17 @@
 	var/datum/integrated_io/mode1 = inputs[3]
 
 	mode = mode1.data
-	if(assembly)
-		if(isnum(xo.data))
-			xo.data = round(xo.data, 1)
-		if(isnum(yo.data))
-			yo.data = round(yo.data, 1)
+	if(isnum(xo.data))
+		xo.data = round(xo.data, 1)
+	if(isnum(yo.data))
+		yo.data = round(yo.data, 1)
 
-		var/turf/T = get_turf(assembly)
-		var/target_x = CLAMP(T.x + xo.data, 0, world.maxx)
-		var/target_y = CLAMP(T.y + yo.data, 0, world.maxy)
+	var/turf/T = get_turf(assembly)
+	var/target_x = CLAMP(T.x + xo.data, 0, world.maxx)
+	var/target_y = CLAMP(T.y + yo.data, 0, world.maxy)
 
-		assembly.visible_message("<span class='danger'>[assembly] fires [installed_gun]!</span>")
-		shootAt(locate(target_x, target_y, T.z))
+	assembly.visible_message("<span class='danger'>[assembly] fires [installed_gun]!</span>")
+	shootAt(locate(target_x, target_y, T.z))
 
 /obj/item/integrated_circuit/weaponized/weapon_firing/proc/shootAt(turf/target)
 	var/turf/T = get_turf(src)
@@ -246,24 +249,28 @@
 	if(!A || A.anchored || A.throwing || A == assembly || istype(A, /obj/item/twohanded) || istype(A, /obj/item/transfer_valve))
 		return
 
-	if(!AT || !AT.air_contents)
+	var/obj/item/I = get_object()
+	var/turf/T = get_turf(I)
+	if(!T)
+		return
+	if(isliving(I.loc))
+		var/mob/living/L = I.loc
+		if(!I.can_trigger_gun(L)) //includes hulk and other chunky fingers checks.
+			return
+		if(HAS_TRAIT(L, TRAIT_PACIFISM) && A.throwforce)
+			to_chat(L, "<span class='notice'> [I] is lethally chambered! You don't want to risk harming anyone...</span>")
+			return
+	else if(T != I.loc)
 		return
 
-	if (istype(assembly.loc, /obj/item/implant/storage)) //Prevents the more abusive form of chestgun.
+	if(!AT || !AT.air_contents)
 		return
 
 	if(max_w_class && (A.w_class > max_w_class))
 		return
 
-	if(!assembly.can_fire_equipped && ishuman(assembly.loc))
-		return
-
 	// Is the target inside the assembly or close to it?
 	if(!check_target(A, exclude_components = TRUE))
-		return
-
-	var/turf/T = get_turf(get_object())
-	if(!T)
 		return
 
 	// If the item is in mob's inventory, try to remove it from there.

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -198,7 +198,12 @@
 
 /obj/item/gun/can_trigger_gun(mob/living/user)
 	. = ..()
+	if(!.)
+		return
 	if(!handle_pins(user))
+		return FALSE
+	if(HAS_TRAIT(user, TRAIT_PACIFISM) && chambered?.harmful) // If the user has the pacifist trait, then they won't be able to fire [src] if the round chambered inside of [src] is lethal.
+		to_chat(user, "<span class='notice'> [src] is lethally chambered! You don't want to risk harming anyone...</span>")
 		return FALSE
 
 /obj/item/gun/proc/handle_pins(mob/living/user)
@@ -275,10 +280,6 @@
 			addtimer(CALLBACK(src, .proc/process_burst, user, target, message, params, zone_override, sprd, randomized_gun_spread, randomized_bonus_spread, rand_spr, i), fire_delay * (i - 1))
 	else
 		if(chambered)
-			if(HAS_TRAIT(user, TRAIT_PACIFISM)) // If the user has the pacifist trait, then they won't be able to fire [src] if the round chambered inside of [src] is lethal.
-				if(chambered.harmful) // Is the bullet chambered harmful?
-					to_chat(user, "<span class='notice'> [src] is lethally chambered! You don't want to risk harming anyone...</span>")
-					return
 			sprd = round((rand() - 0.5) * DUALWIELD_PENALTY_EXTRA_MULTIPLIER * (randomized_gun_spread + randomized_bonus_spread))
 			if(!chambered.fire_casing(target, user, params, , suppressed, zone_override, sprd, src))
 				shoot_with_empty_chamber(user)


### PR DESCRIPTION
## About The Pull Request
Being able to tinker something special without necessarily bloating the code with new features is a nice concept to have, not really ambitous since the most of it has been done already long time ago, yet people do not bother much about patching the several, little or otherwise, shenanigeans, exploits and balance issues associated to it. I can understand that.

More concrete description follows:
Hulks/pacifists/carp-fu goers can't abuse those cannons/guns anymore (if you want to make a remote controller for them, be my guest, at that point you are circumverting the problem instead of straight-out exploiting a consistency issue), pneumatic cannons don't work inside backpacks anymore.
Slown down locomotion circuits, thus nerfing hit'n'run/pAI/MMI and other salt generators assemblies.

## Why It's Good For The Game
Sanity checks, sanity nerfs.

## Changelog
:cl:
fix: Fixed hulks, sleeping carp users, pacifists and people with chunky fingers being able to unrestrictly use gun and pneumatic cannon circuit assemblies.
fix: Fixed gun circuit assemblies being only usable by human mobs.
balance: Doubled the locomotion circuit external cooldown, thus halving the movable assemblies' movespeed.
/:cl:
