### PR TITLE
Removes a bunch of things from captain locker

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets/secure/security.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/security.dm
@@ -9,13 +9,9 @@
 	new /obj/item/storage/backpack/satchel/cap(src)
 	new /obj/item/storage/backpack/duffelbag/captain(src)
 	new /obj/item/clothing/neck/cloak/cap(src)
-	new /obj/item/clothing/neck/petcollar(src)
-	new /obj/item/pet_carrier(src)
 	new /obj/item/clothing/shoes/sneakers/brown(src)
 	new /obj/item/clothing/under/rank/captain(src)
 	new /obj/item/clothing/under/rank/captain/skirt(src)
-	new /obj/item/clothing/suit/armor/vest/capcarapace(src)
-	new /obj/item/clothing/head/caphat(src)
 	new /obj/item/clothing/under/captainparade(src)
 	new /obj/item/clothing/suit/armor/vest/capcarapace/alt(src)
 	new /obj/item/clothing/head/caphat/parade(src)
@@ -24,12 +20,8 @@
 	new /obj/item/clothing/under/rank/captain/femformal(src)  //citadel edit
 	new /obj/item/clothing/head/crown/fancy(src)
 	new /obj/item/cartridge/captain(src)
-	new /obj/item/storage/box/silver_ids(src)
 	new /obj/item/radio/headset/heads/captain/alt(src)
-	new /obj/item/radio/headset/heads/captain(src)
 	new /obj/item/clothing/glasses/sunglasses/gar/supergar(src)
-	new /obj/item/clothing/gloves/color/captain(src)
-	new /obj/item/restraints/handcuffs/cable/zipties(src)
 	new /obj/item/storage/belt/sabre(src)
 	new /obj/item/gun/energy/e_gun(src)
 	new /obj/item/door_remote/captain(src)
@@ -40,6 +32,7 @@
 	name = "\proper head of personnel's locker"
 	req_access = list(ACCESS_HOP)
 	icon_state = "hop"
+
 /obj/structure/closet/secure_closet/hop/PopulateContents()
 	..()
 	new /obj/item/clothing/neck/cloak/hop(src)
@@ -70,6 +63,7 @@
 	name = "\proper head of security's locker"
 	req_access = list(ACCESS_HOS)
 	icon_state = "hos"
+
 /obj/structure/closet/secure_closet/hos/PopulateContents()
 	..()
 	new /obj/item/clothing/neck/cloak/hos(src)
@@ -100,10 +94,12 @@
 	new /obj/item/circuitboard/machine/techfab/department/security(src)
 	new /obj/item/storage/photo_album/HoS(src)
 	new /obj/item/clothing/suit/hooded/wintercoat/hos(src)
+
 /obj/structure/closet/secure_closet/warden
 	name = "\proper warden's locker"
 	req_access = list(ACCESS_ARMORY)
 	icon_state = "warden"
+
 /obj/structure/closet/secure_closet/warden/PopulateContents()
 	..()
 	new /obj/item/radio/headset/headset_sec(src)
@@ -125,10 +121,12 @@
 	new /obj/item/door_remote/head_of_security(src)
 	new /obj/item/gun/ballistic/shotgun/automatic/combat/compact(src)
 	new /obj/item/clothing/head/beret/sec/corporatewarden(src)
+
 /obj/structure/closet/secure_closet/security
 	name = "security officer's locker"
 	req_access = list(ACCESS_SECURITY)
 	icon_state = "sec"
+
 /obj/structure/closet/secure_closet/security/PopulateContents()
 	..()
 	new /obj/item/clothing/suit/armor/vest(src)
@@ -137,26 +135,36 @@
 	new /obj/item/radio/headset/headset_sec/alt(src)
 	new /obj/item/clothing/glasses/hud/security/sunglasses(src)
 	new /obj/item/flashlight/seclite(src)
+
 /obj/structure/closet/secure_closet/security/sec
+
 /obj/structure/closet/secure_closet/security/sec/PopulateContents()
 	..()
 	new /obj/item/storage/belt/security/full(src)
+
 /obj/structure/closet/secure_closet/security/cargo
+
 /obj/structure/closet/secure_closet/security/cargo/PopulateContents()
 	..()
 	new /obj/item/clothing/accessory/armband/cargo(src)
 	new /obj/item/encryptionkey/headset_cargo(src)
+
 /obj/structure/closet/secure_closet/security/engine
+
 /obj/structure/closet/secure_closet/security/engine/PopulateContents()
 	..()
 	new /obj/item/clothing/accessory/armband/engine(src)
 	new /obj/item/encryptionkey/headset_eng(src)
+
 /obj/structure/closet/secure_closet/security/science
+
 /obj/structure/closet/secure_closet/security/science/PopulateContents()
 	..()
 	new /obj/item/clothing/accessory/armband/science(src)
 	new /obj/item/encryptionkey/headset_sci(src)
+
 /obj/structure/closet/secure_closet/security/med
+
 /obj/structure/closet/secure_closet/security/med/PopulateContents()
 	..()
 	new /obj/item/clothing/accessory/armband/medblue(src)
@@ -197,20 +205,24 @@
 /obj/structure/closet/secure_closet/injection
 	name = "lethal injections"
 	req_access = list(ACCESS_HOS)
+
 /obj/structure/closet/secure_closet/injection/PopulateContents()
 	..()
 	for(var/i in 1 to 5)
 		new /obj/item/reagent_containers/syringe/lethal/execution(src)
+
 /obj/structure/closet/secure_closet/brig
 	name = "brig locker"
 	req_access = list(ACCESS_BRIG)
 	anchored = TRUE
 	var/id = null
+
 /obj/structure/closet/secure_closet/evidence
 	anchored = TRUE
 	name = "Secure Evidence Closet"
 	req_access_txt = "0"
 	req_one_access_txt = list(ACCESS_ARMORY, ACCESS_FORENSICS_LOCKERS)
+
 /obj/structure/closet/secure_closet/brig/PopulateContents()
 	..()
 	new /obj/item/clothing/under/rank/prisoner( src )
@@ -220,6 +232,7 @@
 /obj/structure/closet/secure_closet/courtroom
 	name = "courtroom locker"
 	req_access = list(ACCESS_COURT)
+
 /obj/structure/closet/secure_closet/courtroom/PopulateContents()
 	..()
 	new /obj/item/clothing/shoes/sneakers/brown(src)
@@ -229,18 +242,22 @@
 	new /obj/item/clothing/suit/judgerobe (src)
 	new /obj/item/clothing/head/powdered_wig (src)
 	new /obj/item/storage/briefcase(src)
+
 /obj/structure/closet/secure_closet/contraband/armory
 	anchored = TRUE
 	name = "Contraband Locker"
 	req_access = list(ACCESS_ARMORY)
+
 /obj/structure/closet/secure_closet/contraband/heads
 	anchored = TRUE
 	name = "Contraband Locker"
 	req_access = list(ACCESS_HEADS)
+
 /obj/structure/closet/secure_closet/armory1
 	name = "armory armor locker"
 	req_access = list(ACCESS_ARMORY)
 	icon_state = "armory"
+
 /obj/structure/closet/secure_closet/armory1/PopulateContents()
 	..()
 	new /obj/item/clothing/suit/armor/laserproof(src)
@@ -261,10 +278,12 @@
 		new /obj/item/storage/box/rubbershot(src)
 	for(var/i in 1 to 3)
 		new /obj/item/gun/ballistic/shotgun/riot(src)
+
 /obj/structure/closet/secure_closet/armory3
 	name = "armory energy gun locker"
 	req_access = list(ACCESS_ARMORY)
 	icon_state = "armory"
+
 /obj/structure/closet/secure_closet/armory3/PopulateContents()
 	..()
 	new /obj/item/storage/box/firingpins(src)
@@ -273,20 +292,24 @@
 		new /obj/item/gun/energy/e_gun(src)
 	for(var/i in 1 to 3)
 		new /obj/item/gun/energy/laser(src)
+
 /obj/structure/closet/secure_closet/tac
 	name = "armory tac locker"
 	req_access = list(ACCESS_ARMORY)
 	icon_state = "tac"
+
 /obj/structure/closet/secure_closet/tac/PopulateContents()
 	..()
 	new /obj/item/gun/ballistic/automatic/wt550(src)
 	new /obj/item/clothing/head/helmet/alt(src)
 	new /obj/item/clothing/mask/gas/sechailer(src)
 	new /obj/item/clothing/suit/armor/bulletproof(src)
+
 /obj/structure/closet/secure_closet/lethalshots
 	name = "shotgun lethal rounds"
 	req_access = list(ACCESS_ARMORY)
 	icon_state = "tac"
+
 /obj/structure/closet/secure_closet/lethalshots/PopulateContents()
 	..()
 	for(var/i in 1 to 3)


### PR DESCRIPTION
A more robust version of #10287
Also closes #10286
## About The Pull Request
Cleans out - 
Pet collar - Has no use as cap dosnt offten get a animal.
Pet carrier - Same as above.
Cap hat - Has quite some armor, and cap spawns in with it anyways. + the spare white one if needed
Spare capcarapace - Cap spawns with one and theirs a parade verson, basically this is free spare good armor
Normal spare cap headset - They get a brownman, so why have 2?
Spare gloves - Spawns with them, no need to have a spare of it
Silver ID box - Theirs more in brige. Not needed from caps room
Zipties - Every cap just gets normal handcuffs from sec anyways. No real use in these


## Why It's Good For The Game

Caps locker has a lot of powercreep, like 2 full sets of cap level armor for anyone to take + spawning with a full cap armor set. This also helps stop overflowing amout of item creep in this locker.

## Changelog
:cl:
del: Removes several items from captain locker. 
/:cl:
