### PR TITLE
allow guests to use looc

### DIFF
--- a/code/modules/client/verbs/looc.dm
+++ b/code/modules/client/verbs/looc.dm
@@ -10,9 +10,7 @@ GLOBAL_VAR_INIT(normal_looc_colour, "#6699CC")
 		to_chat(usr, "<span class='danger'> Speech is currently admin-disabled.</span>")
 		return
 
-	if(!mob)	return
-	if(IsGuestKey(key))
-		to_chat(src, "Guests may not use OOC.")
+	if(!mob)
 		return
 
 	msg = copytext(sanitize(msg), 1, MAX_MESSAGE_LEN)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I connected as a guest during a BYOND outage, I could OOC but not LOOC because why are we not letting guests LOOC but use actual OOC

## Why It's Good For The Game

we disable guests by default i don't think it'll be an issue to let them looc on the rare chance we actually let people connect as that

## Changelog
:cl:
add: guests can now looc
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
