### PR TITLE
Removes blood duplication via virus mix

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -335,7 +335,7 @@
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			for(var/i in 1 to min(createdvolume, 5))
+			for(var/i in 1 to min(created_volume, 5))
 				D.Devolve()
 
 /datum/chemical_reaction/mix_virus/neuter_virus

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -222,7 +222,6 @@
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"
 	id = "mixvirus"
-	results = list()
 	required_reagents = list(/datum/reagent/consumable/virus_food = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 	var/level_min = 1
@@ -326,19 +325,18 @@
 	level_max = 8
 
 /datum/chemical_reaction/mix_virus/rem_virus
-
 	name = "Devolve Virus"
 	id = "remvirus"
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
 /datum/chemical_reaction/mix_virus/rem_virus/on_reaction(datum/reagents/holder, created_volume)
-
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			D.Devolve()
+			for(var/i in 1 to min(createdvolume, 5))
+				D.Devolve()
 
 /datum/chemical_reaction/mix_virus/neuter_virus
 	name = "Neuter Virus"
@@ -347,14 +345,12 @@
 	required_catalysts = list(/datum/reagent/blood = 1)
 
 /datum/chemical_reaction/mix_virus/neuter_virus/on_reaction(datum/reagents/holder, created_volume)
-
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			D.Neuter()
-
-
+			for(var/i in 1 to min(created_volume, 5))
+				D.Neuter()
 
 ////////////////////////////////// foam and foam precursor ///////////////////////////////////////////////////
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -222,7 +222,7 @@
 /datum/chemical_reaction/mix_virus
 	name = "Mix Virus"
 	id = "mixvirus"
-	results = list(/datum/reagent/blood = 1)
+	results = list()
 	required_reagents = list(/datum/reagent/consumable/virus_food = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 	var/level_min = 1
@@ -234,8 +234,8 @@
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			D.Evolve(level_min, level_max)
-
+			for(var/i in 1 to min(created_volume, 5))
+				D.Evolve(level_min, level_max)
 
 /datum/chemical_reaction/mix_virus/mix_virus_2
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title
Also putting more than 1 unit in of virus mix now results in up to 5 operations to the virus, for 5 units. This is capped to prevent lag.

## Why It's Good For The Game

I don't care either way about this I'm doing it for @Arturlang because vampires and blood duplication too powerful etc etc

## Changelog
:cl:
del: Blood duplication is gone, but viruses now react up to 5 times, 1 time per unit, for virus mix.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
