### PR TITLE
Brings carbon action intent hotkeys down to living.

### DIFF
--- a/code/modules/keybindings/bindings_carbon.dm
+++ b/code/modules/keybindings/bindings_carbon.dm
@@ -3,18 +3,6 @@
 		if("R", "Southwest") // Southwest is End
 			toggle_throw_mode()
 			return
-		if("1")
-			a_intent_change("help")
-			return
-		if("2")
-			a_intent_change("disarm")
-			return
-		if("3")
-			a_intent_change("grab")
-			return
-		if("4")
-			a_intent_change("harm")
-			return
 		if("C")
 			toggle_combat_mode()
 			return

--- a/code/modules/keybindings/bindings_living.dm
+++ b/code/modules/keybindings/bindings_living.dm
@@ -3,5 +3,22 @@
 		if("B")
 			resist()
 			return
+		if("1")
+			if(possible_a_intents)
+				a_intent_change(INTENT_HELP)
+				return
+		if("2")
+			if(possible_a_intents)
+				a_intent_change(INTENT_DISARM)
+				return
+		if("3")
+			if(possible_a_intents)
+				a_intent_change(INTENT_GRAB)
+				return
+		if("4")
+			if(possible_a_intents)
+				a_intent_change(INTENT_HARM)
+				return
+
 
 	return ..()


### PR DESCRIPTION
## About The Pull Request
Considering action intents have living mob level of supports, I assume the hotkeys should too.
Don't worry about silicons, this won't override their keybindings.

## Why It's Good For The Game
This will close #9937. Someone should port customizable keybindings by the by, assuming it's stable now.

## Changelog
:cl:
fix: dextrous simplemobs can now swap action intent with 1, 2, 3, 4 now. Just like humies, ayys and monkys.
/:cl:
