### PR TITLE
Removes mason rig crate

### DIFF
--- a/code/modules/cargo/packs/engine.dm
+++ b/code/modules/cargo/packs/engine.dm
@@ -70,15 +70,6 @@
 	crate_name = "grounding rod crate"
 	crate_type = /obj/structure/closet/crate/engineering/electrical
 
-/datum/supply_pack/engine/mason
-	name = "M.A.S.O.N RIG Crate"
-	desc = "The rare M.A.S.O.N RIG. Requires CE access to open."
-	cost = 15000
-	access = ACCESS_CE
-	contains = list(/obj/item/clothing/suit/space/hardsuit/ancient/mason)
-	crate_name = "M.A.S.O.N Rig"
-	crate_type = /obj/structure/closet/crate/secure/engineering
-
 /datum/supply_pack/engine/PA
 	name = "Particle Accelerator Crate"
 	desc = "A supermassive black hole or hyper-powered teslaball are the perfect way to spice up any party! This \"My First Apocalypse\" kit contains everything you need to build your own Particle Accelerator! Ages 10 and up."


### PR DESCRIPTION

## About The Pull Request

Kev is a fucken lier. He said he would remove these and never did

## Why It's Good For The Game

Broken and unbalanced to the likings of the coder.
Useless for what It was intended for.
Was told that we would remove it by kev, he then never fucken did

## Changelog
:cl:
fix: MASON rig being in cargo
/:cl:
