### PR TITLE
Removes the Mechanical Benefits and Penalties for Combat Mode

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -98,12 +98,8 @@
 	take_damage(I.force, I.damtype, "melee", 1)
 
 /mob/living/attacked_by(obj/item/I, mob/living/user)
-	//CIT CHANGES START HERE - combatmode and resting checks
+	//CIT CHANGES START HERE - resting check
 	var/totitemdamage = I.force
-	if(iscarbon(user))
-		var/mob/living/carbon/tempcarb = user
-		if(!tempcarb.combatmode)
-			totitemdamage *= 0.5
 	if(user.resting)
 		totitemdamage *= 0.5
 	//CIT CHANGES END HERE

--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -71,16 +71,10 @@
 	SEND_SIGNAL(src, COMSIG_ADD_MOOD_EVENT, "embedded", /datum/mood_event/embedded)
 
 /mob/living/carbon/attacked_by(obj/item/I, mob/living/user)
-	//CIT CHANGES START HERE - combatmode and resting checks
+	//CIT CHANGES START HERE - resting check
 	var/totitemdamage = I.force
-	if(iscarbon(user))
-		var/mob/living/carbon/tempcarb = user
-		if(!tempcarb.combatmode)
-			totitemdamage *= 0.5
 	if(user.resting)
 		totitemdamage *= 0.5
-	if(!combatmode)
-		totitemdamage *= 1.5
 	//CIT CHANGES END HERE
 	if(user != src && check_shields(I, totitemdamage, "the [I.name]", MELEE_ATTACK, I.armour_penetration))
 		return FALSE

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1517,13 +1517,9 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 
-		//CITADEL CHANGES - makes resting and disabled combat mode reduce punch damage, makes being out of combat mode result in you taking more damage
-		if(!target.combatmode && damage < user.dna.species.punchstunthreshold)
-			damage = user.dna.species.punchstunthreshold - 1
+		//CITADEL CHANGES - makes resting reduce punch damage
 		if(user.resting)
 			damage *= 0.5
-		if(!user.combatmode)
-			damage *= 0.25
 		//END OF CITADEL CHANGES
 
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -505,7 +505,7 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 //this updates all special effects: stun, sleeping, knockdown, druggy, stuttering, etc..
 /mob/living/carbon/handle_status_effects()
 	..()
-	if(getStaminaLoss() && !combatmode)//CIT CHANGE - prevents stamina regen while combat mode is active
+	if(getStaminaLoss())//CIT CHANGE
 		adjustStaminaLoss(resting ? (recoveringstam ? -7.5 : -6) : -3)//CIT CHANGE - decreases adjuststaminaloss to stop stamina damage from being such a joke
 
 	if(!recoveringstam && incomingstammult != 1)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -36,7 +36,6 @@
 	var/spread = 0						//Spread induced by the gun itself.
 	var/burst_spread = 0				//Spread induced by the gun itself during burst fire per iteration. Only checked if spread is 0.
 	var/randomspread = 1				//Set to 0 for shotguns. This is used for weapons that don't fire all their bullets at once.
-	var/inaccuracy_modifier = 1
 	var/pb_knockback = 0
 
 	lefthand_file = 'icons/mob/inhands/weapons/guns_lefthand.dmi'
@@ -186,7 +185,6 @@
 	var/bonus_spread = 0
 	var/loop_counter = 0
 
-	bonus_spread += getinaccuracy(user) //CIT CHANGE - adds bonus spread while not aiming
 	if(ishuman(user) && user.a_intent == INTENT_HARM)
 		var/mob/living/carbon/human/H = user
 		for(var/obj/item/gun/G in H.held_items)
@@ -527,13 +525,3 @@
 	if(A == chambered)
 		chambered = null
 		update_icon()
-
-/obj/item/gun/proc/getinaccuracy(mob/living/user)
-	if(!iscarbon(user))
-		return FALSE
-	else
-		var/mob/living/carbon/holdingdude = user
-		if(istype(holdingdude) && holdingdude.combatmode)
-			return (max((holdingdude.lastdirchange + weapon_weight * 25) - world.time,0) * inaccuracy_modifier)
-		else
-			return ((weapon_weight * 25) * inaccuracy_modifier)

--- a/code/modules/projectiles/guns/ballistic/launchers.dm
+++ b/code/modules/projectiles/guns/ballistic/launchers.dm
@@ -86,7 +86,6 @@
 	pin = /obj/item/firing_pin/implant/pindicate
 	burst_size = 1
 	fire_delay = 0
-	inaccuracy_modifier = 0.7
 	casing_ejector = FALSE
 	weapon_weight = WEAPON_HEAVY
 	magazine_wording = "rocket"

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/magweapon.dm
@@ -111,7 +111,6 @@
 	casing_ejector = FALSE
 	fire_delay = 2
 	recoil = 0.1
-	inaccuracy_modifier = 0.25
 
 /obj/item/gun/ballistic/automatic/pistol/mag/update_icon()
 	..()
@@ -274,7 +273,6 @@
 	spread = 0
 	recoil = 0.1
 	casing_ejector = FALSE
-	inaccuracy_modifier = 0.5
 	weapon_weight = WEAPON_MEDIUM
 	dualwield_spread_mult = 1.4
 


### PR DESCRIPTION
## About The Pull Request

This PR does the following:
- Combat Mode no longer halts stamina regeneration
- Combat Mode no longer has any bearing on melee damage dealt or received
- Combat Mode and changing direction no longer have any bearing on gun accuracy (all guns are accurate all the time now)

## Why It's Good For The Game

Toggling combat mode on and off is tedious and does not provide the player with any interesting choices or strategy. If you are running away, there is no reason to have it on. If you are fighting, there is no reason to have it off. Given that no conscious choice is being made on the player's part, toggling it on and off is just a chore and serves to confuse new players to the community who don't understand what it is, what it does, and who have no access to resources to learn.

The only thing the statistical benefits of Combat Mode do is artificially increase the difficulty of playing on the server, to no tactical or strategical benefit. It is not depth or meaningful complexity, it is just complication for its own sake.

Any special features of combat mode's control scheme are still active, as they are or can be legitimately useful.

## Changelog
:cl:
balance: There are no longer any numerical benefits associated with combat mode. It is now simply an optional control scheme that unlocks some special interactions.
/:cl:
