### PR TITLE
Riot foam dart design cost consistency.

### DIFF
--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -117,7 +117,7 @@
 	name = "Foam Riot Dart"
 	id = "riot_dart"
 	build_type = AUTOLATHE
-	materials = list(MAT_METAL = 1000) //Discount for making individually - no box = less metal!
+	materials = list(MAT_METAL = 1125) //Discount for making individually - no box = less metal!
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
 	category = list("hacked", "Security")
 


### PR DESCRIPTION
## About The Pull Request
Making it consistent with the foam material amount.

## Why It's Good For The Game
Consistency, got pinged because mat duping.

## Changelog
:cl:
fix: Riot foam dart (not the ammo box) design cost is yet again consistent with the result's material amount.
/:cl:
