### PR TITLE
Prevent Playback Devices from triggering Voice Analyzer

### DIFF
--- a/code/modules/assembly/playback.dm
+++ b/code/modules/assembly/playback.dm
@@ -24,7 +24,7 @@
 	recorded = raw_message
 	listening = FALSE
 	languages = message_language
-	say("Activation message is '[recorded]'.", language = message_language)
+	say("The recorded message is '[recorded]'.", language = message_language)
 
 /obj/item/assembly/playback/activate()
 	if(recorded == "") // Why say anything when there isn't anything to say

--- a/code/modules/assembly/voice.dm
+++ b/code/modules/assembly/voice.dm
@@ -34,9 +34,10 @@
 	if(listening && !radio_freq)
 		record_speech(speaker, raw_message, message_language)
 	else
-		if(message_language == languages) // If it isn't in the same language as the message, don't try to find the message
-			if(check_activation(speaker, raw_message))
-				addtimer(CALLBACK(src, .proc/pulse, 0), 10)
+		if(!istype(speaker, /obj/item/assembly/playback)) // Check if it isn't a playback device to prevent spam and lag
+			if(message_language == languages) // If it isn't in the same language as the message, don't try to find the message
+				if(check_activation(speaker, raw_message)) // Is it the message?
+					addtimer(CALLBACK(src, .proc/pulse, 0), 10)
 
 /obj/item/assembly/voice/proc/record_speech(atom/movable/speaker, raw_message, datum/language/message_language)
 	languages = message_language // Assign the message's language to a variable to use it elsewhere


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This prevent the Voice Analyzer from recognizing Playback Devices as a valid voice input, thus preventing Playback devices from triggering them.

## Why It's Good For The Game
I was told you could attach one of each together and make them trigger each other, thus creating an endless loop and lots of lag. This fix it.

## Changelog
:cl:
fix: fixed being able to use a playback device and a voice analyzer to activate each others
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
