### PR TITLE
PDA cartridges and their contents can no longer be contaminated

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -24,7 +24,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
-	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE //So the cartridges dont annoyingly get irradiated, and the signallers inside being radded as well
+	rad_flags = RAD_PROTECT_CONTENTS //So the cartridges dont annoyingly get irradiated, and the signallers inside being radded as well
 
 	var/obj/item/integrated_signaler/radio = null
 

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -24,6 +24,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	w_class = WEIGHT_CLASS_TINY
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE //So the cartridges dont annoyingly get irradiated, and the signallers inside being radded as well
 
 	var/obj/item/integrated_signaler/radio = null
 


### PR DESCRIPTION
PDA catridges and their contents cant be irradiated anymore, fixing the bug of the internal signallers getting stuck radded with no ways of fixing. And nobody takes out PDA catridges to unrad them anyways.
:cl:
tweak: PDA catridges cant be irradiated anymore.
/:cl:
