### PR TITLE
abductors get agent ids

### DIFF
--- a/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
+++ b/code/modules/antagonists/abductor/equipment/abduction_outfits.dm
@@ -4,6 +4,7 @@
 	shoes = /obj/item/clothing/shoes/combat
 	back = /obj/item/storage/backpack
 	ears = /obj/item/radio/headset/abductor
+	id = /obj/item/card/id/syndicate
 
 /datum/outfit/abductor/proc/link_to_console(mob/living/carbon/human/H, team_number)
 	var/datum/antagonist/abductor/A = H.mind.has_antag_datum(/datum/antagonist/abductor)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

BWOINK: Why did you steal the captain's ID?

## Why It's Good For The Game

lets them steal ids, bit of an abductor buff
yo i still hate abductors and think they're op but this honestly isn't that bad tbh, granted they already have their meme teleports. them not having or even having the incentive to steal ids is good.

## Changelog
:cl:
balance: abductors get agent ids now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
