### PR TITLE
Fixing a few consistency issues with Nightmares.

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -51,11 +51,7 @@
 	. = ..()
 	to_chat(C, "[info_text]")
 
-	C.real_name = "[pick(GLOB.nightmare_names)]"
-	C.name = C.real_name
-	if(C.mind)
-		C.mind.name = C.real_name
-	C.dna.real_name = C.real_name
+	C.fully_replace_character_name("[pick(GLOB.nightmare_names)]")
 
 /datum/species/shadow/nightmare/bullet_act(obj/item/projectile/P, mob/living/carbon/human/H)
 	var/turf/T = H.loc
@@ -127,8 +123,8 @@
 /obj/item/organ/heart/nightmare/Remove(mob/living/carbon/M, special = 0)
 	respawn_progress = 0
 	if(blade && special != HEART_SPECIAL_SHADOWIFY)
-		QDEL_NULL(blade)
 		M.visible_message("<span class='warning'>\The [blade] disintegrates!</span>")
+		QDEL_NULL(blade)
 	..()
 
 /obj/item/organ/heart/nightmare/Stop()
@@ -183,15 +179,21 @@
 	. = ..()
 	if(!proximity)
 		return
-	if(isopenturf(AM)) //So you can actually melee with it
-		return
-	if(isliving(AM))
+	if(isopenturf(AM))
+		var/turf/open/T = AM
+		if(T.light_range && !isspaceturf(T)) //no fairy grass or light tile can escape the fury of the darkness.
+			to_chat(user, "<span class='notice'>You scrape away [T] with your [name] and snuff out its lights.</span>")
+			T.ScrapeAway(flags = CHANGETURF_INHERIT_AIR)
+	else if(isliving(AM))
 		var/mob/living/L = AM
 		if(iscyborg(AM))
 			var/mob/living/silicon/robot/borg = AM
-			if(!borg.lamp_cooldown)
+			if(borg.lamp_intensity)
 				borg.update_headlamp(TRUE, INFINITY)
 				to_chat(borg, "<span class='danger'>Your headlamp is fried! You'll need a human to help replace it.</span>")
+			for(var/obj/item/assembly/flash/cyborg/F in borg.held_items)
+				if(!F.crit_fail)
+					F.burn_out()
 		else
 			for(var/obj/item/O in AM)
 				if(O.light_range && O.light_power)


### PR DESCRIPTION
## About The Pull Request
Allows nightmares to scrape away open turfs with light range, such as light tiles or fairy grass.
Fixes nightmares being unable to kill borg lamps, also allows them to burn out flashes they may be holding.
And ports tgstation PRs #43164 (well, half of it) and #45349 by AnturK and Arkatos.

## Why It's Good For The Game
Fixing some issues. This will close #10226 and close #10211.

## Changelog
:cl: Ghommie (also porting PRs by AnturK and Arkatos)
fix: Fixed light eaters not burning out borg lamplights and flashes.
fix Fixed light eater not affecting open turfs emitting lights such as light tiles and fairy grass.
fix: Fixed an empty reference about light eater armblade disintegration after Heart of Darkness removal.
/:cl:
