### PR TITLE
Night vision trait but it just boosts barely-lit visibility

### DIFF
--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -59,7 +59,7 @@
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
-#define LIGHTING_PLANE_ALPHA_NV_TRAIT 192
+#define LIGHTING_PLANE_ALPHA_NV_TRAIT 160
 #define LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -59,10 +59,12 @@
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
-#define LIGHTING_PLANE_ALPHA_NV_TRAIT 160
+#define LIGHTING_PLANE_ALPHA_NV_TRAIT 175
 #define LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0
+
+#define NIGHT_VISION_DARKSIGHT_RANGE 3
 
 //lighting area defines
 #define DYNAMIC_LIGHTING_DISABLED 0 //dynamic lighting disabled (area stays at full brightness)

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -59,7 +59,7 @@
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
-#define LIGHTING_PLANE_ALPHA_NV_TRAIT 175
+#define LIGHTING_PLANE_ALPHA_NV_TRAIT 223
 #define LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0

--- a/code/__DEFINES/lighting.dm
+++ b/code/__DEFINES/lighting.dm
@@ -59,7 +59,7 @@
 #define LIGHT_RANGE_FIRE		3 //How many tiles standard fires glow.
 
 #define LIGHTING_PLANE_ALPHA_VISIBLE 255
-#define LIGHTING_PLANE_ALPHA_NV_TRAIT 250
+#define LIGHTING_PLANE_ALPHA_NV_TRAIT 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE 192
 #define LIGHTING_PLANE_ALPHA_MOSTLY_INVISIBLE 128 //For lighting alpha, small amounts lead to big changes. even at 128 its hard to figure out what is dark and what is light, at 64 you almost can't even tell.
 #define LIGHTING_PLANE_ALPHA_INVISIBLE 0

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -188,3 +188,18 @@
 /datum/quirk/bloodpressure/remove()
 	var/mob/living/M = quirk_holder
 	M.blood_ratio = 1
+
+/datum/quirk/night_vision
+	name = "Night Vision"
+	desc = "You can see slightly more clearly in full darkness than most people."
+	value = 1
+	mob_trait = TRAIT_NIGHT_VISION
+	gain_text = "<span class='notice'>The shadows seem a little less dark.</span>"
+	lose_text = "<span class='danger'>Everything seems a little darker.</span>"
+
+/datum/quirk/night_vision/on_spawn()
+	var/mob/living/carbon/human/H = quirk_holder
+	var/obj/item/organ/eyes/eyes = H.getorgan(/obj/item/organ/eyes)
+	if(!eyes || eyes.lighting_alpha)
+		return
+	eyes.Insert(H) //refresh their eyesight and vision

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -199,5 +199,4 @@
 
 /datum/quirk/night_vision/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
-	var/obj/item/organ/eyes/eyes = H.getorgan(/obj/item/organ/eyes)
-	eyes.Insert(H) //refresh their eyesight and vision
+	H.update_sight()

--- a/code/datums/traits/good.dm
+++ b/code/datums/traits/good.dm
@@ -200,6 +200,4 @@
 /datum/quirk/night_vision/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/organ/eyes/eyes = H.getorgan(/obj/item/organ/eyes)
-	if(!eyes || eyes.lighting_alpha)
-		return
 	eyes.Insert(H) //refresh their eyesight and vision

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -585,6 +585,9 @@
 		sight |= E.sight_flags
 		if(!isnull(E.lighting_alpha))
 			lighting_alpha = E.lighting_alpha
+		if(HAS_TRAIT(src, TRAIT_NIGHT_VISION))
+			lighting_alpha = min(LIGHTING_PLANE_ALPHA_NV_TRAIT, lighting_alpha)
+			see_in_dark = max(NIGHT_VISION_DARKSIGHT_RANGE, see_in_dark)
 
 	if(client.eye && client.eye != src)
 		var/atom/A = client.eye

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -1,5 +1,3 @@
-#define NIGHT_VISION_DARKSIGHT_RANGE 3
-
 /obj/item/organ/eyes
 	name = BODY_ZONE_PRECISE_EYES
 	icon_state = "eyeballs"
@@ -47,12 +45,8 @@
 			eye_color = H.eye_color
 		if(!special)
 			H.dna?.species?.handle_body() //regenerate eyeballs overlays.
-		if(HAS_TRAIT(H, TRAIT_NIGHT_VISION) && !lighting_alpha)
-			lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
-			see_in_dark = NIGHT_VISION_DARKSIGHT_RANGE
 	M.update_tint()
 	owner.update_sight()
-
 
 /obj/item/organ/eyes/Remove(mob/living/carbon/M, special = 0)
 	clear_eye_trauma()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -1,4 +1,4 @@
-#define NIGHT_VISION_DARKSIGHT_RANGE 2
+#define NIGHT_VISION_DARKSIGHT_RANGE 3
 
 /obj/item/organ/eyes
 	name = BODY_ZONE_PRECISE_EYES

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -1,4 +1,4 @@
-#define NIGHT_VISION_DARKSIGHT_RANGE 3
+#define NIGHT_VISION_DARKSIGHT_RANGE 2
 
 /obj/item/organ/eyes
 	name = BODY_ZONE_PRECISE_EYES

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -1,3 +1,5 @@
+#define NIGHT_VISION_DARKSIGHT_RANGE 3
+
 /obj/item/organ/eyes
 	name = BODY_ZONE_PRECISE_EYES
 	icon_state = "eyeballs"
@@ -47,7 +49,7 @@
 			H.dna?.species?.handle_body() //regenerate eyeballs overlays.
 		if(HAS_TRAIT(H, TRAIT_NIGHT_VISION) && !lighting_alpha)
 			lighting_alpha = LIGHTING_PLANE_ALPHA_NV_TRAIT
-			see_in_dark = 8
+			see_in_dark = NIGHT_VISION_DARKSIGHT_RANGE
 	M.update_tint()
 	owner.update_sight()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Readds night vision as a powerful night vision effect in general, assuming you can see a tile. Also gives you a 5x5 rather than 3x3 darksight range.

## Why It's Good For The Game

Old night vision was too long ranged. This is still pretty strong, just not "I never need lights and no one can hide from me" levels of strong.

## Changelog
:cl:
add: Night vision readded as a darkness dampening effect rather than darksight.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
