### PR TITLE
Makes secret's dynamic roundstart report not tell people to contact a coder

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -236,6 +236,9 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			return rule.round_result()
 	return ..()
 
+/datum/game_mode/dynamic/generate_report()
+	return "Mysterious signals that demonstrate strange dynamics have been detected in your sector. Watch out for oddities."
+
 /datum/game_mode/dynamic/send_intercept()
 	. = "<b><i>Central Command Status Summary</i></b><hr>"
 	switch(round(threat_level))


### PR DESCRIPTION
## About The Pull Request

Secret gets reports from random game modes and Dynamic didn't have a report set up so people kept bugging me about it so here you go.

## Why It's Good For The Game

Gamemode report for dynamic mode not set. Contact a coder.

(Yes, I know that stuff like this is bad oversights that need to be fixed regardless of severity, but it's so hilariously minor that I can't help but make fun of it)

## Changelog
:cl:
fix: Dynamic has a (totally unused for any relevant purpose) roundstart report now.
/:cl: