### PR TITLE
Removes thunder domes lighters

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -2109,7 +2109,6 @@
 /turf/closed/indestructible/riveted,
 /area/space)
 "fy" = (
-/obj/machinery/igniter/on,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/tdome/arena_source)
@@ -15119,7 +15118,6 @@
 /turf/open/floor/plasteel,
 /area/tdome/tdomeobserve)
 "Is" = (
-/obj/machinery/igniter/on,
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/tdome/arena)


### PR DESCRIPTION

## About The Pull Request

Removes the lighters in thunder dome to stop heat death inside + the lag it likely make

## Why It's Good For The Game

No one likes heat death. It ruins the dome quickly and likely makes some lag

## Changelog
:cl:
del: Removed Lighters in thunderdomes
/:cl:
