### PR TITLE
Added second flavor text, not copied anywhere. 

### DIFF
--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -121,6 +121,17 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 		flavor_text = sanitize(new_flavor)
 		to_chat(src, "Your flavor text has been updated.")
 
+//Flavor Text
+/mob/living/carbon/human/verb/set_flavor_2()
+	set name = "Set Temporary Flavor Text"
+	set desc = "Sets a description of your character's current appearance. Use this for emotions, poses etc."
+	set category = "IC"
+
+	var/new_flavor = input(src, "Enter your new temporary flavor text:", "Temporary flavor text", null) as message|null
+	if(!isnull(new_flavor))
+		flavor_text_2 = sanitize(new_flavor)
+		to_chat(src, "Your temporary flavor text has been updated.")
+
 //LOOC toggles
 /client/verb/listen_looc()
 	set name = "Show/Hide LOOC"

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -392,6 +392,13 @@
 			. += "...?"
 		else
 			. += "[print_flavor_text()]"
+	if(print_flavor_text_2())
+		if(get_visible_name() == "Unknown")	//Are we sure we know who this is? Don't show flavor text unless we can recognize them. Prevents certain metagaming with impersonation.
+			. += "...?"
+		else if(skipface) //Sometimes we're not unknown, but impersonating someone in a hardsuit, let's not reveal our flavor text then either.
+			. += "...?"
+		else
+			. += "[print_flavor_text_2()]"
 	. += "*---------*</span>"
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -3,6 +3,7 @@
 //////////////////////////////////////////////////////
 /mob
 	var/flavor_text = "" //tired of fucking double checking this
+	var/flavor_text_2 = ""
 
 /mob/proc/update_flavor_text()
 	set src in usr
@@ -15,6 +16,19 @@
 		msg = html_encode(msg)
 
 		flavor_text = msg
+
+/mob/proc/update_flavor_text_2()
+	set src in usr
+	if(usr != src)
+		to_chat(usr, "No.")
+	var/msg = stripped_multiline_input(usr, "Set the temporary flavor text in your 'examine' verb. This should be used only for things pertaining to the current round!", "Short-Term Flavor Text", html_decode(flavor_text_2), MAX_MESSAGE_LEN*2, TRUE)
+
+	if(!isnull(msg))
+		msg = copytext(msg, 1, MAX_MESSAGE_LEN)
+		msg = html_encode(msg)
+
+		flavor_text_2 = msg
+
 
 /mob/proc/warn_flavor_changed()
 	if(flavor_text && flavor_text != "") // don't spam people that don't use it!
@@ -29,6 +43,16 @@
 			return "<span class='notice'>[html_encode(msg)]</span>"
 		else
 			return "<span class='notice'>[html_encode(copytext(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
+
+/mob/proc/print_flavor_text_2()
+	if(flavor_text && flavor_text != "")
+		// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
+		var/msg = html_decode(replacetext(flavor_text_2, "\n", " "))
+		if(length(msg) <= 40)
+			return "<span class='notice'>[html_encode(msg)]</span>"
+		else
+			return "<span class='notice'>[html_encode(copytext(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
+
 
 /mob/proc/get_top_level_mob()
 	if(istype(src.loc,/mob)&&src.loc!=src)


### PR DESCRIPTION
## About The Pull Request

Adds a second flavor text, meant for "current pose" or "current facial expressions" or things like that. It's not copied to anywhere, it's not saved, it's purely for the current round.

## Why It's Good For The Game

Sometimes you wanna tell people your character's been crying lately or somethin, right?

## Changelog
:cl:
add: Second, temporary flavor text!
/:cl: