### PR TITLE
telescopic iv drips are no longer bluespace magic

### DIFF
--- a/code/game/objects/items/telescopic_iv.dm
+++ b/code/game/objects/items/telescopic_iv.dm
@@ -9,7 +9,7 @@
 
 /obj/item/tele_iv/afterattack(atom/target, mob/user, proximity)
 	. = ..()
-	if(proximity|| isopenturf(target))
+	if(proximity && isopenturf(target) && user.CanReach(target))
 		deploy_iv(user, target)
 
 /obj/item/tele_iv/proc/deploy_iv(mob/user, atom/location)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

you can no longer remote deploy teledrips or stuff them into people

## Why It's Good For The Game

this isn't a dildo stop stuffing each other full of them

## Changelog
:cl:
fix: telescopic iv drips now have the proper sanity checks for deployment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
