### PR TITLE
Nerfing radioactive contamination

### DIFF
--- a/code/datums/radiation_wave.dm
+++ b/code/datums/radiation_wave.dm
@@ -3,6 +3,7 @@
 	var/turf/master_turf //The center of the wave
 	var/steps=0 //How far we've moved
 	var/intensity //How strong it was originaly
+	var/remaining_contam //How much contaminated material it still has
 	var/range_modifier //Higher than 1 makes it drop off faster, 0.5 makes it drop off half etc
 	var/move_dir //The direction of movement
 	var/list/__dirs //The directions to the side of the wave, stored for easy looping
@@ -18,6 +19,7 @@
 	__dirs+=turn(dir, -90)
 
 	intensity = _intensity
+	remaining_contam = intensity
 	range_modifier = _range_modifier
 	can_contaminate = _can_contaminate
 
@@ -46,8 +48,9 @@
 		qdel(src)
 		return
 
-	radiate(atoms, FLOOR(strength, 1))
-
+	if(radiate(atoms, FLOOR(min(strength,remaining_contam), 1)))
+		//oof ow ouch
+		remaining_contam = max(0,remaining_contam-((min(strength,remaining_contam)-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT))
 	check_obstructions(atoms) // reduce our overall strength if there are radiation insulators
 
 /datum/radiation_wave/proc/get_rad_atoms()
@@ -89,7 +92,8 @@
 			intensity *= (1-((1-thing.rad_insulation)/width))
 
 /datum/radiation_wave/proc/radiate(list/atoms, strength)
-	var/contamination_chance = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_CHANCE_COEFFICIENT * min(1, 1/(steps*range_modifier))
+	var/can_contam = strength >= RAD_MINIMUM_CONTAMINATION
+	var/list/contam_atoms = list()
 	for(var/k in 1 to atoms.len)
 		var/atom/thing = atoms[k]
 		if(!thing)
@@ -109,8 +113,14 @@
 			))
 		if(!can_contaminate || blacklisted[thing.type])
 			continue
-		if(prob(contamination_chance)) // Only stronk rads get to have little baby rads
-			if(CHECK_BITFIELD(thing.rad_flags, RAD_NO_CONTAMINATE) || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
-				continue
-			var/rad_strength = (strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT
+		if(CHECK_BITFIELD(thing.rad_flags, RAD_NO_CONTAMINATE) || SEND_SIGNAL(thing, COMSIG_ATOM_RAD_CONTAMINATING, strength) & COMPONENT_BLOCK_CONTAMINATION)
+			continue
+		contam_atoms += thing
+	var/did_contam = 0
+	if(can_contam)
+		var/rad_strength = ((strength-RAD_MINIMUM_CONTAMINATION) * RAD_CONTAMINATION_STR_COEFFICIENT)/contam_atoms.len
+		for(var/k in 1 to contam_atoms.len)
+			var/atom/thing = contam_atoms[k]
 			thing.AddComponent(/datum/component/radioactive, rad_strength, source)
+			did_contam = 1
+	return did_contam


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

This nerfs radioactive contamination by making it STRICTLY reducing over time--no more back-and-forth contamination infinitely increasing forever despite conservation of energy and radiation NOT WORKING THAT WAY. It does this by doing the following:

1. Radiation waves now keep track of how much contamination they've laid down on things and will stop contaminating as soon as they run out.
2. Rather than contaminating every single atom on a tile with full strength, it contaminates each of them proportionally to how many atoms there are on the tile--for example, if there are 5 atoms on a tile, each atom will get 1/5 as much contamination as if there were only 1.

Also makes contamination no longer random--a rad pulse of sufficient strength will always contaminate a certain amount, no RNG element to it whatsoever. 

## Why It's Good For The Game

Radioactive contamination is almost always simply a bad meme. It's a complete pain in the ass to fix, is too easy to cause and leads to a bunch of really dumb stuff like supermatters making 10x as much power as they should because the chamber has been filled with monkeys. It should be noted that this doesn't *completely* destroy those strats; monkeys hold onto radioactive contamination while turfs don't, so they allow pulses to "linger" for longer, but it should no longer be the be-all-end-all of supermatter power.

## Changelog
:cl: Putnam
balance: Contamination is no longer an infinitely spreading deadly contagion causing mass panic
/:cl: