### PR TITLE
Makes ghost cafe mobs actually a ghost role

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -741,7 +741,7 @@ GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 			if (M.mind && (M.mind.special_role || M.mind.antag_datums?.len > 0))
 				current_players[CURRENT_LIVING_ANTAGS].Add(M)
 		else
-			if (istype(M,/mob/dead/observer))
+			if (isobserver(M))
 				var/mob/dead/observer/O = M
 				if (O.started_as_observer) // Observers
 					current_players[CURRENT_OBSERVERS].Add(M)

--- a/code/modules/jobs/jobs.dm
+++ b/code/modules/jobs/jobs.dm
@@ -71,7 +71,7 @@ GLOBAL_LIST_INIT(exp_jobsmap, list(
 GLOBAL_LIST_INIT(exp_specialmap, list(
 	EXP_TYPE_LIVING = list(), // all living mobs
 	EXP_TYPE_ANTAG = list(),
-	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role"), // Ghost roles
+	EXP_TYPE_SPECIAL = list("Lifebringer","Ash Walker","Exile","Servant Golem","Free Golem","Hermit","Translocated Vet","Escaped Prisoner","Hotel Staff","SuperFriend","Space Syndicate","Ancient Crew","Space Doctor","Space Bartender","Beach Bum","Skeleton","Zombie","Space Bar Patron","Lavaland Syndicate","Ghost Role", "Ghost Cafe Visitor"), // Ghost roles
 	EXP_TYPE_GHOST = list() // dead people, observers
 ))
 GLOBAL_PROTECT(exp_jobsmap)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Ghost cafe wasn't included in the ghost roles list. Also made an istype into the standard macro for it.

## Why It's Good For The Game

wouldn't it be annoying if someone got midround traitor but they were in the ghost cafe. wouldn't that suck or what

## Changelog
:cl:
fix: Ghost cafe spawns are actual ghost roles by the game's reckoning now
/:cl: