### PR TITLE
no longer can you wave at things you don't know are there

### DIFF
--- a/modular_citadel/code/_onclick/other_mobs.dm
+++ b/modular_citadel/code/_onclick/other_mobs.dm
@@ -9,6 +9,8 @@
 	return TRUE
 
 /mob/living/carbon/human/AltRangedAttack(atom/A, params)
+	if (!(src in viewers(11,A)))
+		return FALSE
 	if(!has_active_hand())
 		to_chat(src, "<span class='notice'>You ponder your life choices and sigh.</span>")
 		return TRUE


### PR DESCRIPTION
## About The Pull Request

makes a viewers call in waving to check if you can actually see the thing

## Why It's Good For The Game

you can no longer wave at walls and floors from behind things

## Changelog
:cl:
fix: waving at walls from behind a wall
/:cl: