### PR TITLE
flashbangs process flash/bang separately based on blindness/hearing and uses viewers(), which means xray users suffer too if they see them go off

### DIFF
--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -15,8 +15,6 @@
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
 	flashbang_mobs(flashbang_turf, flashbang_range)
-	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
-		bang(get_turf(M), M)
 	qdel(src)
 
 /obj/item/grenade/flashbang/proc/flashbang_mobs(turf/source, range)

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -41,7 +41,6 @@
 /obj/item/grenade/flashbang/proc/flash(mob/living/M, turf/source)
 	if(M.stat == DEAD)	//They're dead!
 		return
-	var/distance = get_dist(get_turf(M, source))
+	var/distance = get_dist(get_turf(M), source)
 	if(M.flash_act(affect_silicon = 1))
 		M.Knockdown(max(200/max(1,distance), 60))
-

--- a/code/game/objects/items/grenades/flashbang.dm
+++ b/code/game/objects/items/grenades/flashbang.dm
@@ -14,23 +14,34 @@
 	do_sparks(rand(5, 9), FALSE, src)
 	playsound(flashbang_turf, 'sound/weapons/flashbang.ogg', 100, TRUE, 8, 0.9)
 	new /obj/effect/dummy/lighting_obj (flashbang_turf, LIGHT_COLOR_WHITE, (flashbang_range + 2), 4, 2)
+	flashbang_mobs(flashbang_turf, flashbang_range)
 	for(var/mob/living/M in get_hearers_in_view(flashbang_range, flashbang_turf))
 		bang(get_turf(M), M)
 	qdel(src)
 
-/obj/item/grenade/flashbang/proc/bang(turf/T , mob/living/M)
+/obj/item/grenade/flashbang/proc/flashbang_mobs(turf/source, range)
+	var/list/banged = get_hearers_in_view(range, source)
+	var/list/flashed = viewers(range, source)
+	for(var/i in banged)
+		bang(i, source)
+	for(var/i in flashed)
+		flash(i, source)
+
+/obj/item/grenade/flashbang/proc/bang(mob/living/M, turf/source)
 	if(M.stat == DEAD)	//They're dead!
 		return
 	M.show_message("<span class='warning'>BANG</span>", MSG_AUDIBLE)
-	var/distance = max(0,get_dist(get_turf(src),T))
-
-//Flash
-	if(M.flash_act(affect_silicon = 1))
-		M.Knockdown(max(200/max(1,distance), 60))
-//Bang
+	var/distance = get_dist(get_turf(M), source)
 	if(!distance || loc == M || loc == M.loc)	//Stop allahu akbarring rooms with this.
 		M.Knockdown(200)
 		M.soundbang_act(1, 200, 10, 15)
-
 	else
 		M.soundbang_act(1, max(200/max(1,distance), 60), rand(0, 5))
+
+/obj/item/grenade/flashbang/proc/flash(mob/living/M, turf/source)
+	if(M.stat == DEAD)	//They're dead!
+		return
+	var/distance = get_dist(get_turf(M, source))
+	if(M.flash_act(affect_silicon = 1))
+		M.Knockdown(max(200/max(1,distance), 60))
+


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tin

## Why It's Good For The Game

a fun way to nerf x-ray and make flashbangs more consistent

## Changelog
:cl:
balance: flashbangs process light/sound separately and uses viewers(), so xray users beware.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
