### PR TITLE
The Great Citadel De-Pissening of 2020

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -193,9 +193,9 @@
 	var/on = FALSE					// 1 if on, 0 if off
 	var/on_gs = FALSE
 	var/static_power_used = 0
-	var/brightness = 8			// luminosity when on, also used in power calculation
+	var/brightness = 11			// luminosity when on, also used in power calculation
 	var/bulb_power = 0.75			// basically the alpha of the emitted light source
-	var/bulb_colour = "#FFEEDD"	// befault colour of the light.
+	var/bulb_colour = "#FFF6ED"	// befault colour of the light.
 	var/status = LIGHT_OK		// LIGHT_OK, _EMPTY, _BURNED or _BROKEN
 	var/flickering = FALSE
 	var/light_type = /obj/item/light/tube		// the type of light item
@@ -231,7 +231,7 @@
 	icon_state = "bulb"
 	base_state = "bulb"
 	fitting = "bulb"
-	brightness = 4
+	brightness = 6
 	bulb_colour = "#FFDDBB"
 	desc = "A small lighting fixture."
 	light_type = /obj/item/light/bulb
@@ -272,11 +272,11 @@
 	spawn(2)
 		switch(fitting)
 			if("tube")
-				brightness = 8
+				brightness = 11
 				if(prob(2))
 					break_light_tube(1)
 			if("bulb")
-				brightness = 4
+				brightness = 6
 				if(prob(5))
 					break_light_tube(1)
 		spawn(1)
@@ -351,11 +351,11 @@
 		set_light(0)
 	update_icon()
 
-	active_power_usage = (brightness * 10)
+	active_power_usage = (brightness * 7.2)
 	if(on != on_gs)
 		on_gs = on
 		if(on)
-			static_power_used = brightness * 20 //20W per unit luminosity
+			static_power_used = brightness * 14.4 //20W per unit luminosity
 			addStaticPower(static_power_used, STATIC_LIGHT)
 		else
 			removeStaticPower(static_power_used, STATIC_LIGHT)
@@ -738,7 +738,7 @@
 	icon_state = "ltube"
 	base_state = "ltube"
 	item_state = "c_tube"
-	brightness = 8
+	brightness = 11
 
 /obj/item/light/tube/broken
 	status = LIGHT_BROKEN
@@ -751,7 +751,7 @@
 	item_state = "contvapour"
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
-	brightness = 4
+	brightness = 6
 
 /obj/item/light/bulb/broken
 	status = LIGHT_BROKEN
@@ -820,7 +820,7 @@
 	icon = 'icons/obj/lighting.dmi'
 	base_state = "floor"		// base description and icon_state
 	icon_state = "floor"
-	brightness = 4
+	brightness = 6
 	layer = 2.5
 	light_type = /obj/item/light/bulb
 	fitting = "bulb"


### PR DESCRIPTION
## About The Pull Request

Lights are now made for human eyes and actually illuminate rooms in the way that a normal human light does. 

Comparison screenshots (before, after):

Bridge
![image](https://user-images.githubusercontent.com/20717737/71708650-b18fc880-2da7-11ea-9d3d-3dbe517496a9.png)
![image](https://user-images.githubusercontent.com/20717737/71708504-be5fec80-2da6-11ea-8af1-bd200b6852bd.png)

Dorms
![image](https://user-images.githubusercontent.com/20717737/71708671-bfdde480-2da7-11ea-8608-5a80dd08b0b2.png)
![image](https://user-images.githubusercontent.com/20717737/71708519-db94bb00-2da6-11ea-8dbd-f2d1660a63a1.png)

Medbay
![image](https://user-images.githubusercontent.com/20717737/71708684-ccfad380-2da7-11ea-88bd-c11b4297a6e6.png)
![image](https://user-images.githubusercontent.com/20717737/71708531-eea78b00-2da6-11ea-828a-bb34a0b99c61.png)

So what does this DO? Lights have a larger radius, which means they don't give up after three tiles and call it a day. They're also less yellow, which should make the overall aesthetic less depressing and queasy.

## Why It's Good For The Game

It's too dark, man. It's depressing. I want to play spacemans because it's fun. The current lighting just makes me sad. Why's it so dark? Why these cheap bulbs? I want my mommy. She knew how to buy white lightbulbs. 

## Changelog
:cl:
tweak: Lighting looks better now. I can say that because the PR wouldn't be merged and you wouldn't be reading this if it wasn't true.
/:cl: