### PR TITLE
RPD ventcrawler escapism sanity check.

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -327,7 +327,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 /obj/item/pipe_dispenser/pre_attack(atom/A, mob/user)
 	var/turf/T = get_turf(A)
-	if(!user.IsAdvancedToolUser() || !A || istype(T, /turf/open/space/transit) || isindestructiblewall(T))
+	if(!user.IsAdvancedToolUser() || !T || istype(T, /turf/open/space/transit) || isindestructiblewall(T))
 		return ..()
 
 	//So that changing the menu settings doesn't affect the pipes already being built.
@@ -374,12 +374,16 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			if(ATMOS_CATEGORY) //Making pipes
 				if(!can_make_pipe)
 					return ..()
+				A = T
+				if(is_type_in_typecache(recipe, ventcrawl_machinery) && isclosedturf(A)) //wall escapism sanity check.
+					to_chat(user, "<span class='warning'>[src]'s error light flickers; there's something in the way!</span>")
+					return
 				playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 				if (recipe.type == /datum/pipe_info/meter)
 					to_chat(user, "<span class='notice'>You start building a meter...</span>")
 					if(do_after(user, atmos_build_speed, target = A))
 						activate()
-						var/obj/item/pipe_meter/PM = new /obj/item/pipe_meter(get_turf(A))
+						var/obj/item/pipe_meter/PM = new /obj/item/pipe_meter(A)
 						PM.setAttachLayer(piping_layer)
 						if(mode&WRENCH_MODE)
 							PM.wrench_act(user, src)
@@ -389,7 +393,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 						activate()
 						var/obj/machinery/atmospherics/path = queued_p_type
 						var/pipe_item_type = initial(path.construction_type) || /obj/item/pipe
-						var/obj/item/pipe/P = new pipe_item_type(get_turf(A), queued_p_type, queued_p_dir)
+						var/obj/item/pipe/P = new pipe_item_type(A, queued_p_type, queued_p_dir)
 
 						if(queued_p_flipped && istype(P, /obj/item/pipe/trinary/flippable))
 							var/obj/item/pipe/trinary/flippable/F = P
@@ -406,7 +410,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			if(DISPOSALS_CATEGORY) //Making disposals pipes
 				if(!can_make_pipe)
 					return ..()
-				A = get_turf(A)
+				A = T
 				if(isclosedturf(A))
 					to_chat(user, "<span class='warning'>[src]'s error light flickers; there's something in the way!</span>")
 					return
@@ -431,7 +435,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			if(TRANSIT_CATEGORY) //Making transit tubes
 				if(!can_make_pipe)
 					return ..()
-				A = get_turf(A)
+				A = T
 				if(isclosedturf(A))
 					to_chat(user, "<span class='warning'>[src]'s error light flickers; there's something in the way!</span>")
 					return

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -326,7 +326,8 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		playsound(get_turf(src), 'sound/effects/pop.ogg', 50, 0)
 
 /obj/item/pipe_dispenser/pre_attack(atom/A, mob/user)
-	if(!user.IsAdvancedToolUser() || istype(A, /turf/open/space/transit))
+	var/turf/T = get_turf(A)
+	if(!user.IsAdvancedToolUser() || !A || istype(T, /turf/open/space/transit) || isindestructiblewall(T))
 		return ..()
 
 	//So that changing the menu settings doesn't affect the pipes already being built.

--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -375,7 +375,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 				if(!can_make_pipe)
 					return ..()
 				A = T
-				if(is_type_in_typecache(recipe, ventcrawl_machinery) && isclosedturf(A)) //wall escapism sanity check.
+				if(is_type_in_typecache(recipe, GLOB.ventcrawl_machinery) && isclosedturf(A)) //wall escapism sanity check.
 					to_chat(user, "<span class='warning'>[src]'s error light flickers; there's something in the way!</span>")
 					return
 				playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)


### PR DESCRIPTION
## About The Pull Request
Updating RPD's pre_attack checks, since movables (including ones whitelisted for piping such as windows and grilles) can travel into transit space without being immediately flung off into deep space... and apparently it's possible to pass through walls by being a dextrous ventcrawler and printing vents/scrubbers into walls (including indestructible ones).

## Why It's Good For The Game
Sanity checks vs madmen escaping the ninja prison thanks autolathe.

## Changelog
:cl:
fix: Fixed a little exploit with ventcrawlers being capable of escaping closed turfs by printing scrubbers/vents into them.
/:cl:
