### PR TITLE
Fixes raven's shuttle computer not being of the emergency shuttle type.

### DIFF
--- a/_maps/shuttles/emergency_raven.dmm
+++ b/_maps/shuttles/emergency_raven.dmm
@@ -56,7 +56,7 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ah" = (
-/obj/machinery/computer/shuttle,
+/obj/machinery/computer/emergency_shuttle,
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ai" = (


### PR DESCRIPTION
## About The Pull Request
See title.

## Why It's Good For The Game
Fixes an issue with this kind of shuttle not being early-launchable.

## Changelog
:cl:
fix: Fixed raven's shuttle computer not being of the emergency shuttle type.
/:cl:
