### PR TITLE
Fixes roundstart mushpeople being unable to MUSH PUUUUUUUUUUUUNCH!!

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -177,6 +177,7 @@
 #define COMSIG_MOB_PRE_PLAYER_CHANGE "mob_pre_player_change"	//sent to the target mob from base of /mob/transfer_ckey() and /mind/transfer_to(): (our_character, their_character)
 //	#define COMPONENT_STOP_MIND_TRANSFER 1
 #define COMSIG_MOB_UPDATE_SIGHT "mob_update_sight"				//from base of /mob/update_sight(): ()
+#define COMSIG_MOB_ON_NEW_MIND "mob_on_new_mind"			//called when a new mind is assigned to a mob: ()
 #define COMSIG_MOB_SAY "mob_say" // from /mob/living/say(): (proc args list)
 	#define COMPONENT_UPPERCASE_SPEECH 1
 	// used to access COMSIG_MOB_SAY argslist

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -140,6 +140,7 @@
 					L.client.prefs.chat_toggles ^= CHAT_OOC
 
 	SEND_SIGNAL(src, COMSIG_MIND_TRANSFER, new_character, old_character)
+	SEND_SIGNAL(new_character, COMSIG_MOB_ON_NEW_MIND)
 
 /datum/mind/proc/store_memory(new_text)
 	if((length(memory) + length(new_text)) <= MAX_MESSAGE_LEN)
@@ -747,6 +748,7 @@
 	else
 		mind = new /datum/mind(key)
 		SSticker.minds += mind
+		SEND_SIGNAL(src, COMSIG_MOB_ON_NEW_MIND)
 	if(!mind.name)
 		mind.name = real_name
 	mind.current = src

--- a/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/mushpeople.dm
@@ -37,11 +37,16 @@
 			H.dna.features["caps"] = "Round"
 			handle_mutant_bodyparts(H)
 		H.faction |= "mushroom"
-		mush = new(null)
-		mush.teach(H)
+		mush = new()
+		mush.teach(H, TRUE)
+	RegisterSignal(C, COMSIG_MOB_ON_NEW_MIND, .proc/on_new_mind)
+
+/datum/species/mush/proc/on_new_mind(mob/owner)
+	mush.teach(owner, TRUE) //make_temporary TRUE as it shouldn't carry over to other mobs on mind transfer_to.
 
 /datum/species/mush/on_species_loss(mob/living/carbon/C)
 	. = ..()
+	UnregisterSignal(C, COMSIG_MOB_ON_NEW_MIND)
 	C.faction -= "mushroom"
 	mush.remove(C)
 	QDEL_NULL(mush)


### PR DESCRIPTION
## About The Pull Request
See title.
Also makes mushpeople's mushpunch properly not transferrable on mind transfer_to(), since it should be tied with their species.

## Why It's Good For The Game
Because martial arts can not be taught to the mindless and player mobs are given a mind only after species customizations are done. Which is quite a nasty aspect of the martial arts datum that could benefit from a refactor later.
This will close #10290.

## Changelog
:cl:
fix: Fixed roundstart mushpeople being unable to MUSH PUUUUUUUUUUUUNCH!!
/:cl:

