### PR TITLE
Corrects telegram hat icon, adds a new dog fashion to telegram hat

### DIFF
--- a/code/modules/clothing/head/misc.dm
+++ b/code/modules/clothing/head/misc.dm
@@ -370,9 +370,9 @@
 /obj/item/clothing/head/hotel
 	name = "Telegram cap"
 	desc = "A bright red cap warn by hotel staff. Or people who want to be a singing telegram"
-	icon_state = "telegramhat"
-	item_color = "telegramhat"
-	dog_fashion = null
+	icon_state = "telegram"
+	item_color = "telegram"
+	dog_fashion = /datum/dog_fashion/head/telegram
 
 /obj/item/clothing/head/colour
 	name = "Singer cap"


### PR DESCRIPTION
## About The Pull Request

Do to lack of coding skills when dealing with icon conflicts, I forgot to change the name back to telegramhat but meh! Fixed now
Forgot to give the hat the doggo fashion as well

## Why It's Good For The Game

I like to be able to see my hats and Corgies are known for being grate.

## Changelog
:cl:
fix: Wrong icon names, missing dog fashion with telegram hat
/:cl:
