### PR TITLE
Adds 16777216 dorms to the ghost dojo

### DIFF
--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -7891,6 +7891,10 @@
 	},
 /turf/open/floor/engine/cult,
 /area/wizard_station)
+"sa" = (
+/obj/item/hilbertshotel/ghostdojo,
+/turf/open/indestructible/hotelwood,
+/area/centcom/holding)
 "sc" = (
 /obj/docking_port/stationary{
 	area_type = /area/syndicate_mothership/control;
@@ -47751,7 +47755,7 @@ Of
 QF
 Nd
 Sd
-Sd
+sa
 Nd
 WN
 Ur

--- a/code/modules/ruins/spaceruin_code/hilbertshotel.dm
+++ b/code/modules/ruins/spaceruin_code/hilbertshotel.dm
@@ -172,6 +172,15 @@ GLOBAL_VAR_INIT(hhmysteryRoomNumber, 1337)
 				var/turf/T = locate(_x, _y, _z)
 				A.forceMove(T)
 
+/obj/item/hilbertshotel/ghostdojo
+	name = "Infinite Dormitories"
+	anchored = TRUE
+	interaction_flags_atom = INTERACT_ATOM_ATTACK_HAND
+
+/obj/item/hilbertshotel/ghostdojo/interact(mob/user)
+	. = ..()
+	promptAndCheckIn(user)
+
 //Template Stuff
 /datum/map_template/hilbertshotel
 	name = "Hilbert's Hotel Room"


### PR DESCRIPTION
## About The Pull Request

Okay, so it actually adds an anchored, unmovable hilbert's hotel to the ghost dojo, named "Infinite Dormitories". Either way, much more space.

## Why It's Good For The Game

Mostly just seems prudent to add a lot more space to this.

## Changelog
:cl:
add: The ghost dojo now has 16777216 more dorms
/:cl