### PR TITLE
Removes mass message from lawyer PDAs

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -186,6 +186,7 @@
 	icon_state = "cart-c"
 	access = ~(CART_CLOWN | CART_MIME | CART_REMOTE_DOOR)
 	bot_access_flags = SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
+	spam_enabled = 1
 
 /obj/item/cartridge/captain/New()
 	..()

--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -103,7 +103,6 @@
 	name = "\improper P.R.O.V.E. cartridge"
 	icon_state = "cart-law"
 	access = CART_SECURITY
-	spam_enabled = 1
 
 /obj/item/cartridge/curator
 	name = "\improper Lib-Tweet cartridge"
@@ -187,7 +186,6 @@
 	icon_state = "cart-c"
 	access = ~(CART_CLOWN | CART_MIME | CART_REMOTE_DOOR)
 	bot_access_flags = SEC_BOT | MULE_BOT | FLOOR_BOT | CLEAN_BOT | MED_BOT | FIRE_BOT
-	spam_enabled = 1
 
 /obj/item/cartridge/captain/New()
 	..()


### PR DESCRIPTION
## About The Pull Request

Tin. 

## Why It's Good For The Game

Lawyers can no longer make the fact that their job is mind-numbingly boring everyone else's problem by shitting up their PDAs with spam about who they're having sex with or want to have sex with or whatever inane garbage they feel like everyone should be subjected to every five minutes for two straight hours.

Captain retains the ability.

For now.

## Changelog
:cl:
del: Lawyers can no longer mass-message with their PDAs.
/:cl: