### PR TITLE
[Ready] EMPing energy based swords will now turn them off

### DIFF
--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -7,7 +7,6 @@
 	var/brightness_on = 3
 	total_mass = 0.4 //Survival flashlights typically weigh around 5 ounces.
 
-
 /obj/item/melee/transforming/energy/Initialize()
 	. = ..()
 	total_mass_on = (total_mass_on ? total_mass_on : (w_class_on * 0.75))
@@ -61,6 +60,17 @@
 	. = "<span class='warning'>[user] swings [user.p_their()] [name][in_mouth]. [user.p_they(TRUE)] light[user.p_s()] [user.p_their()] [A.name] in the process.</span>"
 	playsound(loc, hitsound, get_clamped_volume(), 1, -1)
 	add_fingerprint(user)
+
+/obj/item/melee/transforming/energy/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(active)
+		active = FALSE
+		w_class = w_class_off
+		return
+	else
+		return
 
 /obj/item/melee/transforming/energy/axe
 	name = "energy axe"

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -61,17 +61,6 @@
 	playsound(loc, hitsound, get_clamped_volume(), 1, -1)
 	add_fingerprint(user)
 
-/obj/item/melee/transforming/energy/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	if(active)
-		active = FALSE
-		w_class = w_class_off
-		return
-	else
-		return
-
 /obj/item/melee/transforming/energy/axe
 	name = "energy axe"
 	desc = "An energized battle axe."
@@ -94,6 +83,16 @@
 	light_color = "#40ceff"
 	total_mass = null
 
+/obj/item/melee/transforming/energy/axe/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(!active)
+		return
+	else
+		transform_weapon()
+		return
+
 /obj/item/melee/transforming/energy/axe/suicide_act(mob/user)
 	user.visible_message("<span class='suicide'>[user] swings [src] towards [user.p_their()] head! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS|FIRELOSS)
@@ -114,6 +113,16 @@
 	embedding = list("embed_chance" = 75, "embedded_impact_pain_multiplier" = 10)
 	armour_penetration = 35
 	block_chance = 50
+
+/obj/item/melee/transforming/energy/sword/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(!active)
+		return
+	else
+		transform_weapon()
+		return
 
 /obj/item/melee/transforming/energy/sword/transform_weapon(mob/living/user, supress_message_text)
 	. = ..()

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -17,9 +17,6 @@
 //This rewrite means we don't have two variables for EVERY item which are used only by a few weapons.
 //It also tidies stuff up elsewhere.
 
-
-
-
 /*
  * Twohanded
  */
@@ -298,6 +295,16 @@
 	var/spinnable = TRUE
 	total_mass = 0.4 //Survival flashlights typically weigh around 5 ounces.
 	var/total_mass_on = 3.4
+
+/obj/item/twohanded/dualsaber/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	if(!wielded)
+		return
+	else
+		unwield()
+		return
 
 /obj/item/twohanded/dualsaber/suicide_act(mob/living/carbon/user)
 	if(wielded)


### PR DESCRIPTION
## About The Pull Request
EMPs will now turn off a E-sword if it is active.
EMPs will now turn off Engery axes if its active
Emps will now turn off duelsabers  if its active

#### Tested Code!

## Why It's Good For The Game

Consistency mostly. As well as giving more uses to those EMP based guns sec get outside the use of shooting a clown borg.

## Changelog
:cl:
balance: EMPs will now untransformer a Esword blade 
/:cl:
