### PR TITLE
beaker buff - alt title fuck hypovials and fuck making them free and better alternatives to beakers

### DIFF
--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -115,6 +115,7 @@
 	icon_state = "beaker"
 	item_state = "beaker"
 	materials = list(MAT_GLASS=500)
+	possible_transfer_amounts = list(5,10,15,20,25,30,60)
 	beaker_weakness_bitflag = PH_WEAK
 
 /obj/item/reagent_containers/glass/beaker/Initialize()
@@ -157,7 +158,7 @@
 
 /obj/item/reagent_containers/glass/beaker/jar
 	name = "honey jar"
-	desc = "A jar for honey. It can hold up to 50 units of sweet delight. Unable to withstand reagents of an extreme pH."
+	desc = "A jar for honey. It can hold up to 60 units of sweet delight. Unable to withstand reagents of an extreme pH."
 	icon = 'icons/obj/chemical.dmi'
 	icon_state = "vapour"
 
@@ -168,7 +169,7 @@
 	materials = list(MAT_GLASS=2500)
 	volume = 120
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,120)
+	possible_transfer_amounts = list(5,10,15,20,25,30,40,60,120)
 	container_HP = 3
 
 /obj/item/reagent_containers/glass/beaker/plastic
@@ -178,7 +179,7 @@
 	materials = list(MAT_GLASS=2500, MAT_PLASTIC=3000)
 	volume = 180
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,180)
+	possible_transfer_amounts = list(5,10,15,20,25,30,40,60,120,180)
 
 /obj/item/reagent_containers/glass/beaker/plastic/Initialize()
 	beaker_weakness_bitflag &= ~PH_WEAK
@@ -197,7 +198,7 @@
 	materials = list(MAT_GLASS=2500, MAT_PLASTIC=3000, MAT_GOLD=1000, MAT_TITANIUM=1000)
 	volume = 240
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,120,200,240)
+	possible_transfer_amounts = list(5,10,15,20,25,30,40,60,120,200,240)
 
 /obj/item/reagent_containers/glass/beaker/meta/Initialize() // why the fuck can't you just set the beaker weakness bitflags to nothing? fuck you
 	beaker_weakness_bitflag &= ~PH_WEAK

--- a/code/modules/reagents/reagent_containers/glass.dm
+++ b/code/modules/reagents/reagent_containers/glass.dm
@@ -109,8 +109,9 @@
 
 /obj/item/reagent_containers/glass/beaker
 	name = "beaker"
-	desc = "A beaker. It can hold up to 50 units. Unable to withstand extreme pHes"
+	desc = "A beaker. It can hold up to 60 units. Unable to withstand extreme pHes."
 	icon = 'icons/obj/chemical.dmi'
+	volume = 60
 	icon_state = "beaker"
 	item_state = "beaker"
 	materials = list(MAT_GLASS=500)
@@ -162,22 +163,22 @@
 
 /obj/item/reagent_containers/glass/beaker/large
 	name = "large beaker"
-	desc = "A large beaker. Can hold up to 100 units. Unable to withstand reagents of an extreme pH."
+	desc = "A large beaker. Can hold up to 120 units. Unable to withstand reagents of an extreme pH."
 	icon_state = "beakerlarge"
 	materials = list(MAT_GLASS=2500)
-	volume = 100
+	volume = 120
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100)
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,120)
 	container_HP = 3
 
 /obj/item/reagent_containers/glass/beaker/plastic
 	name = "x-large beaker"
-	desc = "An extra-large beaker. Can hold up to 150 units. Is able to resist acid and alkaline solutions, but melts at 444K"
+	desc = "An extra-large beaker. Can hold up to 180 units. Is able to resist acid and alkaline solutions, but melts at 444 K."
 	icon_state = "beakerwhite"
 	materials = list(MAT_GLASS=2500, MAT_PLASTIC=3000)
-	volume = 150
+	volume = 180
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,150)
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,180)
 
 /obj/item/reagent_containers/glass/beaker/plastic/Initialize()
 	beaker_weakness_bitflag &= ~PH_WEAK
@@ -191,14 +192,14 @@
 
 /obj/item/reagent_containers/glass/beaker/meta
 	name = "metamaterial beaker"
-	desc = "A large beaker. Can hold up to 200 units. Is able to withstand all chemical situations."
+	desc = "A large beaker. Can hold up to 240 units, and is able to withstand all chemical situations."
 	icon_state = "beakergold"
 	materials = list(MAT_GLASS=2500, MAT_PLASTIC=3000, MAT_GOLD=1000, MAT_TITANIUM=1000)
-	volume = 200
+	volume = 240
 	amount_per_transfer_from_this = 10
-	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,200)
+	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,120,200,240)
 
-/obj/item/reagent_containers/glass/beaker/meta/Initialize()
+/obj/item/reagent_containers/glass/beaker/meta/Initialize() // why the fuck can't you just set the beaker weakness bitflags to nothing? fuck you
 	beaker_weakness_bitflag &= ~PH_WEAK
 	. = ..()
 
@@ -228,7 +229,7 @@
 	volume = 300
 	amount_per_transfer_from_this = 10
 	possible_transfer_amounts = list(5,10,15,20,25,30,50,100,300)
