### PR TITLE
Fixes alien tech node not being unlockable with subtypes of the accepted items.

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1050,7 +1050,7 @@
 
 /datum/techweb_node/alientech/New()
 	. = ..()
-	boost_items_paths = typecacheof(list(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
+	boost_item_paths = typecacheof(list(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
 										 /obj/item/retractor/alien, /obj/item/circular_saw/alien, /obj/item/cautery/alien,
 										 /obj/item/surgicaldrill/alien, /obj/item/screwdriver/abductor, /obj/item/wrench/abductor,
 										 /obj/item/crowbar/abductor, /obj/item/multitool/abductor,

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1050,13 +1050,13 @@
 
 /datum/techweb_node/alientech/New()
 	. = ..()
-	boost_item_paths = typecacheof(list(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
-										 /obj/item/retractor/alien, /obj/item/circular_saw/alien, /obj/item/cautery/alien,
-										 /obj/item/surgicaldrill/alien, /obj/item/screwdriver/abductor, /obj/item/wrench/abductor,
-										 /obj/item/crowbar/abductor, /obj/item/multitool/abductor,
-										 /obj/item/stock_parts/cell/infinite/abductor, /obj/item/weldingtool/abductor,
-										 /obj/item/wirecutters/abductor, /obj/item/circuitboard/machine/abductor,
-										 /obj/item/abductor_baton, /obj/item/abductor, /obj/item/stack/sheet/mineral/abductor))
+	boost_item_paths = typesof(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
+							/obj/item/retractor/alien, /obj/item/circular_saw/alien, /obj/item/cautery/alien,
+							/obj/item/surgicaldrill/alien, /obj/item/screwdriver/abductor, /obj/item/wrench/abductor,
+							/obj/item/crowbar/abductor, /obj/item/multitool/abductor,
+							/obj/item/stock_parts/cell/infinite/abductor, /obj/item/weldingtool/abductor,
+							/obj/item/wirecutters/abductor, /obj/item/circuitboard/machine/abductor,
+							/obj/item/abductor_baton, /obj/item/abductor, /obj/item/stack/sheet/mineral/abductor)
 
 /datum/techweb_node/alien_bio
 	id = "alien_bio"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1043,13 +1043,20 @@
 	display_name = "Alien Technology"
 	description = "Things used by the greys."
 	prereq_ids = list("biotech","engineering")
-	boost_item_paths = list(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien, /obj/item/retractor/alien, /obj/item/circular_saw/alien,
-	/obj/item/cautery/alien, /obj/item/surgicaldrill/alien, /obj/item/screwdriver/abductor, /obj/item/wrench/abductor, /obj/item/crowbar/abductor, /obj/item/multitool/abductor, /obj/item/stock_parts/cell/infinite/abductor,
-	/obj/item/weldingtool/abductor, /obj/item/wirecutters/abductor, /obj/item/circuitboard/machine/abductor, /obj/item/abductor_baton, /obj/item/abductor, /obj/item/stack/sheet/mineral/abductor)
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
 	export_price = 20000
 	hidden = TRUE
 	design_ids = list("alienalloy")
+
+/datum/techweb_node/alientech/New()
+	. = ..()
+	boost_items_paths = typecacheof(list(/obj/item/gun/energy/alien, /obj/item/scalpel/alien, /obj/item/hemostat/alien,
+										 /obj/item/retractor/alien, /obj/item/circular_saw/alien, /obj/item/cautery/alien,
+										 /obj/item/surgicaldrill/alien, /obj/item/screwdriver/abductor, /obj/item/wrench/abductor,
+										 /obj/item/crowbar/abductor, /obj/item/multitool/abductor,
+										 /obj/item/stock_parts/cell/infinite/abductor, /obj/item/weldingtool/abductor,
+										 /obj/item/wirecutters/abductor, /obj/item/circuitboard/machine/abductor,
+										 /obj/item/abductor_baton, /obj/item/abductor, /obj/item/stack/sheet/mineral/abductor))
 
 /datum/techweb_node/alien_bio
 	id = "alien_bio"


### PR DESCRIPTION
## About The Pull Request
Moving the boost_items_path setup from typepath compile values to New() since the subsystem is coded to check the exact typepath.

## Why It's Good For The Game
This will close #10074.

## Changelog
:cl:
fix: Fixed alien tech node not being unlockable with subtypes of the accepted items.
/:cl:
