### PR TITLE
Makes mob/Stat on a 1 second timer rather than fast-as-possible to tone down highpop lag

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -568,7 +568,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 
 /mob/Stat(delayoverride)
 	. = ..()
-	var/statdelay = delayoverride || 20
+	var/statdelay = delayoverride || 10
 	if(statpanel("Status"))
 		if (client)
 			stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -567,8 +567,8 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	return 0
 
 /mob/Stat()
-	..()
-
+	. = ..()
+	var/statdelay = 20
 	if(statpanel("Status"))
 		if (client)
 			stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")
@@ -576,7 +576,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		var/datum/map_config/cached = SSmapping.next_map_config
 		if(cached)
 			stat(null, "Next Map: [cached.map_name]")
-		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
+		stat(null, "Round ID: [GLOB.round_id || "NULL"]")
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
 		stat(null, "Round Time: [WORLDTIME2TEXT("hh:mm:ss")]")
 		stat(null, "Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss")]")
@@ -586,8 +586,9 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 			if(ETA)
 				stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")
 
-	if(client && client.holder)
+	if(client?.holder)
 		if(statpanel("MC"))
+			statdelay = 0		//It's assumed that if you're doing this you are doing debug stuff, don't do ioditic things.
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))
 			stat("CPU:", "[world.cpu]")
@@ -613,6 +614,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 			GLOB.ahelp_tickets.stat_entry()
 		if(length(GLOB.sdql2_queries))
 			if(statpanel("SDQL2"))
+				statdelay = 0		//It's assumed that if you're doing this you are doing debug stuff, don't do ioditic things.
 				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
 				for(var/i in GLOB.sdql2_queries)
 					var/datum/SDQL2_query/Q = i
@@ -636,14 +638,13 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 				if(A.IsObscured())
 					continue
 				statpanel(listed_turf.name, null, A)
-
-
 	if(mind)
 		add_spells_to_statpanel(mind.spell_list)
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling)
 			add_stings_to_statpanel(changeling.purchasedpowers)
 	add_spells_to_statpanel(mob_spell_list)
+	sleep(statdelay)
 
 /mob/proc/add_spells_to_statpanel(list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -566,9 +566,9 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 /mob/proc/is_muzzled()
 	return 0
 
-/mob/Stat()
+/mob/Stat(delayoverride)
 	. = ..()
-	var/statdelay = 20
+	var/statdelay = delayoverride || 20
 	if(statpanel("Status"))
 		if (client)
 			stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

Admins on MC/SDQL2 panel get an exception because with those you need updates as fast as possible.
Updating stat for 80 players at once is untenable. Yes, we have worse lag issues, but honestly this isn't bad enough that we need to keep this at an as-fast-as-possible rate.

## Changelog
:cl:
tweak: Stat() slowed down for anti-lag measures.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
