### PR TITLE
Consent logging

### DIFF
--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -53,7 +53,7 @@
 		WRITE_LOG(GLOB.world_game_log, "ADMIN: DSAY: [text]")
 
 /proc/log_consent(text)
-	WRITE_LOG(GLOB.world_game_log,["CONSENT: [text]"])
+	WRITE_LOG(GLOB.world_game_log,"CONSENT: [text]")
 
 /* All other items are public. */
 /proc/log_game(text)

--- a/code/__HELPERS/_logging.dm
+++ b/code/__HELPERS/_logging.dm
@@ -52,6 +52,8 @@
 	if (CONFIG_GET(flag/log_adminchat))
 		WRITE_LOG(GLOB.world_game_log, "ADMIN: DSAY: [text]")
 
+/proc/log_consent(text)
+	WRITE_LOG(GLOB.world_game_log,["CONSENT: [text]"])
 
 /* All other items are public. */
 /proc/log_game(text)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1585,7 +1585,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		if (!HAS_TRAIT(target, TRAIT_PERMABONER))
 			stop_wagging_tail(target)
 		return FALSE
-	else if(aim_for_groin && (target == user || target.lying || same_dir) && (target_on_help || target_restrained || target_aiming_for_groin))
+	else if(!(user.client?.prefs.cit_toggles & NO_ASS_SLAP) && aim_for_groin && (target == user || target.lying || same_dir) && (target_on_help || target_restrained || target_aiming_for_groin))
 		if(target.client?.prefs.cit_toggles & NO_ASS_SLAP)
 			to_chat(user,"A force stays your hand, preventing you from slapping \the [target]'s ass!")
 			return FALSE

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -238,7 +238,7 @@
 		//Actual escaping
 		B.release_specific_contents(src,TRUE) //we might as well take advantage of that specific belly's handling. Else we stay blinded forever.
 		message_admins("[src] used OOC escape to escape from [B.owner]'s belly.")
-		consent_log("[src] used OOC escape to escape from [B.owner]'s belly.")
+		log_consent("[src] used OOC escape to escape from [B.owner]'s belly.")
 		src.stop_sound_channel(CHANNEL_PREYLOOP)
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "fedprey", /datum/mood_event/fedprey)
 		for(var/mob/living/simple_animal/SA in range(10))
@@ -257,8 +257,8 @@
 			return
 		//Actual escaping
 		belly.go_out(src) //Just force-ejects from the borg as if they'd clicked the eject button.
-		message_admins("[src] used OOC escape to escape from [B.owner]'s dogborg sleeper.")
-		consent_log("[src] used OOC escape to escape from [B.owner]'s dogborg sleeper.")
+		message_admins("[src] used OOC escape from a dogborg sleeper.")
+		log_consent("[src] used OOC escape from a dogborg sleeper.")
 	else
 		to_chat(src,"<span class='alert'>You aren't inside anyone, though, is the thing.</span>")
 

--- a/code/modules/vore/eating/living.dm
+++ b/code/modules/vore/eating/living.dm
@@ -237,6 +237,8 @@
 			return
 		//Actual escaping
 		B.release_specific_contents(src,TRUE) //we might as well take advantage of that specific belly's handling. Else we stay blinded forever.
+		message_admins("[src] used OOC escape to escape from [B.owner]'s belly.")
+		consent_log("[src] used OOC escape to escape from [B.owner]'s belly.")
 		src.stop_sound_channel(CHANNEL_PREYLOOP)
 		SEND_SIGNAL(src, COMSIG_CLEAR_MOOD_EVENT, "fedprey", /datum/mood_event/fedprey)
 		for(var/mob/living/simple_animal/SA in range(10))
@@ -255,6 +257,8 @@
 			return
 		//Actual escaping
 		belly.go_out(src) //Just force-ejects from the borg as if they'd clicked the eject button.
+		message_admins("[src] used OOC escape to escape from [B.owner]'s dogborg sleeper.")
+		consent_log("[src] used OOC escape to escape from [B.owner]'s dogborg sleeper.")
 	else
 		to_chat(src,"<span class='alert'>You aren't inside anyone, though, is the thing.</span>")
 

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -164,7 +164,7 @@
 			return target
 		else
 			message_admins("[src] tried to climax with [target], but [target] did not consent.")
-			consent_log("[src] tried to climax with [target], but [target] did not consent.")
+			log_consent("[src] tried to climax with [target], but [target] did not consent.")
 
 /mob/living/carbon/human/proc/pick_climax_container(silent = FALSE)
 	var/list/containers_list = list()

--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -158,9 +158,13 @@
 		return //No one left.
 	var/mob/living/target = input(src, "With whom?", "Sexual partner", null) as null|anything in partners //pick one, default to null
 	if(target && in_range(src, target))
+		to_chat(src,"<span class='notice'>Waiting for consent...</span>")
 		var/consenting = input(target, "Do you want [src] to climax with you?","Climax mechanics","No") in list("Yes","No")
 		if(consenting == "Yes")
 			return target
+		else
+			message_admins("[src] tried to climax with [target], but [target] did not consent.")
+			consent_log("[src] tried to climax with [target], but [target] did not consent.")
 
 /mob/living/carbon/human/proc/pick_climax_container(silent = FALSE)
 	var/list/containers_list = list()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Makes it so that features that involve OOC consent send logs to the admins whenever consent is *not* given.

## Why It's Good For The Game

Should make such situations--which should be unambiguous and, in many cases, quickly resolve in a ban--much easier to resolve properly.

## Changelog
:cl:
admin: Added logging to various consent things.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
