### PR TITLE
Dynamic no longer double dips on refunds for ghost antags with not enough applicants

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -94,11 +94,8 @@
 	var/list/possible_candidates = list()
 	possible_candidates.Add(dead_players)
 	possible_candidates.Add(list_observers)
-	send_applications(possible_candidates)
-	if(assigned.len > 0)
-		return TRUE
-	else
-		return FALSE
+	var/application_successful = send_applications(possible_candidates)
+	return assigned.len > 0 && application_successful
 
 /// This sends a poll to ghosts if they want to be a ghost spawn from a ruleset.
 /datum/dynamic_ruleset/midround/from_ghosts/proc/send_applications(list/possible_volunteers = list())
@@ -113,14 +110,12 @@
 	if(!candidates || candidates.len <= required_candidates)
 		message_admins("The ruleset [name] did not receive enough applications.")
 		log_game("DYNAMIC: The ruleset [name] did not receive enough applications.")
-		mode.refund_threat(cost)
-		mode.log_threat("Rule [name] refunded [cost] (not receive enough applications)",verbose=TRUE)
-		mode.executed_rules -= src
-		return
+		return FALSE
 
 	message_admins("[candidates.len] players volunteered for the ruleset [name].")
 	log_game("DYNAMIC: [candidates.len] players volunteered for [name].")
 	review_applications()
+	return TRUE
 
 /// Here is where you can check if your ghost applicants are valid for the ruleset.
 /// Called by send_applications().

--- a/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_midround.dm
@@ -127,11 +127,6 @@
 /datum/dynamic_ruleset/midround/from_ghosts/proc/review_applications()
 	for (var/i = 1, i <= required_candidates, i++)
 		if(candidates.len <= 0)
-			if(i == 1)
-				// We have found no candidates so far and we are out of applicants.
-				mode.refund_threat(cost)
-				mode.log_threat("Rule [name] refunded [cost] (all applications invalid)",verbose=TRUE)
-				mode.executed_rules -= src
 			break
 		var/mob/applicant = pick(candidates)
 		candidates -= applicant


### PR DESCRIPTION
## About The Pull Request

See title. It was refunding twice. That's bad. It shouldn't do that.

## Why It's Good For The Game

Too much threat, yikes.

## Changelog
:cl:
fix: Dynamic from-ghost antags no longer double dip on threat refunds when the mode fails due to not enough applications.
/:cl: