### PR TITLE
Fixes reagent containers examine.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -35,9 +35,10 @@
 
 /obj/item/reagent_containers/examine(mob/user)
 	. = ..()
-	. += "Currently transferring [amount_per_transfer_from_this] units per use."
-	if(possible_transfer_amounts && user.Adjacent(src))
-		. += "<span class='notice'>Alt-click it to set its transfer amount.</span>"
+	if(length(possible_transfer_amounts) > 1)
+		. += "Currently transferring [amount_per_transfer_from_this] units per use."
+		if(APTFT_altclick && user.Adjacent(src))
+			. += "<span class='notice'>Alt-click it to set its transfer amount.</span>"
 
 /obj/item/reagent_containers/AltClick(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Because many reagent containers, such as food/snacks, have empty lists, thanks to old .len checks.

## Why It's Good For The Game
Peeves.

## Changelog
:cl:
fix: Made reagent containers examine text less annoying.
/:cl:
