### PR TITLE
Who the fuck put 10 shielding when you need 9?

### DIFF
--- a/code/modules/cargo/packs/engine.dm
+++ b/code/modules/cargo/packs/engine.dm
@@ -27,7 +27,7 @@
 
 /datum/supply_pack/engine/am_shielding
 	name = "Antimatter Shielding Crate"
-	desc = "Contains ten Antimatter shields, somehow crammed into a crate."
+	desc = "Contains nine Antimatter shields, somehow crammed into a crate."
 	cost = 2500
 	contains = list(/obj/item/am_shielding_container,
 					/obj/item/am_shielding_container,
@@ -37,8 +37,7 @@
 					/obj/item/am_shielding_container,
 					/obj/item/am_shielding_container,
 					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container,
-					/obj/item/am_shielding_container) //10 shields: 3x3 containment and a core
+					/obj/item/am_shielding_container) //9 shields: 3x3 containment and a core
 	crate_name = "antimatter shielding crate"
 
 /datum/supply_pack/engine/emitter


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This remove an extra Antimatter Shielding from the AM Shielding Crate

## Why It's Good For The Game

You need 9 shielding to make an engine, and from the comment "10 shields: 3x3 containment and a core", it seem that the one who did it didn't understood that the shielding is a core.

Another shielding don't do anything, unless you want to do multiple engines, which then you get an extra one for every 9 crate you order.

## Changelog
:cl:
del: Removed a AM Shielding from the crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
