### PR TITLE
excludes certain ghost roles from being affected by health events

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -134,6 +134,7 @@
 #define TRAIT_NORUNNING			"norunning"		// You walk!
 #define TRAIT_NOMARROW			"nomarrow"		// You don't make blood, with chemicals or nanites.
 #define TRAIT_NOPULSE			"nopulse"		// Your heart doesn't beat.
+#define TRAIT_EXEMPT_HEALTH_EVENTS	"exempt-health-events"
 
 
  //non-mob traits
@@ -193,6 +194,7 @@
 #define ABSTRACT_ITEM_TRAIT "abstract-item"
 #define STATUS_EFFECT_TRAIT "status-effect"
 #define ROUNDSTART_TRAIT "roundstart" //cannot be removed without admin intervention
+#define GHOSTROLE_TRAIT "ghostrole"
 
 // unique trait sources, still defines
 #define STATUE_MUTE "statue"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -30,7 +30,7 @@
 	new/obj/structure/fluff/empty_terrarium(get_turf(src))
 	return ..()
 
-/obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/human/seed_vault/special(mob/living/carbon/human/new_spawn)
 	new_spawn.exempt_from_health_events = TRUE
 //Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
 
@@ -253,7 +253,7 @@
 	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
 	return ..()
 
-/obj/effect/mob_spawn/human/hermit/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/human/hermit/special(mob/living/carbon/human/new_spawn)
 	new_spawn.exempt_from_health_events = TRUE
 
 //Broken rejuvenation pod: Spawns in animal hospitals in lavaland. Ghosts become disoriented interns and are advised to search for help.
@@ -358,7 +358,7 @@
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
 	..()
 
-/obj/effect/mob_spawn/human/hotel_staff/special(mob/living/new_spawn)
+/obj/effect/mob_spawn/human/hotel_staff/special(mob/living/carbon/human/new_spawn)
 	new_spawn.exempt_from_health_events = TRUE
 
 /obj/effect/mob_spawn/human/demonic_friend

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -30,6 +30,8 @@
 	new/obj/structure/fluff/empty_terrarium(get_turf(src))
 	return ..()
 
+/obj/effect/mob_spawn/human/seed_vault/special(mob/living/new_spawn)
+	new_spawn.exempt_from_health_events = TRUE
 //Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
 
 /obj/effect/mob_spawn/human/ash_walker
@@ -251,6 +253,9 @@
 	new/obj/structure/fluff/empty_cryostasis_sleeper(get_turf(src))
 	return ..()
 
+/obj/effect/mob_spawn/human/hermit/special(mob/living/new_spawn)
+	new_spawn.exempt_from_health_events = TRUE
+
 //Broken rejuvenation pod: Spawns in animal hospitals in lavaland. Ghosts become disoriented interns and are advised to search for help.
 /obj/effect/mob_spawn/human/doctor/alive/lavaland
 	name = "broken rejuvenation pod"
@@ -352,6 +357,9 @@
 /obj/effect/mob_spawn/human/hotel_staff/Destroy()
 	new/obj/structure/fluff/empty_sleeper/syndicate(get_turf(src))
 	..()
+
+/obj/effect/mob_spawn/human/hotel_staff/special(mob/living/new_spawn)
+	new_spawn.exempt_from_health_events = TRUE
 
 /obj/effect/mob_spawn/human/demonic_friend
 	name = "Essence of friendship"
@@ -618,6 +626,7 @@
 		O.equip(new_spawn, FALSE, new_spawn.client)
 		SSjob.equip_loadout(null, new_spawn, FALSE)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
+		new_spawn.exempt_from_health_events = TRUE
 
 /datum/outfit/ghostcafe
 	name = "ID, jumpsuit and shoes"
@@ -639,4 +648,4 @@
 			uniform = /obj/item/clothing/under/color/random
 		else
 			uniform = /obj/item/clothing/under/skirt/color/random
-		
+

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -31,7 +31,7 @@
 	return ..()
 
 /obj/effect/mob_spawn/human/seed_vault/special(mob/living/carbon/human/new_spawn)
-	new_spawn.exempt_from_health_events = TRUE
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 //Ash walker eggs: Spawns in ash walker dens in lavaland. Ghosts become unbreathing lizards that worship the Necropolis and are advised to retrieve corpses to create more ash walkers.
 
 /obj/effect/mob_spawn/human/ash_walker
@@ -254,7 +254,7 @@
 	return ..()
 
 /obj/effect/mob_spawn/human/hermit/special(mob/living/carbon/human/new_spawn)
-	new_spawn.exempt_from_health_events = TRUE
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 
 //Broken rejuvenation pod: Spawns in animal hospitals in lavaland. Ghosts become disoriented interns and are advised to search for help.
 /obj/effect/mob_spawn/human/doctor/alive/lavaland
@@ -359,7 +359,7 @@
 	..()
 
 /obj/effect/mob_spawn/human/hotel_staff/special(mob/living/carbon/human/new_spawn)
-	new_spawn.exempt_from_health_events = TRUE
+	ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 
 /obj/effect/mob_spawn/human/demonic_friend
 	name = "Essence of friendship"
@@ -626,7 +626,7 @@
 		O.equip(new_spawn, FALSE, new_spawn.client)
 		SSjob.equip_loadout(null, new_spawn, FALSE)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
-		new_spawn.exempt_from_health_events = TRUE
+		ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 
 /datum/outfit/ghostcafe
 	name = "ID, jumpsuit and shoes"

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -37,7 +37,7 @@
 			continue
 		if(!H.client)
 			continue
-		if(H.exempt_from_health_events)
+		if(HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
 		if(H.stat == DEAD)
 			continue

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -37,6 +37,8 @@
 			continue
 		if(!H.client)
 			continue
+		if(H.exempt_from_health_events)
+			continue
 		if(H.stat == DEAD)
 			continue
 		if(HAS_TRAIT(H, TRAIT_VIRUSIMMUNE)) //Don't pick someone who's virus immune, only for it to not do anything.

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -9,7 +9,7 @@
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest())
+		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest() || H.exempt_from_health_events)
 			continue
 		if(H.satiety <= -60) //Multiple junk food items recently
 			heart_attack_contestants[H] = 3

--- a/code/modules/events/heart_attack.dm
+++ b/code/modules/events/heart_attack.dm
@@ -9,7 +9,7 @@
 /datum/round_event/heart_attack/start()
 	var/list/heart_attack_contestants = list()
 	for(var/mob/living/carbon/human/H in shuffle(GLOB.player_list))
-		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest() || H.exempt_from_health_events)
+		if(!H.client || H.stat == DEAD || H.InCritical() || !H.can_heartattack() || H.has_status_effect(STATUS_EFFECT_EXERCISED) || (/datum/disease/heart_failure in H.diseases) || H.undergoing_cardiac_arrest() || HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
 		if(H.satiety <= -60) //Multiple junk food items recently
 			heart_attack_contestants[H] = 3

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -35,4 +35,8 @@
 												/datum/hallucination/delusion,
 												/datum/hallucination/oh_yeah)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
+				var/mob/living/carbon/human/H = C
+				if (istype(H))
+					if (H.exempt_from_health_events)
+						continue
 				new picked_hallucination(C, TRUE)

--- a/code/modules/events/mass_hallucination.dm
+++ b/code/modules/events/mass_hallucination.dm
@@ -35,8 +35,6 @@
 												/datum/hallucination/delusion,
 												/datum/hallucination/oh_yeah)
 			for(var/mob/living/carbon/C in GLOB.alive_mob_list)
-				var/mob/living/carbon/human/H = C
-				if (istype(H))
-					if (H.exempt_from_health_events)
-						continue
+				if (HAS_TRAIT(C,TRAIT_EXEMPT_HEALTH_EVENTS))
+					continue
 				new picked_hallucination(C, TRUE)

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -15,7 +15,7 @@
 			continue
 		if(H.stat == DEAD)
 			continue
-		if (H.exempt_from_health_events)
+		if (HAS_TRAIT(H,TRAIT_EXEMPT_HEALTH_EVENTS))
 			continue
 		if(!H.getorgan(/obj/item/organ/appendix)) //Don't give the disease to some who lacks it, only for it to be auto-cured
 			continue

--- a/code/modules/events/spontaneous_appendicitis.dm
+++ b/code/modules/events/spontaneous_appendicitis.dm
@@ -15,6 +15,8 @@
 			continue
 		if(H.stat == DEAD)
 			continue
+		if (H.exempt_from_health_events)
+			continue
 		if(!H.getorgan(/obj/item/organ/appendix)) //Don't give the disease to some who lacks it, only for it to be auto-cured
 			continue
 		if(!(MOB_ORGANIC in H.mob_biotypes)) //biotype sleeper bugs strike again, once again making appendicitis pick a target that can't take it

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -68,3 +68,4 @@
 	var/static/list/can_ride_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot))
 	var/lastpuke = 0
 	var/last_fire_update
+	var/exempt_from_health_events = FALSE

--- a/code/modules/mob/living/carbon/human/human_defines.dm
+++ b/code/modules/mob/living/carbon/human/human_defines.dm
@@ -68,4 +68,3 @@
 	var/static/list/can_ride_typecache = typecacheof(list(/mob/living/carbon/human, /mob/living/simple_animal/slime, /mob/living/simple_animal/parrot))
 	var/lastpuke = 0
 	var/last_fire_update
-	var/exempt_from_health_events = FALSE


### PR DESCRIPTION
## About The Pull Request

Some ghost roles can no longer be affected by appendicitis, heart attacks, disease, and hallucinatory events.

## Why It's Good For The Game

Because being in the space cafe chilling and then dying from a heart attack is bad.

## Changelog
:cl:
fix: fixes some ghost roles from dying of stupid shit
/:cl:
