### PR TITLE
Spinfusor nerf, cause a 7k cost supply pack containing 32 explosive munitions that work just fine without the gun is just pure balance.

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/ballistic/spinfusor.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/spinfusor.dm
@@ -5,7 +5,6 @@
 	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
 	icon_state= "spinner"
 	damage = 30
-	dismemberment = 25
 
 /obj/item/projectile/bullet/spinfusor/on_hit(atom/target, blocked = FALSE) //explosion to emulate the spinfusor's AOE
 	..()
@@ -14,21 +13,15 @@
 
 /obj/item/ammo_casing/caseless/spinfusor
 	name = "spinfusor disk"
-	desc = "A magnetic disk designed specifically for the Stormhammer magnetic cannon. Warning: extremely volatile!"
+	desc = "A magnetic disk designed specifically for the Stormhammer magnetic cannon. Packs a punch."
 	projectile_type = /obj/item/projectile/bullet/spinfusor
 	caliber = "spinfusor"
 	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
 	icon_state = "disk"
+	w_class = WEIGHT_CLASS_SMALL
 	throwforce = 15 //still deadly when thrown
+	force = 5
 	throw_speed = 3
-
-/obj/item/ammo_casing/caseless/spinfusor/throw_impact(atom/target) //disks detonate when thrown
-	if(!..()) // not caught in mid-air
-		visible_message("<span class='notice'>[src] detonates!</span>")
-		playsound(src.loc, "sparks", 50, 1)
-		explosion(target, -1, -1, 1, 1, -1)
-		qdel(src)
-		return 1
 
 /obj/item/ammo_box/magazine/internal/spinfusor
 	name = "spinfusor internal magazine"
@@ -71,7 +64,8 @@
 	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
 	icon_state = "spinfusorbox"
 	ammo_type = /obj/item/ammo_casing/caseless/spinfusor
-	max_ammo = 8
+	w_class = WEIGHT_CLASS_NORMAL
+	max_ammo = 3
 
 /datum/supply_pack/security/armory/spinfusor
 	name = "Stormhammer Spinfusor Crate"
@@ -84,7 +78,5 @@
 	name = "Spinfusor Disk Crate"
 	cost = 7000
 	contains = list(/obj/item/ammo_box/aspinfusor,
-					/obj/item/ammo_box/aspinfusor,
-					/obj/item/ammo_box/aspinfusor,
 					/obj/item/ammo_box/aspinfusor)
 	crate_name = "spinfusor disk crate"

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/spinfusor.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/spinfusor.dm
@@ -65,7 +65,7 @@
 	icon_state = "spinfusorbox"
 	ammo_type = /obj/item/ammo_casing/caseless/spinfusor
 	w_class = WEIGHT_CLASS_NORMAL
-	max_ammo = 3
+	max_ammo = 4
 
 /datum/supply_pack/security/armory/spinfusor
 	name = "Stormhammer Spinfusor Crate"


### PR DESCRIPTION
## About The Pull Request
I heard about spinfusors and how they are simply some stupid grenade launcher copycat and gave their m o d u l a r file a look, but holy crap that's 32 munitions for 7k that work just fine when thrown around without the gun. Far more convenient than 12g or that limited ammo 40mm launcher in spess, waaaaay too convenient.

## Why It's Good For The Game
Nerfing this madness a little. I'd like to see it reworked later on, instead of it be a copycat of grenade launchers. It's quite abusable but I don't see a lot of people do so, maybe just because half the player base is a huge let down.

## Changelog
:cl:
balance: Spinfusor nerf: Upped the casing and ammo box size by one step, removed the projectile's dismemberment value (explosions can still rip a limb or two off), halved the ammo box capacity, reduced the spinfusor ammo supply pack contents from 32 to 8, removed the casing's ability to explode when thrown.
/:cl:
