### PR TITLE
Add a way to make opaque plastic flaps

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -673,7 +673,8 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/bone
 
 GLOBAL_LIST_INIT(plastic_recipes, list(
-	new /datum/stack_recipe("plastic flaps", /obj/structure/plasticflaps, 5, one_per_turf = TRUE, on_floor = TRUE, time = 40), \
+	new /datum/stack_recipe("see-through plastic flaps", /obj/structure/plasticflaps, 5, one_per_turf = TRUE, on_floor = TRUE, time = 40), \
+	new /datum/stack_recipe("opaque plastic flaps", /obj/structure/plasticflaps/opaque, 5, one_per_turf = TRUE, on_floor = TRUE, time = 40), \
 	new /datum/stack_recipe("water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/empty), \
 	new /datum/stack_recipe("large water bottle", /obj/item/reagent_containers/glass/beaker/waterbottle/large/empty,3), \
 	new /datum/stack_recipe("large trash cart", /obj/structure/closet/crate/bin,50),\


### PR DESCRIPTION
## About The Pull Request
This make opaque plastic flaps craftable, and rename the current flap recipe to be more clear as a result. The opaque version cost the same as the see-through version, 5 Plastic Sheets.

## Why It's Good For The Game
They are used on every map, but the one that you can make are see-through and nothing you can do can change that. So there was no way to make opaque flaps, even if it could have been useful.

## Changelog
:cl:
add: Added a way to make opaque plastic flaps
change: Change the already existing flap recipe to show that they are see-through
/:cl: