### PR TITLE
Made wooden cabinet/closets... actually made of wood.

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -342,25 +342,21 @@
 	. = TRUE
 	if(opened)
 		if(istype(W, cutting_tool))
+			var/welder = FALSE
 			if(istype(W, /obj/item/weldingtool))
 				if(!W.tool_start_check(user, amount=0))
 					return
-
-				to_chat(user, "<span class='notice'>You begin cutting \the [src] apart...</span>")
-				if(W.use_tool(src, user, 40, volume=50))
-					if(eigen_teleport)
-						to_chat(user, "<span class='notice'>The unstable nature of \the [src] makes it impossible to cut!</span>")
-						return
-					if(!opened)
-						return
-					user.visible_message("<span class='notice'>[user] slices apart \the [src].</span>",
-									"<span class='notice'>You cut \the [src] apart with \the [W].</span>",
-									"<span class='italics'>You hear welding.</span>")
-					deconstruct(TRUE)
-				return
-			else // for example cardboard box is cut with wirecutters
-				user.visible_message("<span class='notice'>[user] cut apart \the [src].</span>", \
-									"<span class='notice'>You cut \the [src] apart with \the [W].</span>")
+				to_chat(user, "<span class='notice'>You begin [welder ? "slicing" : "deconstructing"] \the [src] apart...</span>")
+				welder = TRUE
+			if(W.use_tool(src, user, 40, volume=50))
+				if(eigen_teleport)
+					to_chat(user, "<span class='notice'>The unstable nature of \the [src] makes it impossible to [welder ? "slice" : "deconstruct"]!</span>")
+					return
+				if(!opened)
+					return
+				user.visible_message("<span class='notice'>[user] [welder ? "slice" : "deconstruct"]s apart \the [src].</span>",
+								"<span class='notice'>You [welder ? "slice" : "deconstruct"] \the [src] apart with \the [W].</span>",
+								"<span class='italics'>You hear [welder ? "welding" : "rustling of screws and metal"].</span>")
 				deconstruct(TRUE)
 				return
 		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too

--- a/code/game/objects/structures/crates_lockers/closets/gimmick.dm
+++ b/code/game/objects/structures/crates_lockers/closets/gimmick.dm
@@ -4,6 +4,8 @@
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
+	material_drop = /obj/item/stack/sheet/mineral/wood
+	cutting_tool = /obj/item/screwdriver
 
 /obj/structure/closet/acloset
 	name = "strange closet"

--- a/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/bar.dm
@@ -4,6 +4,8 @@
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
+	material_drop = /obj/item/stack/sheet/mineral/wood
+	cutting_tool = /obj/item/screwdriver
 
 /obj/structure/closet/secure_closet/bar/PopulateContents()
 	..()

--- a/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/personal.dm
@@ -44,6 +44,8 @@
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
+	material_drop = /obj/item/stack/sheet/mineral/wood
+	cutting_tool = /obj/item/screwdriver
 
 /obj/structure/closet/secure_closet/personal/cabinet/PopulateContents()
 	new /obj/item/storage/backpack/satchel/leather/withwallet( src )

--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -161,12 +161,16 @@
 	..()
 	new /obj/item/clothing/accessory/armband/medblue(src)
 	new /obj/item/encryptionkey/headset_med(src)
+
 /obj/structure/closet/secure_closet/detective
 	name = "\improper detective's cabinet"
 	req_access = list(ACCESS_FORENSICS_LOCKERS)
 	icon_state = "cabinet"
 	resistance_flags = FLAMMABLE
 	max_integrity = 70
+	material_drop = /obj/item/stack/sheet/mineral/wood
+	cutting_tool = /obj/item/screwdriver
+
 /obj/structure/closet/secure_closet/detective/PopulateContents()
 	..()
 	new /obj/item/clothing/under/rank/det(src)


### PR DESCRIPTION
## About The Pull Request
They look and burn like they are made of wood, but they were actually not made of wood until now.

Also changing cabinets' deconstruction tool to a screwdriver, and tweaking closet/tool_interact's deconstruction to call the `use_tool` for all sort of associated cutting tools, not just welders, ergo makes wooden cabinets and large crates' deconstruction not instant.

## Why It's Good For The Game
Consistency issue that I noticed months ago but forgot about till now. Could also remove the welding closet shut with welder feature there but I do not wish to hinder gameplay.

## Changelog
:cl:
tweak: Made wooden cabinet/closets... actually made of wood.
tweak: Wooden cabinets are now deconstructable with a screwdriver.
tweak: Deconstruction of large crates and other closet subtypes deconstructable with tools other than the welder is no longer instant.
/:cl:
