### PR TITLE
Allows ghost mentors to orbit around the target instead of setting their view to theirs.

### DIFF
--- a/modular_citadel/code/modules/client/client_procs.dm
+++ b/modular_citadel/code/modules/client/client_procs.dm
@@ -19,6 +19,12 @@
 			mentor_follow(M)
 		return TRUE
 
+	if(href_list["mentor_unfollow"])
+		var/mob/living/M = locate(href_list["mentor_follow"])
+		if(M && mentor_datum.following == M)
+			mentor_unfollow()
+		return TRUE
+
 /client/proc/mentor_datum_set(admin)
 	mentor_datum = GLOB.mentor_datums[ckey]
 	if(!mentor_datum && check_rights_for(src, R_ADMIN,0)) // admin with no mentor datum?let's fix that

--- a/modular_citadel/code/modules/mentor/follow.dm
+++ b/modular_citadel/code/modules/mentor/follow.dm
@@ -1,16 +1,18 @@
 /client/proc/mentor_follow(mob/living/M)
 	if(!is_mentor())
 		return
-	if(isnull(M))
-		return
-	if(!ismob(usr))
-		return
-	mentor_datum.following = M
-	usr.reset_perspective(M)
-	verbs += /client/proc/mentor_unfollow
-	to_chat(GLOB.admins, "<span class='mentor'><span class='prefix'>MENTOR:</span> <EM>[key_name(usr)]</EM> is now following <EM>[key_name(M)]</span>")
-	to_chat(usr, "<span class='info'>Click the \"Stop Following\" button in the Mentor tab to stop following [key_name(M)].</span>")
-	log_mentor("[key_name(usr)] began following [key_name(M)]")
+	var/orbiting = TRUE
+	if(!isobserver(usr))
+		mentor_datum.following = M
+		usr.reset_perspective(M)
+		verbs += /client/proc/mentor_unfollow
+		to_chat(usr, "<span class='info'>Click the <a href='?_src_=mentor;mentor_unfollow=[REF(M)];[MentorHrefToken(TRUE)]'>\"Stop Following\"</a> button here or in the Mentor tab to stop following [key_name(M)].</span>")
+		orbiting = FALSE
+	else
+		var/mob/dead/observer/O = usr
+		O.ManualFollow(M)
+	to_chat(GLOB.admins, "<span class='mentor'><span class='prefix'>MENTOR:</span> <EM>[key_name(usr)]</EM> is now [orbiting ? "orbiting" : "following"] <EM>[key_name(M)][key_name(M)][orbiting ? " as a ghost" : ""].</span>")
+	log_mentor("[key_name(usr)] [orbiting ? "is now orbiting" : "began following"][key_name(M)][orbiting ? " as a ghost" : ""].")
 
 /client/proc/mentor_unfollow()
 	set category = "Mentor"
@@ -21,6 +23,6 @@
 		return
 	usr.reset_perspective()
 	verbs -= /client/proc/mentor_unfollow
-	to_chat(GLOB.admins, "<span class='mentor'><span class='prefix'>MENTOR:</span> <EM>[key_name(usr)]</EM> is no longer following <EM>[key_name(mentor_datum.following)]</span>")
-	log_mentor("[key_name(usr)] stopped following [key_name(mentor_datum.following)]")
+	to_chat(GLOB.admins, "<span class='mentor'><span class='prefix'>MENTOR:</span> <EM>[key_name(usr)]</EM> is no longer following <EM>[key_name(mentor_datum.following)].</span>")
+	log_mentor("[key_name(usr)] stopped following [key_name(mentor_datum.following)].")
 	mentor_datum.following = null

--- a/modular_citadel/code/modules/mentor/mentorhelp.dm
+++ b/modular_citadel/code/modules/mentor/mentorhelp.dm
@@ -19,7 +19,7 @@
 	log_mentor("MENTORHELP: [key_name_mentor(src, 0, 0, 0, 0)]: [msg]")
 
 	for(var/client/X in GLOB.mentors | GLOB.admins)
-		X << 'sound/items/bikehorn.ogg'
+		SEND_SOUND(X, 'sound/items/bikehorn.ogg')
 		to_chat(X, mentor_msg)
 
 	to_chat(src, "<span class='mentornotice'><font color='purple'>PM to-<b>Mentors</b>: [msg]</font></span>")


### PR DESCRIPTION
## About The Pull Request
A little inconsistency with mentors, being the little snowflake old not admin datums they are, their follow function differs from admins'.
I'm not going to grant them admin-ghost capabilities here nor sanitize these catacombs, but to provide mentors some QoL.

## Why It's Good For The Game
Just here to close #8339.

## Changelog
:cl:
admin: Ghost mentors can now orbit around the target instead of setting their view to theirs'.
/:cl:
