### PR TITLE
good idea: .357 speedloaders printable with advanced illegal ballistics, bad idea: revolver now gets an extra speedloader and a box

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -391,3 +391,9 @@
 
 	if(prob(50))
 		new /obj/item/seeds/random(src) //oops, an additional packet might have slipped its way into the box
+
+/obj/item/storage/box/syndie_kit/revolver
+
+/obj/item/storage/box/syndie_kit/revolver/PopulateContents()
+	new /obj/item/gun/ballistic/revolver(src)
+	new /obj/item/ammo_box/a357(src)

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1095,13 +1095,13 @@
 			continue
 		boost_item_paths |= UI.item	//allows deconning to unlock.
 
-/datum/techweb_node/advanced_illegl_ballistics
+/datum/techweb_node/advanced_illegal_ballistics
 	id = "advanced_illegal_ballistics"
-	display_name = "Advanced Illegal Ballistics"
-	description = "Advanced Ballistic for Illegal weaponds."
-	design_ids = list("10mm","10mmap","10mminc","10mmhp","pistolm9mm","m45","bolt_clip")
+	display_name = "Advanced Non-Standard Ballistics"
+	description = "Ballistic ammunition for non-standard firearms. Usually the ones you don't have nor want to be involved with."
+	design_ids = list("10mm","10mmap","10mminc","10mmhp","sl357","pistolm9mm","m45","bolt_clip")
 	prereq_ids = list("ballistic_weapons","syndicate_basic","explosive_weapons")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 25000) //This gives sec lethal mags/clips for guns form traitors or space.
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 25000) //This gives sec lethal mags/clips for guns from traitors, space, or anything in between.
 	export_price = 7000
 
 //Helpers for debugging/balancing the techweb in its entirety!

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -357,9 +357,9 @@
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/dangerous/revolver
-	name = "Syndicate Revolver"
-	desc = "A brutally simple syndicate revolver that fires .357 Magnum rounds and has 7 chambers."
-	item = /obj/item/gun/ballistic/revolver
+	name = "Syndicate Revolver Kit"
+	desc = "A sleek box containing a brutally simple Syndicate revolver that fires .357 Magnum rounds and has 7 chambers, and an extra speedloader."
+	item = /obj/item/storage/box/syndie_kit/revolver
 	cost = 13
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)

--- a/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -50,11 +50,11 @@
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
 
-/datum/design/m45 //Kinda NT in throey
+/datum/design/m45 //Kinda NT in theory
 	name = "handgun magazine (.45)"
 	id = "m45"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 80000)
+	materials = list(MAT_METAL = 60000)
 	build_path = /obj/item/ammo_box/magazine/m45
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
@@ -64,7 +64,17 @@
 	desc = "A gun magazine."
 	id = "pistolm9mm"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 80000)
+	materials = list(MAT_METAL = 55000)
 	build_path = /obj/item/ammo_box/magazine/pistolm9mm
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/sl357
+	name = "revolver speedloader (.357)"
+	desc = "A revolver speedloader."
+	id = "sl357"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 30000)
+	build_path = /obj/item/ammo_box/a357
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY

--- a/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -54,7 +54,7 @@
 	name = "handgun magazine (.45)"
 	id = "m45"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 60000)
+	materials = list(MAT_METAL = 80000)
 	build_path = /obj/item/ammo_box/magazine/m45
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
@@ -64,7 +64,7 @@
 	desc = "A gun magazine."
 	id = "pistolm9mm"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 55000)
+	materials = list(MAT_METAL = 80000)
 	build_path = /obj/item/ammo_box/magazine/pistolm9mm
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
## About The Pull Request
good: alright so i made .357 speedloaders printable with this one tech node thats expensive as shit
bad: but i also made it so the .357 revolver itself comes with an extra speedloader
## Why It's Good For The Game
with speedloaders getting uninstalled from autolathes i thought "damn, what if i put this back in"
but then i also gave the .357 one (1) extra speedloader
## Changelog
:cl:
add: .357 speedloaders can now be printed with the Advanced Illegal Ballistics node on the tech tree!
balance: okay so i may have given the .357 an extra speedloader at the same cost but it comes in a box now
/:cl: