### PR TITLE
Attempts to fix the bug where UI blocks are always random by stopping a race condition where dna gets updated before being initialized

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -204,10 +204,10 @@
 		blood_type = newblood_type
 	if(!needs_init)
 		return
+	features = random_features()
 	unique_enzymes = generate_unique_enzymes()
 	uni_identity = generate_uni_identity()
 	struc_enzymes = generate_struc_enzymes()
-	features = random_features()
 	needs_init = FALSE
 
 

--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -15,6 +15,7 @@
 	var/list/previous = list() //For temporary name/ui/ue/blood_type modifications
 	var/mob/living/holder
 	var/delete_species = TRUE //Set to FALSE when a body is scanned by a cloner to fix #38875
+	var/needs_init = TRUE //done to prevent race conditions where dna gets updated before it actually gets initialized, resulting in uni blocks being randomized, such as with player spawning.
 
 /datum/dna/New(mob/living/new_holder)
 	if(istype(new_holder))
@@ -193,16 +194,21 @@
 
 //used to update dna UI, UE, and dna.real_name.
 /datum/dna/proc/update_dna_identity()
+	if(needs_init)
+		initialize_dna()
 	uni_identity = generate_uni_identity()
 	unique_enzymes = generate_unique_enzymes()
 
 /datum/dna/proc/initialize_dna(newblood_type)
 	if(newblood_type)
 		blood_type = newblood_type
+	if(!needs_init)
+		return
 	unique_enzymes = generate_unique_enzymes()
 	uni_identity = generate_uni_identity()
 	struc_enzymes = generate_struc_enzymes()
 	features = random_features()
+	needs_init = FALSE
 
 
 /datum/dna/stored //subtype used by brain mob's stored_dna


### PR DESCRIPTION
## About The Pull Request

Fwee, this was fun to figure out. So the thing about cloning is that DNA is currently bugged in that spacemen aren't actually spawning with their DNA set properly; everyone spawns with completely random UI blocks. This means that when you clone a spaceman or fiddle with its UI blocks at all, you'll usually end up with something that looks only vaguely similar due to the UI change forcing an update that results in the spaceman spontaneously changing appearance to match what their UI blocks actually are. This is because for whatever reason, the update proc was getting called before the initialize proc did. Yeah, I have no idea how this got overlooked, either. This PR does not fix the lack of certain DNA features still not being included in UI blocks, but those are very easy to add for anyone looking to do so, and adding the missing features to spaceman DNA will not conflict with this PR. 

## Changelog
:cl: Bhijn
fix: Fixed a race condition where DNA gets updated before it actually gets initialized, fixing the bug where cloning and radiation causes a spaceman's appearance to appear to randomize completely.
fix: Also restores a fix that was regressed a year ago, where UI blocks are generated before there's an actual features list initialized, causing several parts of the UI blocks to be null.
/:cl:
