### PR TITLE
Fixes bubblegum's death not unlocking the arena shuttle buyment since the medals subsystem is not hub enabled

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -118,8 +118,10 @@
 	recovery_time = world.time + buffer_time
 
 /mob/living/simple_animal/hostile/megafauna/proc/grant_achievement(medaltype, scoretype, crusher_kill)
-	if(!medal_type || (flags_1 & ADMIN_SPAWNED_1) || !SSmedals.hub_enabled) //Don't award medals if the medal type isn't set
+	if(!medal_type || (flags_1 & ADMIN_SPAWNED_1)) //Don't award medals if the medal type isn't set
 		return FALSE
+	if(!SSmedals.hub_enabled) // This allows subtypes to carry on other special rewards not tied with medals. (such as bubblegum's arena shuttle)
+		return TRUE
 
 	for(var/mob/living/L in view(7,src))
 		if(L.stat || !L.client)


### PR DESCRIPTION
## About The Pull Request
Achievements/Medals updates need to be ported from tgstation later on, thus migrated to the database.

## Why It's Good For The Game
This will close #10065.

## Changelog
:cl:
fix: Fixes bubblegum's death not unlocking the arena shuttle buyment.
/:cl:
