### PR TITLE
Adds the ability to knock down sprinting spacemen with heavy objects

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -196,3 +196,11 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
 #define TOTAL_MASS_HAND_REPLACEMENT	5 //standard punching stamina cost. most hand replacements are huge items anyway.
 #define TOTAL_MASS_MEDIEVAL_WEAPON	3.6 //very, very generic average sword/warpick/etc. weight in pounds.
 #define TOTAL_MASS_TOY_SWORD 1.5
+
+//Defines that control the sprinting knockdown on hit.
+#define SPRINT_KNOCKDOWN_DISABLED	0
+#define SPRINT_KNOCKDOWN_DEFAULT	1
+#define SPRINT_KNOCKDOWN_FORCED		2
+#define MIN_SPRINT_KNOCKDOWN_MASS	TOTAL_MASS_BULKY_ITEM
+#define SPRINT_KNOCKDOWN_STRENGTH	13 //Strong enough for huge items to do a disarm, too weak for bulky items to disarm. Based off total mass
+#define CAN_SPRINT_KNOCKDOWN(I)		(I?.sprint_knockdown && (I?.sprint_knockdown == SPRINT_KNOCKDOWN_FORCED || I?.getweight() >= MIN_SPRINT_KNOCKDOWN_MASS))

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -34,6 +34,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	var/throwhitsound = null
 	var/w_class = WEIGHT_CLASS_NORMAL
 	var/total_mass //Total mass in arbitrary pound-like values. If there's no balance reasons for an item to have otherwise, this var should be the item's weight in pounds.
+	var/sprint_knockdown = SPRINT_KNOCKDOWN_DEFAULT //Controls whether or not this item is capable of knocking down sprinting spacemen.
 	var/slot_flags = 0		//This is used to determine on which slots an item can fit.
 	pass_flags = PASSTABLE
 	pressure_resistance = 4

--- a/code/game/objects/items/his_grace.dm
+++ b/code/game/objects/items/his_grace.dm
@@ -15,6 +15,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 12
 	total_mass = TOTAL_MASS_NORMAL_ITEM // average toolbox
+	sprint_knockdown = SPRINT_KNOCKDOWN_FORCED
 	attack_verb = list("robusted")
 	hitsound = 'sound/weapons/smash.ogg'
 	var/awakened = FALSE

--- a/code/game/objects/items/singularityhammer.dm
+++ b/code/game/objects/items/singularityhammer.dm
@@ -17,6 +17,7 @@
 	resistance_flags = FIRE_PROOF | ACID_PROOF
 	force_string = "LORD SINGULOTH HIMSELF"
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	sprint_knockdown = SPRINT_KNOCKDOWN_FORCED
 
 /obj/item/twohanded/singularityhammer/New()
 	..()
@@ -86,6 +87,7 @@
 	throw_range = 7
 	w_class = WEIGHT_CLASS_HUGE
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	sprint_knockdown = SPRINT_KNOCKDOWN_FORCED
 
 /obj/item/twohanded/mjollnir/proc/shock(mob/living/target)
 	target.Stun(60)

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -587,6 +587,7 @@
 	force = 10
 	w_class = WEIGHT_CLASS_BULKY
 	slot_flags = ITEM_SLOT_BACK
+	sprint_knockdown = SPRINT_KNOCKDOWN_DISABLED
 	force_unwielded = 10
 	force_wielded = 18
 	throwforce = 20

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -70,6 +70,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	total_mass = TOTAL_MASS_MEDIEVAL_WEAPON
+	sprint_knockdown = SPRINT_KNOCKDOWN_FORCED
 
 /obj/item/claymore/Initialize()
 	. = ..()
@@ -85,6 +86,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	item_flags = DROPDEL
 	slot_flags = null
 	block_chance = 0 //RNG WON'T HELP YOU NOW, PANSY
+	sprint_knockdown = SPRINT_KNOCKDOWN_DISABLED //AND NEITHER WILL KNOCKDOWNS
 	light_range = 3
 	attack_verb = list("brutalized", "eviscerated", "disemboweled", "hacked", "carved", "cleaved") //ONLY THE MOST VISCERAL ATTACK VERBS
 	var/notches = 0 //HOW MANY PEOPLE HAVE BEEN SLAIN WITH THIS BLADE
@@ -516,6 +518,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/homerun_ready = 0
 	var/homerun_able = 0
 	total_mass = 2.7 //a regular wooden major league baseball bat weighs somewhere between 2 to 3.4 pounds, according to google
+	sprint_knockdown = SPRINT_KNOCKDOWN_FORCED
 
 /obj/item/melee/baseball_bat/chaplain
 	name = "blessed baseball bat"

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1744,6 +1744,11 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			I.add_mob_blood(H)
 			playsound(get_turf(H), I.get_dismember_sound(), 80, 1)
 
+	//Knocks this spaceman down if they're actively moving.
+	if(iscarbon(H) && !H.resting && H.sprinting && H.client?.move_delay <= world.time + 2 && CAN_SPRINT_KNOCKDOWN(I))
+		H.Knockdown(I.getweight() * SPRINT_KNOCKDOWN_STRENGTH)
+		H.visible_message("<span class='danger'>[H] loses balance and falls!</span>", "<span class='userdanger'>You lose balance and fall!</span>")
+
 	var/bloody = 0
 	if(((I.damtype == BRUTE) && I.force && prob(25 + (I.force * 2))))
 		if(affecting.status == BODYPART_ORGANIC)

--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -149,6 +149,9 @@
 			apply_damage(I.throwforce, dtype, zone, armor)
 			if(I.thrownby)
 				log_combat(I.thrownby, src, "threw and hit", I)
+			if(iscarbon(src) && !resting && sprinting && client?.move_delay <= world.time + 2 && CAN_SPRINT_KNOCKDOWN(I))
+				Knockdown(I.getweight() * SPRINT_KNOCKDOWN_STRENGTH)
+				visible_message("<span class='danger'>[src] loses balance and falls!</span>", "<span class='userdanger'>You lose balance and fall!</span>")
 		else
 			return 1
 	else


### PR DESCRIPTION
## About The Pull Request

This PR adds the ability to knock down a sprinting spaceman by simply smacking them with a heavy object. For items using the default weight calculation, this means bulky items and larger. This can behavior can be forced on  on a per-item basis with the `SPRINT_KNOCKDOWN_FORCED` value for `sprint_knockdown` or disabled entirely via `SPRINT_KNOCKDOWN_DISABLED`

## Why It's Good For The Game

Sprinting is still ridiculously strong in combat, and the sprint buffer exacerbated the issues quite a bit. This means the meta in melee combat is still to just yakkety-sax your way around the opponent, which simply is not fun to play against since you have to rely on high resolution displays with DPI scaling disabled and low mouse sensitivities for a reasonable accuracy rate in combat (And I'm someone that unashamedly exploits that fact). There's also the additional current issue that bulky items and heavier/larger are fairly useless in combat due to their high stamina cost for little to no gain in way of utility or damage, as lighter/smaller items more or less do exactly the same things they can do but more efficiently.

So this PR hits both birds with one stone. This allows you to use any bulky item to knock down spacemen that're mid-sprint by simply attacking them once. This means that sprinting in melee combat suddenly becomes a much riskier thing to do against most targets, as getting hit one single time while you're sprinting instantly puts you on the ground, which is a fairly inefficient place to fight due to the incredibly reduced movement speed and reduced melee damage. This also adds actual utility to bulky objects in the context of combat, as suddenly you have a choice between a light stamina-efficient object that deals 15 force or a heavy stamina-inefficient object that deals 15 force and is capable of knocking down sprinting spacemen, creating a much better variety in terms of viable options for melee combat, and giving more stationary combat styles a way to hard counter the current yakkety-sax meta.

## Changelog
:cl:
add: You can now knock down sprinting spacemen by simply smacking them with a sufficiently heavy object. Heavier objects are capable of disarming on top of the knockdown. Yakkety-sax meta begone.
/:cl:
