### PR TITLE
Significantly lowers the forcefield projector health, lowers armor.

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -10,7 +10,7 @@
 	lefthand_file = 'icons/mob/inhands/misc/devices_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/misc/devices_righthand.dmi'
 	materials = list(MAT_METAL=250, MAT_GLASS=500)
-	var/max_shield_integrity = 250
+	var/max_shield_integrity = 100
 	var/shield_integrity = 250
 	var/max_fields = 3
 	var/list/current_fields
@@ -87,7 +87,7 @@
 	mouse_opacity = MOUSE_OPACITY_OPAQUE
 	resistance_flags = INDESTRUCTIBLE
 	CanAtmosPass = ATMOS_PASS_DENSITY
-	armor = list("melee" = 0, "bullet" = 25, "laser" = 50, "energy" = 50, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
+	armor = list("melee" = 0, "bullet" = 25, "laser" = 25, "energy" = 25, "bomb" = 25, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)
 	var/obj/item/forcefield_projector/generator
 
 /obj/structure/projected_forcefield/Initialize(mapload, obj/item/forcefield_projector/origin)


### PR DESCRIPTION
_**Redid this because I am a dumb and did not branch properly.**_

Having a 250 health portable shield that you can deploy on up to three tiles, has shielding resistant to everything but melee, and can be reset and redeployed quickly has been nothing but abused lately.

This drops the health down to 100 from 250, keeping shield integrity. Armor is halved on bullets and lasers. 