### PR TITLE
Grenades can now actually have their timers adjusted

### DIFF
--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -1,4 +1,4 @@
-/obj/item/grenade
+ /obj/item/grenade
 	name = "grenade"
 	desc = "It has an adjustable timer."
 	w_class = WEIGHT_CLASS_SMALL
@@ -93,9 +93,8 @@
 		var/obj/item/I = loc
 		I.grenade_prime_react(src)
 
-
-/obj/item/grenade/attackby(obj/item/W, mob/user, params)
-	if(istype(W, /obj/item/screwdriver))
+/obj/item/grenade/tool_act(mob/living/user, obj/item/I, tool_behaviour)
+	if(tool_behaviour == TOOL_SCREWDRIVER)
 		switch(det_time)
 			if ("1")
 				det_time = 10

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -1,4 +1,4 @@
- /obj/item/grenade
+/obj/item/grenade
 	name = "grenade"
 	desc = "It has an adjustable timer."
 	w_class = WEIGHT_CLASS_SMALL


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

tin

screwdrivers call tool_act(), not attackby when attempting to screwdriver.
pre_attack_chain or whatever the thing next to tool_attack_chain also does not trigger because this is not a bludgeonable object or whatever the flag was for allowing it to be attacked.

## Why It's Good For The Game

because bugfix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Grenades can now have their timers adjusted.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
