### PR TITLE
Ports "Roundstart borg brains no longer decay."

### DIFF
--- a/code/modules/mob/living/brain/MMI.dm
+++ b/code/modules/mob/living/brain/MMI.dm
@@ -125,6 +125,7 @@
 	else if(!brain)
 		brain = new(src)
 		brain.name = "[L.real_name]'s brain"
+	brain.organ_flags |= ORGAN_FROZEN
 
 	name = "Man-Machine Interface: [brainmob.real_name]"
 	update_icon()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -159,6 +159,7 @@
 	else if(!mmi || !mmi.brainmob)
 		mmi = new (src)
 		mmi.brain = new /obj/item/organ/brain(mmi)
+		mmi.brain.organ_flags |= ORGAN_FROZEN
 		mmi.brain.name = "[real_name]'s brain"
 		mmi.icon_state = "mmi_full"
 		mmi.name = "Man-Machine Interface: [real_name]"


### PR DESCRIPTION
## About The Pull Request
Ports tgstation PR #46042 by nemvar.
Roundstart borg brains are initialized into MMI through dark magic, thus skipping that sanity flag.

## Why It's Good For The Game
Pretty sure this will close #10106.

## Changelog
:cl: nemvar
fix: The brains of roundstart borgs no longer decay.
/:cl:
