### PR TITLE
.357 AP printable from illegal ballistics

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -1117,7 +1117,7 @@
 	id = "advanced_illegal_ballistics"
 	display_name = "Advanced Non-Standard Ballistics"
 	description = "Ballistic ammunition for non-standard firearms. Usually the ones you don't have nor want to be involved with."
-	design_ids = list("10mm","10mmap","10mminc","10mmhp","sl357","pistolm9mm","m45","bolt_clip")
+	design_ids = list("10mm","10mmap","10mminc","10mmhp","sl357","sl357ap","pistolm9mm","m45","bolt_clip")
 	prereq_ids = list("ballistic_weapons","syndicate_basic","explosive_weapons")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 25000) //This gives sec lethal mags/clips for guns from traitors, space, or anything in between.
 	export_price = 7000

--- a/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/modular_citadel/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -78,3 +78,13 @@
 	build_path = /obj/item/ammo_box/a357
 	category = list("Ammo")
 	departmental_flags = DEPARTMENTAL_FLAG_SECURITY
+
+/datum/design/sl357ap
+	name = "revolver speedloader (.357 AP)"
+	desc = "A revolver speedloader. Cuts through like a hot knife through butter."
+	id = "sl357ap"
+	build_type = PROTOLATHE
+	materials = list(MAT_METAL = 30000, MAT_TITANIUM = 45000)
+	build_path = /obj/item/ammo_box/a357/ap
+	category = list("Ammo")
+	departmental_flags = DEPARTMENTAL_FLAG_SECURITY


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
parity with 10mm magazine printables
## Changelog
:cl:
add: You can now print .357 AP speedloaders from Security techfabs after you pick up the Advanced Non-Standard Ballistics node.
/:cl: