### PR TITLE
Increase radiation plasma usage in radiation collector

### DIFF
--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -38,7 +38,7 @@
 	name = "robotics radio encryption key"
 	desc = "An encryption key for a radio headset.  To access the engineering channel, use :e. For research, use :n."
 	icon_state = "rob_cypherkey"
-	channels = list("Science" = 1, "Engineering" = 1)
+	channels = list("Science" = 1)
 
 /obj/item/encryptionkey/headset_med
 	name = "medical radio encryption key"

--- a/code/game/objects/items/devices/radio/encryptionkey.dm
+++ b/code/game/objects/items/devices/radio/encryptionkey.dm
@@ -38,7 +38,7 @@
 	name = "robotics radio encryption key"
 	desc = "An encryption key for a radio headset.  To access the engineering channel, use :e. For research, use :n."
 	icon_state = "rob_cypherkey"
-	channels = list("Science" = 1)
+	channels = list("Science" = 1, "Engineering" = 1)
 
 /obj/item/encryptionkey/headset_med
 	name = "medical radio encryption key"

--- a/code/modules/power/singularity/collector.dm
+++ b/code/modules/power/singularity/collector.dm
@@ -44,8 +44,8 @@
 			eject()
 		else
 			var/gasdrained = min(powerproduction_drain*drainratio,loaded_tank.air_contents.gases[/datum/gas/plasma])
-			loaded_tank.air_contents.gases[/datum/gas/plasma] -= gasdrained
-			loaded_tank.air_contents.gases[/datum/gas/tritium] += gasdrained
+			loaded_tank.air_contents.gases[/datum/gas/plasma] -= 2.7 * gasdrained
+			loaded_tank.air_contents.gases[/datum/gas/tritium] += 	2.7 * gasdrained
 			GAS_GARBAGE_COLLECT(loaded_tank.air_contents.gases)
 
 			var/power_produced = RAD_COLLECTOR_OUTPUT


### PR DESCRIPTION
## About The Pull Request

Makes the unfilled plasma tanks run out in the middle of the shift, _not_ the plasma tanks refilled with the plasma tank. The increase is +170% the normal rate, it looks like a lot, but I can show the math and trials that I did if anyone's curious.

EDIT: Also, please testmerge this before merging, the math could be off for a full shift, some of the timing is off on my testing.

## Why It's Good For The Game

A few reasons:
1. It teaches engineers to fill plasma tanks, giving more of a reason to learn how to properly mass manage plasma tanks.
2. Gives players who are good at the SM another avenue to follow up on that.
3. Teaches players how the radiation collectors work ("Why did the SM stop producing energy") from purely in-game mechanics.
4. Gives more of a source of tritium for general usage.

## Changelog
:cl:
tweak: Increases plasma usage in radiation collectors
/:cl: