### PR TITLE
adds anemia, changes ABD

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -2,18 +2,35 @@
 
 /datum/quirk/blooddeficiency
 	name = "Acute Blood Deficiency"
-	desc = "Your body can't produce enough blood to sustain itself."
-	value = -2
-	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
+	desc = "Your body can't produce enough blood to sustain itself.Will eventually result in death if not treated."
+	value = -3
+	gain_text = "<span class='danger'>You feel your vigor quickly fading away.</span>"
 	lose_text = "<span class='notice'>You feel vigorous again.</span>"
-	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood."
+	medical_record_text = "Patient requires regular treatment for blood loss due to low production of blood. Lack of treatment will result in death."
 
 /datum/quirk/blooddeficiency/on_process()
 	var/mob/living/carbon/human/H = quirk_holder
 	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
 		return
 	else
-		quirk_holder.blood_volume -= 0.275
+		if(quirk_holder.blood_volume > 336) //60% blood volume, eventually lethal
+			quirk_holder.blood_volume -= 0.275
+
+/datum/quirk/anemia
+	name = "Anemia"
+	desc = "Your body can barely produce enough blood to sustain itself. Will result in fatigue and fainting spells if not treated."
+	value = -1
+	gain_text = "<span class='danger'>You feel your vigor slowly fading away.</span>"
+	lose_text = "<span class='notice'>You feel vigorous again.</span>"
+	medical_record_text = "Patient requires occasional treatment for blood loss due to low production of blood."
+
+/datum/quirk/anemia/on_process()
+	var/mob/living/carbon/human/H = quirk_holder
+	if(NOBLOOD in H.dna.species.species_traits) //can't lose blood if your species doesn't have any
+		return
+	else
+		if(quirk_holder.blood_volume > 420) //blaze it 75%% blood volume, not lethal just annoying
+			quirk_holder.blood_volume -= 0.275
 
 /datum/quirk/depression
 	name = "Depression"


### PR DESCRIPTION
Adds anemia, which acts as ABD-lite, nonlethal, slightly dangerous, and
annoying, and caps ABD bloodloss at 60% blood, keeping it lethal but not
comical

## About The Pull Request

Adds Anemia quirk for -1 point, loses blood at the same rate as ABD but caps at 75% blood which is nonlethal, softcaps at about 5 oxygen damage, gives you "you feel woozy" messages, and can become lethal with very small(5% or more) losses of blood from external sources. Blood will regenerate normally. if you drop below this point.

Changes Acute Blood Deficiency quirk- changes the value to -3 to match its lethal nature to the brain tumor, which, notably, actually kills you SLOWER than ABD does and is easier to treat, as well as capping its bloodloss at 60% blood, still lethal and QUICKLY lethal, but no longer comically so, and no more ABD patients left in a coma with 35% blood being kept alive in their cursed existence by salbutamol and rage

## Why It's Good For The Game

Anemia will act as a more RP-friendly version of Acute Blood Deficiency, allowing people to actually roleplay with it safely instead of just dropping dead from oxyloss at regular intervals and draining the medbay dry of all their bloodbags. Comas dont make good roleplay.
ABD is capped at 60%, which can be changed to any number really, to avoid situations in which someone reaches 20% through the abuse of oxyheal chems or saline-glucose and instantly dies, unrevivable, as well as making it less punishing for the doctors AND for the patients.

## Changelog
:cl:
add: Anemia quirk
balance: Acute Blood Deficiency points increased, bloodloss capped
/:cl: