### PR TITLE
Adds the "View Crew Manifest" verb to Robots

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -260,15 +260,6 @@
 	viewalerts = 1
 	src << browse(dat, "window=aialerts&can_close=0")
 
-/mob/living/silicon/ai/proc/ai_roster()
-	var/dat = "<html><head><title>Crew Roster</title></head><body><b>Crew Roster:</b><br><br>"
-
-	dat += GLOB.data_core.get_manifest()
-	dat += "</body></html>"
-
-	src << browse(dat, "window=airoster")
-	onclose(src, "airoster")
-
 /mob/living/silicon/ai/proc/ai_call_shuttle()
 	if(control_disabled)
 		to_chat(usr, "<span class='warning'>Wireless control is disabled!</span>")

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -1299,3 +1299,11 @@
 /mob/living/silicon/robot/adjustStaminaLossBuffered(amount, updating_health = 1)
 	if(istype(cell))
 		cell.charge -= amount*5
+
+/mob/living/silicon/robot/verb/viewmanifest()
+	set category = "Robot Commands"
+	set name = "View Crew Manifest"
+
+	if(usr.stat == DEAD)
+		return //won't work if dead
+	ai_roster()

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -389,6 +389,15 @@
 	if (aicamera)
 		return aicamera.selectpicture(user)
 
+/mob/living/silicon/proc/ai_roster()
+	var/dat = "<html><head><title>Crew Roster</title></head><body><b>Crew Roster:</b><br><br>"
+
+	dat += GLOB.data_core.get_manifest()
+	dat += "</body></html>"
+
+	src << browse(dat, "window=airoster")
+	onclose(src, "airoster")
+
 /mob/living/silicon/update_transform()
 	var/matrix/ntransform = matrix(transform) //aka transform.Copy()
 	var/changed = 0


### PR DESCRIPTION
## About The Pull Request

Moves the "ai_roster()" proc up to silicon and grants robots access to it via a new verb. 

## Why It's Good For The Game

A ton of a silicon's moment-to-moment gameplay and decision-making is based on information they don't have access to! This should aid in that process.

## Changelog
:cl:
add: Robots can now check the crew manifest from anywhere with the "View Crew Manifest" verb.
/:cl: