### PR TITLE
Restores meteor warnings with slight more punishment for ignoring them

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -21,7 +21,7 @@
 
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
-	startWhen = rand(60, 90) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	startWhen = rand(180, 360) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
 	if(GLOB.singularity_counter)
 		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60
@@ -35,9 +35,9 @@
 /datum/round_event/meteor_wave/proc/determine_wave_type()
 	if(!wave_name)
 		wave_name = pickweight(list(
-			"normal" = 50,
+			"normal" = 45,
 			"threatening" = 40,
-			"catastrophic" = 10))
+			"catastrophic" = 15))
 	switch(wave_name)
 		if("normal")
 			wave_type = GLOB.meteors_normal
@@ -71,7 +71,7 @@
 	weight = 5
 	min_players = 20
 	max_occurrences = 3
-	earliest_start = 35 MINUTES
+	earliest_start = 45 MINUTES
 
 /datum/round_event/meteor_wave/threatening
 	wave_name = "threatening"
@@ -80,9 +80,9 @@
 	name = "Meteor Wave: Catastrophic"
 	typepath = /datum/round_event/meteor_wave/catastrophic
 	weight = 7
-	min_players = 25
-	max_occurrences = 3
-	earliest_start = 45 MINUTES
+	min_players = 30
+	max_occurrences = 2
+	earliest_start = 60 MINUTES
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"


### PR DESCRIPTION
Having a minute to react to catastrophic meteors makes absolutely no logical sense, particularly when dealing with other station wide antagonists.

This PR restores the time of warning to give engineers the actual ability to set these up, discussion has proven that nobody is going to waste time setting up the shields preemptively.

Ultimately it

Restores it back to the 3-6 minute warning.
Gives a very slight increase of weight to stronger meteor waves to punish ignoring it (and steer the playerbase into hopefully becoming more proactive)

Slightly increases the player count needed for more destructive waves because low pop catastrophic is unfun for literally everyone.

Slightly increases the time needed for catastrophic meteors to balance their increased chance. Dropping them to only 2 per round if rolled (which 3 couldn't happen anyway with the round timing)