### PR TITLE
Buffs bandoliers to hold more types of casings.

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -582,7 +582,7 @@
 
 /obj/item/storage/belt/bandolier
 	name = "bandolier"
-	desc = "A bandolier for holding shotgun ammunition."
+	desc = "A bandolier for holding ammunition."
 	icon_state = "bandolier"
 	item_state = "bandolier"
 
@@ -592,7 +592,7 @@
 	STR.max_items = 18
 	STR.display_numerical_stacking = TRUE
 	STR.can_hold = typecacheof(list(
-		/obj/item/ammo_casing/shotgun
+		/obj/item/ammo_casing
 		))
 
 /obj/item/storage/belt/bandolier/durathread


### PR DESCRIPTION

## About The Pull Request

Bandoliers the barkeep gets now holds any type of caseing for a bullet
QoL I guess?

## Why It's Good For The Game

The durathreat one holds 2x the amout as well as any bullet. Which is nice for when someone wants to got the mile and get one, but for barkeep not to be able to hold a lot for the .357 or other items of that kind is really lacking

## Changelog
:cl:
tweak: allows bandoliers to hold any ammo type as long as it has a casing
/:cl: