### PR TITLE
Remove the engie-borg ability to RCD R-Walls

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -556,7 +556,6 @@ RLD
 /obj/item/construction/rcd/borg
 	no_ammo_message = "<span class='warning'>Insufficient charge.</span>"
 	desc = "A device used to rapidly build walls and floors."
-	canRturf = TRUE
 	upgrade = TRUE
 	var/energyfactor = 72
 


### PR DESCRIPTION
## About The Pull Request
This remove the ability to deconstruct r-walls from the EngieBorg's RCD

## Why It's Good For The Game
All the others actual RCDs that can remove R-walls are Admin-Only. And the Engie Borgs were recently buffed since they can now place circuits into machine frames, make APCs, Air Alarms and all that, plus they don't need to upgrade their RCD and don't need to refill them. So it is only fair to remove something that didn't really make sense given that they are not _that_ weak to need it and they have AA anyway.

I don't consider Mech's RCD to be an actual RCD since it is both not a subtype of a RCD like all the others, but also because it don't do the same checks as every other RCDs.
And ERTs are admin-only.

## Changelog
:cl:
del: Removed the ability to RCD R-walls for borgs
/:cl: