### PR TITLE
Knocks down cargo passive gen 750 -> 500

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -37,7 +37,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/points = 5000					//number of trade-points we have
 	var/centcom_message = ""			//Remarks from CentCom on how well you checked the last order.
 	var/list/discoveredPlants = list()	//Typepaths for unusual plants we've already sent CentCom, associated with their potencies
-	var/passive_supply_points_per_minute = 750
+	var/passive_supply_points_per_minute = 500
 
 	var/list/supply_packs = list()
 	var/list/shoppinglist = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

People keep saying that cargo has nothing to do because of this, and with Trilby's exports I feel like this is augmenting easy exports too much. This is supposed to be an emergency reserve thing letting you trickle order if you have nowhere else to go but it's a little strong right now.

## Changelog
:cl:
balance: Cargo passive gen is now 500 down from 750.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
