### PR TITLE
Makes anomalies not spawnable in dorms.

### DIFF
--- a/code/modules/events/anomaly.dm
+++ b/code/modules/events/anomaly.dm
@@ -22,7 +22,8 @@
 		/area/engine,
 		/area/solar,
 		/area/holodeck,
-		/area/shuttle)
+		/area/shuttle,
+		/area/crew_quarters/dorms)
 		)
 
 		//Subtypes from the above that actually should explode.


### PR DESCRIPTION
## About The Pull Request

Anomalies can no longer spawn in dorms and blow them the fuck up. This might not seem like a problem except that the command report system sometimes doesn't tell anyone that there's an anomaly except by making a report on the command console, giving no warning to the people within.

## Why It's Good For The Game

gotta preserve the hugbox mechanically at least a *little*

## Changelog
:cl:
tweak: dorms are now exempt from anomaly spawning.
/:cl: