### PR TITLE
Modular Solar Power!

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -1,7 +1,11 @@
 /* Glass stack types
  * Contains:
  *		Glass sheets
+ *		Plasma glass
  *		Reinforced glass sheets
+ *		Reinforced plasma glass
+ *		Titanium glass - NT Glass
+ *		Plastitanium glass - Sydi Glass
  *		Glass shards - TODO: Move this into code/game/object/item/weapons
  */
 

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -14,6 +14,7 @@
 	max_integrity = 150
 	integrity_failure = 50
 	var/obscured = 0
+	var/glass_effect = 1 //Different types of glass makes collects more power then others
 	var/sunfrac = 0
 	var/adir = SOUTH // actual dir
 	var/ndir = SOUTH // target dir
@@ -51,7 +52,24 @@
 	else
 		S.forceMove(src)
 	if(S.glass_type == /obj/item/stack/sheet/rglass) //if the panel is in reinforced glass
-		max_integrity *= 2 								 //this need to be placed here, because panels already on the map don't have an assembly linked to
+		max_integrity *= 1.2								 //this need to be placed here, because panels already on the map don't have an assembly linked to
+		glass_effect = 1.2
+		obj_integrity = max_integrity
+	if(S.glass_type == /obj/item/stack/sheet/plasmaglass) //if the panel is in plasma glass
+		max_integrity *= 1.4
+		glass_effect = 1.4
+		obj_integrity = max_integrity
+	if(S.glass_type == /obj/item/stack/sheet/plasmarglass) //if the panel is in reinforced plasma glass
+		max_integrity *= 1.6
+		glass_effect = 1.6
+		obj_integrity = max_integrity
+	if(S.glass_type == /obj/item/stack/sheet/titaniumglass) //if the panel is in titanium glass
+		max_integrity *= 1.8
+		glass_effect = 1.8
+		obj_integrity = max_integrity
+	if(S.glass_type == /obj/item/stack/sheet/plastitaniumglass) //if the panel is in evil plastitanium glass
+		max_integrity *= 2
+		glass_effect = 2
 		obj_integrity = max_integrity
 	update_icon()
 
@@ -131,7 +149,7 @@
 		if(powernet == control.powernet)//check if the panel is still connected to the computer
 			if(obscured) //get no light from the sun, so don't generate power
 				return
-			var/sgen = SOLARGENRATE * sunfrac
+			var/sgen = glass_effect * SOLARGENRATE * sunfrac
 			add_avail(sgen)
 			control.gen += sgen
 		else //if we're no longer on the same powernet, remove from control computer

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -231,7 +231,7 @@
 			W.play_tool_sound(src, 75)
 		return 1
 
-	if(istype(W, /obj/item/stack/sheet/glass) || istype(W, /obj/item/stack/sheet/rglass))
+	if(istype(W, /obj/item/stack/sheet/glass) || istype(W, /obj/item/stack/sheet/rglass) || istype(W, /obj/item/stack/sheet/plasmaglass) || istype(W, /obj/item/stack/sheet/plasmarglass) || istype(W, /obj/item/stack/sheet/titaniumglass) || istype(W, /obj/item/stack/sheet/plastitaniumglass))
 		if(!anchored)
 			to_chat(user, "<span class='warning'>You need to secure the assembly before you can add glass.</span>")
 			return

--- a/code/modules/power/solar.dm
+++ b/code/modules/power/solar.dm
@@ -14,7 +14,7 @@
 	max_integrity = 150
 	integrity_failure = 50
 	var/obscured = 0
-	var/glass_effect = 1 //Different types of glass makes collects more power then others
+	var/power_multiplier = 1 //Different types of glass makes collects more power then others
 	var/sunfrac = 0
 	var/adir = SOUTH // actual dir
 	var/ndir = SOUTH // target dir
@@ -53,23 +53,23 @@
 		S.forceMove(src)
 	if(S.glass_type == /obj/item/stack/sheet/rglass) //if the panel is in reinforced glass
 		max_integrity *= 1.2								 //this need to be placed here, because panels already on the map don't have an assembly linked to
-		glass_effect = 1.2
+		power_multiplier = 1.2
 		obj_integrity = max_integrity
 	if(S.glass_type == /obj/item/stack/sheet/plasmaglass) //if the panel is in plasma glass
 		max_integrity *= 1.4
-		glass_effect = 1.4
+		power_multiplier = 1.4
 		obj_integrity = max_integrity
 	if(S.glass_type == /obj/item/stack/sheet/plasmarglass) //if the panel is in reinforced plasma glass
 		max_integrity *= 1.6
-		glass_effect = 1.6
+		power_multiplier = 1.6
 		obj_integrity = max_integrity
 	if(S.glass_type == /obj/item/stack/sheet/titaniumglass) //if the panel is in titanium glass
 		max_integrity *= 1.8
-		glass_effect = 1.8
+		power_multiplier = 1.8
 		obj_integrity = max_integrity
 	if(S.glass_type == /obj/item/stack/sheet/plastitaniumglass) //if the panel is in evil plastitanium glass
 		max_integrity *= 2
-		glass_effect = 2
+		power_multiplier = 2
 		obj_integrity = max_integrity
 	update_icon()
 
@@ -149,7 +149,7 @@
 		if(powernet == control.powernet)//check if the panel is still connected to the computer
 			if(obscured) //get no light from the sun, so don't generate power
 				return
-			var/sgen = glass_effect * SOLARGENRATE * sunfrac
+			var/sgen = power_multiplier * SOLARGENRATE * sunfrac
 			add_avail(sgen)
 			control.gen += sgen
 		else //if we're no longer on the same powernet, remove from control computer


### PR DESCRIPTION
#10542 Same as that one
## About The Pull Request

Different types of glass now makes more or less power!
Makes the glass file notes correct

## Why It's Good For The Game

Solar is not used all that much other then in some space ruins. And when needed is only kinda able to fully run a station. Adding more ways to Power gamers to get that little bit more juice out of mats that are never really used to build with is a nice way to give use and want to make a solar field thats worth a damn

## Changelog
:cl:
add: All types of glass can be used to make a solar panel. Different types of glass will make more power then others, as well as be stronger then others
code: cleans up a note to be better
/:cl:
