### PR TITLE
Cloning no longer scrambles identity blocks

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -365,6 +365,12 @@
 	var/datum/mutation/human/num = pick(candidates)
 	. = num.force_give(src)
 
+/mob/living/carbon/proc/randmutng()
+	if(!has_dna())
+		return
+	var/datum/mutation/human/HM = pick((GLOB.not_good_mutations) - GLOB.mutations_list[RACEMUT])
+	. = HM.force_give(src)
+
 /mob/living/carbon/proc/randmutb()
 	if(!has_dna())
 		return

--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -164,7 +164,7 @@
 	H.hardset_dna(ui, se, H.real_name, null, mrace, features)
 
 	if(prob(50 - efficiency*10)) //Chance to give a bad mutation.
-		H.randmutb() //100% bad mutation. Can be cured with mutadone.
+		H.randmutng() //Not good mutation. Can be cured with mutadone.
 
 	H.silent = 20 //Prevents an extreme edge case where clones could speak if they said something at exactly the right moment.
 	occupant = H


### PR DESCRIPTION
## About The Pull Request

Cloning no longer randomly scrambles identity blocks, because it's incredibly irritating. Thanks, Burger.

This is accomplished by having the cloner pull from the list of "not good" mutations, which doesn't contain the "unstable dna" mutation that scrables identity blocks.

## Why It's Good For The Game

This is a huge annoyance that isn't always fixable, and the original PR that added random mutations was merged when the creator stated it wouldn't do exactly this. 

## Changelog
:cl:
fix: Fixed an oversight that caused cloning to occasionally scramble identity blocks
/:cl:
