### PR TITLE
Nukes away bad NSFW autosurgeons.

### DIFF
--- a/code/_globalvars/lists/maintenance_loot.dm
+++ b/code/_globalvars/lists/maintenance_loot.dm
@@ -113,7 +113,5 @@ GLOBAL_LIST_INIT(maintenance_loot, list(
 	/obj/item/storage/pill_bottle/breast_enlargement = 2,
 	/obj/item/clothing/shoes/wheelys = 1,
 	/obj/item/clothing/shoes/kindleKicks = 1,
-	/obj/item/autosurgeon/penis = 1,
-	/obj/item/autosurgeon/testicles = 1,
 	"" = 3
 	))

--- a/code/modules/surgery/organs/autosurgeon.dm
+++ b/code/modules/surgery/organs/autosurgeon.dm
@@ -122,28 +122,3 @@
 	while(contents.len <= amount)
 		implant = pick(boxed)
 		new implant(src)
-
-/obj/item/autosurgeon/penis
-	desc = "A single use autosurgeon that contains a penis. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/genital/penis
-
-/obj/item/autosurgeon/testicles
-	desc = "A single use autosurgeon that contains a set of testicles. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/genital/testicles
-
-/obj/item/autosurgeon/vagina
-	desc = "A single use autosurgeon that contains a vagina. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/genital/vagina
-
-/obj/item/autosurgeon/breasts
-	desc = "A single use autosurgeon that contains a set of breasts. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/genital/breasts
-
-/obj/item/autosurgeon/womb
-	desc = "A single use autosurgeon that contains a womb. A screwdriver can be used to remove it, but implants can't be placed back in."
-	uses = 1
-	starting_organ = /obj/item/organ/genital/womb


### PR DESCRIPTION
## About The Pull Request
I thought about the these autosurgeons for a while after removing them from cargo and came to the conclusion that, in the current state, these are just plain bad maintenance loot filler trash and don't offer any interesting degree of customization, unlike the character setup menu. (still, I don't think that'd suffice to keep them around)

## Why It's Good For The Game
Removing some bad maintanance loot trash.

## Changelog
:cl:
del: Removed some bad privates autosurgeons.
/:cl: