### PR TITLE
Makes wallets hold more stuff

### DIFF
--- a/code/game/objects/items/storage/wallets.dm
+++ b/code/game/objects/items/storage/wallets.dm
@@ -37,7 +37,15 @@
 		/obj/item/screwdriver,
 		/obj/item/valentine,
 		/obj/item/stamp,
-		/obj/item/key))
+		/obj/item/key,
+		/obj/item/cartridge,
+		/obj/item/camera_film,
+		/obj/item/stack/ore/bluespace_crystal,
+		/obj/item/reagent_containers/food/snacks/grown/poppy,
+		/obj/item/instrument/harmonica,
+		/obj/item/mining_voucher,
+		/obj/item/suit_voucher,
+		/obj/item/reagent_containers/pill))
 
 /obj/item/storage/wallet/Exited(atom/movable/AM)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request
Makes wallets hold carts for PDAs, poppy flowers, bs shard, photo reel, miner vouchers, single pills, harmonicas

## Why It's Good For The Game
Wallets not holding things like spare flowers/photos and vouchers seems like a over sight rather then intented
## Changelog
:cl:
add: wallets are known for now holding more items
/:cl:
