### PR TITLE
 Fixes reviver implant having been a crapshot ever since soft-crit was introduced years ago.

### DIFF
--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -44,6 +44,9 @@
 	hunger_threshold = NUTRITION_LEVEL_HUNGRY
 	poison_amount = 10
 
+#define MAX_HEAL_COOLDOWN 15 MINUTES
+#define DEF_CONVALESCENCE_TIME 15 SECONDS
+
 /obj/item/organ/cyberimp/chest/reviver
 	name = "Reviver implant"
 	desc = "This implant will attempt to revive and heal you if you lose consciousness. For the faint of heart!"
@@ -51,43 +54,49 @@
 	implant_color = "#AD0000"
 	slot = ORGAN_SLOT_HEART_AID
 	var/revive_cost = 0
-	var/reviving = 0
+	var/reviving = FALSE
 	var/cooldown = 0
+	var/convalescence_time = 0
 
 /obj/item/organ/cyberimp/chest/reviver/on_life()
 	if(reviving)
-		if(owner.stat == UNCONSCIOUS)
-			addtimer(CALLBACK(src, .proc/heal), 30)
+		var/do_heal = world.time < convalescence_time
+		if(revive_cost >= MAX_HEAL_COOLDOWN)
+			do_heal = FALSE
+		else if(owner.stat && ownder.stat != DEAD)
+			do_heal = TRUE
+		else if(!do_heal)
+			convalescence_time = world.time + DEF_CONVALESCENCE_TIME
+		if(do_heal)
+			addtimer(CALLBACK(src, .proc/heal), 3 SECONDS)
 		else
 			cooldown = revive_cost + world.time
 			reviving = FALSE
 			to_chat(owner, "<span class='notice'>Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)].</span>")
 		return
 
-	if(cooldown > world.time)
-		return
-	if(owner.stat != UNCONSCIOUS)
-		return
-	if(owner.suiciding)
+	if(cooldown > world.time || owner.stat == CONSCIOUS || owner.stat == DEAD || owner.suiciding)
 		return
 
 	revive_cost = 0
+	convalescence_time = 0
 	reviving = TRUE
 	to_chat(owner, "<span class='notice'>You feel a faint buzzing as your reviver implant starts patching your wounds...</span>")
 
 /obj/item/organ/cyberimp/chest/reviver/proc/heal()
 	if(owner.getOxyLoss())
 		owner.adjustOxyLoss(-5)
-		revive_cost += 5
+		revive_cost += 0.5 SECONDS
 	if(owner.getBruteLoss())
 		owner.adjustBruteLoss(-2)
-		revive_cost += 40
+		revive_cost += 4 SECONDS
 	if(owner.getFireLoss())
 		owner.adjustFireLoss(-2)
-		revive_cost += 40
+		revive_cost += 4 SECONDS
 	if(owner.getToxLoss())
 		owner.adjustToxLoss(-1)
-		revive_cost += 40
+		revive_cost += 4 SECONDS
+
 
 /obj/item/organ/cyberimp/chest/reviver/emp_act(severity)
 	. = ..()
@@ -95,25 +104,27 @@
 		return
 
 	if(reviving)
-		revive_cost += 200
+		revive_cost += 20 SECONDS
 	else
-		cooldown += 200
+		cooldown += 20 SECONDS
 
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		if(H.stat != DEAD && prob(50 / severity) && H.can_heartattack())
 			H.set_heartattack(TRUE)
 			to_chat(H, "<span class='userdanger'>You feel a horrible agony in your chest!</span>")
-			addtimer(CALLBACK(src, .proc/undo_heart_attack), 600 / severity)
+			addtimer(CALLBACK(src, .proc/undo_heart_attack), 60 SECONDS / severity)
 
 /obj/item/organ/cyberimp/chest/reviver/proc/undo_heart_attack()
 	var/mob/living/carbon/human/H = owner
-	if(!istype(H))
+	if(!H || !istype(H))
 		return
 	H.set_heartattack(FALSE)
-	if(H.stat == CONSCIOUS)
+	if(H.stat == CONSCIOUS || stat == SOFT_CRIT)
 		to_chat(H, "<span class='notice'>You feel your heart beating again!</span>")
 
+#undef MAX_HEAL_COOLDOWN
+#undef DEF_CONVALESCENCE_TIME
 
 /obj/item/organ/cyberimp/chest/thrusters
 	name = "implantable thrusters set"

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -63,7 +63,7 @@
 		var/do_heal = world.time < convalescence_time
 		if(revive_cost >= MAX_HEAL_COOLDOWN)
 			do_heal = FALSE
-		else if(owner.stat && ownder.stat != DEAD)
+		else if(owner.stat && owner.stat != DEAD)
 			do_heal = TRUE
 		else if(!do_heal)
 			convalescence_time = world.time + DEF_CONVALESCENCE_TIME
@@ -120,7 +120,7 @@
 	if(!H || !istype(H))
 		return
 	H.set_heartattack(FALSE)
-	if(H.stat == CONSCIOUS || stat == SOFT_CRIT)
+	if(H.stat == CONSCIOUS || H.stat == SOFT_CRIT)
 		to_chat(H, "<span class='notice'>You feel your heart beating again!</span>")
 
 #undef MAX_HEAL_COOLDOWN


### PR DESCRIPTION
## About The Pull Request
Adding soft crit checks to reviver implants. Adding a "convalescence" timer to allow revivers to continue working for a short while to ensure the user is stabilized.
Adding a hardcap to the revive_cost cooldown to prevents revivers from potentially stalling the user in crit for so long it becomes almost boring. the cooldown hardcap equivales to 150 points total of brute/burn healed.

## Why It's Good For The Game
This will close #10080.

## Changelog
:cl:
fix: Fixes reviver implant having been a crapshot ever since soft-crit was introduced years ago.
tweak: Added a "convalescence" time (about 15 seconds) after the user is out of unconsciousbess/crit to ensure they are properly stabilized.
tweak: Added a 15 minutes hardcap for accumulated revive cooldown (equivalent to 150 points of brute or burn healed) above which the implant starts cooling down regardless of user's conditions.
/:cl:
