### PR TITLE
Effectively removes the old unused roboticist encryption key and headset.

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -44,11 +44,6 @@
 	icon_state = "eng_cypherkey"
 	channels = list(RADIO_CHANNEL_ENGINEERING = 1)
 
-/obj/item/encryptionkey/headset_rob
-	name = "robotics radio encryption key"
-	icon_state = "rob_cypherkey"
-	channels = list(RADIO_CHANNEL_SCIENCE = 1, RADIO_CHANNEL_ENGINEERING = 1)
-
 /obj/item/encryptionkey/headset_med
 	name = "medical radio encryption key"
 	icon_state = "med_cypherkey"

--- a/code/game/objects/items/devices/radio/headset.dm
+++ b/code/game/objects/items/devices/radio/headset.dm
@@ -123,12 +123,6 @@ GLOBAL_LIST_INIT(channel_tokens, list(
 	icon_state = "eng_headset"
 	keyslot = new /obj/item/encryptionkey/headset_eng
 
-/obj/item/radio/headset/headset_rob
-	name = "robotics radio headset"
-	desc = "Made specifically for the roboticists, who cannot decide between departments."
-	icon_state = "rob_headset"
-	keyslot = new /obj/item/encryptionkey/headset_rob
-
 /obj/item/radio/headset/headset_med
 	name = "medical radio headset"
 	desc = "A headset for the trained staff of the medbay."

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -135,7 +135,6 @@
 					/obj/item/clothing/gloves/fingerless = 3,
 					/obj/item/clothing/head/soft/black = 3,
 					/obj/item/clothing/mask/bandana/skull = 2)
-	premium = list(/obj/item/radio/headset/headset_rob = 2) //Cit change
 	contraband = list(/obj/item/clothing/suit/hooded/techpriest = 2)
 	refill_canister = /obj/item/vending_refill/wardrobe/robo_wardrobe
 


### PR DESCRIPTION
## About The Pull Request
An upset engineer comes to me complaining about ignorant roboticists always roasting engineering whenever they get their toaster hands on that legacy encryption key.

## Why It's Good For The Game
This is why we can't have nice things.

## Changelog
:cl:
del: Removed the old (almost) unused roboticist encryption key and headset.
/:cl:

