### PR TITLE
ORM lasers actually affect point return

### DIFF
--- a/code/modules/mining/machine_redemption.dm
+++ b/code/modules/mining/machine_redemption.dm
@@ -50,7 +50,7 @@
 /obj/machinery/mineral/ore_redemption/examine(mob/user)
 	. = ..()
 	if(in_range(user, src) || isobserver(user))
-		. += "<span class='notice'>The status display reads: Smelting <b>[sheet_per_ore]</b> sheet(s) per piece of ore.<br>Ore pickup speed at <b>[ore_pickup_rate]</b>.</span>"
+		. += "<span class='notice'>The status display reads: Smelting <b>[sheet_per_ore]</b> sheet(s) per piece of ore.<br>Reward point generation at <b>[point_upgrade*100]%</b>.<br>Ore pickup speed at <b>[ore_pickup_rate]</b>.</span>"
 
 /obj/machinery/mineral/ore_redemption/proc/smelt_ore(obj/item/stack/ore/O)
 	var/datum/component/material_container/mat_container = materials.mat_container
@@ -63,7 +63,7 @@
 	ore_buffer -= O
 
 	if(O && O.refined_type)
-		points += O.points * O.amount
+		points += O.points * point_upgrade * O.amount
 
 	var/material_amount = mat_container.get_item_material_amount(O)
 


### PR DESCRIPTION
## About The Pull Request
makes ORM laser upgrades actually affect how many points are generated per ore piece processed
## Why It's Good For The Game
feature got lost somehow during the "what if I just made IDs not need to be shoved into the ORM" thing
## Changelog
:cl:
balance: ore redemption machines actually get affected by lasers again kthx
/:cl: