### PR TITLE
Fixes Fermi plushie reaction. Removes carbonation of caramel

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -84,14 +84,6 @@
 	required_temp = 413
 	mob_react = FALSE
 
-/datum/chemical_reaction/caramel_burned
-	name = "Caramel burned"
-	id = "caramel_burned"
-	results = list("carbon" = 1)
-	required_reagents = list("caramel" = 1)
-	required_temp = 483
-	mob_react = FALSE
-
 /datum/chemical_reaction/cheesewheel
 	name = "Cheesewheel"
 	id = "cheesewheel"

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -142,9 +142,9 @@
 /datum/chemical_reaction/fermis_plush
 	name = "Fermis plush"
 	id = "fermis_plush"
-	required_reagents = list("sugar" = 10, "blood" = 10, "stable_plasma" = 10)
+	required_reagents = list("caramel" = 10, "blood" = 10, "stable_plasma" = 10)
 	mob_react = FALSE
-	required_temp = 400
+	required_temp = 300
 
 /datum/chemical_reaction/fermis_plush/on_reaction(datum/reagents/holder, created_volume)
 	var/location = get_turf(holder.my_atom)

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -105,7 +105,7 @@
 	name = "Eigenstasium"
 	id = "eigenstate"
 	results = list("eigenstate" = 1)
-	required_reagents = list("bluespace" = 1, "stable_plasma" = 1, "sugar" = 1)
+	required_reagents = list("bluespace" = 1, "stable_plasma" = 1, "caramel" = 1)
 	mix_message = "the reaction zaps suddenly!"
 	//FermiChem vars:
 	OptimalTempMin 		= 350 // Lower area of bell curve for determining heat based rate reactions

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -504,7 +504,7 @@
 	name = "secretcatchem"
 	id = "secretcatchem"
 	results = list("secretcatchem" = 5)
-	required_reagents = list("stable_plasma" = 1, "sugar" = 1, "cream" = 1, "clonexadone" = 1)//Yes this will make a kitty if you don't lucky guess. It'll eat all your reagents too.
+	required_reagents = list("stable_plasma" = 1, "caramel" = 1, "cream" = 1, "clonexadone" = 1)//Yes this will make a kitty if you don't lucky guess. It'll eat all your reagents too.
 	required_catalysts = list("SDGF" = 1)
 	required_temp = 500
 	mix_message = "the reaction gives off a meow!"


### PR DESCRIPTION
## About The Pull Request
Makes fermi plushie need caramel rather then sugar
Lowers the heating needed

## Why It's Good For The Game

This reaction is unable to be done without this fix
Removes caramel carbonation

## Changelog
:cl:
fix: Fermi plushie can be made once again
/:cl:
