### PR TITLE
[Needs discussion]Dead xenomorph hosts no longer burst.

### DIFF
--- a/code/game/objects/items/body_egg.dm
+++ b/code/game/objects/items/body_egg.dm
@@ -27,12 +27,6 @@
 		INVOKE_ASYNC(src, .proc/RemoveInfectionImages, owner)
 	..()
 
-/obj/item/organ/body_egg/on_death()
-	. = ..()
-	if(!owner)
-		return
-	egg_process()
-
 /obj/item/organ/body_egg/on_life()
 	. = ..()
 	egg_process()

--- a/code/modules/mob/living/simple_animal/hostile/headcrab.dm
+++ b/code/modules/mob/living/simple_animal/hostile/headcrab.dm
@@ -56,6 +56,12 @@
 	var/datum/mind/origin
 	var/time
 
+/obj/item/organ/body_egg/changeling_egg/on_death()
+	. = ..()
+	if(!owner)
+		return
+	egg_process()
+
 /obj/item/organ/body_egg/changeling_egg/egg_process()
 	// Changeling eggs grow in dead people
 	time++


### PR DESCRIPTION
This gives xenomorphs a reason to keep alive hosts, until they burst, so aliens wont be no longer encouraged to kill their host once infected, which gives the host no chance to escape, why not give them a chance, maybe? Xenomorphs already are horribly strong.
🆑
balance: Xenomorph embryos no longer grow in dead hosts.
/🆑