### PR TITLE
Makes cultist coats hold respective items, can actually make them and adds cosmetic versions to the loadout

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -67,7 +67,9 @@
 		/obj/item/clothing/shoes/kindleKicks = ARCADE_WEIGHT_RARE,
 		/obj/item/storage/belt/military/snack = ARCADE_WEIGHT_RARE,
 
-		/obj/item/clothing/mask/fakemoustache/italian = ARCADE_WEIGHT_RARE
+		/obj/item/clothing/mask/fakemoustache/italian = ARCADE_WEIGHT_RARE,
+		/obj/item/clothing/suit/hooded/wintercoat/ratvar/fake = ARCADE_WEIGHT_TRICK,
+		/obj/item/clothing/suit/hooded/wintercoat/narsie/fake = ARCADE_WEIGHT_TRICK
 	)
 
 	light_color = LIGHT_COLOR_GREEN

--- a/code/modules/antagonists/clockcult/clock_helpers/fabrication_helpers.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/fabrication_helpers.dm
@@ -345,3 +345,8 @@
 	if(!power_amount)
 		power_amount = -(CLOCKCULT_POWER_UNIT*0.02)
 	return ..()
+
+
+// Winter coat
+/obj/item/clothing/suit/hooded/wintercoat/fabrication_vals(mob/living/user, obj/item/clockwork/replica_fabricator/fabricator, silent) //four sheets of metal
+	return list("operation_time" = 30, "new_obj_type" = /obj/item/clothing/suit/hooded/wintercoat/ratvar, "power_cost" = POWER_METAL * 4, "spawn_dir" = SOUTH)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -589,6 +589,7 @@
 			var/obj/item/clothing/suit/hooded/wintercoat/candidate = target
 			if (do_after(user,30,target=candidate))
 				new /obj/item/clothing/suit/hooded/wintercoat/narsie(T)
+				qdel(candidate)
 				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the winter coat, transforming it into a narsian winter coat!</span>")
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else if(istype(target,/mob/living/silicon/robot))

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -585,6 +585,12 @@
 				new /obj/item/stack/sheet/runed_metal(T,quantity)
 				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
+		if(istype(target, /obj/item/clothing/suit/hooded/wintercoat))
+			var/obj/item/clothing/suit/hooded/wintercoat/candidate = target
+			if (do_after(user,30,target=candidate))
+				new /obj/item/clothing/suit/hooded/wintercoat/narsie(T)
+				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the winter coat, transforming it into a narsian winter coat!</span>")
+				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else if(istype(target,/mob/living/silicon/robot))
 			var/mob/living/silicon/robot/candidate = target
 			if(candidate.mmi)

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -585,12 +585,11 @@
 				new /obj/item/stack/sheet/runed_metal(T,quantity)
 				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the plasteel, transforming it into runed metal!</span>")
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
-		if(istype(target, /obj/item/clothing/suit/hooded/wintercoat))
-			var/obj/item/clothing/suit/hooded/wintercoat/candidate = target
-			if (do_after(user,30,target=candidate))
+		if(istype(target, /obj/item/clothing/suit/hooded/wintercoat) && target.type != /obj/item/clothing/suit/hooded/wintercoat/narsie)
+			if (do_after(user,30,target=target))
 				new /obj/item/clothing/suit/hooded/wintercoat/narsie(T)
-				qdel(candidate)
-				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around the winter coat, transforming it into a narsian winter coat!</span>")
+				qdel(target)
+				to_chat(user, "<span class='warning'>A dark cloud emanates from you hand and swirls around [target], transforming it into a narsian winter coat!</span>")
 				SEND_SOUND(user, sound('sound/effects/magic.ogg',0,1,25))
 		else if(istype(target,/mob/living/silicon/robot))
 			var/mob/living/silicon/robot/candidate = target

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -763,7 +763,7 @@
 	name = "ratvarian winter coat"
 	icon_state = "coatratvar"
 	item_state = "coatratvar"
-	armor = list("melee" = 30, "bullet" = 20, "laser" = 0,"energy" = 10, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 30, "acid" = 30)
+	armor = list("melee" = 30, "bullet" = 45, "laser" = -10, "energy" = 0, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 60, "acid" = 60)
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/clockwork/replica_fabricator, /obj/item/clockwork/integration_cog, /obj/item/clockwork/slab, /obj/item/clockwork/weapon/ratvarian_spear)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/ratvar
 	var/real = TRUE

--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -742,6 +742,7 @@
 	name = "assistant's formal winter coat"
 	icon_state = "coataformal"
 	item_state = "coataformal"
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter,/obj/item/clothing/gloves/color/yellow)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/aformal
 
 /obj/item/clothing/head/hooded/winterhood/aformal
@@ -762,7 +763,10 @@
 	name = "ratvarian winter coat"
 	icon_state = "coatratvar"
 	item_state = "coatratvar"
+	armor = list("melee" = 30, "bullet" = 20, "laser" = 0,"energy" = 10, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 30, "acid" = 30)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/clockwork/replica_fabricator, /obj/item/clockwork/integration_cog, /obj/item/clockwork/slab, /obj/item/clockwork/weapon/ratvarian_spear)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/ratvar
+	var/real = TRUE
 
 /obj/item/clothing/head/hooded/winterhood/ratvar
 	icon_state = "winterhood_ratvar"
@@ -770,14 +774,58 @@
 	light_power = 1
 	light_color = "#B18B25" //clockwork slab background top color
 
+/obj/item/clothing/suit/hooded/wintercoat/ratvar/equipped(mob/living/user,slot)
+	..()
+	if (slot != SLOT_WEAR_SUIT || !real)
+		return
+	if (is_servant_of_ratvar(user))
+		return
+	else
+		user.dropItemToGround(src)
+		to_chat(user,"<span class='large_brass'>\"Amusing that you think you are fit to wear this.\"</span>")
+		to_chat(user,"<span class='userdanger'>Your skin burns where the coat touched your skin!</span>")
+		user.adjustFireLoss(rand(10,16))
+
 /obj/item/clothing/suit/hooded/wintercoat/narsie
 	name = "narsian winter coat"
 	icon_state = "coatnarsie"
 	item_state = "coatnarsie"
+	armor = list("melee" = 30, "bullet" = 20, "laser" = 30,"energy" = 10, "bomb" = 30, "bio" = 10, "rad" = 10, "fire" = 30, "acid" = 30)
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter, /obj/item/restraints/legcuffs/bola/cult,/obj/item/melee/cultblade,/obj/item/melee/cultblade/dagger,/obj/item/reagent_containers/glass/beaker/unholywater,/obj/item/cult_shift,/obj/item/flashlight/flare/culttorch,/obj/item/twohanded/cult_spear)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/narsie
+	var/real = TRUE
+
+/obj/item/clothing/suit/hooded/wintercoat/narsie/equipped(mob/living/user,slot)
+	..()
+	if (slot != SLOT_WEAR_SUIT || !real)
+		return
+	if (iscultist(user))
+		return
+	else
+		user.dropItemToGround(src)
+		to_chat(user,"<span class='cultlarge'>\"You are not fit to wear my follower's coat!\"</span>")
+		to_chat(user,"<span class='userdanger'>Sharp spines jab you from within the coat!</span>")
+		user.adjustBruteLoss(rand(10,16))
 
 /obj/item/clothing/head/hooded/winterhood/narsie
 	icon_state = "winterhood_narsie"
+
+/obj/item/clothing/suit/hooded/wintercoat/ratvar/fake
+	name = "brass winter coat"
+	icon_state = "coatratvar"
+	item_state = "coatratvar"
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	real = FALSE
+
+/obj/item/clothing/suit/hooded/wintercoat/narsie/fake
+	name = "runed winter coat"
+	icon_state = "coatnarsie"
+	item_state = "coatnarsie"
+	allowed = list(/obj/item/flashlight, /obj/item/tank/internals/emergency_oxygen, /obj/item/tank/internals/plasmaman, /obj/item/toy, /obj/item/storage/fancy/cigarettes, /obj/item/lighter)
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0)
+	real = FALSE
+
 
 /obj/item/clothing/suit/spookyghost
 	name = "spooky ghost"

--- a/modular_citadel/code/modules/client/loadout/suit.dm
+++ b/modular_citadel/code/modules/client/loadout/suit.dm
@@ -69,6 +69,16 @@
 	category = SLOT_WEAR_SUIT
 	path = /obj/item/clothing/suit/hooded/wintercoat/aformal
 
+/datum/gear/coat/runed
+	name = "Runed winter coat"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/hooded/wintercoat/narsie/fake
+
+/datum/gear/coat/brass
+	name = "Brass winter coat"
+	category = SLOT_WEAR_SUIT
+	path = /obj/item/clothing/suit/hooded/wintercoat/ratvar/fake
+
 /* Commented out until it is "balanced"
 /datum/gear/coat/sec
 	name = "Security winter coat"


### PR DESCRIPTION
## About The Pull Request

Adds cosmetic versions of narsian and ratvarian coats to the loadout (brass and runed coats).
Narsian winter coat can be made with twisted construction on a winter coat.
Ratvarian winter coat can be made with replica fabricator on a winter coat.
Both can hold their respective cult items.

Also lets assistant's formal winter coat be able to hold insuls.

## Why It's Good For The Game

Because more winter coats are nice, and makes it so these aren't just adminspawn only.

## Changelog
:cl:
add: added the runed and brass winter coats (cosmetic ratvarian/narsian)
tweak: how the narsian/ratvarian coats can be made
/:cl: