### PR TITLE
Halves research points obtained through bombs. Makes 25k cap.

### DIFF
--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -72,4 +72,4 @@
 	TECHWEB_POINT_TYPE_GENERIC = "General Research"\
 	)
 
-#define TECHWEB_BOMB_POINTCAP		50000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100
+#define TECHWEB_BOMB_POINTCAP		25000 //Adjust as needed; Stops toxins from nullifying RND progression mechanics. Current Value Cap Radius: 100

--- a/code/game/machinery/doppler_array.dm
+++ b/code/game/machinery/doppler_array.dm
@@ -121,7 +121,7 @@ GLOBAL_LIST_EMPTY(doppler_arrays)
 		say("Explosion not large enough for research calculations.")
 		return
 	else if(orig_light < 4500)
-		point_gain = (83300 * orig_light) / (orig_light + 3000)
+		point_gain = (41650 * orig_light) / (orig_light + 3000)
 	else
 		point_gain = TECHWEB_BOMB_POINTCAP
 


### PR DESCRIPTION
Does as it says on the tin.

Getting a bit exhausting seeing research make a 50k point bomb sub 10 minutes into the shift and have a fully decked out research tree that can counter whatever has been announced. This makes it less stronger, because it seems almost every antagonist now has to hard counter science far too early in the shift. 
