### PR TITLE
Nerfs RLDs because they hard counter nightmares and night ops.

### DIFF
--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -677,18 +677,18 @@ RLD
 	icon_state = "rld"
 	lefthand_file = 'icons/mob/inhands/equipment/tools_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/tools_righthand.dmi'
-	matter = 500
-	max_matter = 500
-	sheetmultiplier = 16
+	matter = 200
+	max_matter = 200
+	sheetmultiplier = 5
 	var/mode = LIGHT_MODE
 	actions_types = list(/datum/action/item_action/pick_color)
 	ammo_sections = 5
 	has_ammobar = TRUE
 
-	var/wallcost = 10
-	var/floorcost = 15
-	var/launchcost = 5
-	var/deconcost = 10
+	var/wallcost = 20
+	var/floorcost = 25
+	var/launchcost = 10
+	var/deconcost = 20
 
 	var/walldelay = 10
 	var/floordelay = 10


### PR DESCRIPTION

## About The Pull Request

Reduces RLD matter capacity from 500 to 200
Reduces RLD matter increase per sheet from 16 to 5
Increases RLD wall Light construction and deconstruction costs from 10 to 20 (50 uses -> 10 uses)
Increases RLD floor light construction costs from 15 to 25 (~35 uses -> 8 uses)
Increases Light launch cost from 5 to 10 (100 uses -> 20 uses)

Costs will probably need adjustment, but are leaning towards the harsher end for now. Ideally they should be on par with RCDs in terms of costs and benefits.

## Why It's Good For The Game

Rapid Light Dispensers are currently very overpowered because of their ability to effectively spam maintenance with a flood of lights that antagonists/nightmares really cannot compete with. Darkness can be a very important tool for antags and removing that so easily with a single RLD capable of lighting up entire halves of maint is just not fun. It doesn't help that it's cheap as hell to do so in both mats and credits.

## Changelog
:cl:
balance: RLDs now cost more to use, have reduced matter capacity, and sheets are worth less when refilling them.
/:cl:
