### PR TITLE
[s] Fixes traitors

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -525,7 +525,7 @@
 		if(!objective)
 			to_chat(usr,"Invalid objective.")
 			return
-		//qdel(objective) Needs cleaning objective destroys
+		qdel(objective) //TODO: Needs cleaning objective destroys (whatever that means)
 		message_admins("[key_name_admin(usr)] removed an objective for [current]: [objective.explanation_text]")
 		log_admin("[key_name(usr)] removed an objective for [current]: [objective.explanation_text]")
 

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -182,7 +182,7 @@
 			destroy_objective.owner = owner
 			destroy_objective.find_target()
 			add_objective(destroy_objective)
-		else if(prob(30) || (mode.storyteller.flags & NO_ASSASSIN))
+		else if(prob(30) || (is_dynamic && (mode.storyteller.flags & NO_ASSASSIN)))
 			var/datum/objective/maroon/maroon_objective = new
 			maroon_objective.owner = owner
 			maroon_objective.find_target()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Traitors were checking for storytellers in non-dynamic modes, sometimes. Yikes.

Also allowed removing of objectives, which #9716 silently commented out a single line of while keeping the rest of the proc exactly the same, making it seem as if objectives were being deleted when they weren't. Yikes.

## Why It's Good For The Game

Assassination bad? But it's not working cause of a bug? So let's bring it back.

## Changelog
:cl:
fix: Traitor objectives don't take a dump when they try to add an assassinate anymore
admin: Objective removal with antag panel no longer commented out silently while still being an option that gives useful feedback on stuff it's not doing in any respect
/:cl: