### PR TITLE
Honey no longer murders slimes

### DIFF
--- a/code/modules/reagents/chemistry/reagents/food_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/food_reagents.dm
@@ -622,7 +622,7 @@
 		M.adjustBruteLoss(-1*REM, 0)
 		M.adjustFireLoss(-1*REM, 0)
 		M.adjustOxyLoss(-1*REM, 0)
-		M.adjustToxLoss(-1*REM, 0)
+		M.adjustToxLoss(-1*REM, 0, TRUE) //heals TOXINLOVERs
 	..()
 
 /datum/reagent/consumable/honey/reaction_mob(mob/living/M, method=TOUCH, reac_volume)


### PR DESCRIPTION

## About The Pull Request

Honey now heals slimes and not kills them well somehow.

## Why It's Good For The Game

Honey slime when. Likely will legit make one...

## Changelog
:cl:
balance: honey now will not kill slimes. Honey slimepeople can be a thing now, go sci.
/:cl:
