### PR TITLE
Fixes reactive armor onmob overlays not updating when toggled and reactive teleport armor still using forceMove()

### DIFF
--- a/code/modules/clothing/suits/reactive_armour.dm
+++ b/code/modules/clothing/suits/reactive_armour.dm
@@ -50,7 +50,8 @@
 		icon_state = "reactiveoff"
 		item_state = "reactiveoff"
 	add_fingerprint(user)
-	return
+	if(user.get_item_by_slot(SLOT_WEAR_SUIT) == src)
+		user.update_inv_wear_suit()
 
 /obj/item/clothing/suit/armor/reactive/emp_act(severity)
 	. = ..()
@@ -71,8 +72,9 @@
 	reactivearmor_cooldown_duration = 100
 
 /obj/item/clothing/suit/armor/reactive/teleport/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
+	. = FALSE
 	if(!active)
-		return 0
+		return
 	if(prob(hit_reaction_chance))
 		var/mob/living/carbon/human/H = owner
 		if(world.time < reactivearmor_cooldown)
@@ -95,12 +97,11 @@
 		var/turf/picked = pick(turfs)
 		if(!isturf(picked))
 			return
-		H.forceMove(picked)
+		do_teleport(H, picked, no_effects = TRUE, channel = TELEPORT_CHANNEL_WORMHOLE)
 		radiation_pulse(old, rad_amount_before)
 		radiation_pulse(src, rad_amount)
 		reactivearmor_cooldown = world.time + reactivearmor_cooldown_duration
-		return 1
-	return 0
+		return TRUE
 
 //Fire
 


### PR DESCRIPTION
## About The Pull Request
Fixing some issues with simple issues with reactive armors. 

## Why It's Good For The Game
This will close #10078. 

## Changelog
:cl:
fix: Fixed reactive armor onmob overlays not updating when toggled and reactive teleport armor still using forceMove() instead of do_teleport()
/:cl:
