### PR TITLE
Hotfix for CI line endings

### DIFF
--- a/tools/travis/check_line_endings.py
+++ b/tools/travis/check_line_endings.py
@@ -7,8 +7,8 @@ import glob
 WINDOWS_NEWLINE = b'\r\n'
 
 FILES_TO_READ = []
-FILES_TO_READ.extend(glob.glob(r"**\*.dm", recursive=True))
-FILES_TO_READ.extend(glob.glob(r"**\*.dmm", recursive=True))
+FILES_TO_READ.extend(glob.glob(r"**/*.dm", recursive=True))
+FILES_TO_READ.extend(glob.glob(r"**/*.dmm", recursive=True))
 FILES_TO_READ.extend(glob.glob(r"*.dme"))
 #for i in FILES_TO_READ:
 #	if os.path.isdir(i):


### PR DESCRIPTION
## About The Pull Request
Dont hate me for webedits. Linux handles `\` and `/` **VERY** differently to windows, which just treat them the same. This PR is a hotfix for the line ending CI which was only tested under windows.

## Why It's Good For The Game
CI should work damnit

## Changelog
:cl:
code: Line ending CI works now
/:cl:
