### PR TITLE
Removes shrink rays from abductor console.

### DIFF
--- a/code/modules/antagonists/abductor/machinery/console.dm
+++ b/code/modules/antagonists/abductor/machinery/console.dm
@@ -46,7 +46,6 @@
 		dat += "<a href='?src=[REF(src)];dispense=baton'>Advanced Baton (2 Credits)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=mind_device'>Mental Interface Device (2 Credits)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=chem_dispenser'>Reagent Synthesizer (2 Credits)</A><br>"
-		dat += "<a href='?src=[REF(src)];dispense=shrink_ray'>Shrink Ray Blaster (2 Credits)</a><br>"
 		dat += "<a href='?src=[REF(src)];dispense=helmet'>Agent Helmet (1 Credit)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=vest'>Agent Vest (1 Credit)</A><br>"
 		dat += "<a href='?src=[REF(src)];dispense=silencer'>Radio Silencer (1 Credit)</A><br>"
@@ -119,8 +118,6 @@
 				Dispense(/obj/item/abductor_machine_beacon/chem_dispenser,cost=2)
 			if("tongue")
 				Dispense(/obj/item/organ/tongue/abductor)
-			if("shrink_ray")
-				Dispense(/obj/item/gun/energy/shrink_ray,cost=2)
 	updateUsrDialog()
 
 /obj/machinery/abductor/console/proc/TeleporterRetrieve()


### PR DESCRIPTION
Does as says on tin.

Removes purchase option of shrink rays from console as an abductor.

This was discussed in depth with multiple maintainers and determined to be something that was forked over from TG but a bit too chaotic for Citadel. This only writes out the purchase option but keeps the physical gun for other uses.