### PR TITLE
Ghost Cafe patrons now spawn with chameleon kits

### DIFF
--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -663,6 +663,4 @@
 	new /obj/item/clothing/head/chameleon(src)
 	new /obj/item/clothing/mask/chameleon(src)
 	new /obj/item/storage/backpack/chameleon(src)
-	new /obj/item/radio/headset/chameleon(src)
-	new /obj/item/stamp/chameleon(src)
 	new /obj/item/clothing/neck/cloak/chameleon(src)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -605,7 +605,7 @@
 	rank = "Gunner"
 
 /obj/effect/mob_spawn/human/ghostcafe
-	name = "ghost cafe sleeper"
+	name = "Ghost Cafe Sleeper"
 	uses = -1
 	icon = 'icons/obj/machines/sleeper.dmi'
 	icon_state = "sleeper"
@@ -633,6 +633,7 @@
 	uniform = /obj/item/clothing/under/color/random
 	shoes = /obj/item/clothing/shoes/sneakers/black
 	id = /obj/item/card/id
+	r_hand = /obj/item/storage/box/syndie_kit/chameleon/ghostcafe
 
 
 /datum/outfit/ghostcafe/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
@@ -649,3 +650,19 @@
 		else
 			uniform = /obj/item/clothing/under/skirt/color/random
 
+/obj/item/storage/box/syndie_kit/chameleon/ghostcafe
+	name = "ghost cafe costuming kit"
+	desc = "Look just the way you did in life - or better!"
+
+/obj/item/storage/box/syndie_kit/chameleon/ghostcafe/PopulateContents() // Doesn't contain a PDA, for isolation reasons.
+	new /obj/item/clothing/under/chameleon(src)
+	new /obj/item/clothing/suit/chameleon(src)
+	new /obj/item/clothing/gloves/chameleon(src)
+	new /obj/item/clothing/shoes/chameleon(src)
+	new /obj/item/clothing/glasses/chameleon(src)
+	new /obj/item/clothing/head/chameleon(src)
+	new /obj/item/clothing/mask/chameleon(src)
+	new /obj/item/storage/backpack/chameleon(src)
+	new /obj/item/radio/headset/chameleon(src)
+	new /obj/item/stamp/chameleon(src)
+	new /obj/item/clothing/neck/cloak/chameleon(src)


### PR DESCRIPTION
## About The Pull Request

Adds the "/ghostcafe" variant of the chameleon box, which does not contain a PDA, and adds it to the ghost cafe outfit.

## Why It's Good For The Game

Fashion is important.

## Changelog
:cl:
add: Ghost Cafe patrons now spawn with chameleon kits. Dress up! Be fancy!
/:cl:
