### PR TITLE
Makes meat hook fit in boh again

### DIFF
--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -398,6 +398,7 @@
 	fire_sound = 'sound/weapons/batonextend.ogg'
 	max_charges = 1
 	item_flags = NEEDS_PERMIT | NOBLUDGEON
+	w_class = WEIGHT_CLASS_BULKY
 	force = 18
 
 /obj/item/ammo_casing/magic/hook


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Nerfed meat hook a bit with boh changes that were not ment to be changed.
Corrects that

## Why It's Good For The Game

Meet hook is p-shitty weapon and should fit in the boh like its ment to - DND like
## Changelog
:cl:
tweak: meat hook from HUGE to bulky
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
