### PR TITLE
the one where the combat medic kit gets buffed

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -551,7 +551,7 @@
 
 /obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle/PopulateContents()
 	new /obj/item/clothing/shoes/magboots/syndie(src)
-	new /obj/item/storage/firstaid/tactical(src)
+	new /obj/item/storage/firstaid/tactical/nukeop(src)
 	new /obj/item/gun/ballistic/automatic/l6_saw/toy(src)
 	new /obj/item/ammo_box/foambox/riot(src)
 

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -172,8 +172,25 @@
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_NORMAL
+	STR.max_combined_w_class = 16
+	STR.max_items = 8
 
 /obj/item/storage/firstaid/tactical/PopulateContents()
+	if(empty)
+		return
+	new /obj/item/stack/medical/gauze(src)
+	new /obj/item/defibrillator/compact/combat/loaded(src)
+	new /obj/item/reagent_containers/hypospray/combat/omnizine(src)
+	new /obj/item/reagent_containers/medspray/styptic(src)
+	new /obj/item/reagent_containers/medspray/silver_sulf(src)
+	new /obj/item/healthanalyzer/advanced(src)
+	new /obj/item/reagent_containers/syringe/lethal/choral(src) // what the fuck does anyone use this piece of shit for
+	new /obj/item/clothing/glasses/hud/health/night(src)
+
+/obj/item/storage/firstaid/tactical/nukeop
+	name = "improved combat medical kit"
+
+/obj/item/storage/firstaid/tactical/nukeop/PopulateContents()
 	if(empty)
 		return
 	new /obj/item/stack/medical/gauze(src)
@@ -184,7 +201,7 @@
 	new /obj/item/healthanalyzer/advanced(src)
 	new /obj/item/reagent_containers/syringe/lethal/choral(src) // what the fuck does anyone use this piece of shit for
 	new /obj/item/clothing/glasses/hud/health/night(src)
-
+	
 /*
  * Pill Bottles
  */

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -179,9 +179,10 @@
 	new /obj/item/stack/medical/gauze(src)
 	new /obj/item/defibrillator/compact/combat/loaded(src)
 	new /obj/item/reagent_containers/hypospray/combat(src)
