### PR TITLE
Adds view and viewers checks for ranged construction devices such as ARCD and RLD.

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -130,18 +130,11 @@ RLD
 	return .
 
 /obj/item/construction/proc/range_check(atom/A, mob/user)
-	if(!(A in range(custom_range, get_turf(user))))
+	if(!(A in range(custom_range, get_turf(user))) || !((A in view(user.client.view, user)) || (user in viewers(user.client.view, A))))
 		to_chat(user, "<span class='warning'>The \'Out of Range\' light on [src] blinks red.</span>")
 		return FALSE
 	else
 		return TRUE
-
-/obj/item/construction/proc/prox_check(proximity)
-	if(proximity)
-		return TRUE
-	else
-		return FALSE
-
 
 /obj/item/construction/rcd
 	name = "rapid-construction-device (RCD)"
@@ -523,7 +516,12 @@ RLD
 
 /obj/item/construction/rcd/afterattack(atom/A, mob/user, proximity)
 	. = ..()
-	if(!prox_check(proximity))
+	if(!proximity)
+		if(!ranged || !range_check(A,user)) //early return not-in-range sanity.
+			return
+		if(target_check(A,user))
+			user.Beam(A,icon_state="rped_upgrade",time=30)
+		rcd_create(A,user)
 		return
 	rcd_create(A, user)
 
@@ -635,6 +633,7 @@ RLD
 	max_matter = INFINITY
 	matter = INFINITY
 	upgrade = TRUE
+	ranged = TRUE
 
 // Ranged RCD
 
@@ -650,18 +649,8 @@ RLD
 	item_state = "oldrcd"
 	has_ammobar = FALSE
 
-/obj/item/construction/rcd/arcd/afterattack(atom/A, mob/user)
-	. = ..()
-	if(!range_check(A,user))
-		return
-	if(target_check(A,user))
-		user.Beam(A,icon_state="rped_upgrade",time=30)
-	rcd_create(A,user)
-
-
 
 // RAPID LIGHTING DEVICE
-
 
 
 /obj/item/construction/rld

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -130,11 +130,16 @@ RLD
 	return .
 
 /obj/item/construction/proc/range_check(atom/A, mob/user)
-	if(!(A in range(custom_range, get_turf(user))) || !((A in view(user.client.view, user)) || (user in viewers(user.client.view, A))))
+	if(!(A in range(custom_range, get_turf(user))))
 		to_chat(user, "<span class='warning'>The \'Out of Range\' light on [src] blinks red.</span>")
 		return FALSE
-	else
-		return TRUE
+	var/view_range = user.client ? user.client.view : world.view
+	//if user can't be seen from A (only checks surroundings' opaqueness) and can't see A.
+	//jarring, but it should stop people from targetting atoms they can't see...
+	//excluding darkness, to allow RLD to be used to light pitch black dark areas.
+	if(!((user in view(view_range, A)) || (user in viewers(view_range, A))))
+		return FALSE
+	return TRUE
 
 /obj/item/construction/rcd
 	name = "rapid-construction-device (RCD)"

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -138,6 +138,7 @@ RLD
 	//jarring, but it should stop people from targetting atoms they can't see...
 	//excluding darkness, to allow RLD to be used to light pitch black dark areas.
 	if(!((user in view(view_range, A)) || (user in viewers(view_range, A))))
+		to_chat(user, "<span class='warning'>You focus, pointing \the [src] at whatever outside your field of vision in the given direction... to no avail.</span>")
 		return FALSE
 	return TRUE
 


### PR DESCRIPTION
## About The Pull Request
Makes the ranged var actually meaningful and the admin RCD ranged too.
Removes useless proc overhead.
Adds view/viewers sanity checks (feel free to suggest improvements and the such) to range_check(), thus ARCD and RLD.

## Why It's Good For The Game
This should close #10030.

## Changelog
:cl:
tweak: You shouldn't be able to target objects you can't see (excluding darkness) with the ARCD and RLD
tweak: The admin RCD is ranged too, just like the ARCD.
/:cl:
