### PR TITLE
makes the officer's sabre play the un/sheating noise properly

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -79,17 +79,17 @@
 		final_block_chance = 0 //Don't bring a sword to a gunfight
 	return ..()
 
-/obj/item/melee/sabre/on_exit_storage(obj/item/storage/S)
-	..()
-	var/obj/item/storage/belt/sabre/B = S
+/obj/item/melee/sabre/on_exit_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/unsheath.ogg', 25, 1)
-
-/obj/item/melee/sabre/on_enter_storage(obj/item/storage/S)
 	..()
-	var/obj/item/storage/belt/sabre/B = S
+
+/obj/item/melee/sabre/on_enter_storage(datum/component/storage/S)
+	var/obj/item/storage/belt/sabre/B = S.parent
 	if(istype(B))
 		playsound(B, 'sound/items/sheath.ogg', 25, 1)
+	..()
 
 /obj/item/melee/sabre/get_belt_overlay()
 	return mutable_appearance('icons/obj/clothing/belt_overlays.dmi', "sabre")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
whoever wrote this uhh didn't know how on_exit_storage works apparently

## Changelog
:cl:
fix: officer's sabre now properly makes the unsheating and resheating noise
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
