### PR TITLE
Makes HE pipes realistically radiate away heat

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -9,12 +9,13 @@
 #define META_GAS_FUSION_POWER   7
 //ATMOS
 //stuff you should probably leave well alone!
-#define R_IDEAL_GAS_EQUATION	8.31	//kPa*L/(K*mol)
-#define ONE_ATMOSPHERE			101.325	//kPa
-#define TCMB					2.7		// -270.3degC
-#define TCRYO					225		// -48.15degC
-#define T0C						273.15	// 0degC
-#define T20C					293.15	// 20degC
+#define R_IDEAL_GAS_EQUATION	8.31446261815324	//kPa*L/(K*mol)
+#define ONE_ATMOSPHERE			101.325				//kPa
+#define TCMB					2.7					// -270.3degC
+#define TCRYO					225					// -48.15degC
+#define T0C						273.15				// 0degC
+#define T20C					293.15				// 20degC
+#define STEFANBOLTZMANN			(5.670373*10e-8) 	// W/(m^2*K^4)
 
 #define MOLES_CELLSTANDARD		(ONE_ATMOSPHERE*CELL_VOLUME/(T20C*R_IDEAL_GAS_EQUATION))	//moles in a 2.5 m^3 cell at 101.325 Pa and 20 degC
 #define M_CELL_WITH_RATIO		(MOLES_CELLSTANDARD * 0.005) //compared against for superconductivity
@@ -149,9 +150,9 @@
 
 //OPEN TURF ATMOS
 #define OPENTURF_DEFAULT_ATMOS		"o2=22;n2=82;TEMP=293.15" //the default air mix that open turfs spawn
-#define TCOMMS_ATMOS				"n2=100;TEMP=80" //-193,15°C telecommunications. also used for xenobiology slime killrooms
+#define TCOMMS_ATMOS				"n2=100;TEMP=80" //-193,15ï¿½C telecommunications. also used for xenobiology slime killrooms
 #define AIRLESS_ATMOS				"TEMP=2.7" //space
-#define FROZEN_ATMOS				"o2=22;n2=82;TEMP=180" //-93.15°C snow and ice turfs
+#define FROZEN_ATMOS				"o2=22;n2=82;TEMP=180" //-93.15ï¿½C snow and ice turfs
 #define BURNMIX_ATMOS				"o2=2500;plasma=5000;TEMP=370" //used in the holodeck burn test program
 
 //ATMOSPHERICS DEPARTMENT GAS TANK TURFS

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -152,7 +152,7 @@
 #define OPENTURF_DEFAULT_ATMOS		"o2=22;n2=82;TEMP=293.15" //the default air mix that open turfs spawn
 #define TCOMMS_ATMOS				"n2=100;TEMP=80" //-193,15�C telecommunications. also used for xenobiology slime killrooms
 #define AIRLESS_ATMOS				"TEMP=2.7" //space
-#define FROZEN_ATMOS				"o2=22;n2=82;TEMP=180" //-93.15�C snow and ice turfs
+#define FROZEN_ATMOS				"o2=22;n2=82;TEMP=180" //-93.15°C snow and ice turfs
 #define BURNMIX_ATMOS				"o2=2500;plasma=5000;TEMP=370" //used in the holodeck burn test program
 
 //ATMOSPHERICS DEPARTMENT GAS TANK TURFS

--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -150,7 +150,7 @@
 
 //OPEN TURF ATMOS
 #define OPENTURF_DEFAULT_ATMOS		"o2=22;n2=82;TEMP=293.15" //the default air mix that open turfs spawn
-#define TCOMMS_ATMOS				"n2=100;TEMP=80" //-193,15�C telecommunications. also used for xenobiology slime killrooms
+#define TCOMMS_ATMOS				"n2=100;TEMP=80" //-193,15°C telecommunications. also used for xenobiology slime killrooms
 #define AIRLESS_ATMOS				"TEMP=2.7" //space
 #define FROZEN_ATMOS				"o2=22;n2=82;TEMP=180" //-93.15°C snow and ice turfs
 #define BURNMIX_ATMOS				"o2=2500;plasma=5000;TEMP=370" //used in the holodeck burn test program

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -155,9 +155,10 @@
 	var/target_temperature
 	var/target_heat_capacity
 	// first calculate heat from radiation. there's an implied "* 1 tick" here.
-	// Minimizing temp to 4 billion is mostly to prevent -infinity temperatures.
 	// 0.05 magic multiplicand is, first, 0.1 deciseconds; second, half of the radiation's going right back into the gas.
-	var/heat = (STEFANBOLTZMANN*(share_volume**(2/3))*(min(air.temperature,4000000000)**4))*0.05
+	var/share_constant = STEFANBOLTZMANN*(share_volume**(2/3))*0.05
+	// Minimizing temp to 4 billion is mostly to prevent -infinity temperatures.
+	var/heat = share_constant*(min(air.temperature,4000000000)**4)
 
 	if(isopenturf(target))
 
@@ -169,7 +170,7 @@
 
 			if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
 				var/delta_temperature = air.temperature - target_temperature
-
+				heat -= share_constant*(min(target_temperature,4000000000)**4)
 				heat += thermal_conductivity*delta_temperature* \
 					(partial_heat_capacity*target_heat_capacity/(partial_heat_capacity+target_heat_capacity))
 
@@ -187,6 +188,7 @@
 			var/sharer_temperature_delta = 0
 
 			if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
+				heat -= share_constant*(min(target_temperature,4000000000)**4)
 				heat += thermal_conductivity*delta_temperature* \
 					(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
 
@@ -203,6 +205,7 @@
 		if((target.heat_capacity>0) && (partial_heat_capacity>0))
 			var/delta_temperature = air.temperature - target.temperature
 
+			heat -= share_constant*(min(target.temperature,4000000000)**4)
 			heat += thermal_conductivity*delta_temperature* \
 				(partial_heat_capacity*target.heat_capacity/(partial_heat_capacity+target.heat_capacity))
 

--- a/code/modules/atmospherics/machinery/datum_pipeline.dm
+++ b/code/modules/atmospherics/machinery/datum_pipeline.dm
@@ -154,6 +154,10 @@
 	var/partial_heat_capacity = total_heat_capacity*(share_volume/air.volume)
 	var/target_temperature
 	var/target_heat_capacity
+	// first calculate heat from radiation. there's an implied "* 1 tick" here.
+	// Minimizing temp to 4 billion is mostly to prevent -infinity temperatures.
+	// 0.05 magic multiplicand is, first, 0.1 deciseconds; second, half of the radiation's going right back into the gas.
+	var/heat = (STEFANBOLTZMANN*(share_volume**(2/3))*(min(air.temperature,4000000000)**4))*0.05
 
 	if(isopenturf(target))
 
@@ -166,7 +170,7 @@
 			if((modeled_location.heat_capacity>0) && (partial_heat_capacity>0))
 				var/delta_temperature = air.temperature - target_temperature
 
-				var/heat = thermal_conductivity*delta_temperature* \
+				heat += thermal_conductivity*delta_temperature* \
 					(partial_heat_capacity*target_heat_capacity/(partial_heat_capacity+target_heat_capacity))
 
 				air.temperature -= heat/total_heat_capacity
@@ -183,7 +187,7 @@
 			var/sharer_temperature_delta = 0
 
 			if((sharer_heat_capacity>0) && (partial_heat_capacity>0))
-				var/heat = thermal_conductivity*delta_temperature* \
+				heat += thermal_conductivity*delta_temperature* \
 					(partial_heat_capacity*sharer_heat_capacity/(partial_heat_capacity+sharer_heat_capacity))
 
 				self_temperature_delta = -heat/total_heat_capacity
@@ -199,10 +203,11 @@
 		if((target.heat_capacity>0) && (partial_heat_capacity>0))
 			var/delta_temperature = air.temperature - target.temperature
 
-			var/heat = thermal_conductivity*delta_temperature* \
+			heat += thermal_conductivity*delta_temperature* \
 				(partial_heat_capacity*target.heat_capacity/(partial_heat_capacity+target.heat_capacity))
 
 			air.temperature -= heat/total_heat_capacity
+	air.temperature = CLAMP(air.temperature,TCMB,INFINITY) // i have no idea why TCMB needs to be the min but i ain't changing it
 	update = TRUE
 
 /datum/pipeline/proc/return_air()

--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/he_pipes.dm
@@ -26,9 +26,7 @@
 
 	var/turf/T = loc
 	if(istype(T))
-		if(islava(T))
-			environment_temperature = 5000
-		else if(T.blocks_air)
+		if(T.blocks_air)
 			environment_temperature = T.temperature
 		else
 			var/turf/open/OT = T


### PR DESCRIPTION
## About The Pull Request

1. Heat exchange now also radiate heat proportional to their blackbody radiation. This makes space cooling loops WAY stronger at >6000 kelvins, to the point that it's now feasible to cool down fusion cans and such. Of course, this also makes HE pipes being used as weapons stronger.
2. Makes HE pipes not special case lava tiles when lava tiles already have a special case temperature get that HE pipes use anyway.
3. Makes the ideal gas equation more precise (before 8.31, now 8.31446261815324, its exact value in SI, though it should be noted that some of this precision is lost to floating point math).

I thought about making space cooling loops *only* work based on radiation, like IRL, but it turns out that would make them *extremely* weak at even lowish temperatures (e.g. 3000x as weak at fire temperatures), so nah.

## Why It's Good For The Game

Fusion cans shouldn't be eternal heat sinks impossible to fix.

## Changelog
:cl:
balance: Buffed HE pipes by making them realistically radiate away heat.
/:cl:
