### PR TITLE
Makes grass distill into light beer

### DIFF
--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -27,7 +27,7 @@
 	bitesize_mod = 2
 	var/stacktype = /obj/item/stack/tile/grass
 	var/tile_coefficient = 0.02 // 1/50
-	wine_power = 15
+	distill_reagent = "/datum/reagent/consumable/ethanol/beer/light"
 
 /obj/item/reagent_containers/food/snacks/grown/grass/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You prepare the astroturf.</span>")

--- a/code/modules/hydroponics/grown/grass_carpet.dm
+++ b/code/modules/hydroponics/grown/grass_carpet.dm
@@ -27,7 +27,7 @@
 	bitesize_mod = 2
 	var/stacktype = /obj/item/stack/tile/grass
 	var/tile_coefficient = 0.02 // 1/50
-	distill_reagent = "/datum/reagent/consumable/ethanol/beer/light"
+	distill_reagent = /datum/reagent/consumable/ethanol/beer/light
 
 /obj/item/reagent_containers/food/snacks/grown/grass/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>You prepare the astroturf.</span>")


### PR DESCRIPTION
Requires #10329 
## About The Pull Request
Grass now makes light beer rather then grass wine

## Why It's Good For The Game
Light beer is used in a case of the autobottler but can only be gotten via silver slimes, adminbuss or coin/dollar in buzz fuzz

## Changelog
:cl:
add: Grass now makes light beer when distilled
/:cl: