### PR TITLE
Renames created volume in pyrotechnics to multiplier to alleviate confusion

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -15,9 +15,9 @@
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 	mob_react = FALSE
 
-/datum/chemical_reaction/tofu/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/tofu/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/tofu(location)
 	return
 
@@ -26,9 +26,9 @@
 	id = "chocolate_bar"
 	required_reagents = list(/datum/reagent/consumable/soymilk = 2, /datum/reagent/consumable/coco = 2, /datum/reagent/consumable/sugar = 2)
 
-/datum/chemical_reaction/chocolate_bar/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/chocolate_bar/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/chocolatebar(location)
 	return
 
@@ -39,9 +39,9 @@
 	required_reagents = list(/datum/reagent/consumable/milk/chocolate_milk = 4, /datum/reagent/consumable/sugar = 2)
 	mob_react = FALSE
 
-/datum/chemical_reaction/chocolate_bar2/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/chocolate_bar2/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/chocolatebar(location)
 	return
 
@@ -90,9 +90,9 @@
 	required_reagents = list(/datum/reagent/consumable/milk = 40)
 	required_catalysts = list(/datum/reagent/consumable/enzyme = 5)
 
-/datum/chemical_reaction/cheesewheel/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/cheesewheel/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/store/cheesewheel(location)
 
 /datum/chemical_reaction/synthmeat
@@ -101,9 +101,9 @@
 	required_reagents = list(/datum/reagent/blood = 5, /datum/reagent/medicine/cryoxadone = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/synthmeat/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/synthmeat/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/meat/slab/synthmeat(location)
 
 /datum/chemical_reaction/hot_ramen
@@ -137,9 +137,9 @@
 	required_reagents = list(/datum/reagent/water = 10, /datum/reagent/consumable/flour = 15)
 	mix_message = "The ingredients form a dough."
 
-/datum/chemical_reaction/dough/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/dough/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/dough(location)
 
 /datum/chemical_reaction/cakebatter
@@ -148,9 +148,9 @@
 	required_reagents = list(/datum/reagent/consumable/eggyolk = 15, /datum/reagent/consumable/flour = 15, /datum/reagent/consumable/sugar = 5)
 	mix_message = "The ingredients form a cake batter."
 
-/datum/chemical_reaction/cakebatter/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/cakebatter/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/cakebatter(location)
 
 /datum/chemical_reaction/cakebatter/vegan

--- a/code/modules/reagents/chemistry/recipes.dm
+++ b/code/modules/reagents/chemistry/recipes.dm
@@ -36,7 +36,7 @@
 	var/PurityMin 				= 0.15 		//If purity is below 0.15, it explodes too. Set to 0 to disable this.
 
 
-/datum/chemical_reaction/proc/on_reaction(datum/reagents/holder, created_volume, specialreact)
+/datum/chemical_reaction/proc/on_reaction(datum/reagents/holder, multiplier, specialreact)
 	return
 	//I recommend you set the result amount to the total volume of all components.
 

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -53,9 +53,9 @@
 	required_reagents = list(/datum/reagent/iron = 5, /datum/reagent/consumable/frostoil = 5, /datum/reagent/toxin/plasma = 20)
 	mob_react = FALSE
 
-/datum/chemical_reaction/plasmasolidification/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/plasmasolidification/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/stack/sheet/mineral/plasma(location)
 
 /datum/chemical_reaction/goldsolidification
@@ -64,9 +64,9 @@
 	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/gold = 20, /datum/reagent/iron = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/goldsolidification/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/goldsolidification/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/stack/sheet/mineral/gold(location)
 
 /datum/chemical_reaction/capsaicincondensation
@@ -88,9 +88,9 @@
 	results = list(/datum/reagent/consumable/mustard = 5)
 	required_reagents = list(/datum/reagent/mustardgrind = 1, /datum/reagent/water  = 10, /datum/reagent/consumable/enzyme= 1)
 
-/datum/chemical_reaction/soapification/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/soapification/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/soap/homemade(location)
 
 /datum/chemical_reaction/candlefication
@@ -100,9 +100,9 @@
 	required_temp = 374
 	mob_react = FALSE
 
-/datum/chemical_reaction/candlefication/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/candlefication/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/candle(location)
 
 /datum/chemical_reaction/meatification
@@ -111,9 +111,9 @@
 	required_reagents = list(/datum/reagent/liquidgibs = 10, /datum/reagent/consumable/nutriment = 10, /datum/reagent/carbon = 10)
 	mob_react = FALSE
 
-/datum/chemical_reaction/meatification/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/meatification/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i++)
+	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/reagent_containers/food/snacks/meat/slab/meatproduct(location)
 	return
 
@@ -146,9 +146,9 @@
 	mob_react = FALSE
 	required_temp = 300
 
-/datum/chemical_reaction/fermis_plush/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/fermis_plush/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= created_volume, i+=10)
+	for(var/i = 1, i <= multiplier, i+=10)
 		new /obj/item/toy/plush/catgirl/fermis(location)
 
 ////////////////////////////////// VIROLOGY //////////////////////////////////////////
@@ -227,13 +227,13 @@
 	var/level_min = 1
 	var/level_max = 2
 
-/datum/chemical_reaction/mix_virus/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/mix_virus/on_reaction(datum/reagents/holder, multiplier)
 
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			for(var/i in 1 to min(created_volume, 5))
+			for(var/i in 1 to min(multiplier, 5))
 				D.Evolve(level_min, level_max)
 
 /datum/chemical_reaction/mix_virus/mix_virus_2
@@ -330,12 +330,12 @@
 	required_reagents = list(/datum/reagent/medicine/synaptizine = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
-/datum/chemical_reaction/mix_virus/rem_virus/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/mix_virus/rem_virus/on_reaction(datum/reagents/holder, multiplier)
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			for(var/i in 1 to min(created_volume, 5))
+			for(var/i in 1 to min(multiplier, 5))
 				D.Devolve()
 
 /datum/chemical_reaction/mix_virus/neuter_virus
@@ -344,12 +344,12 @@
 	required_reagents = list(/datum/reagent/toxin/formaldehyde = 1)
 	required_catalysts = list(/datum/reagent/blood = 1)
 
-/datum/chemical_reaction/mix_virus/neuter_virus/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/mix_virus/neuter_virus/on_reaction(datum/reagents/holder, multiplier)
 	var/datum/reagent/blood/B = locate(/datum/reagent/blood) in holder.reagent_list
 	if(B && B.data)
 		var/datum/disease/advance/D = locate(/datum/disease/advance) in B.data["viruses"]
 		if(D)
-			for(var/i in 1 to min(created_volume, 5))
+			for(var/i in 1 to min(multiplier, 5))
 				D.Neuter()
 
 ////////////////////////////////// foam and foam precursor ///////////////////////////////////////////////////
@@ -367,12 +367,12 @@
 	required_reagents = list(/datum/reagent/fluorosurfactant = 1, /datum/reagent/water = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/foam/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	for(var/mob/M in viewers(5, location))
 		to_chat(M, "<span class='danger'>The solution spews out foam!</span>")
 	var/datum/effect_system/foam_spread/s = new()
-	s.set_up(created_volume*2, location, holder)
+	s.set_up(multiplier*2, location, holder)
 	s.start()
 	holder.clear_reagents()
 	return
@@ -384,14 +384,14 @@
 	required_reagents = list(/datum/reagent/aluminium = 3, /datum/reagent/foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/metalfoam/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 
 	for(var/mob/M in viewers(5, location))
 		to_chat(M, "<span class='danger'>The solution spews out a metallic foam!</span>")
 
 	var/datum/effect_system/foam_spread/metal/s = new()
-	s.set_up(created_volume*5, location, holder, 1)
+	s.set_up(multiplier*5, location, holder, 1)
 	s.start()
 	holder.clear_reagents()
 
@@ -401,11 +401,11 @@
 	required_reagents = list(/datum/reagent/aluminium = 3, /datum/reagent/smart_foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
 	mob_react = TRUE
 
-/datum/chemical_reaction/smart_foam/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/smart_foam/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/location = get_turf(holder.my_atom)
 	location.visible_message("<span class='danger'>The solution spews out metallic foam!</span>")
 	var/datum/effect_system/foam_spread/metal/smart/s = new()
-	s.set_up(created_volume * 5, location, holder, TRUE)
+	s.set_up(multiplier * 5, location, holder, TRUE)
 	s.start()
 	holder.clear_reagents()
 
@@ -415,12 +415,12 @@
 	required_reagents = list(/datum/reagent/iron = 3, /datum/reagent/foaming_agent = 1, /datum/reagent/toxin/acid/fluacid = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/ironfoam/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	for(var/mob/M in viewers(5, location))
 		to_chat(M, "<span class='danger'>The solution spews out a metallic foam!</span>")
 	var/datum/effect_system/foam_spread/metal/s = new()
-	s.set_up(created_volume*5, location, holder, 2)
+	s.set_up(multiplier*5, location, holder, 2)
 	s.start()
 	holder.clear_reagents()
 
@@ -521,8 +521,8 @@
 	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/blood = 1)
 	required_temp = 374
 
-/datum/chemical_reaction/life/on_reaction(datum/reagents/holder, created_volume)
-	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life") // Lol.
+/datum/chemical_reaction/life/on_reaction(datum/reagents/holder, multiplier)
+	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life") // Lol.
 
 //This is missing, I'm adding it back (see tgwiki). Not sure why we don't have it.
 /datum/chemical_reaction/life_friendly
@@ -531,8 +531,8 @@
 	required_reagents = list(/datum/reagent/medicine/strange_reagent = 1, /datum/reagent/medicine/synthflesh = 1, /datum/reagent/consumable/sugar = 1)
 	required_temp = 374
 
-/datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, created_volume)
-	chemical_mob_spawn(holder, rand(1, round(created_volume, 1)), "Life (friendly)", FRIENDLY_SPAWN) //Pray for cute cats
+/datum/chemical_reaction/life_friendly/on_reaction(datum/reagents/holder, multiplier)
+	chemical_mob_spawn(holder, rand(1, round(multiplier, 1)), "Life (friendly)", FRIENDLY_SPAWN) //Pray for cute cats
 
 /datum/chemical_reaction/corgium
 	name = "corgium"
@@ -540,9 +540,9 @@
 	required_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/colorful_reagent = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/blood = 1)
 	required_temp = 374
 
-/datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/corgium/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i = rand(1, created_volume), i <= created_volume, i++) // More lulz.
+	for(var/i = rand(1, multiplier), i <= multiplier, i++) // More lulz.
 		new /mob/living/simple_animal/pet/dog/corgi(location)
 	..()
 
@@ -600,9 +600,9 @@
 	required_reagents = list(/datum/reagent/oil = 5, /datum/reagent/toxin/acid = 2, /datum/reagent/ash = 3)
 	required_temp = 374 //lazily consistent with soap & other crafted objects generically created with heat.
 
-/datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/plastic_polymers/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	for(var/i in 1 to created_volume)
+	for(var/i in 1 to multiplier)
 		new /obj/item/stack/sheet/plastic(location)
 
 /datum/chemical_reaction/pax

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -5,7 +5,7 @@
 	var/modifier = 0
 	var/noexplosion = FALSE
 
-/datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, created_volume, turf/override)
+/datum/chemical_reaction/reagent_explosion/on_reaction(datum/reagents/holder, multiplier, turf/override)
 	if(!noexplosion)
 		var/turf/T = override || get_turf(holder.my_atom)
 		var/inside_msg
@@ -20,7 +20,7 @@
 		message_admins("Reagent explosion reaction occurred at [ADMIN_VERBOSEJMP(T)][inside_msg]. Last Fingerprint: [touch_msg].")
 		log_game("Reagent explosion reaction occurred at [AREACOORD(T)]. Last Fingerprint: [lastkey ? lastkey : "N/A"]." )
 		var/datum/effect_system/reagents_explosion/e = new()
-		e.set_up(modifier + round(created_volume/strengthdiv, 1), T, 0, 0)
+		e.set_up(modifier + round(multiplier/strengthdiv, 1), T, 0, 0)
 		e.start()
 	holder.clear_reagents()
 
@@ -32,10 +32,10 @@
 	required_reagents = list(/datum/reagent/glycerol = 1, /datum/reagent/toxin/acid/fluacid = 1, /datum/reagent/toxin/acid = 1)
 	strengthdiv = 2
 
-/datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/reagent_explosion/nitroglycerin/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
-	holder.remove_reagent(/datum/reagent/nitroglycerin, created_volume*2)
+	holder.remove_reagent(/datum/reagent/nitroglycerin, multiplier*2)
 	..()
 
 /datum/chemical_reaction/reagent_explosion/nitroglycerin_explosion
@@ -57,10 +57,10 @@
 	id = "holyboom"
 	required_reagents = list(/datum/reagent/water/holywater = 1, /datum/reagent/potassium = 1)
 
-/datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/reagent_explosion/potassium_explosion/holyboom/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/T = get_turf(holder.my_atom)
-	if(created_volume >= 150)
-		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, 0, round(created_volume/48))
+	if(multiplier >= 150)
+		playsound(get_turf(holder.my_atom), 'sound/effects/pray.ogg', 80, 0, round(multiplier/48))
 		strengthdiv = 8
 		for(var/mob/living/simple_animal/revenant/R in get_hearers_in_view(7,get_turf(holder.my_atom)))
 			var/deity
@@ -73,13 +73,13 @@
 			R.reveal(100)
 			R.adjustHealth(50)
 		sleep(20)
-		for(var/mob/living/carbon/C in get_hearers_in_view(round(created_volume/48,1),get_turf(holder.my_atom)))
+		for(var/mob/living/carbon/C in get_hearers_in_view(round(multiplier/48,1),get_turf(holder.my_atom)))
 			if(iscultist(C))
 				to_chat(C, "<span class='userdanger'>The divine explosion sears you!</span>")
 				C.Knockdown(40)
 				C.adjust_fire_stacks(5)
 				C.IgniteMob()
-	..(holder, created_volume, T)
+	..(holder, multiplier, T)
 
 
 /datum/chemical_reaction/blackpowder
@@ -97,9 +97,9 @@
 	modifier = 1
 	mix_message = "<span class='boldannounce'>Sparks start flying around the black powder!</span>"
 
-/datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/reagent_explosion/blackpowder_explosion/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/T = get_turf(holder.my_atom)
-	..(holder, created_volume, T)
+	..(holder, multiplier, T)
 
 /datum/chemical_reaction/thermite
 	name = "Thermite"
@@ -112,11 +112,11 @@
 	id = "emp_pulse"
 	required_reagents = list(/datum/reagent/uranium = 1, /datum/reagent/iron = 1) // Yes, laugh, it's the best recipe I could think of that makes a little bit of sense
 
-/datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	// 100 created volume = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 created volume = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, round(created_volume / 12), round(created_volume / 7), 1)
+	// 100 multiplier = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
+	// 200 multiplier = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
+	empulse(location, round(multiplier / 12), round(multiplier / 7), 1)
 	holder.clear_reagents()
 
 
@@ -125,9 +125,9 @@
 	id = "beesplosion"
 	required_reagents = list(/datum/reagent/consumable/honey = 1, /datum/reagent/medicine/strange_reagent = 1, /datum/reagent/radium = 1)
 
-/datum/chemical_reaction/beesplosion/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/beesplosion/on_reaction(datum/reagents/holder, multiplier)
 	var/location = holder.my_atom.drop_location()
-	if(created_volume < 5)
+	if(multiplier < 5)
 		playsound(location,'sound/effects/sparks1.ogg', 100, TRUE)
 	else
 		playsound(location,'sound/creatures/bee.ogg', 100, TRUE)
@@ -137,7 +137,7 @@
 			if(required_reagents[R.type])
 				continue
 			beeagents += R
-		var/bee_amount = round(created_volume * 0.2)
+		var/bee_amount = round(multiplier * 0.2)
 		for(var/i in 1 to bee_amount)
 			var/mob/living/simple_animal/hostile/poison/bees/short/new_bee = new(location)
 			if(LAZYLEN(beeagents))
@@ -157,7 +157,7 @@
 	required_reagents = list(/datum/reagent/chlorine = 1, /datum/reagent/fluorine = 3)
 	required_temp = 424
 
-/datum/chemical_reaction/clf3/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/clf3/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(1,T))
 		new /obj/effect/hotspot(turf)
@@ -172,7 +172,7 @@
 	modifier = 1
 	mob_react = FALSE
 
-/datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/reagent_explosion/methsplosion/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/T = get_turf(holder.my_atom)
 	for(var/turf/turf in range(1,T))
 		new /obj/effect/hotspot(turf)
@@ -190,12 +190,12 @@
 	results = list(/datum/reagent/sorium = 4)
 	required_reagents = list(/datum/reagent/mercury = 1, /datum/reagent/oxygen = 1, /datum/reagent/nitrogen = 1, /datum/reagent/carbon = 1)
 
-/datum/chemical_reaction/sorium/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/sorium/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
-	holder.remove_reagent(/datum/reagent/sorium, created_volume*4)
+	holder.remove_reagent(/datum/reagent/sorium, multiplier*4)
 	var/turf/T = get_turf(holder.my_atom)
-	var/range = CLAMP(sqrt(created_volume*4), 1, 6)
+	var/range = CLAMP(sqrt(multiplier*4), 1, 6)
 	goonchem_vortex(T, 1, range)
 
 /datum/chemical_reaction/sorium_vortex
@@ -204,9 +204,9 @@
 	required_reagents = list(/datum/reagent/sorium = 1)
 	required_temp = 474
 
-/datum/chemical_reaction/sorium_vortex/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/sorium_vortex/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/T = get_turf(holder.my_atom)
-	var/range = CLAMP(sqrt(created_volume), 1, 6)
+	var/range = CLAMP(sqrt(multiplier), 1, 6)
 	goonchem_vortex(T, 1, range)
 
 /datum/chemical_reaction/liquid_dark_matter
@@ -215,12 +215,12 @@
 	results = list(/datum/reagent/liquid_dark_matter = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/radium = 1, /datum/reagent/carbon = 1)
 
-/datum/chemical_reaction/liquid_dark_matter/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/liquid_dark_matter/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
-	holder.remove_reagent(/datum/reagent/liquid_dark_matter, created_volume*3)
+	holder.remove_reagent(/datum/reagent/liquid_dark_matter, multiplier*3)
 	var/turf/T = get_turf(holder.my_atom)
-	var/range = CLAMP(sqrt(created_volume*3), 1, 6)
+	var/range = CLAMP(sqrt(multiplier*3), 1, 6)
 	goonchem_vortex(T, 0, range)
 
 /datum/chemical_reaction/ldm_vortex
@@ -229,9 +229,9 @@
 	required_reagents = list(/datum/reagent/liquid_dark_matter = 1)
 	required_temp = 474
 
-/datum/chemical_reaction/ldm_vortex/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/ldm_vortex/on_reaction(datum/reagents/holder, multiplier)
 	var/turf/T = get_turf(holder.my_atom)
-	var/range = CLAMP(sqrt(created_volume/2), 1, 6)
+	var/range = CLAMP(sqrt(multiplier/2), 1, 6)
 	goonchem_vortex(T, 0, range)
 
 /datum/chemical_reaction/flash_powder
@@ -240,12 +240,12 @@
 	results = list(/datum/reagent/flash_powder = 3)
 	required_reagents = list(/datum/reagent/aluminium = 1, /datum/reagent/potassium = 1, /datum/reagent/sulfur = 1 )
 
-/datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/flash_powder/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
-	var/range = created_volume/3
+	var/range = multiplier/3
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
 		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
@@ -255,7 +255,7 @@
 				C.Knockdown(60)
 			else
 				C.Stun(100)
-	holder.remove_reagent(/datum/reagent/flash_powder, created_volume*3)
+	holder.remove_reagent(/datum/reagent/flash_powder, multiplier*3)
 
 /datum/chemical_reaction/flash_powder_flash
 	name = "Flash powder activation"
@@ -263,10 +263,10 @@
 	required_reagents = list(/datum/reagent/flash_powder = 1)
 	required_temp = 374
 
-/datum/chemical_reaction/flash_powder_flash/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/flash_powder_flash/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	do_sparks(2, TRUE, location)
-	var/range = created_volume/10
+	var/range = multiplier/10
 	if(isatom(holder.my_atom))
 		var/atom/A = holder.my_atom
 		A.flash_lighting_fx(_range = (range + 2), _reset_lighting = FALSE)
@@ -283,11 +283,11 @@
 	results = list(/datum/reagent/smoke_powder = 3)
 	required_reagents = list(/datum/reagent/potassium = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/phosphorus = 1)
 
-/datum/chemical_reaction/smoke_powder/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/smoke_powder/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
-	holder.remove_reagent(/datum/reagent/smoke_powder, created_volume*3)
-	var/smoke_radius = round(sqrt(created_volume * 1.5), 1)
+	holder.remove_reagent(/datum/reagent/smoke_powder, multiplier*3)
+	var/smoke_radius = round(sqrt(multiplier * 1.5), 1)
 	var/location = get_turf(holder.my_atom)
 	var/datum/effect_system/smoke_spread/chem/S = new
 	S.attach(location)
@@ -305,9 +305,9 @@
 	required_temp = 374
 	mob_react = FALSE
 
-/datum/chemical_reaction/smoke_powder_smoke/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/smoke_powder_smoke/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	var/smoke_radius = round(sqrt(created_volume / 2), 1)
+	var/smoke_radius = round(sqrt(multiplier / 2), 1)
 	var/datum/effect_system/smoke_spread/chem/S = new
 	S.attach(location)
 	playsound(location, 'sound/effects/smoke.ogg', 50, 1, -3)
@@ -323,13 +323,13 @@
 	results = list(/datum/reagent/sonic_powder = 3)
 	required_reagents = list(/datum/reagent/oxygen = 1, /datum/reagent/consumable/space_cola = 1, /datum/reagent/phosphorus = 1)
 
-/datum/chemical_reaction/sonic_powder/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/sonic_powder/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
-	holder.remove_reagent(/datum/reagent/sonic_powder, created_volume*3)
+	holder.remove_reagent(/datum/reagent/sonic_powder, multiplier*3)
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, 1)
-	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/3, location))
+	for(var/mob/living/carbon/C in get_hearers_in_view(multiplier/3, location))
 		C.soundbang_act(1, 100, rand(0, 5))
 
 /datum/chemical_reaction/sonic_powder_deafen
@@ -338,10 +338,10 @@
 	required_reagents = list(/datum/reagent/sonic_powder = 1)
 	required_temp = 374
 
-/datum/chemical_reaction/sonic_powder_deafen/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/sonic_powder_deafen/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	playsound(location, 'sound/effects/bang.ogg', 25, 1)
-	for(var/mob/living/carbon/C in get_hearers_in_view(created_volume/10, location))
+	for(var/mob/living/carbon/C in get_hearers_in_view(multiplier/10, location))
 		C.soundbang_act(1, 100, rand(0, 5))
 
 /datum/chemical_reaction/phlogiston
@@ -350,12 +350,12 @@
 	results = list(/datum/reagent/phlogiston = 3)
 	required_reagents = list(/datum/reagent/phosphorus = 1, /datum/reagent/toxin/acid = 1, /datum/reagent/stable_plasma = 1)
 
-/datum/chemical_reaction/phlogiston/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/phlogiston/on_reaction(datum/reagents/holder, multiplier)
 	if(holder.has_reagent(/datum/reagent/stabilizing_agent))
 		return
 	var/turf/open/T = get_turf(holder.my_atom)
 	if(istype(T))
-		T.atmos_spawn_air("plasma=[created_volume];TEMP=1000")
+		T.atmos_spawn_air("plasma=[multiplier];TEMP=1000")
 	holder.clear_reagents()
 	return
 
@@ -371,7 +371,7 @@
 	results = list(/datum/reagent/cryostylane = 3)
 	required_reagents = list(/datum/reagent/water = 1, /datum/reagent/stable_plasma = 1, /datum/reagent/nitrogen = 1)
 
-/datum/chemical_reaction/cryostylane/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/cryostylane/on_reaction(datum/reagents/holder, multiplier)
 	holder.chem_temp = 20 // cools the fuck down
 	return
 
@@ -382,8 +382,8 @@
 	required_reagents = list(/datum/reagent/cryostylane = 1, /datum/reagent/oxygen = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/cryostylane_oxygen/on_reaction(datum/reagents/holder, created_volume)
-	holder.chem_temp = max(holder.chem_temp - 10*created_volume,0)
+/datum/chemical_reaction/cryostylane_oxygen/on_reaction(datum/reagents/holder, multiplier)
+	holder.chem_temp = max(holder.chem_temp - 10*multiplier,0)
 
 /datum/chemical_reaction/pyrosium_oxygen
 	name = "ephemeral pyrosium reaction"
@@ -392,8 +392,8 @@
 	required_reagents = list(/datum/reagent/pyrosium = 1, /datum/reagent/oxygen = 1)
 	mob_react = FALSE
 
-/datum/chemical_reaction/pyrosium_oxygen/on_reaction(datum/reagents/holder, created_volume)
-	holder.chem_temp += 10*created_volume
+/datum/chemical_reaction/pyrosium_oxygen/on_reaction(datum/reagents/holder, multiplier)
+	holder.chem_temp += 10*multiplier
 
 /datum/chemical_reaction/pyrosium
 	name = "pyrosium"
@@ -401,7 +401,7 @@
 	results = list(/datum/reagent/pyrosium = 3)
 	required_reagents = list(/datum/reagent/stable_plasma = 1, /datum/reagent/radium = 1, /datum/reagent/phosphorus = 1)
 
-/datum/chemical_reaction/pyrosium/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/pyrosium/on_reaction(datum/reagents/holder, multiplier)
 	holder.chem_temp = 20 // also cools the fuck down
 	return
 
@@ -431,20 +431,20 @@
 	mix_sound = 'sound/machines/defib_zap.ogg'
 	var/tesla_flags = TESLA_MOB_DAMAGE | TESLA_OBJ_DAMAGE | TESLA_MOB_STUN
 
-/datum/chemical_reaction/reagent_explosion/teslium_lightning/on_reaction(datum/reagents/holder, created_volume)
-	var/T1 = created_volume * 20		//100 units : Zap 3 times, with powers 2000/5000/12000. Tesla revolvers have a power of 10000 for comparison.
-	var/T2 = created_volume * 50
-	var/T3 = created_volume * 120
+/datum/chemical_reaction/reagent_explosion/teslium_lightning/on_reaction(datum/reagents/holder, multiplier)
+	var/T1 = multiplier * 20		//100 units : Zap 3 times, with powers 2000/5000/12000. Tesla revolvers have a power of 10000 for comparison.
+	var/T2 = multiplier * 50
+	var/T3 = multiplier * 120
 	sleep(5)
-	if(created_volume >= 75)
+	if(multiplier >= 75)
 		tesla_zap(holder.my_atom, 7, T1, tesla_flags)
 		playsound(holder.my_atom, 'sound/machines/defib_zap.ogg', 50, 1)
 		sleep(15)
-	if(created_volume >= 40)
+	if(multiplier >= 40)
 		tesla_zap(holder.my_atom, 7, T2, tesla_flags)
 		playsound(holder.my_atom, 'sound/machines/defib_zap.ogg', 50, 1)
 		sleep(15)
-	if(created_volume >= 10)			//10 units minimum for lightning, 40 units for secondary blast, 75 units for tertiary blast.
+	if(multiplier >= 10)			//10 units minimum for lightning, 40 units for secondary blast, 75 units for tertiary blast.
 		tesla_zap(holder.my_atom, 7, T3, tesla_flags)
 		playsound(holder.my_atom, 'sound/machines/defib_zap.ogg', 50, 1)
 	..()
@@ -490,7 +490,7 @@
 	else
 		return FALSE
 
-/datum/chemical_reaction/reagent_explosion/lingblood/on_reaction(datum/reagents/holder, created_volume, specialreact)
+/datum/chemical_reaction/reagent_explosion/lingblood/on_reaction(datum/reagents/holder, multiplier, specialreact)
 	if(specialreact >= 10)
 		return ..()
 	else

--- a/code/modules/reagents/chemistry/recipes/slime_extracts.dm
+++ b/code/modules/reagents/chemistry/recipes/slime_extracts.dm
@@ -290,7 +290,7 @@
 	required_container = /obj/item/slime_extract/yellow
 	required_other = TRUE
 
-/datum/chemical_reaction/slime/slimeoverload/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/slime/slimeoverload/on_reaction(datum/reagents/holder, multiplier)
 	empulse(get_turf(holder.my_atom), 3, 7)
 	..()
 
@@ -301,7 +301,7 @@
 	required_container = /obj/item/slime_extract/yellow
 	required_other = TRUE
 
-/datum/chemical_reaction/slime/slimecell/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/slime/slimecell/on_reaction(datum/reagents/holder, multiplier)
 	new /obj/item/stock_parts/cell/high/slime(get_turf(holder.my_atom))
 	..()
 
@@ -505,7 +505,7 @@
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = TRUE
 
-/datum/chemical_reaction/slime/slimefloor2/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/slime/slimefloor2/on_reaction(datum/reagents/holder, multiplier)
 	new /obj/item/stack/tile/bluespace(get_turf(holder.my_atom), 25)
 	..()
 
@@ -517,7 +517,7 @@
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = TRUE
 
-/datum/chemical_reaction/slime/slimecrystal/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/slime/slimecrystal/on_reaction(datum/reagents/holder, multiplier)
 	var/obj/item/stack/ore/bluespace_crystal/BC = new (get_turf(holder.my_atom))
 	BC.visible_message("<span class='notice'>The [BC.name] appears out of thin air!</span>")
 	..()
@@ -529,7 +529,7 @@
 	required_container = /obj/item/slime_extract/bluespace
 	required_other = TRUE
 
-/datum/chemical_reaction/slime/slimeradio/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/slime/slimeradio/on_reaction(datum/reagents/holder, multiplier)
 	new /obj/item/slimepotion/slime/slimeradio(get_turf(holder.my_atom))
 	..()
 
@@ -626,8 +626,8 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/rainbow
 
-/datum/chemical_reaction/slime/slimeRNG/on_reaction(datum/reagents/holder, created_volume)
-	if(created_volume >= 5)
+/datum/chemical_reaction/slime/slimeRNG/on_reaction(datum/reagents/holder, multiplier)
+	if(multiplier >= 5)
 		var/obj/item/grenade/clusterbuster/slime/S = new (get_turf(holder.my_atom))
 		S.visible_message("<span class='danger'>Infused with plasma, the core begins to expand uncontrollably!</span>")
 		S.icon_state = "[S.base_state]_active"
@@ -646,7 +646,7 @@
 	required_other = TRUE
 	required_container = /obj/item/slime_extract/rainbow
 
-/datum/chemical_reaction/slime/slimebomb/on_reaction(datum/reagents/holder, created_volume)
+/datum/chemical_reaction/slime/slimebomb/on_reaction(datum/reagents/holder, multiplier)
 	var/obj/item/grenade/clusterbuster/slime/volatile/S = new (holder.my_atom.loc)
 	S.visible_message("<span class='danger'>Infused with slime jelly, the core begins to expand uncontrollably!</span>")
 	S.icon_state = "[S.base_state]_active"


### PR DESCRIPTION
Created volume is a misnomer. It uses MULTIPLIER, aka the most "units" of reactions it can make.

With a 1:1:1:1 reaction, you'd expect it to be 600 created for 150/150/150/150 because that's default right?
No, it's 150, because that's the most amount of "times" it can react, assuming one reaction is a single unit (which it isn't but it's more simplified this way.)
With nitroglycerin which ACTUALLY SAYS IT CREATES 2 UNITS FOR 1:1, you'd expect 300/300 to be 600 CREATED VOLUME right?
No.
300. Because that's the most amount of unit reactions it can produce, regardless of result. 

The procs use multiplier, not created volume. This was just misleading from the start.