-	new /obj/item/reagent_containers/pill/patch/styptic(src)
-	new /obj/item/reagent_containers/pill/patch/silver_sulf(src)
-	new /obj/item/reagent_containers/syringe/lethal/choral(src)
+	new /obj/item/reagent_containers/medspray/styptic(src)
+	new /obj/item/reagent_containers/medspray/silver_sulf(src)
+	new /obj/item/healthanalyzer/advanced(src)
+	new /obj/item/reagent_containers/syringe/lethal/choral(src) // what the fuck does anyone use this piece of shit for
 	new /obj/item/clothing/glasses/hud/health/night(src)
 
 /*

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1186,7 +1186,30 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	M.adjustToxLoss(-5*REM, 0)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15*REM)
 	M.adjustCloneLoss(-3*REM, 0)
+	M.adjustStaminaLoss(-25*REM,0)
+	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
+		M.blood_volume += 40 // blood fall out man bad
+	..()
+	. = 1
+
+/datum/reagent/medicine/lesser_syndicate_nanites // the one in the injector
+	name = "Regenerative Nanites"
+	id = "lesser_syndicate_nanites"
+	description = "Miniature medical robots that restore damage and get operatives back in the fight."
+	reagent_state = SOLID
+	color = "#555555"
+	pH = 11
+
+/datum/reagent/medicine/lesser_syndicate_nanites/on_mob_life(mob/living/carbon/M)
+	M.adjustBruteLoss(-3*REM, 0) // hidden gold shh
+	M.adjustFireLoss(-3*REM, 0)
+	M.adjustOxyLoss(-15, 0)
+	M.adjustToxLoss(-3*REM, 0)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15*REM)
+	M.adjustCloneLoss(-3*REM, 0)
 	M.adjustStaminaLoss(-20*REM,0)
+	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
+		M.blood_volume += 20 // blood fall out man bad
 	..()
 	. = 1
 

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -56,12 +56,12 @@
 
 /obj/item/reagent_containers/hypospray/combat
 	name = "combat stimulant injector"
-	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat."
+	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat and get people back in the fight."
 	amount_per_transfer_from_this = 10
 	icon_state = "combat_hypo"
 	volume = 90
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("epinephrine" = 30, "omnizine" = 30, "leporazine" = 15, "atropine" = 15)
+	list_reagents = list("epinephrine" = 30, "lesser_syndicate_nanites" = 30, "leporazine" = 15, "atropine" = 15)
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with experimental medical compounds for rapid healing."

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -63,6 +63,11 @@
 	ignore_flags = 1 // So they can heal their comrades.
 	list_reagents = list("epinephrine" = 30, "lesser_syndicate_nanites" = 40, "leporazine" = 15, "atropine" = 15)
 
+/obj/item/reagent_containers/hypospray/combat/omnizine // owned idiot
+	desc = "A modified air-needle autoinjector, used by underfunded support operatives to slowly heal injuries in combat and limp away from a fight."
+	volume = 90
+	list_reagents = list("epinephrine" = 30, "omnizine" = 30, "leporazine" = 15, "atropine" = 15)
+
 /obj/item/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with experimental medical compounds for rapid healing."
 	volume = 100

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -59,9 +59,9 @@
 	desc = "A modified air-needle autoinjector, used by support operatives to quickly heal injuries in combat and get people back in the fight."
 	amount_per_transfer_from_this = 10
 	icon_state = "combat_hypo"
-	volume = 90
+	volume = 100
 	ignore_flags = 1 // So they can heal their comrades.
-	list_reagents = list("epinephrine" = 30, "lesser_syndicate_nanites" = 30, "leporazine" = 15, "atropine" = 15)
+	list_reagents = list("epinephrine" = 30, "lesser_syndicate_nanites" = 40, "leporazine" = 15, "atropine" = 15)
 
 /obj/item/reagent_containers/hypospray/combat/nanites
 	desc = "A modified air-needle autoinjector for use in combat situations. Prefilled with experimental medical compounds for rapid healing."
@@ -135,7 +135,7 @@
 	list_reagents = list("stimulants" = 50)
 
 /obj/item/reagent_containers/hypospray/medipen/stimulants/baseball
-	name = "the reason the syndicate major league team wins."
+	name = "the reason the syndicate major league team wins"
 	desc = "They say drugs never win, but look where you are now, then where they are."
 	icon_state = "baseballstim"
 	volume = 50

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -1543,7 +1543,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 	desc = "This first aid kit is a suspicious brown and red. Included is a combat stimulant injector \
 			for rapid healing, a medical night vision HUD for quick identification of injured personnel, \
 			and other supplies helpful for a field medic."
-	item = /obj/item/storage/firstaid/tactical
+	item = /obj/item/storage/firstaid/tactical/nukeop
 	cost = 4
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
@@ -1557,7 +1557,7 @@ datum/uplink_item/stealthy_weapons/taeclowndo_shoes
 /datum/uplink_item/device_tools/surgerybag_adv
 	name = "Advanced Syndicate Surgery Duffel Bag"
 	desc = "The Syndicate surgery duffel bag is a toolkit containing all advanced surgery tools, surgical drapes, \
-			a Syndicate brand MMI, a straitjacket, a muzzle, and a full Syndicate Combat Medic Kit."
+			a Syndicate brand MMI, a straitjacket, a muzzle, and an outdated, yet still useful Combat Medic Kit."
 	item = /obj/item/storage/backpack/duffelbag/syndie/surgery_adv
 	cost = 10
 


### PR DESCRIPTION
## About The Pull Request
- adds Regenerative Nanites; like the Restorative Nanites the Syndicate Medical Cyborg gets, except less heal-y (-3 instead of -5 per tick)
- replaces the patches in the syndicate kit with medisprays 
- replaces chloral syringe with an advanced health analyzer

edit:

- readds the chloral syringe because fucking trilby will not get off my back about it

edit 2:

- the advanced surgery duffel now has the previous shitty omnizine injector, the nukies get the better one in the medic bundle/the 4 TC item
- it now holds an extra small/tiny item

both regenerative and restorative nanites restore blood, because that's not getting fixed any time soon
## Why It's Good For The Game
the medical injector is no longer fucking useless for healing yourself or your teammates if you don't have a medbeam or if you got the omnizine injector
## Changelog
:cl:
add: Regenerative nanites, a "chemical" used in the combat stimulant injector. Actually quite stimulating, and not bad in a pinch for a nuclear operative. Check the Combat Medic Kit!
tweak: The Combat Medic Kit now has an advanced health analyzer and medisprays instead of patches and a chloral syringe.
balance: The Advanced Syndicate Surgery Duffelbag or whatever it was doesn't get the better injector, because nobody uses it and so nobody's bothered to update it.
/:cl: