### PR TITLE
Restores function to the hound modules' tongues and noses

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -137,11 +137,11 @@
 		rebuild_modules()
 	return I
 
-//Adds flavoursome dogborg items to dogborg variants without mechanical benefits
+//Sleepers are purely flavor, the tongue and nose are functional
 /obj/item/robot_module/proc/dogborg_equip()
-	var/obj/item/I = new /obj/item/analyzer/nose/flavour(src)
+	var/obj/item/I = new /obj/item/analyzer/nose(src)
 	basic_modules += I
-	I = new /obj/item/soap/tongue/flavour(src)
+	I = new /obj/item/soap/tongue(src)
 	basic_modules += I
 	I = new /obj/item/dogborg/sleeper/K9/flavour(src)
 	if(istype(src, /obj/item/robot_module/engineering))


### PR DESCRIPTION
## About The Pull Request

Dogborgs now get their functional noses and tongues back. Bellies are still scene-only.

## Why It's Good For The Game

The unique flavor of the hound modules is important to preserve. Destroying interesting and appropriately flavorful mechanics from hound modules in order to standardize silicons is misguided, and only creates a situation where the role loses some of its draw in order to satisfy no-one. 

These features are limited in their use, but satisfying and fun to bring into play when the opportunity arises, and removing them was a mistake. 

## Changelog
:cl:
tweak: Dogborg tongues and noses are now functional again
/:cl:
