### PR TITLE
Removes greentext

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -545,10 +545,7 @@
 	var/list/objective_parts = list()
 	var/count = 1
 	for(var/datum/objective/objective in objectives)
-		if(objective.check_completion())
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</span>"
-		else
-			objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
+		objective_parts += "<b>Objective #[count]</b>: [objective.explanation_text]"
 		count++
 	return objective_parts.Join("<br>")
 

--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -130,18 +130,8 @@ GLOBAL_LIST_EMPTY(antagonists)
 
 	report += printplayer(owner)
 
-	var/objectives_complete = TRUE
 	if(objectives.len)
 		report += printobjectives(objectives)
-		for(var/datum/objective/objective in objectives)
-			if(!objective.check_completion())
-				objectives_complete = FALSE
-				break
-
-	if(objectives.len == 0 || objectives_complete)
-		report += "<span class='greentext big'>The [name] was successful!</span>"
-	else
-		report += "<span class='redtext big'>The [name] has failed!</span>"
 
 	return report.Join("<br>")
 

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -33,19 +33,10 @@
 
 	if(objectives.len)
 		report += "<span class='header'>Team had following objectives:</span>"
-		var/win = TRUE
 		var/objective_count = 1
 		for(var/datum/objective/objective in objectives)
-			if(objective.check_completion())
-				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'><B>Success!</span>"
-			else
-				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-				win = FALSE
+				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text]"
 			objective_count++
-		if(win)
-			report += "<span class='greentext'>The [name] was successful!</span>"
-		else
-			report += "<span class='redtext'>The [name] have failed!</span>"
 
 
 	return "<div class='panel redborder'>[report.Join("<br>")]</div>"

--- a/code/modules/antagonists/_common/antag_team.dm
+++ b/code/modules/antagonists/_common/antag_team.dm
@@ -35,7 +35,7 @@
 		report += "<span class='header'>Team had following objectives:</span>"
 		var/objective_count = 1
 		for(var/datum/objective/objective in objectives)
-				report += "<B>Objective #[objective_count]</B>: [objective.explanation_text]"
+			report += "<B>Objective #[objective_count]</B>: [objective.explanation_text]"
 			objective_count++
 
 

--- a/code/modules/antagonists/abductor/abductor.dm
+++ b/code/modules/antagonists/abductor/abductor.dm
@@ -141,15 +141,6 @@
 /datum/team/abductor_team/roundend_report()
 	var/list/result = list()
 
-	var/won = TRUE
-	for(var/datum/objective/O in objectives)
-		if(!O.check_completion())
-			won = FALSE
-	if(won)
-		result += "<span class='greentext big'>[name] team fulfilled its mission!</span>"
-	else
-		result += "<span class='redtext big'>[name] team failed its mission.</span>"
-
 	result += "<span class='header'>The abductors of [name] were:</span>"
 	for(var/datum/mind/abductor_mind in members)
 		result += printplayer(abductor_mind)

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -105,7 +105,6 @@
 	parts += "<span class='header'>The blood brothers of [name] were:</span>"
 	for(var/datum/mind/M in members)
 		parts += printplayer(M)
-	var/win = TRUE
 	var/objective_count = 1
 	for(var/datum/objective/objective in objectives)
 		parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text]"

--- a/code/modules/antagonists/brother/brother.dm
+++ b/code/modules/antagonists/brother/brother.dm
@@ -108,16 +108,8 @@
 	var/win = TRUE
 	var/objective_count = 1
 	for(var/datum/objective/objective in objectives)
-		if(objective.check_completion())
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='greentext'><B>Success!</span>"
-		else
-			parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-			win = FALSE
+		parts += "<B>Objective #[objective_count]</B>: [objective.explanation_text]"
 		objective_count++
-	if(win)
-		parts += "<span class='greentext'>The blood brothers were successful!</span>"
-	else
-		parts += "<span class='redtext'>The blood brothers have failed!</span>"
 
 	return "<div class='panel redborder'>[parts.Join("<br>")]</div>"
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -552,17 +552,8 @@
 	if(objectives.len)
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
-			if(objective.check_completion())
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='greentext'>Success!</b></span>"
-			else
-				parts += "<b>Objective #[count]</b>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-				changelingwin = 0
+			parts += "<b>Objective #[count]</b>: [objective.explanation_text]"
 			count++
