### PR TITLE
Significantly lowers the forcefield projector health

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -10,11 +10,11 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	materials = list(MAT_METAL=250, MAT_GLASS=500)
-	var/max_shield_integrity = 250
-	var/shield_integrity = 250
+	var/max_shield_integrity = 100
+	var/shield_integrity = 100
 	var/max_fields = 3
 	var/list/current_fields
-	var/field_distance_limit = 7
+	var/field_distance_limit = 4
 
 /obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()


### PR DESCRIPTION
Does what it says on the tin. 

Having a 250 health portable shield that you can deploy on up to three tiles, has shielding resistant to everything but melee, and can be reset and redeployed quickly has been nothing but abused lately.

This drops the health down to 100 from 250, keeping shield integrity. This also shortens the distance you can place them to four tiles, so no more reaching across the map with this.

 