### PR TITLE
Fixing some not safe for work oddity.

### DIFF
--- a/modular_citadel/code/modules/arousal/organs/breasts.dm
+++ b/modular_citadel/code/modules/arousal/organs/breasts.dm
@@ -119,7 +119,7 @@
 	shape = D.features["breasts_shape"]
 	fluid_id = D.features["breasts_fluid"]
 	if(!D.features["breasts_producing"])
-		DISABLE_BITFIELD(genital_flags, GENITAL_FUID_PRODUCTION)
+		DISABLE_BITFIELD(genital_flags, GENITAL_FUID_PRODUCTION|CAN_CLIMAX_WITH|CAN_MASTURBATE_WITH)
 	if(!isnum(size))
 		cached_size = breast_values[size]
 	else


### PR DESCRIPTION
## About The Pull Request
Disabling the fluid production flag effectively turns the organ into an "aesthetic" feature, interacting with failing climax attempts in a rather confusing way for the naive players.
That said I'm also disabling the other two flags to stop this awkwardness.

## Why It's Good For The Game
Improving this joke of a module beyond easier maintainability is not currently on my queue. Just fixing a minor issue.

## Changelog
I don't care about the cl here.