-
-	if(changelingwin)
-		parts += "<span class='greentext'>The changeling was successful!</span>"
-	else
-		parts += "<span class='redtext'>The changeling has failed.</span>"
 
 	return parts.Join("<br>")
 

--- a/code/modules/antagonists/changeling/changeling.dm
+++ b/code/modules/antagonists/changeling/changeling.dm
@@ -539,10 +539,6 @@
 /datum/antagonist/changeling/roundend_report()
 	var/list/parts = list()
 
-	var/changelingwin = 1
-	if(!owner.current)
-		changelingwin = 0
-
 	parts += printplayer(owner)
 
 	//Removed sanity if(changeling) because we -want- a runtime to inform us that the changelings list is incorrect and needs to be fixed.

--- a/code/modules/antagonists/disease/disease_datum.dm
+++ b/code/modules/antagonists/disease/disease_datum.dm
@@ -40,25 +40,15 @@
 	result += "<b>Disease name:</b> [disease_name]"
 	result += printplayer(owner)
 
-	var/win = TRUE
 	var/objectives_text = ""
-	var/count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
-			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
-		else
-			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-			win = FALSE
+			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 		count++
 
 	result += objectives_text
 
 	var/special_role_text = lowertext(name)
-
-	if(win)
-		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
-	else
-		result += "<span class='redtext'>The [special_role_text] has failed!</span>"
 
 	if(istype(owner.current, /mob/camera/disease))
 		var/mob/camera/disease/D = owner.current

--- a/code/modules/antagonists/disease/disease_datum.dm
+++ b/code/modules/antagonists/disease/disease_datum.dm
@@ -41,14 +41,13 @@
 	result += printplayer(owner)
 
 	var/objectives_text = ""
+	var/count = 1
 	for(var/datum/objective/objective in objectives)
 		if(objective.check_completion())
 			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 		count++
 
 	result += objectives_text
-
-	var/special_role_text = lowertext(name)
 
 	if(istype(owner.current, /mob/camera/disease))
 		var/mob/camera/disease/D = owner.current

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -379,8 +379,6 @@
 
 	result += objectives_text
 
-	var/special_role_text = lowertext(name)
-
 	return result.Join("<br>")
 
 /datum/antagonist/traitor/roundend_report_footer()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -367,11 +367,7 @@
 	if(objectives.len)//If the traitor had no objectives, don't need to process this.
 		var/count = 1
 		for(var/datum/objective/objective in objectives)
-			if(objective.check_completion())
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
-			else
-				objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-				traitorwin = FALSE
+			objectives_text += "<br><B>Objective #[count]</B>: [objective.explanation_text]"
 			count++
 
 	if(uplink_true)
@@ -384,12 +380,6 @@
 	result += objectives_text
 
 	var/special_role_text = lowertext(name)
-
-	if(traitorwin)
-		result += "<span class='greentext'>The [special_role_text] was successful!</span>"
-	else
-		result += "<span class='redtext'>The [special_role_text] has failed!</span>"
-		SEND_SOUND(owner.current, 'sound/ambience/ambifailure.ogg')
 
 	return result.Join("<br>")
 

--- a/code/modules/antagonists/wizard/wizard.dm
+++ b/code/modules/antagonists/wizard/wizard.dm
@@ -259,19 +259,9 @@
 	parts += printplayer(owner)
 
 	var/count = 1
-	var/wizardwin = 1
 	for(var/datum/objective/objective in objectives)
-		if(objective.check_completion())
-			parts += "<B>Objective #[count]</B>: [objective.explanation_text] <span class='greentext'>Success!</span>"
-		else
-			parts += "<B>Objective #[count]</B>: [objective.explanation_text] <span class='redtext'>Fail.</span>"
-			wizardwin = 0
+		parts += "<B>Objective #[count]</B>: [objective.explanation_text]"
 		count++
-
-	if(wizardwin)
-		parts += "<span class='greentext'>The wizard was successful!</span>"
-	else
-		parts += "<span class='redtext'>The wizard has failed!</span>"
 
 	if(owner.spell_list.len>0)
 		parts += "<B>[owner.name] used the following spells: </B>"


### PR DESCRIPTION
## About The Pull Request

Only lists antag objectives, not saying whether they succeeded or failed.

## Why It's Good For The Game

Greentext is pretty universally recognized to be unhealthy, so I've just gone and removed it here. Let's see if it improves anything or if we end up with more "ooc I GREENTEXTED Y'ALL"

## Changelog
:cl: Putnam
del: Greentext is gone
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
