### PR TITLE
blood drunk buff probably shouldnt cripple you

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -292,6 +292,7 @@
 			var/mob/living/carbon/C = owner
 			for(var/X in C.bodyparts)
 				var/obj/item/bodypart/BP = X
+				BP.max_damage *= 10
 				BP.brute_dam *= 10
 				BP.burn_dam *= 10
 		owner.toxloss *= 10
@@ -377,6 +378,7 @@
 			var/obj/item/bodypart/BP = X
 			BP.brute_dam *= 0.1
 			BP.burn_dam *= 0.1
+			BP.max_damage /= 10
 	owner.toxloss *= 0.1
 	owner.oxyloss *= 0.1
 	owner.cloneloss *= 0.1


### PR DESCRIPTION
## About The Pull Request
being blood drunk (see blood drunk miner eye trophy) is unlikely to cripple you now, port of tgstation#42795
## Why It's Good For The Game
getting crippled for an oversight is a 4head bruh moment
## Changelog
:cl:
fix: Blood-drunk buff from blood-drunk eye crusher trophy is less likely to cripple its user.
/:cl: