### PR TITLE
Makes the gorilla shuttle emag only

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -380,8 +380,13 @@
 /datum/map_template/shuttle/emergency/gorilla
 	suffix = "gorilla"
 	name = "Gorilla Cargo Freighter"
-	description = "A rustic, barely excuseable shuttle transporting important cargo. Not for crew who are about to go ape."
+	description = "(Emag only) A rustic, barely excuseable shuttle transporting important cargo. Not for crew who are about to go ape."
 	credit_cost = 2000
+
+/datum/map_template/shuttle/emergency/gorilla/prerequisites_met()
+	if("emagged" in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
 
 /datum/map_template/shuttle/ferry/base
 	suffix = "base"


### PR DESCRIPTION
## About The Pull Request

why wasn't this done yet

## Why It's Good For The Game

this is not a safe shuttle, why would nt let you buy this? seriously. and every single time, it's ordered by a shitter captain/shitter and ends up killing everyone.

## Changelog
:cl:
tweak: makes gorilla shuttle emag only
/:cl:
