### PR TITLE
Fix goose meat.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/goose.dm
+++ b/code/modules/mob/living/simple_animal/hostile/goose.dm
@@ -9,7 +9,7 @@
 	mob_biotypes = list(MOB_ORGANIC, MOB_BEAST)
 	speak_chance = 0
 	turns_per_move = 5
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat = 2)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab = 2)
 	response_help = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm = "kicks"


### PR DESCRIPTION
## About The Pull Request
Stops goose meat from being a dummy snacks subtype.

## Why It's Good For The Game
This will close #10261.

## Changelog
:cl:
fix: Fixed goose meat.
/:cl:
