### PR TITLE
[TESTMERGE READY] Makes jukeboxes stream the songs instead of forcing instant downloads.

### DIFF
--- a/code/controllers/subsystem/jukeboxes.dm
+++ b/code/controllers/subsystem/jukeboxes.dm
@@ -117,6 +117,6 @@ SUBSYSTEM_DEF(jukeboxes)
 			else
 				song_played.status = SOUND_MUTE | SOUND_UPDATE	//Setting volume = 0 doesn't let the sound properties update at all, which is lame.
 
-			M.playsound_local(currentturf, null, 100, channel = jukeinfo[2], S = song_played, envwet = (inrange ? -250 : 0), envdry = (inrange ? 0 : -10000))
+			M.playsound_local(currentturf, null, 100, channel = jukeinfo[2], S = song_played, envwet = (inrange ? -250 : 0), envdry = (inrange ? 0 : -10000), stream = TRUE)
 			CHECK_TICK
 	return

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -42,7 +42,7 @@
 	S.volume = vol
 	S.environment = 7
 	if(stream)
-		S.status = SOUND_STREAM
+		S.status = SOUND_STREAM | SOUND_UPDATE
 
 	if(vary)
 		if(frequency)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -42,7 +42,7 @@
 	S.volume = vol
 	S.environment = 7
 	if(stream)
-		S.status = SOUND_STREAM | SOUND_UPDATE
+		S.status |= SOUND_STREAM
 
 	if(vary)
 		if(frequency)

--- a/code/game/sound.dm
+++ b/code/game/sound.dm
@@ -27,10 +27,10 @@
 		if(get_dist(M, turf_source) <= maxdistance)
 			M.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, soundenvwet, soundenvdry)
 
-/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, envwet = -10000, envdry = 0, manual_x, manual_y)
+/mob/proc/playsound_local(turf/turf_source, soundin, vol as num, vary, frequency, falloff, channel = 0, pressure_affected = TRUE, sound/S, envwet = -10000, envdry = 0, manual_x, manual_y, stream = FALSE)
 	if(audiovisual_redirect)
 		var/turf/T = get_turf(src)
-		audiovisual_redirect.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, 0, -1000, turf_source.x - T.x, turf_source.y - T.y)
+		audiovisual_redirect.playsound_local(turf_source, soundin, vol, vary, frequency, falloff, channel, pressure_affected, S, 0, -1000, turf_source.x - T.x, turf_source.y - T.y, stream)
 	if(!client || !can_hear())
 		return
 
@@ -41,6 +41,8 @@
 	S.channel = channel || open_sound_channel()
 	S.volume = vol
 	S.environment = 7
+	if(stream)
+		S.status = SOUND_STREAM
 
 	if(vary)
 		if(frequency)


### PR DESCRIPTION
## About The Pull Request

The title explains it.

## Why It's Good For The Game
 
Stops the lagspikes when songs are switched.

## Changelog
:cl:
fix: added stream flags to songs played by jukeboxes
/:cl:

