### PR TITLE
Reduces Forcefield Projector Range to Two Tiles

### DIFF
--- a/code/game/objects/items/devices/forcefieldprojector.dm
+++ b/code/game/objects/items/devices/forcefieldprojector.dm
@@ -1,6 +1,6 @@
 /obj/item/forcefield_projector
 	name = "forcefield projector"
-	desc = "An experimental device that can create several forcefields at a distance."
+	desc = "An experimental device that can create several forcefields at a short distance."
 	icon = 'icons/obj/device.dmi'
 	icon_state = "signmaker_forcefield"
 	slot_flags = ITEM_SLOT_BELT
@@ -14,7 +14,7 @@
 	var/shield_integrity = 250
 	var/max_fields = 3
 	var/list/current_fields
-	var/field_distance_limit = 7
+	var/field_distance_limit = 2
 
 /obj/item/forcefield_projector/afterattack(atom/target, mob/user, proximity_flag)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Lowers the range of the forcefield projector from **7 tiles** (!?) to a more reasonable 2 tiles.

## Why It's Good For The Game

Forcefield projectors currently see no legitimate use from engineering, existing only as a tool to gay baby jail players. This reduces their usefulness as a gay baby jail tool by removing their ability to trap players from across entire rooms (or even several hallways if the user has x-ray, since forcefield projectors can be placed through walls as long as the user has vision), while retaining their ability to be used as a ranged engineering barrier (which is honestly the only legitimate use for them).

## Changelog
:cl:
tweak: Reduces the range of the forcefield projector from 7 tiles to 2 tiles.
/:cl: