### PR TITLE
remove trait genes without disks

### DIFF
--- a/code/modules/hydroponics/gene_modder.dm
+++ b/code/modules/hydroponics/gene_modder.dm
@@ -234,8 +234,8 @@
 					dat += "<tr><td width='260px'>[G.get_name()]</td><td>"
 					if(can_extract && G.mutability_flags & PLANT_GENE_EXTRACTABLE)
 						dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=extract'>Extract</a>"
-						if(G.mutability_flags & PLANT_GENE_REMOVABLE)
-							dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=remove'>Remove</a>"
+					if(G.mutability_flags & PLANT_GENE_REMOVABLE)
+						dat += "<a href='?src=[REF(src)];gene=[REF(G)];op=remove'>Remove</a>"
 					dat += "</td></tr>"
 				dat += "</table>"
 			else


### PR DESCRIPTION
## About The Pull Request
botany fix that lets you remove trait genes in seeds without having to have a redundant disk inserted
you could already do this with content genes???

## Why It's Good For The Game
it fixes a bug

## Changelog
:cl:
fix: fixed not being able to remove trait genes without a disk being inserted into the dna manipulator
/:cl: