### PR TITLE
Added a ghost role with its own spawner for the purposes of chillling in the ninja holding facility.

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -11585,11 +11585,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/centcom/holding)
-"Bp" = (
-/obj/item/paicard,
-/obj/structure/table/wood,
-/turf/open/floor/engine/cult,
-/area/wizard_station)
 "Bs" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/libraryconsole/bookmanagement,
@@ -16598,6 +16593,10 @@
 "Mm" = (
 /turf/open/floor/grass,
 /area/centcom/holding)
+"Ms" = (
+/obj/effect/mob_spawn/human/ghostcafe,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Mt" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -17246,6 +17245,11 @@
 "Qe" = (
 /turf/open/ai_visible,
 /area/ai_multicam_room)
+"Qi" = (
+/obj/item/paicard,
+/obj/structure/table/wood,
+/turf/open/floor/engine/cult,
+/area/wizard_station)
 "Qk" = (
 /obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/ppflowers,
@@ -25747,7 +25751,7 @@ lI
 lI
 lI
 Ax
-Bp
+Qi
 qZ
 qZ
 Ax
@@ -47628,7 +47632,7 @@ Xk
 GY
 NT
 Xk
-Xk
+Ms
 Xk
 NT
 vt

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -63,21 +63,21 @@
 	pixel_y = 4
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "am" = (
 /obj/structure/closet/crate/bin,
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "an" = (
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "ao" = (
@@ -86,8 +86,8 @@
 	layer = 3.3
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "ap" = (
@@ -166,15 +166,15 @@
 	pixel_y = 8
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aA" = (
 /obj/structure/chair/wood/normal,
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aB" = (
@@ -218,16 +218,16 @@
 	dir = 4
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aJ" = (
 /obj/structure/table/wood/poker,
 /obj/item/clothing/mask/cigarette/pipe,
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aK" = (
@@ -235,8 +235,8 @@
 /obj/structure/table/wood/poker,
 /obj/effect/holodeck_effect/cards,
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aL" = (
@@ -244,8 +244,8 @@
 	dir = 8
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aM" = (
@@ -259,8 +259,8 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aO" = (
@@ -272,15 +272,15 @@
 	dir = 4
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aQ" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aR" = (
@@ -299,8 +299,8 @@
 	pixel_y = 10
 	},
 /turf/open/floor/holofloor{
-	icon_state = "wood";
-	dir = 9
+	dir = 9;
+	icon_state = "wood"
 	},
 /area/holodeck/rec_center/lounge)
 "aU" = (
@@ -1403,7 +1403,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/mass_driver{
 	dir = 1;
-	icon_state = "mass_driver";
 	id = "trektorpedo1";
 	name = "photon torpedo tube"
 	},
@@ -1452,7 +1451,6 @@
 /obj/structure/window/reinforced,
 /obj/machinery/mass_driver{
 	dir = 1;
-	icon_state = "mass_driver";
 	id = "trektorpedo2";
 	name = "photon torpedo tube"
 	},
@@ -1470,14 +1468,14 @@
 	dir = 4
 	},
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "dT" = (
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 4
+	dir = 4;
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "dU" = (
@@ -1489,8 +1487,8 @@
 /area/holodeck/rec_center/chapelcourt)
 "dV" = (
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "dW" = (
@@ -1498,8 +1496,8 @@
 	dir = 8
 	},
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 4
+	dir = 4;
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "dX" = (
@@ -1523,8 +1521,8 @@
 	dir = 8
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white";
-	dir = 8
+	dir = 8;
+	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
 "eb" = (
@@ -1539,8 +1537,8 @@
 	dir = 4
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white";
-	dir = 4
+	dir = 4;
+	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
 "ed" = (
@@ -1611,8 +1609,7 @@
 /area/holodeck/rec_center/chapelcourt)
 "en" = (
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 2
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "eo" = (
@@ -1635,8 +1632,7 @@
 	dir = 8
 	},
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 2
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "er" = (
@@ -1644,8 +1640,8 @@
 	dir = 8
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white";
-	dir = 10
+	dir = 10;
+	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
 "es" = (
@@ -1658,8 +1654,8 @@
 	dir = 4
 	},
 /turf/open/floor/holofloor{
-	icon_state = "white";
-	dir = 6
+	dir = 6;
+	icon_state = "white"
 	},
 /area/holodeck/rec_center/firingrange)
 "eu" = (
@@ -1679,8 +1675,8 @@
 /area/holodeck/rec_center/spacechess)
 "ex" = (
 /turf/open/floor/holofloor{
-	icon_state = "stairs-old";
-	dir = 8
+	dir = 8;
+	icon_state = "stairs-old"
 	},
 /area/holodeck/rec_center/thunderdome1218)
 "ey" = (
@@ -1780,8 +1776,8 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 1
+	dir = 1;
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "eN" = (
@@ -1789,8 +1785,8 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 4
+	dir = 4;
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "eO" = (
@@ -1827,8 +1823,7 @@
 	dir = 1
 	},
 /turf/open/floor/holofloor{
-	icon_state = "chapel";
-	dir = 2
+	icon_state = "chapel"
 	},
 /area/holodeck/rec_center/chapelcourt)
 "eT" = (
@@ -2517,9 +2512,9 @@
 /area/ctf)
 "gB" = (
 /obj/structure/window/reinforced/fulltile{
-	obj_integrity = 5000;
 	max_integrity = 5000;
-	name = "hardened window"
+	name = "hardened window";
+	obj_integrity = 5000
 	},
 /turf/open/floor/plating,
 /area/ctf)
@@ -3398,7 +3393,7 @@
 /area/centcom/supply)
 "iS" = (
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -3471,8 +3466,7 @@
 "ja" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1
+	name = "CentCom"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -3565,7 +3559,6 @@
 /area/centcom/control)
 "jk" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "XCCQMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
@@ -3580,9 +3573,7 @@
 /area/centcom/supply)
 "jl" = (
 /obj/structure/plasticflaps,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "XCCQMLoad2"
@@ -3591,13 +3582,10 @@
 /area/centcom/supply)
 "jm" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "XCCQMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/conveyor{
 	dir = 4;
 	id = "XCCQMLoad2"
@@ -3683,7 +3671,6 @@
 	pixel_y = -5
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "XCCQMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
@@ -3760,7 +3747,6 @@
 /area/centcom/control)
 "jI" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "XCCQMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
@@ -3779,14 +3765,11 @@
 	dir = 8;
 	id = "XCCQMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "jK" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "XCCQMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
@@ -3794,9 +3777,7 @@
 	dir = 8;
 	id = "XCCQMLoad"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "jL" = (
@@ -3883,7 +3864,7 @@
 /area/centcom/control)
 "jV" = (
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4103,7 +4084,6 @@
 "ki" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership;
-	dir = 1;
 	dwidth = 25;
 	height = 50;
 	id = "emergency_syndicate";
@@ -4231,7 +4211,7 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4282,8 +4262,7 @@
 /area/centcom/control)
 "kG" = (
 /obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 2
+	color = "#596479"
 	},
 /turf/open/floor/plasteel/grimy,
 /area/centcom/control)
@@ -4431,19 +4410,14 @@
 "kZ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "la" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 2;
-	icon_state = "leftsecure";
 	name = "CentCom Stand";
 	req_access_txt = "109"
 	},
@@ -4479,8 +4453,6 @@
 	},
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 2;
-	icon_state = "leftsecure";
 	name = "CentCom Stand";
 	req_access_txt = "109"
 	},
@@ -4498,8 +4470,6 @@
 "lf" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 2;
-	icon_state = "leftsecure";
 	name = "CentCom Stand";
 	req_access_txt = "109"
 	},
@@ -4701,12 +4671,9 @@
 "lJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office";
-	opacity = 1;
 	req_access_txt = "109"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "lK" = (
@@ -4714,9 +4681,7 @@
 	name = "CentCom Supply";
 	req_access_txt = "106"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "lL" = (
@@ -4792,10 +4757,16 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/centcom/control)
+"lS" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja1";
+	name = "Dorm 1"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "lT" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -4852,6 +4823,16 @@
 	icon_state = "alien11"
 	},
 /area/abductor_ship)
+"ma" = (
+/obj/machinery/button/door{
+	id = "Ninja7";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "mb" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/tile/neutral{
@@ -5249,9 +5230,7 @@
 /area/centcom/control)
 "mR" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "mS" = (
@@ -5769,13 +5748,11 @@
 "nQ" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 2;
-	icon_state = "leftsecure";
 	name = "CentCom Stand";
 	req_access_txt = "109"
 	},
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -5793,13 +5770,11 @@
 "nR" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 2;
-	icon_state = "leftsecure";
 	name = "CentCom Stand";
 	req_access_txt = "109"
 	},
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -6295,7 +6270,6 @@
 "oJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -6610,11 +6584,11 @@
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
 /obj/machinery/door/window/brigdoor{
-	name = "CentCom Customs";
-	icon_state = "rightsecure";
+	base_state = "rightsecure";
 	dir = 4;
-	req_access_txt = "109";
-	base_state = "rightsecure"
+	icon_state = "rightsecure";
+	name = "CentCom Customs";
+	req_access_txt = "109"
 	},
 /obj/item/clipboard,
 /obj/item/folder/yellow,
@@ -6866,7 +6840,7 @@
 /area/centcom/ferry)
 "pM" = (
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
@@ -6893,7 +6867,7 @@
 /obj/item/clothing/gloves/color/black,
 /obj/item/clothing/glasses/eyepatch,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel/grimy,
@@ -6990,9 +6964,7 @@
 /area/ai_multicam_room)
 "pZ" = (
 /obj/machinery/washing_machine,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
+/turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
 "qa" = (
 /obj/structure/flora/tree/pine,
@@ -7275,8 +7247,8 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
+	icon_state = "asteroid5";
+	name = "plating"
 	},
 /area/centcom/control)
 "qx" = (
@@ -7334,24 +7306,26 @@
 /turf/closed/indestructible/riveted/uranium,
 /area/wizard_station)
 "qI" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"qP" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "qQ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "qR" = (
@@ -7361,23 +7335,17 @@
 "qS" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/centcom/supply)
 "qT" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1
+	name = "CentCom"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -7747,8 +7715,8 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
+	icon_state = "asteroid5";
+	name = "plating"
 	},
 /area/centcom/control)
 "rI" = (
@@ -7940,7 +7908,6 @@
 "sc" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership/control;
-	dir = 1;
 	dwidth = 3;
 	height = 7;
 	name = "escape pod loader";
@@ -8259,7 +8226,6 @@
 "sL" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -8388,7 +8354,6 @@
 "te" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Auxillary Dock";
-	opacity = 1;
 	req_access_txt = ""
 	},
 /turf/open/floor/plating,
@@ -8751,6 +8716,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"tZ" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "uc" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -8764,9 +8733,7 @@
 /obj/item/storage/crayons,
 /obj/structure/table,
 /obj/item/storage/crayons,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
+/turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
 "uf" = (
 /obj/effect/turf_decal/tile/brown{
@@ -8777,6 +8744,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"uh" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja2";
+	name = "Dorm 2"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "uj" = (
 /obj/item/clipboard,
 /obj/item/folder/red,
@@ -9078,12 +9052,9 @@
 "uO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Shuttle Control Office";
-	opacity = 1;
 	req_access_txt = "109"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "uP" = (
@@ -9214,7 +9185,7 @@
 	pixel_y = -32
 	},
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -9309,9 +9280,9 @@
 	dwidth = 25;
 	height = 50;
 	id = "emergency_away";
+	json_key = "emergency";
 	name = "CentCom Emergency Shuttle Dock";
-	width = 50;
-	json_key = "emergency"
+	width = 50
 	},
 /turf/open/space,
 /area/space)
@@ -9446,12 +9417,9 @@
 "vF" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Administrative Office";
-	opacity = 1;
 	req_access_txt = "109"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "vG" = (
@@ -9755,6 +9723,13 @@
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/three)
+"wj" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	desc = "Swipe your ID on the closet to claim it. First come first serve, this one is wooden and fancy. Store your stuff here.";
+	name = "Personal ID-Locked Closet"
+	},
+/turf/open/floor/carpet/royalblue,
+/area/centcom/holding)
 "wl" = (
 /obj/structure/table/wood,
 /obj/item/paicard,
@@ -9814,7 +9789,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9881,7 +9855,6 @@
 "wC" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Customs";
-	opacity = 1;
 	req_access_txt = "109"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -9914,8 +9887,7 @@
 /area/centcom/control)
 "wE" = (
 /obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 2
+	color = "#596479"
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -9967,8 +9939,7 @@
 "wJ" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1
+	name = "CentCom"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10033,9 +10004,7 @@
 /area/syndicate_mothership)
 "xa" = (
 /obj/machinery/door/window/northright{
-	base_state = "right";
 	dir = 4;
-	icon_state = "right";
 	name = "Security Desk";
 	req_access_txt = "103"
 	},
@@ -10266,6 +10235,14 @@
 /obj/item/bedsheet/syndie,
 /turf/open/floor/plasteel/dark,
 /area/syndicate_mothership)
+"xO" = (
+/obj/structure/curtain,
+/obj/machinery/shower,
+/obj/structure/window{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/holding)
 "xQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/light,
@@ -10396,7 +10373,6 @@
 "yj" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -10441,12 +10417,9 @@
 "yr" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Briefing Room";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
 "ys" = (
@@ -10652,11 +10625,17 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"yS" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja7";
+	name = "Dorm 7"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "yU" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1
+	name = "CentCom"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -10828,7 +10807,6 @@
 "zj" = (
 /obj/structure/closet/secure_closet/ertCom,
 /obj/structure/sign/directions/command{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -10838,9 +10816,7 @@
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "zl" = (
@@ -11017,7 +10993,7 @@
 	dir = 8
 	},
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -11098,6 +11074,13 @@
 /obj/item/reagent_containers/food/snacks/carpmeat,
 /turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
+"zW" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja5";
+	name = "Dorm 5"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "zX" = (
 /obj/structure/table,
 /obj/machinery/light{
@@ -11105,6 +11088,14 @@
 	},
 /obj/item/soap/deluxe,
 /turf/open/floor/plasteel/cafeteria,
+/area/centcom/holding)
+"zY" = (
+/obj/item/bedsheet/wiz{
+	desc = "A glow in the dark blue bedsheet.";
+	name = "blue bedsheet"
+	},
+/obj/structure/bed,
+/turf/open/floor/carpet/royalblue,
 /area/centcom/holding)
 "Aa" = (
 /turf/open/floor/mech_bay_recharge_floor,
@@ -11344,6 +11335,16 @@
 /obj/effect/decal/remains/xeno,
 /turf/open/floor/grass,
 /area/wizard_station)
+"AC" = (
+/obj/machinery/button/door{
+	id = "Ninja5";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "AD" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Leader's Room";
@@ -11841,12 +11842,9 @@
 "BM" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/evac)
 "BN" = (
@@ -12152,7 +12150,6 @@
 	icon_state = "plant-22"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
 	name = "Briefing Room APC";
 	pixel_y = -26
 	},
@@ -12318,7 +12315,7 @@
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/taperecorder,
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -12385,7 +12382,7 @@
 "CM" = (
 /obj/structure/filingcabinet/medical,
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -12871,11 +12868,11 @@
 /obj/item/folder/red,
 /obj/item/pen/red,
 /obj/machinery/door/window/brigdoor{
-	name = "CentCom Customs";
-	icon_state = "rightsecure";
+	base_state = "rightsecure";
 	dir = 4;
-	req_access_txt = "109";
-	base_state = "rightsecure"
+	icon_state = "rightsecure";
+	name = "CentCom Customs";
+	req_access_txt = "109"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -12886,11 +12883,11 @@
 /obj/item/folder/white,
 /obj/item/pen/blue,
 /obj/machinery/door/window/brigdoor{
-	name = "CentCom Customs";
-	icon_state = "rightsecure";
+	base_state = "rightsecure";
 	dir = 8;
-	req_access_txt = "109";
-	base_state = "rightsecure"
+	icon_state = "rightsecure";
+	name = "CentCom Customs";
+	req_access_txt = "109"
 	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
@@ -13096,12 +13093,9 @@
 /area/wizard_station)
 "Eg" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Booth";
-	opacity = 1
+	name = "Thunderdome Booth"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/centcom/control)
 "Eh" = (
@@ -13116,7 +13110,6 @@
 /area/wizard_station)
 "Ej" = (
 /obj/vehicle/ridden/scooter/skateboard{
-	icon_state = "skateboard";
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/line,
@@ -13156,9 +13149,7 @@
 /area/tdome/tdomeobserve)
 "Eq" = (
 /obj/machinery/door/airlock/external,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "Er" = (
@@ -13258,12 +13249,9 @@
 "EB" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
@@ -13276,9 +13264,7 @@
 /turf/open/floor/engine/cult,
 /area/wizard_station)
 "ED" = (
-/obj/machinery/vending/boozeomat{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/boozeomat,
 /turf/closed/indestructible{
 	icon = 'icons/turf/walls/wood_wall.dmi';
 	icon_state = "wood";
@@ -13318,8 +13304,8 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
+	icon_state = "asteroid5";
+	name = "plating"
 	},
 /area/tdome/tdomeobserve)
 "EH" = (
@@ -13586,7 +13572,6 @@
 "Fr" = (
 /obj/machinery/door/window/brigdoor{
 	base_state = "rightsecure";
-	dir = 2;
 	icon_state = "rightsecure";
 	name = "Thunderdome Booth";
 	req_access_txt = "109"
@@ -13726,8 +13711,7 @@
 /area/tdome/tdomeobserve)
 "FK" = (
 /obj/machinery/door/airlock/centcom{
-	name = "Thunderdome Backstage";
-	opacity = 1
+	name = "Thunderdome Backstage"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -13979,9 +13963,9 @@
 /area/tdome/tdomeobserve)
 "Gr" = (
 /obj/structure/window/reinforced{
-	resistance_flags = 3;
 	color = "#008000";
-	dir = 1
+	dir = 1;
+	resistance_flags = 3
 	},
 /turf/open/lava,
 /area/wizard_station)
@@ -13999,9 +13983,7 @@
 /area/tdome/tdomeobserve)
 "Gv" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "Gw" = (
@@ -14011,12 +13993,9 @@
 "Gx" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "Gy" = (
@@ -14028,9 +14007,9 @@
 	resistance_flags = 3
 	},
 /obj/structure/window/reinforced{
-	resistance_flags = 3;
 	color = "#008000";
-	dir = 1
+	dir = 1;
+	resistance_flags = 3
 	},
 /turf/open/lava/airless,
 /area/wizard_station)
@@ -14506,7 +14485,7 @@
 /area/tdome/tdomeobserve)
 "Hq" = (
 /obj/machinery/firealarm{
-	dir = 4;
+	dir = 8;
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/white,
@@ -14549,7 +14528,7 @@
 /area/tdome/tdomeobserve)
 "Hu" = (
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/bar,
@@ -14818,12 +14797,9 @@
 "HS" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Locker Room";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "HT" = (
@@ -15171,12 +15147,9 @@
 "Ix" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
-	opacity = 1;
 	req_access_txt = "102"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
@@ -15343,9 +15316,7 @@
 /area/tdome/tdomeadmin)
 "IS" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeadmin)
 "IT" = (
@@ -15437,8 +15408,8 @@
 /obj/structure/flora/ausbushes/lavendergrass,
 /obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/plasteel{
-	name = "plating";
-	icon_state = "asteroid5"
+	icon_state = "asteroid5";
+	name = "plating"
 	},
 /area/tdome/tdomeadmin)
 "Je" = (
@@ -15830,7 +15801,7 @@
 	icon_state = "plant-21"
 	},
 /obj/machinery/firealarm{
-	dir = 8;
+	dir = 4;
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -15873,6 +15844,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tdome/tdomeadmin)
+"Kf" = (
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/item/lighter,
+/obj/item/stack/sheet/mineral/wood{
+	amount = 10
+	},
+/turf/open/floor/carpet/red,
+/area/centcom/holding)
 "Kg" = (
 /turf/closed/indestructible/fakedoor{
 	name = "Thunderdome Admin"
@@ -15882,7 +15861,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
-	opacity = 1;
 	req_access_txt = "102"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -16194,7 +16172,6 @@
 /area/centcom/evac)
 "KL" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	id = "pod4_away";
@@ -16205,7 +16182,6 @@
 /area/space)
 "KM" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	id = "pod3_away";
@@ -16317,6 +16293,12 @@
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/centcom/evac)
+"Ln" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/holding)
 "Lp" = (
 /obj/structure/chair{
 	dir = 4
@@ -16594,7 +16576,9 @@
 /turf/open/floor/grass,
 /area/centcom/holding)
 "Ms" = (
-/obj/effect/mob_spawn/human/ghostcafe,
+/obj/effect/mob_spawn/human/ghostcafe{
+	dir = 8
+	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Mt" = (
@@ -16700,6 +16684,13 @@
 "MI" = (
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"MJ" = (
+/obj/structure/bed,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "MM" = (
 /obj/structure/window/reinforced,
 /turf/open/floor/carpet/black,
@@ -16766,12 +16757,9 @@
 "Nk" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -16809,9 +16797,7 @@
 /area/syndicate_mothership)
 "Nv" = (
 /obj/structure/table,
-/turf/open/floor/plasteel/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "Nw" = (
 /obj/machinery/recharge_station,
@@ -16851,12 +16837,9 @@
 "NG" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -16887,12 +16870,9 @@
 /area/centcom/holding)
 "NU" = (
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1
+	name = "CentCom"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -16932,6 +16912,9 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/syndicate_mothership)
+"Of" = (
+/turf/open/floor/carpet/red,
+/area/centcom/holding)
 "Oh" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -16941,8 +16924,7 @@
 "Oj" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
-	name = "CentCom";
-	opacity = 1
+	name = "CentCom"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -16952,6 +16934,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/control)
+"Ol" = (
+/obj/structure/table/wood/fancy,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Om" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -16985,6 +16971,12 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Ox" = (
+/obj/machinery/door/airlock/wood/glass{
+	name = "Cryo"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Oz" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -17120,7 +17112,9 @@
 /turf/open/floor/wood,
 /area/syndicate_mothership)
 "Px" = (
-/obj/machinery/vr_sleeper,
+/obj/structure/mineral_door/paperframe{
+	name = "Arcade"
+	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "PA" = (
@@ -17134,7 +17128,10 @@
 /area/syndicate_mothership)
 "PF" = (
 /obj/machinery/vr_sleeper{
-	dir = 1
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 4
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -17165,6 +17162,12 @@
 /area/syndicate_mothership)
 "PL" = (
 /obj/machinery/autolathe,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"PM" = (
+/obj/machinery/vending/clothing{
+	extended_inventory = 1
+	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "PO" = (
@@ -17277,11 +17280,8 @@
 /turf/open/floor/plasteel,
 /area/syndicate_mothership)
 "Qu" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 4
+/obj/machinery/door/airlock/wood/glass{
+	name = "Dorms"
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -17296,9 +17296,25 @@
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership)
+"QC" = (
+/obj/machinery/door/airlock/wood{
+	name = "Bathroom"
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/holding)
 "QE" = (
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"QF" = (
+/obj/machinery/button/door{
+	id = "Ninja3";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "QH" = (
 /obj/machinery/chem_master/condimaster{
 	desc = "Used to separate out liquids - useful for purifying botanical extracts. Also dispenses condiments.";
@@ -17333,6 +17349,12 @@
 /obj/structure/flora/ausbushes/palebush,
 /obj/structure/window/reinforced/fulltile,
 /turf/open/floor/grass,
+/area/centcom/holding)
+"QN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
 /area/centcom/holding)
 "QP" = (
 /obj/machinery/computer/mech_bay_power_console{
@@ -17470,6 +17492,21 @@
 /obj/item/tank/internals/plasmaman/belt/full,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Rq" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#cee5d2"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Ru" = (
+/obj/structure/fireplace,
+/turf/open/floor/carpet/red,
+/area/centcom/holding)
+"Rv" = (
+/obj/structure/dresser,
+/turf/open/floor/carpet/royalblue,
+/area/centcom/holding)
 "Rz" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plating,
@@ -17484,9 +17521,20 @@
 	},
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/basketball)
-"RL" = (
-/obj/structure/mineral_door/paperframe{
-	name = "Arcade"
+"RO" = (
+/obj/machinery/shower{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 8
+	},
+/obj/structure/curtain,
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/holding)
+"RP" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja4";
+	name = "Dorm 4"
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -17509,6 +17557,12 @@
 /obj/item/nullrod/claymore/glowing{
 	damtype = "stamina";
 	force = 30
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
+"RX" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479"
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
@@ -17622,9 +17676,7 @@
 	pixel_x = -3;
 	pixel_y = 6
 	},
-/turf/open/floor/plasteel/cafeteria{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cafeteria,
 /area/centcom/holding)
 "SH" = (
 /obj/effect/turf_decal/tile/green{
@@ -17652,6 +17704,9 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/space/basic,
 /area/centcom/supplypod)
+"ST" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/holding)
 "SU" = (
 /obj/structure/table/wood,
 /obj/item/camera/detective{
@@ -17690,8 +17745,25 @@
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"SZ" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja3";
+	name = "Dorm 3"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Tb" = (
 /obj/structure/closet/crate/freezer/blood,
+/turf/open/floor/wood,
+/area/centcom/holding)
+"Tc" = (
+/obj/machinery/button/door{
+	id = "Ninja2";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Tj" = (
@@ -17808,6 +17880,10 @@
 /obj/effect/landmark/holding_facility,
 /turf/open/floor/wood,
 /area/centcom/holding)
+"Uf" = (
+/obj/structure/closet/secure_closet,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Ug" = (
 /obj/machinery/door/poddoor/shuttledock{
 	checkdir = 1;
@@ -17865,15 +17941,15 @@
 "Un" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
+"Ur" = (
+/turf/open/floor/carpet/royalblue,
+/area/centcom/holding)
 "Uu" = (
 /obj/machinery/light{
 	dir = 8
@@ -17899,6 +17975,13 @@
 /obj/machinery/vending/cola,
 /turf/open/floor/plasteel,
 /area/centcom/supplypod)
+"UD" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	desc = "Swipe your ID on the closet to claim it. First come first serve, this one is wooden and fancy. Store your stuff here.";
+	name = "Personal ID-Locked Closet"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "UE" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood,
@@ -17922,7 +18005,6 @@
 "UO" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -18002,15 +18084,13 @@
 	dir = 8
 	},
 /obj/machinery/door/window{
-	name = "Tactical Toilet";
-	icon_state = "right";
 	dir = 8;
+	icon_state = "right";
+	name = "Tactical Toilet";
 	opacity = 1
 	},
 /obj/structure/window/reinforced/tinted,
-/turf/open/floor/plasteel/freezer{
-	dir = 2
-	},
+/turf/open/floor/plasteel/freezer,
 /area/syndicate_mothership)
 "Vm" = (
 /obj/machinery/gibber,
@@ -18128,7 +18208,6 @@
 "Wc" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -18159,11 +18238,24 @@
 "Wr" = (
 /turf/open/floor/plasteel/dark,
 /area/centcom/supplypod)
+"Ws" = (
+/obj/machinery/door/airlock/wood{
+	id_tag = "Ninja6";
+	name = "Dorm 6"
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "WC" = (
 /obj/structure/table/reinforced,
 /obj/item/pen,
 /turf/open/floor/mineral/plastitanium/red,
 /area/centcom/evac)
+"WE" = (
+/obj/machinery/vending/kink{
+	extended_inventory = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "WH" = (
 /obj/structure/table/reinforced,
 /obj/item/reagent_containers/food/drinks/bottle/whiskey{
@@ -18174,12 +18266,9 @@
 "WJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Thunderdome Administration";
-	opacity = 1;
 	req_access_txt = "102"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -18198,6 +18287,16 @@
 	},
 /turf/open/floor/wood,
 /area/centcom/holding)
+"WN" = (
+/obj/machinery/button/door{
+	id = "Ninja6";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "WO" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18209,7 +18308,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -18224,6 +18322,14 @@
 /obj/structure/closet/syndicate/personal,
 /turf/open/floor/wood,
 /area/syndicate_mothership)
+"WV" = (
+/obj/structure/bed,
+/obj/item/bedsheet/hos{
+	desc = "A fancy red bedsheet.";
+	name = "red bedsheet"
+	},
+/turf/open/floor/carpet/red,
+/area/centcom/holding)
 "WW" = (
 /obj/machinery/processor,
 /turf/open/floor/plasteel/cafeteria,
@@ -18236,9 +18342,7 @@
 /turf/open/floor/grass,
 /area/centcom/holding)
 "Xe" = (
-/obj/machinery/vending/autodrobe{
-	req_access_txt = "0"
-	},
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Xg" = (
@@ -18264,9 +18368,8 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/syndicate_mothership)
 "Xn" = (
-/obj/machinery/door/airlock/wood{
-	req_one_access_txt = "0"
-	},
+/obj/structure/bed,
+/obj/item/bedsheet/random,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Xo" = (
@@ -18291,20 +18394,15 @@
 /turf/open/floor/plasteel,
 /area/centcom/supplypod/loading/four)
 "Xs" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/syndicate_mothership)
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Xt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plasteel,
 /area/centcom/control)
@@ -18318,6 +18416,10 @@
 /obj/effect/turf_decal/tile/green,
 /turf/open/floor/holofloor,
 /area/holodeck/rec_center/firingrange)
+"Xw" = (
+/obj/structure/table/wood/fancy/royalblue,
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Xx" = (
 /obj/machinery/light{
 	dir = 4
@@ -18336,6 +18438,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/centcom/ferry)
+"XD" = (
+/obj/machinery/button/door{
+	id = "Ninja4";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = 25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "XE" = (
 /obj/machinery/door/airlock/centcom{
 	name = "Kitchen";
@@ -18376,6 +18488,16 @@
 	},
 /turf/open/floor/plating,
 /area/syndicate_mothership)
+"Ya" = (
+/obj/machinery/button/door{
+	id = "Ninja1";
+	name = "Dorm Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "Yc" = (
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
@@ -18432,12 +18554,9 @@
 "Yt" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -18477,6 +18596,12 @@
 /mob/living/simple_animal/chicken,
 /turf/open/floor/grass,
 /area/centcom/holding)
+"YO" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/centcom/holding)
 "YQ" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker,
@@ -18498,6 +18623,9 @@
 	force = 30
 	},
 /turf/open/floor/wood,
+/area/centcom/holding)
+"YW" = (
+/turf/open/floor/plating,
 /area/centcom/holding)
 "Za" = (
 /obj/machinery/door/airlock/wood{
@@ -18533,11 +18661,10 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel/dark,
 /area/syndicate_mothership)
-"Zt" = (
-/obj/machinery/vr_sleeper{
-	dir = 1
+"Zu" = (
+/obj/machinery/vending/autodrobe/all_access{
+	extended_inventory = 1
 	},
-/obj/machinery/light,
 /turf/open/floor/wood,
 /area/centcom/holding)
 "Zw" = (
@@ -18558,6 +18685,16 @@
 /obj/effect/landmark/start/nukeop_leader,
 /turf/open/floor/wood,
 /area/syndicate_mothership)
+"ZE" = (
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 28
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/centcom/holding)
 "ZF" = (
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
@@ -18574,7 +18711,6 @@
 "ZJ" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -18633,12 +18769,9 @@
 "ZX" = (
 /obj/machinery/door/airlock/centcom{
 	name = "CentCom Security";
-	opacity = 1;
 	req_access_txt = "101"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
@@ -39899,7 +40032,7 @@ aa
 aa
 aa
 QV
-Xs
+Yc
 MI
 MI
 MI
@@ -40413,7 +40546,7 @@ aa
 aa
 aa
 QV
-Xs
+Yc
 MI
 MI
 MI
@@ -40670,7 +40803,7 @@ aa
 aa
 aa
 QV
-Xs
+Yc
 MI
 MI
 MI
@@ -42759,17 +42892,17 @@ Nd
 Nd
 Nd
 Nd
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -43013,20 +43146,20 @@ CT
 oV
 CT
 CT
+CT
 oV
 CT
 Nd
+Xk
+Xk
+Xk
+Nd
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Uf
+Xk
+Xk
+Nd
 aa
 aa
 aa
@@ -43272,18 +43405,18 @@ Xk
 Xk
 Xk
 Xk
+Xk
+Nd
+Gs
+Xk
+HH
 Nd
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+MJ
+Xk
+YW
+Nd
 aa
 aa
 aa
@@ -43523,24 +43656,24 @@ UV
 CV
 Xk
 NT
-Xk
+Dj
 PF
+Dj
 Xk
-Px
+Dj
+PF
+Dj
+Nd
 Xk
-Zt
+Xk
+Xk
 Nd
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+ma
+YW
+Xk
+Nd
 aa
 aa
 aa
@@ -43779,25 +43912,25 @@ Nd
 Gs
 Xk
 Xk
-RL
-Xk
-PF
-Xk
-Px
-Xk
-PF
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Px
+Nd
+Nd
+Nd
+Nd
+Nd
+Ox
+Nd
+Nd
+Nd
+Nd
+Nd
+yS
+Nd
+Nd
 aa
 aa
 aa
@@ -44038,23 +44171,23 @@ CV
 Xk
 NT
 Xk
-PF
+Yo
 Xk
-Px
 Xk
-Zt
+Xk
+Yo
+Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xk
+Xk
+Yo
+Xk
+Xk
+Yo
+Xk
+Xk
+WE
+Nd
 aa
 aa
 aa
@@ -44281,7 +44414,7 @@ Nd
 Xk
 Yo
 Xk
-Xn
+XL
 Xk
 Xk
 Tn
@@ -44293,25 +44426,25 @@ NT
 Zh
 Xk
 Xk
-NT
+Re
 Xk
 Xk
 Xk
 Xk
 Xk
 Xk
+Xk
+Qu
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Zu
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
 aa
 aa
 aa
@@ -44551,24 +44684,24 @@ Ym
 CV
 Xk
 NT
-Dj
-Qu
-Dj
-Dj
-Qu
-Dj
+Xk
+Xx
+Xk
+Xk
+Xk
+Xx
+Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+Xk
+PM
+Nd
 aa
 aa
 aa
@@ -44815,17 +44948,17 @@ Nd
 Nd
 Nd
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Rq
+HH
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -45072,17 +45205,17 @@ OU
 RS
 VF
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UD
+tZ
+SY
+Nd
+Xk
+Xk
+Nd
+SY
+Ri
+UD
+Nd
 aa
 aa
 aa
@@ -45329,17 +45462,17 @@ Xk
 Xk
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Gs
+Xk
+Xk
+lS
+Xk
+Xk
+RP
+Xk
+Xk
+HH
+Nd
 aa
 aa
 aa
@@ -45586,17 +45719,17 @@ XM
 XM
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xn
+Xk
+Ya
+Nd
+Xk
+Xk
+Nd
+XD
+Xk
+Xn
+Nd
 aa
 aa
 aa
@@ -45843,17 +45976,17 @@ Po
 ZU
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Xk
+Xk
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -46100,17 +46233,17 @@ Sd
 MM
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+UD
+tZ
+SY
+Nd
+Xk
+Xk
+Nd
+SY
+Ri
+UD
+Nd
 aa
 aa
 aa
@@ -46357,17 +46490,17 @@ Sd
 MM
 TM
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Gs
+Xk
+Xk
+uh
+Xk
+Xk
+zW
+Xk
+Xk
+HH
+Nd
 aa
 aa
 aa
@@ -46614,17 +46747,17 @@ Sd
 MM
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xn
+Xk
+Tc
+Nd
+Xk
+Xk
+Nd
+AC
+Xk
+Xn
+Nd
 aa
 aa
 aa
@@ -46871,17 +47004,17 @@ PA
 Pl
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Rq
+HH
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -47128,17 +47261,17 @@ GY
 GY
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Xs
+Ol
+YO
+Nd
+Xk
+Xk
+Nd
+RX
+Xw
+qP
+Nd
 aa
 aa
 aa
@@ -47385,17 +47518,17 @@ Xk
 Xk
 Xk
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Gs
+Xk
+Xk
+SZ
+Xk
+Xk
+Ws
+Xk
+Xk
+HH
+Nd
 aa
 aa
 aa
@@ -47642,17 +47775,17 @@ Tb
 Uh
 tW
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Ru
+Of
+QF
+Nd
+Xk
+Xk
+Nd
+WN
+Ur
+wj
+Nd
 aa
 aa
 aa
@@ -47899,17 +48032,17 @@ Nd
 Nd
 Nd
 Nd
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Kf
+WV
+Xk
+Nd
+Nd
+Nd
+Nd
+Xk
+zY
+Rv
+Nd
 aa
 aa
 aa
@@ -48155,18 +48288,18 @@ aa
 aa
 aa
 aa
+Nd
+Nd
+Nd
+QC
+Nd
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+QC
+Nd
+Nd
+Nd
 aa
 aa
 aa
@@ -48412,18 +48545,18 @@ aa
 aa
 aa
 aa
+Nd
+Ln
+ST
+ST
+Nd
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+ST
+ST
+Ln
+Nd
 aa
 aa
 aa
@@ -48669,18 +48802,18 @@ aa
 aa
 aa
 aa
+Nd
+xO
+QN
+ZE
+Nd
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+ZE
+QN
+RO
+Nd
 aa
 aa
 aa
@@ -48926,18 +49059,18 @@ aa
 aa
 aa
 aa
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
-aa
+Nd
+Nd
+Nd
+Nd
+Nd
 aa
 aa
 aa

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -624,4 +624,19 @@
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	id = /obj/item/card/id
+
+
+/datum/outfit/ghostcafe/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
+	..()
+	var/suited = !preference_source || preference_source.prefs.jumpsuit_style == PREF_SUIT
+	if (CONFIG_GET(flag/grey_assistants))
+		if(suited)
+			uniform = /obj/item/clothing/under/color/grey
+		else
+			uniform = /obj/item/clothing/under/skirt/color/grey
+	else
+		if(suited)
+			uniform = /obj/item/clothing/under/color/random
+		else
+			uniform = /obj/item/clothing/under/skirt/color/random
 		

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -607,33 +607,21 @@
 	density = FALSE
 	death = FALSE
 	assignedrole = "Ghost Cafe Visitor"
+	flavour_text = "Is this what life after death is like?"
+	skip_reentry_check = TRUE
+	banType = "ghostcafe"
 
 /obj/effect/mob_spawn/human/ghostcafe/special(mob/living/carbon/human/new_spawn)
 	if(new_spawn.client)
-		new_spawn.fully_replace_character_name(newname = new_spawn.client.prefs.real_name)
-		new_spawn.nameless = new_spawn.client.prefs.nameless
-		new_spawn.gender = new_spawn.client.prefs.gender
-		new_spawn.dna.features = new_spawn.client.prefs.features.Copy()
-		new_spawn.flavor_text = new_spawn.dna.features["flavor_text"]
-		new_spawn.dna.custom_species = new_spawn.client.prefs.custom_species
-		new_spawn.eye_color = new_spawn.client.prefs.eye_color
-		new_spawn.hair_color = new_spawn.client.prefs.facial_hair_color
-		new_spawn.skin_tone = new_spawn.client.prefs.skin_tone
-		new_spawn.facial_hair_style = new_spawn.client.prefs.facial_hair_style
-		new_spawn.hair_color = new_spawn.client.prefs.hair_color
-		new_spawn.hair_style = new_spawn.client.prefs.hair_style
-		new_spawn.saved_socks = new_spawn.client.prefs.socks
-		new_spawn.socks = new_spawn.client.prefs.socks
-		new_spawn.socks_color = new_spawn.client.prefs.socks_color
-		new_spawn.saved_undershirt = new_spawn.client.prefs.undershirt
-		new_spawn.undershirt = new_spawn.client.prefs.undershirt
-		new_spawn.shirt_color = new_spawn.client.prefs.shirt_color
-		new_spawn.saved_underwear = new_spawn.client.prefs.underwear
-		new_spawn.underwear = new_spawn.client.prefs.underwear
-		new_spawn.undie_color = new_spawn.client.prefs.undie_color
-		new_spawn.set_species(new_spawn.client.prefs.pref_species, icon_update=1)
-		new_spawn.give_genitals(TRUE)
-		var/datum/outfit/O = new /datum/outfit/vr()
+		new_spawn.client.prefs.copy_to(new_spawn)
+		var/datum/outfit/O = new /datum/outfit/ghostcafe()
 		O.equip(new_spawn)
 		SSjob.equip_loadout(null, new_spawn, FALSE)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
+
+/datum/outfit/ghostcafe
+	name = "ID, jumpsuit and shoes"
+	uniform = /obj/item/clothing/under/color/random
+	shoes = /obj/item/clothing/shoes/sneakers/black
+	id = /obj/item/card/id
+		

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -615,7 +615,7 @@
 	if(new_spawn.client)
 		new_spawn.client.prefs.copy_to(new_spawn)
 		var/datum/outfit/O = new /datum/outfit/ghostcafe()
-		O.equip(new_spawn)
+		O.equip(new_spawn, FALSE, new_spawn.client)
 		SSjob.equip_loadout(null, new_spawn, FALSE)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
 

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -595,3 +595,45 @@
 
 /obj/effect/mob_spawn/human/pirate/gunner
 	rank = "Gunner"
+
+/obj/effect/mob_spawn/human/ghostcafe
+	name = "ghost cafe sleeper"
+	uses = -1
+	icon = 'icons/obj/machines/sleeper.dmi'
+	icon_state = "sleeper"
+	mob_name = "a ghost cafe visitor"
+	roundstart = FALSE
+	anchored = TRUE
+	density = FALSE
+	death = FALSE
+	assignedrole = "Ghost Cafe Visitor"
+
+/obj/effect/mob_spawn/human/ghostcafe/special(mob/living/carbon/human/new_spawn)
+	if(new_spawn.client)
+		new_spawn.fully_replace_character_name(newname = new_spawn.client.prefs.real_name)
+		new_spawn.nameless = new_spawn.client.prefs.nameless
+		new_spawn.gender = new_spawn.client.prefs.gender
+		new_spawn.dna.features = new_spawn.client.prefs.features.Copy()
+		new_spawn.flavor_text = new_spawn.dna.features["flavor_text"]
+		new_spawn.dna.custom_species = new_spawn.client.prefs.custom_species
+		new_spawn.eye_color = new_spawn.client.prefs.eye_color
+		new_spawn.hair_color = new_spawn.client.prefs.facial_hair_color
+		new_spawn.skin_tone = new_spawn.client.prefs.skin_tone
+		new_spawn.facial_hair_style = new_spawn.client.prefs.facial_hair_style
+		new_spawn.hair_color = new_spawn.client.prefs.hair_color
+		new_spawn.hair_style = new_spawn.client.prefs.hair_style
+		new_spawn.saved_socks = new_spawn.client.prefs.socks
+		new_spawn.socks = new_spawn.client.prefs.socks
+		new_spawn.socks_color = new_spawn.client.prefs.socks_color
+		new_spawn.saved_undershirt = new_spawn.client.prefs.undershirt
+		new_spawn.undershirt = new_spawn.client.prefs.undershirt
+		new_spawn.shirt_color = new_spawn.client.prefs.shirt_color
+		new_spawn.saved_underwear = new_spawn.client.prefs.underwear
+		new_spawn.underwear = new_spawn.client.prefs.underwear
+		new_spawn.undie_color = new_spawn.client.prefs.undie_color
+		new_spawn.set_species(new_spawn.client.prefs.pref_species, icon_update=1)
+		new_spawn.give_genitals(TRUE)
+		var/datum/outfit/O = new /datum/outfit/vr()
+		O.equip(new_spawn)
+		SSjob.equip_loadout(null, new_spawn, FALSE)
+		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)

--- a/code/modules/awaymissions/corpse.dm
+++ b/code/modules/awaymissions/corpse.dm
@@ -29,6 +29,7 @@
 	var/show_flavour = TRUE
 	var/banType = "lavaland"
 	var/ghost_usable = TRUE
+	var/skip_reentry_check = FALSE //Skips the ghost role blacklist time for people who ghost/suicide/cryo
 
 //ATTACK GHOST IGNORING PARENT RETURN VALUE
 /obj/effect/mob_spawn/attack_ghost(mob/user, latejoinercalling)
@@ -44,7 +45,7 @@
 		return
 	if(isobserver(user))
 		var/mob/dead/observer/O = user
-		if(!O.can_reenter_round())
+		if(!O.can_reenter_round() && !skip_reentry_check)
 			return FALSE
 	var/ghost_role = alert(latejoinercalling ? "Latejoin as [mob_name]? (This is a ghost role, and as such, it's very likely to be off-station.)" : "Become [mob_name]? (Warning, You can no longer be cloned!)",,"Yes","No")
 	if(ghost_role == "No" || !loc)


### PR DESCRIPTION
## Why It's Good For The Game

People who have been taken out of the round can now choose to continue their RP or whatever.

## Changelog
:cl:
add: Ghost cafe spawner. For letting people spawn as their own character in the ninja holding facility. It bypasses the usual check, so people who have suicided/ghosted/cryod may use it.
add: Dorms in the ninja holding facility.
/:cl: