### PR TITLE
Cargo shuttle now silently leaves behind slaughter demons + revenants

### DIFF
--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,6 +26,13 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,
 		/obj/item/hilbertshotel
+	))
+	- typecacheof(list(/mob/living/simple_animal/revenant, /mob/living/simple_animal/slaughter))	//These things have snowflake handling.
+	)
+
+GLOBAL_LIST_INIT(cargo_shuttle_leave_behind_typecache, typecacheof(list(
+	/mob/living/simple_animal/revenant,
+	/mob/living/simple_animal/slaughter
 	)))
 
 /obj/docking_port/mobile/supply
@@ -50,16 +57,27 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 
 /obj/docking_port/mobile/supply/canMove()
 	if(is_station_level(z))
-		return check_blacklist(shuttle_areas)
+		return check_blacklist(shuttle_areas, GLOB.blacklisted_cargo_types)
 	return ..()
 
-/obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances)
+/obj/docking_port/mobile/supply/enterTransit()
+	var/list/leave_behind = list()
+	for(var/i in check_blacklist(shuttle_areas, GLOB.cargo_shuttle_leave_behind_typecache))
+		var/atom/movable/AM = i
+		leave_behind[AM] = AM.loc
+	. = ..()
+	for(var/kicked in leave_behind)
+		var/atom/movable/victim = kicked
+		var/atom/oldloc = leave_behind[victim]
+		victim.forceMove(oldloc)
+
+/obj/docking_port/mobile/supply/proc/check_blacklist(areaInstances, list/typecache)
 	for(var/place in areaInstances)
 		var/area/shuttle/shuttle_area = place
 		for(var/trf in shuttle_area)
 			var/turf/T = trf
 			for(var/a in T.GetAllContents())
-				if(is_type_in_typecache(a, GLOB.blacklisted_cargo_types))
+				if(is_type_in_typecache(a, typecache))
 					return FALSE
 				if(istype(a, /obj/structure/closet))//Prevents eigenlockers from ending up at CC
 					var/obj/structure/closet/c = a

--- a/code/modules/shuttle/supply.dm
+++ b/code/modules/shuttle/supply.dm
@@ -26,9 +26,7 @@ GLOBAL_LIST_INIT(blacklisted_cargo_types, typecacheof(list(
 		/obj/structure/extraction_point,
 		/obj/machinery/syndicatebomb,
 		/obj/item/hilbertshotel
-	))
-	- typecacheof(list(/mob/living/simple_animal/revenant, /mob/living/simple_animal/slaughter))	//These things have snowflake handling.
-	)
+	)))
 
 GLOBAL_LIST_INIT(cargo_shuttle_leave_behind_typecache, typecacheof(list(
 	/mob/living/simple_animal/revenant,
@@ -57,7 +55,7 @@ GLOBAL_LIST_INIT(cargo_shuttle_leave_behind_typecache, typecacheof(list(
 
 /obj/docking_port/mobile/supply/canMove()
 	if(is_station_level(z))
-		return check_blacklist(shuttle_areas, GLOB.blacklisted_cargo_types)
+		return check_blacklist(shuttle_areas, GLOB.blacklisted_cargo_types - GLOB.cargo_shuttle_leave_behind_typecache)
 	return ..()
 
 /obj/docking_port/mobile/supply/enterTransit()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

tin

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Something about untouchable mobs blocking the supply shuttle (and no, "break all the walls and apply salt" has been considered already)

## Changelog
:cl:
add: Cargo shuttle now silently ignores slaughter demons/revenants instead of being blocked even while they are jaunted. A drawback is that manifested ones can't block it either, any more.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