-	container_HP = 4
+	container_HP = 5
 
 /obj/item/reagent_containers/glass/beaker/cryoxadone
 	list_reagents = list("cryoxadone" = 30)

--- a/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/code/modules/reagents/reagent_containers/hypovial.dm
@@ -27,8 +27,8 @@
 	for(var/R in comes_with)
 		reagents.add_reagent(R,comes_with[R])
 	update_icon()
-	beaker_weakness_bitflag |= PH_WEAK // fuck you if you're using these like beakers
-	beaker_weakness_bitflag |= TEMP_WEAK
+//	beaker_weakness_bitflag |= PH_WEAK // fuck you if you're using these like beakers
+//	beaker_weakness_bitflag |= TEMP_WEAK
 
 
 /obj/item/reagent_containers/glass/bottle/vial/on_reagent_change()
@@ -62,11 +62,11 @@
 /obj/item/reagent_containers/glass/bottle/vial/small
 	name = "hypovial"
 	volume = 60
-	possible_transfer_amounts = list(1)
+	possible_transfer_amounts = list(1,2,5,10,20,30)
 
 /obj/item/reagent_containers/glass/bottle/vial/small/bluespace
 	volume = 120
-	possible_transfer_amounts = list(1)
+	possible_transfer_amounts = list(1,2,5,10,20,30,40)
 	name = "bluespace hypovial"
 	icon_state = "hypovialbs"
 	unique_reskin = null
@@ -76,7 +76,7 @@
 	desc = "A large hypovial, for deluxe hypospray models."
 	icon_state = "hypoviallarge"
 	volume = 120
-	possible_transfer_amounts = list(1)
+	possible_transfer_amounts = list(1,2,5,10,20,30,40,60)
 	unique_reskin = list("large hypovial" = "hypoviallarge",
 						"large red hypovial" = "hypoviallarge-b",
 						"large blue hypovial" = "hypoviallarge-d",
@@ -108,7 +108,7 @@
 		add_overlay(filling)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/bluespace
-	possible_transfer_amounts = list(1)
+	possible_transfer_amounts = list(1,2,5,10,20,30,40,60)
 	name = "bluespace large hypovial"
 	volume = 240
 	icon_state = "hypoviallargebs"

--- a/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/code/modules/reagents/reagent_containers/hypovial.dm
@@ -1,6 +1,6 @@
 //hypovials used with the MkII hypospray. See hypospray.dm.
 
-/obj/item/reagent_containers/glass/bottle/vial
+/obj/item/reagent_containers/glass/bottle/vial // these have literally no fucking right to just be better beakers that you can shit out of a chemmaster
 	name = "broken hypovial"
 	desc = "A hypovial compatible with most hyposprays."
 	icon_state = "hypovial"
@@ -27,6 +27,8 @@
 	for(var/R in comes_with)
 		reagents.add_reagent(R,comes_with[R])
 	update_icon()
+	beaker_weakness_bitflag |= PH_WEAK // fuck you if you're using these like beakers
+	beaker_weakness_bitflag |= TEMP_WEAK
 
 
 /obj/item/reagent_containers/glass/bottle/vial/on_reagent_change()
@@ -60,11 +62,11 @@
 /obj/item/reagent_containers/glass/bottle/vial/small
 	name = "hypovial"
 	volume = 60
-	possible_transfer_amounts = list(5,10)
+	possible_transfer_amounts = list(1)
 
 /obj/item/reagent_containers/glass/bottle/vial/small/bluespace
 	volume = 120
-	possible_transfer_amounts = list(5,10)
+	possible_transfer_amounts = list(1)
 	name = "bluespace hypovial"
 	icon_state = "hypovialbs"
 	unique_reskin = null
@@ -74,7 +76,7 @@
 	desc = "A large hypovial, for deluxe hypospray models."
 	icon_state = "hypoviallarge"
 	volume = 120
-	possible_transfer_amounts = list(5,10,15,20)
+	possible_transfer_amounts = list(1)
 	unique_reskin = list("large hypovial" = "hypoviallarge",
 						"large red hypovial" = "hypoviallarge-b",
 						"large blue hypovial" = "hypoviallarge-d",
@@ -106,7 +108,7 @@
 		add_overlay(filling)
 
 /obj/item/reagent_containers/glass/bottle/vial/large/bluespace
-	possible_transfer_amounts = list(5,10,15,20)
+	possible_transfer_amounts = list(1)
 	name = "bluespace large hypovial"
 	volume = 240
 	icon_state = "hypoviallargebs"


### PR DESCRIPTION
## About The Pull Request
makes beakers the primary chemical mixing tool they should have been

edit: hypovials are pH/temp proofed again but i swear to god if chemistry is up to something i will fuck them over again

changes:
- beakers 50 -> 60u
- large beakers 100 -> 120u
- x-large beaker 150 -> 180u
- metabeaker 200 -> 240u
- bluespace beaker +1 arbitrary health unit
## Why It's Good For The Game
makes beakers relevant in chemistry again. fuck hypovials. fuck hypovial users. fuck med mains. i fucking hate chemists. fuck them all. they're all shitheads and they don't deserve to play the game.
## Changelog
:cl:
balance: Beakers are generally more useful now, with slight capacity increases.
tweak: Transfer amounts are different now. Adjust your muscle memory to compensate.
/:cl: