### PR TITLE
[s] Fixes Dragon's Tooth Sword 50% armor penetration by making it 35%

### DIFF
--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -374,7 +374,7 @@
 			It appears to have a wooden grip and a shaved down guard."
 	icon_state = "cxsword_hilt_traitor"
 	force_on = 30
-	armour_penetration = 50
+	armour_penetration = 35
 	embedding = list("embedded_pain_multiplier" = 10, "embed_chance" = 75, "embedded_fall_chance" = 0, "embedded_impact_pain_multiplier" = 10)
 	block_chance = 50
 	hitsound_on = 'sound/weapons/blade1.ogg'


### PR DESCRIPTION
## About The Pull Request

Lowers Dragon's Tooth Sword to 35% armor penetration, like normal eswords. As its a reskin

## Why It's Good For The Game

Consistenty and making it not legit better then a normal esword that has better armor penetration 

## Changelog
:cl: Bhijn helped
fix: Fixes Dragon's Tooth Sword 50% armor penetration by making it 35%
/:cl: