### PR TITLE
Made suicide a config flag

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -178,7 +178,7 @@
 		if(!C.credits)
 			C.RollCredits()
 		C.playtitlemusic(40)
-
+	CONFIG_SET(flag/suicide_allowed,TRUE) // EORG suicides allowed
 	var/popcount = gather_roundend_feedback()
 	display_report(popcount)
 

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -408,3 +408,5 @@
 
 /datum/config_entry/number/dropped_modes
 	config_entry_value = 3
+
+/datum/config_entry/flag/suicide_allowed

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -208,6 +208,7 @@
 
 /mob/living/proc/canSuicide()
 	if(!CONFIG_GET(flag/suicide_allowed))
+		to_chat(src, "Suicide is not enabled in the config.")
 		return FALSE
 	switch(stat)
 		if(CONSCIOUS)

--- a/code/modules/client/verbs/suicide.dm
+++ b/code/modules/client/verbs/suicide.dm
@@ -207,6 +207,8 @@
 	message_admins("[key_name(src)] (job: [src.job ? "[src.job]" : "None"]) [is_special_character(src) ? "(ANTAG!) " : ""][ghosting ? "ghosted" : "committed suicide"] at [AREACOORD(src)].")
 
 /mob/living/proc/canSuicide()
+	if(!CONFIG_GET(flag/suicide_allowed))
+		return FALSE
 	switch(stat)
 		if(CONSCIOUS)
 			return TRUE

--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -597,3 +597,6 @@ MODETIER_VOTING
 
 ## Number of modes dropped by the modetier vote during mode selection, after vote.
 DROPPED_MODES 3
+
+## Whether the suicide verb is allowed.
+# SUICIDE_ALLOWED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Allows disabling of suicide in the config

## Why It's Good For The Game

Suicide verb's kinda banbait at this point. Let's see if we can go without.

## Changelog
:cl:
config: Added suicide to the config.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
