### PR TITLE
Slimepeople can no longer just chill on vitality matrixes

### DIFF
--- a/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
+++ b/code/modules/antagonists/clockcult/clock_effects/clock_sigils.dm
@@ -316,9 +316,9 @@
 				L.dust()
 			else
 				if(!GLOB.ratvar_awakens && L.stat == CONSCIOUS)
-					vitality_drained = L.adjustToxLoss(1)
+					vitality_drained = L.adjustToxLoss(1, forced = TRUE)
 				else
-					vitality_drained = L.adjustToxLoss(1.5)
+					vitality_drained = L.adjustToxLoss(1.5, forced = TRUE)
 			if(vitality_drained)
 				GLOB.clockwork_vitality += vitality_drained
 			else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Hey did you know that clockcult vitality matrixes were not using 'forced' when applying their toxdamage? Yeah me neither. This fixes that and makes it so you can actually drain vitality from jelly / slimepeople.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Slime immune to matrix bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Vitality matrixes now correctly succ slimes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
