### PR TITLE
Fixed gibtonite instantly exploding on pick mining

### DIFF
--- a/code/game/turfs/simulated/minerals.dm
+++ b/code/game/turfs/simulated/minerals.dm
@@ -65,13 +65,16 @@
 
 		if(I.use_tool(src, user, 40, volume=50))
 			var/range = I.digrange //Store the current digrange so people don't cheese digspeed swapping for faster mining
+			var/list/dug_tiles = list()
 			if(ismineralturf(src))
 				if(I.digrange > 0)
 					for(var/turf/closed/mineral/M in range(user,range))
 						if(get_dir(user,M)&stored_dir)
-							M.gets_drilled()
+							M.gets_drilled(user)
+							dug_tiles += M
 				to_chat(user, "<span class='notice'>You finish cutting into the rock.</span>")
-				gets_drilled(user)
+				if(!(src in dug_tiles))
+					gets_drilled(user)
 				SSblackbox.record_feedback("tally", "pick_used_mining", 1, I.type)
 	else
 		return attack_hand(user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Gibtonite would explode if you mined it, instantly.

## Why It's Good For The Game

It, uh, shouldn't do that, and in fact that's the WORST place for it to do that.

## Changelog
:cl:
fix: Gibtonite no longer instantly explodes upon being pickaxe'd.
/:cl: