### PR TITLE
Revert "Makes mob/Stat on a 1 second timer rather than fast-as-possible to tone down highpop lag"

### DIFF
--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -567,9 +567,9 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 /mob/proc/is_muzzled()
 	return 0
 
-/mob/Stat(delayoverride)
-	. = ..()
-	var/statdelay = delayoverride || 10
+/mob/Stat()
+	..()
+
 	if(statpanel("Status"))
 		if (client)
 			stat(null, "Ping: [round(client.lastping, 1)]ms (Average: [round(client.avgping, 1)]ms)")
@@ -577,7 +577,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		var/datum/map_config/cached = SSmapping.next_map_config
 		if(cached)
 			stat(null, "Next Map: [cached.map_name]")
-		stat(null, "Round ID: [GLOB.round_id || "NULL"]")
+		stat(null, "Round ID: [GLOB.round_id ? GLOB.round_id : "NULL"]")
 		stat(null, "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]")
 		stat(null, "Round Time: [WORLDTIME2TEXT("hh:mm:ss")]")
 		stat(null, "Station Time: [STATION_TIME_TIMESTAMP("hh:mm:ss")]")
@@ -587,9 +587,8 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 			if(ETA)
 				stat(null, "[ETA] [SSshuttle.emergency.getTimerStr()]")
 
-	if(client?.holder)
+	if(client && client.holder)
 		if(statpanel("MC"))
-			statdelay = 0		//It's assumed that if you're doing this you are doing debug stuff, don't do ioditic things.
 			var/turf/T = get_turf(client.eye)
 			stat("Location:", COORD(T))
 			stat("CPU:", "[world.cpu]")
@@ -615,7 +614,6 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 			GLOB.ahelp_tickets.stat_entry()
 		if(length(GLOB.sdql2_queries))
 			if(statpanel("SDQL2"))
-				statdelay = 0		//It's assumed that if you're doing this you are doing debug stuff, don't do ioditic things.
 				stat("Access Global SDQL2 List", GLOB.sdql2_vv_statobj)
 				for(var/i in GLOB.sdql2_queries)
 					var/datum/SDQL2_query/Q = i
@@ -639,13 +637,14 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 				if(A.IsObscured())
 					continue
 				statpanel(listed_turf.name, null, A)
+
+
 	if(mind)
 		add_spells_to_statpanel(mind.spell_list)
 		var/datum/antagonist/changeling/changeling = mind.has_antag_datum(/datum/antagonist/changeling)
 		if(changeling)
 			add_stings_to_statpanel(changeling.purchasedpowers)
 	add_spells_to_statpanel(mob_spell_list)
-	sleep(statdelay)
 
 /mob/proc/add_spells_to_statpanel(list/spells)
 	for(var/obj/effect/proc_holder/spell/S in spells)


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#10246

Alright the game is legitimately unplayable at times because of this and as much as we love our performance I think this is worth the sacrifice.
We should instead just look into removing certain stat lines or combining them at some point maybe, rather than hard delays, or just speeding up other parts of the code.