### PR TITLE
Makes fragile suit less likely to brake from toys

### DIFF
--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -434,7 +434,7 @@ Contains:
 	strip_delay = 65
 
 /obj/item/clothing/suit/space/fragile/hit_reaction(mob/living/carbon/human/owner, atom/movable/hitby, attack_text = "the attack", final_block_chance = 0, damage = 0, attack_type = MELEE_ATTACK)
-	if(!torn && prob(50))
+	if(!torn && prob(50) && damage >= 5)
 		to_chat(owner, "<span class='warning'>[src] tears from the damage, breaking the air-tight seal!</span>")
 		clothing_flags &= ~STOPSPRESSUREDAMAGE
 		name = "torn [src]."


### PR DESCRIPTION
## About The Pull Request

Hey why does a toy sword brake some space suit?

## Why It's Good For The Game

This will close #10525. 

Hey Spacers, did you know toys are /harmless/ Well now you do with are new, paper reinforced space suits, now comes with ANTI-NERFDART braking. Buy wait theirs less!
Disablers still brake the suits as well as those metal nerf darts do to being high tech paper killing projectiles. 

Basiclly no damage objects and a few soft hitting items like paper plains cant brake a suit

## Changelog
:cl:
fix: Fixed fragile space suits breaking from weak and non-damaging "weapons" (such as the Sord, toys and foam darts).
/:cl: