### PR TITLE
Makes rubber tool boxes have plastic

### DIFF
--- a/code/game/objects/items/storage/toolbox.dm
+++ b/code/game/objects/items/storage/toolbox.dm
@@ -121,6 +121,7 @@ GLOBAL_LIST_EMPTY(rubber_toolbox_icons)
 	desc = "A toolbox painted black with a red stripe. It looks more heavier than normal toolboxes."
 	force = 15
 	throwforce = 18
+	can_rubberify = FALSE
 
 /obj/item/storage/toolbox/syndicate/ComponentInitialize()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

Plastic tool boxes are made of plastic!

## Why It's Good For The Game

Look at rubber tool box in amazement as its not even made of plastic

## Changelog
:cl:
fix: Corrects rubber toolboxes not being plastic
/:cl:
