### PR TITLE
Made metabolic synthesis nanites stop if not fed

### DIFF
--- a/code/modules/research/nanites/nanite_programs/utility.dm
+++ b/code/modules/research/nanites/nanite_programs/utility.dm
@@ -206,7 +206,7 @@
 	if(!iscarbon(host_mob))
 		return FALSE
 	var/mob/living/carbon/C = host_mob
-	if(C.nutrition <= NUTRITION_LEVEL_STARVING)
+	if(C.nutrition <= NUTRITION_LEVEL_FED)
 		return FALSE
 	return ..()
 


### PR DESCRIPTION
## About The Pull Request

Previous: metabolic synthesis would run until the user was starving.
With PR: metabolic synthesis runs only if user is fed, i.e. not particularly close to being hungry.

## Why It's Good For The Game

Overall, I would say this is a nerf for the big powergamers and a buff for randos. Being hungry is annoying, but nanites are *much, much* stronger than being hungry makes you weak, so this, while being a buff to "quality of life" with nanites, is actually a nerf to nanite power in general.

## Changelog
:cl:
balance: Metabolic synthesis disables if user isn't well-fed rather than if user is starving
/:cl: