### PR TITLE
Fixes ranged syndicate mobs stormtrooper training: The port.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/hostile.dm
+++ b/code/modules/mob/living/simple_animal/hostile/hostile.dm
@@ -427,7 +427,7 @@
 	if(casingtype)
 		var/obj/item/ammo_casing/casing = new casingtype(startloc)
 		playsound(src, projectilesound, 100, 1)
-		casing.fire_casing(targeted_atom, src, null, null, null, ran_zone(), src)
+		casing.fire_casing(targeted_atom, src, null, null, null, ran_zone(), 0, src)
 	else if(projectiletype)
 		var/obj/item/projectile/P = new projectiletype(startloc)
 		playsound(src, projectilesound, 100, 1)


### PR DESCRIPTION
## About The Pull Request
Basically tgstation PR #44700 by AnturK. Even though I was just double checking to confirm my thoughts on the source of this issue.
Basically mending what's been broken by extra fantasy suffixes' components.

## Why It's Good For The Game
Fixing a month old issue BlackMajor just pinged me about.

## Changelog
:cl: AnturK
fix: Fixed ranged syndicate mobs stormtrooper training.
/:cl:
