### PR TITLE
Buffs Engine Goggles a lot!

### DIFF
--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -19,7 +19,7 @@
 
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE
-	var/range = 6
+	var/range = 1
 
 /obj/item/clothing/glasses/meson/engine/prescription
 	name = "prescription engineering scanner goggles"
@@ -90,7 +90,7 @@
 
 	for(var/i in rad_places)
 		var/turf/place = i
-		if(get_dist(user, place) >= range*2)	//Rads are easier to see than wires under the floor
+		if(get_dist(user, place) >= range*8)	//Rads are easier to see than wires under the floor
 			continue
 		var/strength = round(rad_places[i] / 1000, 0.1)
 		var/image/pic = new(loc = place)
@@ -139,7 +139,6 @@
 	item_state = "trayson-t-ray"
 	desc = "Used by engineering staff to see underfloor objects such as cables and pipes."
 	range = 2
-
 	modes = list(MODE_NONE = MODE_TRAY, MODE_TRAY = MODE_NONE)
 
 /obj/item/clothing/glasses/meson/engine/tray/prescription
@@ -152,7 +151,6 @@
 	icon_state = "trayson-shuttle"
 	item_state = "trayson-shuttle"
 	desc = "Used to see the boundaries of shuttle regions."
-
 	modes = list(MODE_NONE = MODE_SHUTTLE, MODE_SHUTTLE = MODE_NONE)
 
 #undef MODE_NONE

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -43,11 +43,11 @@
 		if(MODE_MESON)
 			vision_flags = SEE_TURFS
 			darkness_view = 1
-			range = 1
 			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE
+			darkness_view = 2
 			lighting_alpha = null
 
 	if(ishuman(user))

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -43,11 +43,19 @@
 		if(MODE_MESON)
 			vision_flags = SEE_TURFS
 			darkness_view = 1
+			range = 1
 			lighting_alpha = LIGHTING_PLANE_ALPHA_MOSTLY_VISIBLE
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE
 			darkness_view = 2
+			range = 4
+			lighting_alpha = null
+
+		if(MODE_RAD) //undoes the last mode, tray
+			vision_flags = NONE
+			darkness_view = 4
+			range = 12
 			lighting_alpha = null
 
 	if(ishuman(user))

--- a/code/modules/clothing/glasses/engine_goggles.dm
+++ b/code/modules/clothing/glasses/engine_goggles.dm
@@ -19,7 +19,7 @@
 
 	var/list/modes = list(MODE_NONE = MODE_MESON, MODE_MESON = MODE_TRAY, MODE_TRAY = MODE_RAD, MODE_RAD = MODE_NONE)
 	var/mode = MODE_NONE
-	var/range = 1
+	var/range = 6
 
 /obj/item/clothing/glasses/meson/engine/prescription
 	name = "prescription engineering scanner goggles"
@@ -48,14 +48,6 @@
 
 		if(MODE_TRAY) //undoes the last mode, meson
 			vision_flags = NONE
-			darkness_view = 2
-			range = 4
-			lighting_alpha = null
-
-		if(MODE_RAD) //undoes the last mode, tray
-			vision_flags = NONE
-			darkness_view = 4
-			range = 12
 			lighting_alpha = null
 
 	if(ishuman(user))


### PR DESCRIPTION
## About The Pull Request

The Rad-Scanners now see 4x the tiles!

## Why It's Good For The Game

https://cdn.discordapp.com/attachments/336748540690825216/659907637608972293/unknown.png
Rad mode is hard as hell to see as it is, and is slow. Making it see farther is a needed buff so that you know whom/what/were is leaking rads
Tray buff do to it being so shit, well still making the handscanner usefull

## Changelog
:cl:
tweak: range on Engi Tray scanners and Rad-Scanners 
/:cl:
