### PR TITLE
fixes on_mob eyes overlays not updating properly in certain cases.

### DIFF
--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -228,10 +228,11 @@
 			if(new_eye_color)
 				var/n_color = sanitize_hexcolor(new_eye_color)
 				var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
-				eyes?.eye_color = n_color
+				if(eyes)
+					eyes.eye_color = n_color
 				H.eye_color = n_color
 				H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
-				H.update_body()
+				H.dna.species.handle_body()
 	if(choice)
 		curse(user)
 

--- a/code/game/objects/structures/mirror.dm
+++ b/code/game/objects/structures/mirror.dm
@@ -226,7 +226,10 @@
 			if(!user.canUseTopic(src, BE_CLOSE, FALSE, NO_TK))
 				return
 			if(new_eye_color)
-				H.eye_color = sanitize_hexcolor(new_eye_color)
+				var/n_color = sanitize_hexcolor(new_eye_color)
+				var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
+				eyes?.eye_color = n_color
+				H.eye_color = n_color
 				H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
 				H.update_body()
 	if(choice)

--- a/code/modules/antagonists/cult/cult.dm
+++ b/code/modules/antagonists/cult/cult.dm
@@ -128,7 +128,8 @@
 	current.clear_alert("bloodsense")
 	if(ishuman(current))
 		var/mob/living/carbon/human/H = current
-		H.eye_color = initial(H.eye_color)
+		var/obj/item/organ/eyes/eyes = H.getorganslot(ORGAN_SLOT_EYES)
+		H.eye_color = eyes?.eye_color || initial(H.eye_color)
 		H.dna.update_ui_block(DNA_EYE_COLOR_BLOCK)
 		REMOVE_TRAIT(H, TRAIT_CULT_EYES, "valid_cultist")
 		H.update_body()

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -252,7 +252,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			QDEL_NULL(eyes)
 		if(should_have_eyes && !eyes)
 			eyes = new mutanteyes
-			eyes.Insert(C)
+			eyes.Insert(C, TRUE)
 
 		if(ears && (replace_current || !should_have_ears))
 			ears.Remove(C,1)

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -44,8 +44,8 @@
 		else
 			eye_color = H.eye_color
 		if(!special)
-			H.dna.species.handle_body() //regenerate eyeballs overlays.
-		if(HAS_TRAIT(HMN, TRAIT_NIGHT_VISION) && !lighting_alpha)
+			H.dna?.species?.handle_body() //regenerate eyeballs overlays.
+		if(HAS_TRAIT(H, TRAIT_NIGHT_VISION) && !lighting_alpha)
 			lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
 			see_in_dark = 8
 	M.update_tint()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -31,17 +31,20 @@
 	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
 
 /obj/item/organ/eyes/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
-	..()
+	. = ..()
+	if(!.)
+		return
 	if(damage == initial(damage))
 		clear_eye_trauma()
 	if(ishuman(owner))
-		var/mob/living/carbon/human/HMN = owner
-		old_eye_color = HMN.eye_color
+		var/mob/living/carbon/human/H = owner
+		old_eye_color = H.eye_color
 		if(eye_color)
-			HMN.eye_color = eye_color
-			HMN.regenerate_icons()
+			H.eye_color = eye_color
 		else
-			eye_color = HMN.eye_color
+			eye_color = H.eye_color
+		if(!special)
+			H.dna.species.handle_body() //regenerate eyeballs overlays.
 		if(HAS_TRAIT(HMN, TRAIT_NIGHT_VISION) && !lighting_alpha)
 			lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
 			see_in_dark = 8
@@ -51,13 +54,15 @@
 
 /obj/item/organ/eyes/Remove(mob/living/carbon/M, special = 0)
 	clear_eye_trauma()
-	..()
+	. = ..()
 	if(ishuman(M) && eye_color)
-		var/mob/living/carbon/human/HMN = M
-		HMN.eye_color = old_eye_color
-		HMN.regenerate_icons()
-	M.update_tint()
-	M.update_sight()
+		var/mob/living/carbon/human/H = M
+		H.eye_color = old_eye_color
+		if(!special)
+			H.dna.species.handle_body()
+	if(!special)
+		M.update_tint()
+		M.update_sight()
 
 /obj/item/organ/eyes/on_life()
 	..()


### PR DESCRIPTION
## About The Pull Request
I kind of noticed this issue too with humanized monkeys in the past too, cause `eyes/Remove()` regenerates the mob icons, while `eyes/Insert()` only does so if the eyes' eye_color is already set, which is not the case for most eyes of non-human source.
Skipping the clustered interaction of organs, species and overlays I won't bother explaining, this kills two birds with one stone by making the overlays update only skippable with the special arg set TRUE.
Also makes cult deconversion reset eyes color to their actual color instead of "000" (black), and made magic mirrors also modify the organ's eye_color.

## Why It's Good For The Game
This will close #10055, if I read through all that concetenated mess correctly. 

## Changelog
:cl:
fix: Fixed on_mob eyes overlays not updating properly in certain cases.
fix: Fixed deconversion from bloodshot eyes blood cult resetting your eyes' color to pitch black instead of their previous color, more or less.
/:cl:
