### PR TITLE
A few reagents related fixes.

### DIFF
--- a/code/game/objects/items/extinguisher.dm
+++ b/code/game/objects/items/extinguisher.dm
@@ -65,7 +65,7 @@
 	icon_state = "foam_extinguisher0"
 	//item_state = "foam_extinguisher" needs sprite
 	dog_fashion = null
-	chem = "firefighting_foam"
+	chem = /datum/reagent/firefighting_foam
 	tanktype = /obj/structure/reagent_dispensers/foamtank
 	sprite_name = "foam_extinguisher"
 	precision = TRUE

--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -615,7 +615,7 @@
 	name = "marshmallow"
 	desc = "A marshmallow filled with fluffy marshmallow fluff."
 	icon_state = "marshmallow"
-	list_reagents = list("sugar" = 5, "nutriment" = 2)
+	list_reagents = list(/datum/reagent/consumable/sugar = 5, /datum/reagent/consumable/nutriment = 2)
 	filling_color = "#fafafa"
 	w_class = WEIGHT_CLASS_TINY
 	tastes = list("marshmallow" = 2)

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -92,8 +92,11 @@
 
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
-	for(var/list/L in list(dispensable_reagents, emagged_reagents, upgrade_reagents, upgrade_reagents2, upgrade_reagents3))
-		L = sortList(L, /proc/cmp_reagents_asc)
+	emagged_reagents = sortList(emagged_reagents, /proc/cmp_reagents_asc)
+	upgrade_reagents = sortList(upgrade_reagents, /proc/cmp_reagents_asc)
+	upgrade_reagents2 = sortList(upgrade_reagents2, /proc/cmp_reagents_asc)
+	upgrade_reagents3 = sortList(upgrade_reagents3, /proc/cmp_reagents_asc)
+	dispensable_reagents = sortList(dispensable_reagents, /proc/cmp_reagents_asc)
 	update_icon()
 
 /obj/machinery/chem_dispenser/Destroy()

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -92,10 +92,14 @@
 
 /obj/machinery/chem_dispenser/Initialize()
 	. = ..()
-	emagged_reagents = sortList(emagged_reagents, /proc/cmp_reagents_asc)
-	upgrade_reagents = sortList(upgrade_reagents, /proc/cmp_reagents_asc)
-	upgrade_reagents2 = sortList(upgrade_reagents2, /proc/cmp_reagents_asc)
-	upgrade_reagents3 = sortList(upgrade_reagents3, /proc/cmp_reagents_asc)
+	if(emagged_reagents)
+		emagged_reagents = sortList(emagged_reagents, /proc/cmp_reagents_asc)
+	if(upgrade_reagents)
+		upgrade_reagents = sortList(upgrade_reagents, /proc/cmp_reagents_asc)
+	if(upgrade_reagents2)
+		upgrade_reagents2 = sortList(upgrade_reagents2, /proc/cmp_reagents_asc)
+	if(upgrade_reagents3)
+		upgrade_reagents3 = sortList(upgrade_reagents3, /proc/cmp_reagents_asc)
 	dispensable_reagents = sortList(dispensable_reagents, /proc/cmp_reagents_asc)
 	update_icon()
 

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -31,6 +31,7 @@ Borg Hypospray
 	var/accepts_reagent_upgrades = TRUE //If upgrades can increase number of reagents dispensed.
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.
+	var/list/reagent_names = list()
 
 /obj/item/reagent_containers/borghypo/Initialize()
 	. = ..()
@@ -54,7 +55,7 @@ Borg Hypospray
 	return 1
 
 // Use this to add more chemicals for the borghypo to produce.
-/obj/item/reagent_containers/borghypo/proc/add_reagent(reagent)
+/obj/item/reagent_containers/borghypo/proc/add_reagent(datum/reagent/reagent)
 	reagent_ids |= reagent
 	var/datum/reagents/RG = new(30)
 	RG.my_atom = src
@@ -64,9 +65,11 @@ Borg Hypospray
 	R.add_reagent(reagent, 30)
 
 	modes[reagent] = modes.len + 1
+	reagent_names[initial(reagent.name)] = reagent
 
-/obj/item/reagent_containers/borghypo/proc/del_reagent(reagent)
+/obj/item/reagent_containers/borghypo/proc/del_reagent(datum/reagent/reagent)
 	reagent_ids -= reagent
+	reagent_names -= initial(reagent.name)
 	var/datum/reagents/RG
 	var/datum/reagents/TRG
 	for(var/i in 1 to reagent_ids.len)
@@ -112,7 +115,7 @@ Borg Hypospray
 	log_combat(user, M, "injected", src, "(CHEMICALS: [english_list(injected)])")
 
 /obj/item/reagent_containers/borghypo/attack_self(mob/user)
-	var/chosen_reagent = modes[input(user, "What reagent do you want to dispense?") as null|anything in reagent_ids]
+	var/chosen_reagent = modes[reagent_names[input(user, "What reagent do you want to dispense?") as null|anything in reagent_names]]
 	if(!chosen_reagent)
 		return
 	mode = chosen_reagent

--- a/code/modules/reagents/reagent_dispenser.dm
+++ b/code/modules/reagents/reagent_dispenser.dm
@@ -184,7 +184,7 @@
 	icon_state = "virus_food"
 	anchored = TRUE
 	density = FALSE
-	reagent_id = /datum/reagent/toxin/mutagen/mutagenvirusfood
+	reagent_id = /datum/reagent/consumable/virus_food
 
 /obj/structure/reagent_dispensers/cooking_oil
 	name = "vat of cooking oil"


### PR DESCRIPTION
## About The Pull Request
Some fixes and things I missed with the id -> typepath PR

## Why It's Good For The Game
banishes some issues. Will close #10517 since the health scanner issue was fixed in another PR.

## Changelog
:cl:
fix: Virus food dispensers dispense virus food again.
fix: Borg hypos inputs do not display typepaths anymore.
fix: Restored chem dispensers alphabetical order.
/:cl:
