### PR TITLE
Trilby's solar panels PR but improved.

### DIFF
--- a/code/game/objects/items/stacks/sheets/glass.dm
+++ b/code/game/objects/items/stacks/sheets/glass.dm
@@ -26,6 +26,7 @@ GLOBAL_LIST_INIT(glass_recipes, list ( \
 	grind_results = list(/datum/reagent/silicon = 20)
 	point_value = 1
 	tableVariant = /obj/structure/table/glass
+	shard_type = /obj/item/shard
 
 /obj/item/stack/sheet/glass/suicide_act(mob/living/carbon/user)
 	user.visible_message("<span class='suicide'>[user] begins to slice [user.p_their()] neck with \the [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
@@ -93,6 +94,7 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/plasmaglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10)
 	tableVariant = /obj/structure/table/plasmaglass
+	shard_type = /obj/item/shard/plasma
 
 /obj/item/stack/sheet/plasmaglass/fifty
 	amount = 50
@@ -120,7 +122,9 @@ GLOBAL_LIST_INIT(pglass_recipes, list ( \
 	else
 		return ..()
 
-
+/obj/item/stack/sheet/plasmaglass/on_solar_construction(obj/machinery/power/solar/S)
+	S.obj_integrity *= 1.2
+	S.efficiency *= 1.2
 
 /*
  * Reinforced glass sheets
@@ -145,10 +149,14 @@ GLOBAL_LIST_INIT(reinforced_glass_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/rglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/iron = 10)
 	point_value = 4
+	shard_type = /obj/item/shard
 
 /obj/item/stack/sheet/rglass/attackby(obj/item/W, mob/user, params)
 	add_fingerprint(user)
 	..()
+
+/obj/item/stack/sheet/rglass/on_solar_construction(obj/machinery/power/solar/S)
+	S.obj_integrity *= 2
 
 /obj/item/stack/sheet/rglass/cyborg
 	materials = list()
@@ -188,6 +196,11 @@ GLOBAL_LIST_INIT(prglass_recipes, list ( \
 	merge_type = /obj/item/stack/sheet/plasmarglass
 	grind_results = list(/datum/reagent/silicon = 20, /datum/reagent/toxin/plasma = 10, /datum/reagent/iron = 10)
 	point_value = 23
+	shard_type = /obj/item/shard/plasma
+
+/obj/item/stack/sheet/plasmarglass/on_solar_construction(obj/machinery/power/solar/S)
+	S.obj_integrity *= 2.2
+	S.efficiency *= 1.2
 
 /obj/item/stack/sheet/plasmarglass/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.prglass_recipes
@@ -207,6 +220,11 @@ GLOBAL_LIST_INIT(titaniumglass_recipes, list(
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/titaniumglass
+	shard_type = /obj/item/shard
+
+/obj/item/stack/sheet/titaniumglass/on_solar_construction(obj/machinery/power/solar/S)
+	S.obj_integrity *= 2.5
+	S.efficiency *= 1.5
 
 /obj/item/stack/sheet/titaniumglass/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.titaniumglass_recipes
@@ -226,10 +244,15 @@ GLOBAL_LIST_INIT(plastitaniumglass_recipes, list(
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 100)
 	resistance_flags = ACID_PROOF
 	merge_type = /obj/item/stack/sheet/plastitaniumglass
+	shard_type = /obj/item/shard
 
 /obj/item/stack/sheet/plastitaniumglass/Initialize(mapload, new_amount, merge = TRUE)
 	recipes = GLOB.plastitaniumglass_recipes
 	return ..()
+
+/obj/item/stack/sheet/titaniumglass/on_solar_construction(obj/machinery/power/solar/S)
+	S.obj_integrity *= 2
+	S.efficiency *= 2
 
 /obj/item/shard
 	name = "shard"

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -16,3 +16,15 @@
 	var/is_fabric = FALSE //is this  a valid material for the loom?
 	var/loom_result //result from pulling on the loom
 	var/pull_effort = 0 //amount of delay when pulling on the loom
+	var/shard_type // the shard debris typepath left over by solar panels and windows etc.
+	var/solars_multiplier = 1
+
+/**
+  * Called on the glass sheet upon solar construction (duh):
+  * Different glass sheets can modify different stas/vars, such as obj_integrity or efficiency
+  * and possibly extra effects if you wish to code them.
+  * Keep in mind the solars' max_integrity is set equal to the obj_integrity by the end of the initialization,
+  * so you don't have to do so here.
+  */
+/obj/item/stack/sheet/proc/on_solar_construction(/obj/machinery/power/solar/S)
+	return

--- a/code/game/objects/items/stacks/sheets/sheets.dm
+++ b/code/game/objects/items/stacks/sheets/sheets.dm
@@ -17,14 +17,13 @@
 	var/loom_result //result from pulling on the loom
 	var/pull_effort = 0 //amount of delay when pulling on the loom
 	var/shard_type // the shard debris typepath left over by solar panels and windows etc.
-	var/solars_multiplier = 1
 
 /**
   * Called on the glass sheet upon solar construction (duh):
   * Different glass sheets can modify different stas/vars, such as obj_integrity or efficiency
   * and possibly extra effects if you wish to code them.
-  * Keep in mind the solars' max_integrity is set equal to the obj_integrity by the end of the initialization,
-  * so you don't have to do so here.
+  * Keep in mind the solars' max_integrity is set equal to the obj_integrity later,
+  * so you won't have to do so here.
   */
 /obj/item/stack/sheet/proc/on_solar_construction(/obj/machinery/power/solar/S)
 	return

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -15,7 +15,8 @@
 	var/decon_speed = 30
 	var/wtype = "glass"
 	var/fulltile = FALSE
-	var/glass_type = /obj/item/stack/sheet/glass
+	var/obj/item/stack/sheet/glass_type = /obj/item/stack/sheet/glass
+	var/cleanable_type = /obj/effect/decal/cleanable/glass
 	var/glass_amount = 1
 	var/mutable_appearance/crack_overlay
 	can_be_unanchored = TRUE
@@ -277,12 +278,15 @@
 
 /obj/structure/window/proc/spawnDebris(location)
 	. = list()
-	. += new /obj/item/shard(location)
-	. += new /obj/effect/decal/cleanable/glass(location)
+	var/shard = initial(glass_type.shard_type)
+	if(shard)
+		. += new shard(location)
+		if (fulltile)
+			. += new shard(location)
+	if(cleanable_type)
+		. += new cleanable_type(location)
 	if (reinf)
 		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
-	if (fulltile)
-		. += new /obj/item/shard(location)
 
 /obj/structure/window/proc/can_be_rotated(mob/user,rotation_type)
 	if (get_dist(src,user) > 1)
@@ -416,16 +420,8 @@
 	max_integrity = 150
 	explosion_block = 1
 	glass_type = /obj/item/stack/sheet/plasmaglass
+	cleanable_type = /obj/effect/decal/cleanable/glass/plasma
 	rad_insulation = RAD_NO_INSULATION
-
-/obj/structure/window/plasma/spawnDebris(location)
-	. = list()
-	. += new /obj/item/shard/plasma(location)
-	. += new /obj/effect/decal/cleanable/glass/plasma(location)
-	if (reinf)
-		. += new /obj/item/stack/rods(location, (fulltile ? 2 : 1))
-	if (fulltile)
-		. += new /obj/item/shard/plasma(location)
 
 /obj/structure/window/plasma/spawner/east
 	dir = EAST
@@ -661,11 +657,6 @@
 	max_integrity = 120
 	level = 3
 	glass_amount = 2
-
-/obj/structure/window/reinforced/clockwork/spawnDebris(location)
-	. = list()
-	for(var/i in 1 to 4)
-		. += new /obj/item/clockwork/alloy_shards/medium/gear_bit(location)
 
 /obj/structure/window/reinforced/clockwork/Initialize(mapload, direct)
 	made_glow = TRUE

--- a/code/modules/power/tracker.dm
+++ b/code/modules/power/tracker.dm
@@ -16,6 +16,7 @@
 	var/id = 0
 	var/sun_angle = 0		// sun angle as set by sun datum
 	var/obj/machinery/power/solar_control/control = null
+	var/obj/item/solar_assembly/assembly
 
 /obj/machinery/power/tracker/Initialize(mapload, obj/item/solar_assembly/S)
 	. = ..()
@@ -42,11 +43,12 @@
 
 /obj/machinery/power/tracker/proc/Make(obj/item/solar_assembly/S)
 	if(!S)
-		S = new /obj/item/solar_assembly(src)
-		S.glass_type = /obj/item/stack/sheet/glass
-		S.tracker = 1
+		S = new /obj/item/solar_assembly
+		S.glass_type = new /obj/item/stack/sheet/glass(null, 2)
+		S.tracker = TRUE
 		S.anchored = TRUE
-	S.forceMove(src)
+	else
+		S.moveToNullspace()
 	update_icon()
 
 //updates the tracker icon and the facing angle for the control computer
@@ -77,14 +79,14 @@
 /obj/machinery/power/solar/deconstruct(disassembled = TRUE)
 	if(!(flags_1 & NODECONSTRUCT_1))
 		if(disassembled)
-			var/obj/item/solar_assembly/S = locate() in src
-			if(S)
-				S.forceMove(loc)
-				S.give_glass(stat & BROKEN)
+			if(assembly)
+				assembly.forceMove(loc)
+				assembly.give_glass(stat & BROKEN)
 		else
 			playsound(src, "shatter", 70, 1)
-			new /obj/item/shard(src.loc)
-			new /obj/item/shard(src.loc)
+			var/shard = assembly?.glass_type ? assembly.glass_type.shard_type : /obj/item/shard
+			new shard(loc)
+			new shard(loc)
 	qdel(src)
 
 // Tracker Electronic


### PR DESCRIPTION
## About The Pull Request
Overhaul of #10553 by Trilby, plus some code update to fit in the feature better such as converting glass_type from typepath to sheet reference variable, moving things into nullspace instead of inside the machine and making the shards dropped off by broken solar panels and windows less hardcoded and dependent on the glass type.

## Why It's Good For The Game
Giving a little extra depth to the solar engines.

## Changelog
:cl: Trilbyspaceclone, Ghommie
add: More types of glass can now be used to make a solar panel, with different sturdiness and efficiency depending the type.
/:cl:
