### PR TITLE
Stops humanoids whose skin_tone variable is set to "albino" from showing up as pale when examined should their species not use skintones anyway.

### DIFF
--- a/code/modules/antagonists/bloodsucker/bloodsucker_integration.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_integration.dm
@@ -128,7 +128,7 @@
 
 /mob/living/carbon/human/ShowAsPaleExamine()
 	// Check for albino, as per human/examine.dm's check.
-	if(skin_tone == "albino")
+	if(dna.species.use_skintones && skin_tone == "albino")
 		return TRUE
 
 	return ..() // Return vamp check


### PR DESCRIPTION
## About The Pull Request
To be honest I'd like to stop most antropomorphs from showing up as pale regardless of circumstances, but the players wouldn't appreciate such a "fuck you" change.

## Why It's Good For The Game
This will close #10236.

## Changelog
:cl:
fix: Stops humanoids whose skin_tone variable is set to "albino" from showing up as pale when examined should their species not use skintones anyway.
/:cl:
