### PR TITLE
Nukies and deathsquaddies can now finally fix their mechs internal fires

### DIFF
--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -265,6 +265,7 @@
 	armor = list("melee" = 40, "bullet" = 40, "laser" = 50, "energy" = 35, "bomb" = 20, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 100)
 	max_temperature = 35000
 	operation_req_access = list(ACCESS_SYNDICATE)
+	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/honker/dark
 	max_equip = 3
 	spawn_tracked = FALSE

--- a/code/game/mecha/combat/gygax.dm
+++ b/code/game/mecha/combat/gygax.dm
@@ -27,6 +27,7 @@
 	max_temperature = 35000
 	leg_overload_coeff = 100
 	operation_req_access = list(ACCESS_SYNDICATE)
+	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/gygax/dark
 	max_equip = 4
 	spawn_tracked = FALSE

--- a/code/game/mecha/combat/honker.dm
+++ b/code/game/mecha/combat/honker.dm
@@ -10,6 +10,7 @@
 	max_temperature = 25000
 	infra_luminosity = 5
 	operation_req_access = list(ACCESS_THEATRE)
+	internals_req_access = list(ACCESS_THEATRE, ACCESS_ROBOTICS)
 	wreckage = /obj/structure/mecha_wreckage/honker
 	add_req_access = 0
 	max_equip = 3

--- a/code/game/mecha/combat/marauder.dm
+++ b/code/game/mecha/combat/marauder.dm
@@ -10,6 +10,7 @@
 	resistance_flags = LAVA_PROOF | FIRE_PROOF | ACID_PROOF
 	infra_luminosity = 3
 	operation_req_access = list(ACCESS_CENT_SPECOPS)
+	internals_req_access = list(ACCESS_CENT_SPECOPS, ACCESS_ROBOTICS)
 	wreckage = /obj/structure/mecha_wreckage/marauder
 	add_req_access = 0
 	internal_damage_threshold = 25
@@ -46,6 +47,7 @@
 	name = "\improper Seraph"
 	icon_state = "seraph"
 	operation_req_access = list(ACCESS_CENT_SPECOPS)
+	internals_req_access = list(ACCESS_CENT_SPECOPS, ACCESS_ROBOTICS)
 	step_in = 3
 	max_integrity = 550
 	wreckage = /obj/structure/mecha_wreckage/seraph
@@ -72,6 +74,7 @@
 	name = "\improper Mauler"
 	icon_state = "mauler"
 	operation_req_access = list(ACCESS_SYNDICATE)
+	internals_req_access = list(ACCESS_SYNDICATE)
 	wreckage = /obj/structure/mecha_wreckage/mauler
 	max_equip = 5
 

--- a/code/game/mecha/combat/neovgre.dm
+++ b/code/game/mecha/combat/neovgre.dm
@@ -12,6 +12,8 @@
 	layer = ABOVE_MOB_LAYER
 	breach_time = 100 //ten seconds till all goes to shit
 	recharge_rate = 100
+	internals_req_access = list()
+	add_req_access = 0
 	wreckage = /obj/structure/mecha_wreckage/durand/neovgre
 	spawn_tracked = FALSE
 

--- a/code/game/mecha/combat/reticence.dm
+++ b/code/game/mecha/combat/reticence.dm
@@ -10,6 +10,7 @@
 	max_temperature = 15000
 	wreckage = /obj/structure/mecha_wreckage/reticence
 	operation_req_access = list(ACCESS_THEATRE)
+	internals_req_access = list(ACCESS_THEATRE, ACCESS_ROBOTICS)
 	add_req_access = 0
 	internal_damage_threshold = 25
 	max_equip = 2

--- a/code/game/mecha/mecha.dm
+++ b/code/game/mecha/mecha.dm
@@ -68,7 +68,7 @@
 	var/internal_damage = 0 //contains bitflags
 
 	var/list/operation_req_access = list()//required access level for mecha operation
-	var/list/internals_req_access = list(ACCESS_ENGINE,ACCESS_ROBOTICS)//REQUIRED ACCESS LEVEL TO OPEN CELL COMPARTMENT
+	var/list/internals_req_access = list(ACCESS_ROBOTICS)//REQUIRED ACCESS LEVEL TO OPEN CELL COMPARTMENT
 
 	var/wreckage
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This changes up mech internals access (the access required to initiate maintenance protocols to swap cells / fix internal damage) of special mechs to include their likely owners, making it e.g. nukies can fix up their mechs without having to steal a robotics ID... 
Also removed engineers / anyone with engine access from engaging maint protocols on mechs because thats robotics' job anyways.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Currently, if you get a malfunction as for example nukies, you are pretty much dead since you can't fix it until you steal a robotics ID. Thats pretty annoying and I believe its good to have special factions have access to their own mechs which the normal roboticists willl prooobably have a problem with.
Also Engineering having access to mech maint protocols seems like a old remnant and thats robotics' job anyways, so I don't think it'd nagativly affect anything by removing their access. If you have a problem with that part, tell me, the engi access thingy isn't my main focus for this PR anyways, just thought it should be adressed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed mecha internals access for some special mechs.
tweak: no more mech maintenance access for engineers.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
