### PR TITLE
Allows users to vote their least favorite game modes in secret/extended vote

### DIFF
--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -341,7 +341,7 @@
 		if(probabilities[M.config_tag]<=0)
 			qdel(M)
 			continue
-		if(M.config_tag in SSvote.stored_gamemode_votes && SSvote.stored_gamemode_votes[M.config_tag] < Get(/datum/config_entry/number/dropped_modes))
+		if(M.config_tag in SSvote.stored_modetier_results && SSvote.stored_modetier_results[M.config_tag] < Get(/datum/config_entry/number/dropped_modes))
 			qdel(M)
 			continue
 		if(min_pop[M.config_tag])

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -236,7 +236,6 @@
 			if(!(M.config_tag in modes))		// ensure each mode is added only once
 				modes += M.config_tag
 				mode_names[M.config_tag] = M.name
-				probabilities[M.config_tag] = M.probability
 				mode_reports[M.config_tag] = M.generate_report()
 				if(probabilities[M.config_tag]>0)
 					mode_false_report_weight[M.config_tag] = M.false_report_weight
@@ -340,6 +339,9 @@
 			qdel(M)
 			continue
 		if(probabilities[M.config_tag]<=0)
+			qdel(M)
+			continue
+		if(M.config_tag in SSvote.stored_gamemode_votes && SSvote.stored_gamemode_votes[M.config_tag] < Get(/datum/config_entry/number/dropped_modes))
 			qdel(M)
 			continue
 		if(min_pop[M.config_tag])

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -392,3 +392,6 @@
 
 /datum/config_entry/flag/allow_clockwork_marauder_on_station
 	config_entry_value = TRUE
+
+/datum/config_entry/number/dropped_modes
+	config_entry_value = 3

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -393,5 +393,8 @@
 /datum/config_entry/flag/allow_clockwork_marauder_on_station
 	config_entry_value = TRUE
 
+/datum/config_entry/flag/modetier_voting
+	config_entry_value = TRUE
+
 /datum/config_entry/number/dropped_modes
 	config_entry_value = 3

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -221,7 +221,7 @@ SUBSYSTEM_DEF(ticker)
 	var/init_start = world.timeofday
 		//Create and announce mode
 	var/list/datum/game_mode/runnable_modes
-	if(SSvote.mode && (SSvote.mode == "roundtype" || SSvote.mode == "dynamic" || SSvote.mode == "modetiers"))
+	if(SSvote.mode && (SSvote.mode == "roundtype" || SSvote.mode == "dynamic" || SSvote.mode == "mode tiers"))
 		SSvote.result()
 		SSpersistence.SaveSavedVotes()
 		for(var/client/C in SSvote.voting)

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -221,6 +221,12 @@ SUBSYSTEM_DEF(ticker)
 	var/init_start = world.timeofday
 		//Create and announce mode
 	var/list/datum/game_mode/runnable_modes
+	if(SSvote.mode && (SSvote.mode == "roundtype" || SSvote.mode == "dynamic" || SSvote.mode == "modetiers"))
+		SSvote.result()
+		SSpersistence.SaveSavedVotes()
+		for(var/client/C in SSvote.voting)
+			C << browse(null, "window=vote;can_close=0")
+		SSvote.reset()
 	if(GLOB.master_mode == "random" || GLOB.master_mode == "secret")
 		runnable_modes = config.get_runnable_modes()
 
@@ -484,9 +490,10 @@ SUBSYSTEM_DEF(ticker)
 		SSticker.modevoted = TRUE
 		var/dynamic = CONFIG_GET(flag/dynamic_voting)
 		if(dynamic)
-			SSvote.initiate_vote("dynamic","server",hideresults=TRUE,votesystem=SCORE_VOTING,forced=TRUE,vote_time = 2 MINUTES)
+			SSvote.initiate_vote("dynamic","server",hideresults=TRUE,votesystem=SCORE_VOTING,forced=TRUE,vote_time = 20 MINUTES)
 		else
-			SSvote.initiate_vote("roundtype","server",hideresults=TRUE,votesystem=RANKED_CHOICE_VOTING,forced=TRUE, vote_time = 2 MINUTES)
+			SSvote.initiate_vote("roundtype","server",hideresults=TRUE,votesystem=PLURALITY_VOTING,forced=TRUE, \
+			vote_time = (CONFIG_GET(flag/modetier_voting) ? 1 MINUTES : 20 MINUTES))
 
 /datum/controller/subsystem/ticker/Recover()
 	current_state = SSticker.current_state

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -486,7 +486,7 @@ SUBSYSTEM_DEF(ticker)
 		if(dynamic)
 			SSvote.initiate_vote("dynamic","server",hideresults=TRUE,votesystem=SCORE_VOTING,forced=TRUE,vote_time = 2 MINUTES)
 		else
-			SSvote.initiate_vote("roundtype","server",hideresults=TRUE,votesystem=PLURALITY_VOTING,forced=TRUE, vote_time = 2 MINUTES)
+			SSvote.initiate_vote("roundtype","server",hideresults=TRUE,votesystem=RANKED_CHOICE_VOTING,forced=TRUE, vote_time = 2 MINUTES)
 
 /datum/controller/subsystem/ticker/Recover()
 	current_state = SSticker.current_state

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -116,10 +116,8 @@ SUBSYSTEM_DEF(vote)
 				var/opposite_pref = d[j][i]
 				if(pref_number>opposite_pref)
 					p[i][j] = d[i][j]
-					p[j][i] = 0
 				else
 					p[i][j] = 0
-					p[j][i] = d[i][j]
 	for(var/i in 1 to choices.len)
 		for(var/j in 1 to choices.len)
 			if(i != j)
@@ -248,6 +246,10 @@ SUBSYSTEM_DEF(vote)
 			if("roundtype") //CIT CHANGE - adds the roundstart extended/secret vote
 				if(SSticker.current_state > GAME_STATE_PREGAME)//Don't change the mode if the round already started.
 					return message_admins("A vote has tried to change the gamemode, but the game has already started. Aborting.")
+				if(choices["secret"] > choices["extended"])
+					. = "secret"
+				else
+					. = "extended"
 				GLOB.master_mode = .
 				SSticker.save_mode(.)
 				message_admins("The gamemode has been voted for, and has been changed to: [GLOB.master_mode]")
@@ -382,6 +384,12 @@ SUBSYSTEM_DEF(vote)
 					choices |= M
 			if("roundtype") //CIT CHANGE - adds the roundstart secret/extended vote
 				choices.Add("secret", "extended")
+				var/list/modes_to_add = config.votable_modes
+				var/list/probabilities = CONFIG_GET(keyed_list/probability)
+				for(var/tag in modes_to_add)
+					if(probabilities[tag] <= 0)
+						modes_to_add -= tag
+				choices.Add(modes_to_add)
 			if("dynamic")
 				for(var/T in config.storyteller_cache)
 					var/datum/dynamic_storyteller/S = T

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -580,5 +580,8 @@ BOX_RANDOM_ENGINE Engine SM
 BOX_RANDOM_ENGINE Engine Tesla
 BOX_RANDOM_ENGINE Engine Singulo
 
-## Number of modes dropped by the secret vote during mode selection, after vote.
+## Whether or not there's a mode tier list vote after the secret/extended vote.
+MODETIER_VOTING
+
+## Number of modes dropped by the modetier vote during mode selection, after vote.
 DROPPED_MODES 3

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -579,3 +579,6 @@ DYNAMIC_VOTING
 BOX_RANDOM_ENGINE Engine SM
 BOX_RANDOM_ENGINE Engine Tesla
 BOX_RANDOM_ENGINE Engine Singulo
+
+## Number of modes dropped by the secret vote during mode selection, after vote.
+DROPPED_MODES 3


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Right after the secret/extended vote ends, the game presents another vote containing all the game modes secret can roll. This uses the Schulze method of scoring, which gives a strict ranking of all candidates. Using these results, we drop the 3 least popular game modes from contention for secret, assuming secret was voted. If extended was voted, the vote is summarily ignored, but still held to preserve hidden votes.

## Why It's Good For The Game

It turns some people latejoin explicitly to maliciously exploit the algorithms to make their most hated game modes worse for everyone involved, and also, a lot of people cryo with their most hated game mode, so this just takes the most hated 3 gamemodes of everyone playing out of the game entirely for a round.

Also we get data on which modes are favorite and least favorite cause of how the voting works, which is nice.

## Changelog
:cl:
add: Added a sort of "game mode ban" by way of having people rank their game modes favorite to least favorite after the secret/extended vote.
fix: Turns out the schulze scoring was written wrong and it was setting things to 0 that shouldn't have been, so that's fixed.
/:cl: