### PR TITLE
gives ninjas a full-size oxygen jet harness and a double emergency oxygen tank

### DIFF
--- a/code/game/objects/items/tanks/jetpack.dm
+++ b/code/game/objects/items/tanks/jetpack.dm
@@ -144,6 +144,10 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_NORMAL
 
+/obj/item/tank/jetpack/oxygen/harness/full
+	name = "expanded jet harness (oxygen)"
+	volume = 70
+
 /obj/item/tank/jetpack/oxygen/captain
 	name = "\improper Captain's jetpack"
 	desc = "A compact, lightweight jetpack containing a high amount of compressed oxygen."

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -8,9 +8,9 @@
 	ears = /obj/item/radio/headset
 	shoes = /obj/item/clothing/shoes/space_ninja
 	gloves = /obj/item/clothing/gloves/space_ninja
-	back = /obj/item/tank/jetpack/carbondioxide
+	back = /obj/item/tank/jetpack/oxygen/harness/full
 	l_pocket = /obj/item/grenade/plastic/x4
-	r_pocket = /obj/item/tank/internals/emergency_oxygen
+	r_pocket = /obj/item/tank/internals/emergency_oxygen/double
 	internals_slot = SLOT_R_STORE
 	belt = /obj/item/energy_katana
 	implants = list(/obj/item/implant/explosive)


### PR DESCRIPTION
## About The Pull Request
what the fuck do you think i set the title for
(gives ninjas an expanded (read: standard jetpack volume) oxygen-based jet harness (a la nukies) and a double emergency oxygen tank in their pocket)
## Why It's Good For The Game
a little more breathing room for the ninja. also the harness looks cooler
## Changelog
:cl:
balance: Space ninjas now have a jet harness with standard jetpack volume (70 volume, normal harnesses have 50) and a double emergency oxygen tank.
/:cl: