### PR TITLE
[s] Fixes anti-ghost-role vars a little.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -528,3 +528,5 @@ GLOBAL_LIST_INIT(pda_reskins, list(PDA_SKIN_CLASSIC = 'icons/obj/pda.dmi', PDA_S
 #define FOURSPACES "&nbsp;&nbsp;&nbsp;&nbsp;"
 
 #define CRYOMOBS 'icons/obj/cryo_mobs.dmi'
+
+#define CANT_REENTER_ROUND -1

--- a/code/__HELPERS/game.dm
+++ b/code/__HELPERS/game.dm
@@ -447,7 +447,7 @@
 	var/list/candidates = list()
 
 	for(var/mob/dead/observer/G in GLOB.player_list)
-		if(G.reenter_round_timeout < world.realtime)
+		if(G.can_reenter_round(TRUE))
 			candidates += G
 
 	return pollCandidates(Question, jobbanType, gametypeCheck, be_special_flag, poll_time, ignore_category, flashwindow, candidates)

--- a/code/modules/client/client_defines.dm
+++ b/code/modules/client/client_defines.dm
@@ -80,3 +80,7 @@
 	var/next_keysend_reset = 0
 	var/next_keysend_trip_reset = 0
 	var/keysend_tripped = FALSE
+
+	// stops players from coming back through ghost/midround roles after suicide/cryo
+	// for a duration set by CONFIG_GET(number/suicide_reenter_round_timer) and CONFIG_GET(number/roundstart_suicide_time_limit)
+	var/reenter_round_timeout = 0

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -18,3 +18,6 @@
 
 	update_icon(preferred_form)
 	updateghostimages()
+
+	client.reenter_round_timeout = max(client.reenter_round_timeout, clientless_round_timeout)
+	clientless_round_timeout = client.reenter_round_timeout

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -3,8 +3,6 @@ GLOBAL_LIST_EMPTY(ghost_images_simple) //this is a list of all ghost images as t
 
 GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 
-#define CANT_REENTER_ROUND -1
-
 /mob/dead/observer
 	name = "ghost"
 	desc = "It's a g-g-g-g-ghooooost!" //jinkies!
@@ -21,7 +19,7 @@ GLOBAL_VAR_INIT(observer_default_invisibility, INVISIBILITY_OBSERVER)
 	hud_type = /datum/hud/ghost
 	movement_type = GROUND | FLYING
 	var/can_reenter_corpse
-	var/reenter_round_timeout = 0 // used to prevent people from coming back through ghost roles/midround antags as they suicide/cryo for a duration set by CONFIG_GET(number/suicide_reenter_round_timer) and CONFIG_GET(number/roundstart_suicide_time_limit)
+	var/clientless_round_timeout = 0 //mobs will lack a client as long as their player is disconnected. See client_defines.dm "reenter_round_timeout"
 	var/datum/hud/living/carbon/hud = null // hud
 	var/bootime = 0
 	var/started_as_observer //This variable is set to 1 when you enter the game as an observer.
@@ -277,9 +275,13 @@ Works together with spawning an observer, noted above.
 		if(world.time < roundstart_quit_limit) //add up the time difference to their antag rolling penalty if they quit before half a (ingame) hour even passed.
 			penalty += roundstart_quit_limit - world.time
 		if(penalty)
-			ghost.reenter_round_timeout = world.realtime + penalty
-			if(ghost.reenter_round_timeout - SSshuttle.realtimeofstart > SSshuttle.auto_call + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
-				ghost.reenter_round_timeout = CANT_REENTER_ROUND
+			penalty += world.realtime
+			if(penalty - SSshuttle.realtimeofstart > SSshuttle.auto_call + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
+				penalty = CANT_REENTER_ROUND
+			if(client)
+				client.reenter_round_timeout = penalty
+			else //A disconnected player (quite likely for cryopods)
+				ghost.clientless_round_timeout = penalty
 	transfer_ckey(ghost, FALSE)
 	return ghost
 
@@ -338,10 +340,13 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	ghostize(0, penalize = TRUE)
 
 /mob/dead/observer/proc/can_reenter_round(silent = FALSE)
-	if(reenter_round_timeout != CANT_REENTER_ROUND && reenter_round_timeout <= world.realtime)
+	var/timeout = clientless_round_timeout
+	if(client)
+		timeout = client.reenter_round_timeout
+	if(timeout != CANT_REENTER_ROUND && timeout <= world.realtime)
 		return TRUE
-	if(!silent)
-		to_chat(src, "<span class='warning'>You are unable to reenter the round[reenter_round_timeout != CANT_REENTER_ROUND ? " yet. Your ghost role blacklist will expire in [DisplayTimeText(reenter_round_timeout - world.realtime)]" : ""].</span>")
+	if(!silent && client)
+		to_chat(src, "<span class='warning'>You are unable to reenter the round[timeout != CANT_REENTER_ROUND ? " yet. Your ghost role blacklist will expire in [DisplayTimeText(timeout - world.realtime)]" : ""].</span>")
 	return FALSE
 
 /mob/dead/observer/Move(NewLoc, direct)
@@ -897,5 +902,3 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		spawners_menu = new(src)
 
 	spawners_menu.ui_interact(src)
-
-#undef CANT_REENTER_ROUND


### PR DESCRIPTION
## About The Pull Request
Stops ghost roles time locks (or whatever we can call them) from resetting due respawns and roles that don't check it (such ghost cafe, round-ending things such as nar-sie / ratvar / true devils, CTF) by moving the variable to the client, leaving some remnants for clientless ghosts (tied to the player on login)

## Why It's Good For The Game
Stops some inconsistencies and exploits with this bad feature.

## Changelog
None.