### PR TITLE
Sprinting in general is now a config

### DIFF
--- a/code/__DEFINES/configuration.dm
+++ b/code/__DEFINES/configuration.dm
@@ -1,6 +1,7 @@
 //config files
 #define CONFIG_GET(X) global.config.Get(/datum/config_entry/##X)
 #define CONFIG_SET(X, Y) global.config.Set(/datum/config_entry/##X, ##Y)
+#define CONFIG_GET_ENTRY(X) global.config.GetEntryDatum(/datum/config_entry/##X)
 
 #define CONFIG_MAPS_FILE "maps.txt"
 

--- a/code/controllers/configuration/configuration.dm
+++ b/code/controllers/configuration/configuration.dm
@@ -193,6 +193,13 @@
 	stat("[name]:", statclick)
 
 /datum/controller/configuration/proc/Get(entry_type)
+	var/datum/config_entry/E = GetEntryDatum(entry_type)
+	if((E.protection & CONFIG_ENTRY_HIDDEN) && IsAdminAdvancedProcCall() && GLOB.LastAdminCalledProc == "Get" && GLOB.LastAdminCalledTargetRef == "[REF(src)]")
+		log_admin_private("Config access of [entry_type] attempted by [key_name(usr)]")
+		return
+	return E.config_entry_value
+
+/datum/controller/configuration/proc/GetEntryDatum(entry_type)
 	var/datum/config_entry/E = entry_type
 	var/entry_is_abstract = initial(E.abstract_type) == entry_type
 	if(entry_is_abstract)
@@ -200,10 +207,7 @@
 	E = entries_by_type[entry_type]
 	if(!E)
 		CRASH("Missing config entry for [entry_type]!")
-	if((E.protection & CONFIG_ENTRY_HIDDEN) && IsAdminAdvancedProcCall() && GLOB.LastAdminCalledProc == "Get" && GLOB.LastAdminCalledTargetRef == "[REF(src)]")
-		log_admin_private("Config access of [entry_type] attempted by [key_name(usr)]")
-		return
-	return E.config_entry_value
+	return E
 
 /datum/controller/configuration/proc/Set(entry_type, new_val)
 	var/datum/config_entry/E = entry_type

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -249,8 +249,17 @@
 
 /datum/config_entry/number/movedelay/walk_delay
 
-/datum/config_entry/number/movedelay/sprint_speed_increase
+/datum/config_entry/number/sprint_speed_increase
 	config_entry_value = 1
+
+/datum/config_entry/number/sprint_buffer_max
+	config_entry_value = 42
+
+/datum/config_entry/number/sprint_stamina_cost
+	config_entry_value = 0.7
+
+/datum/config_entry/number/sprint_buffer_regen_per_ds
+	config_entry_value = 0.3
 
 /////////////////////////////////////////////////Outdated move delay
 /datum/config_entry/number/outdated_movedelay

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -249,16 +249,16 @@
 
 /datum/config_entry/number/movedelay/walk_delay
 
-/datum/config_entry/number/sprint_speed_increase
+/datum/config_entry/number/movedelay/sprint_speed_increase
 	config_entry_value = 1
 
-/datum/config_entry/number/sprint_buffer_max
+/datum/config_entry/number/movedelay/sprint_buffer_max
 	config_entry_value = 42
 
-/datum/config_entry/number/sprint_stamina_cost
+/datum/config_entry/number/movedelay/sprint_stamina_cost
 	config_entry_value = 0.7
 
-/datum/config_entry/number/sprint_buffer_regen_per_ds
+/datum/config_entry/number/movedelay/sprint_buffer_regen_per_ds
 	config_entry_value = 0.3
 
 /////////////////////////////////////////////////Outdated move delay

--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -249,6 +249,9 @@
 
 /datum/config_entry/number/movedelay/walk_delay
 
+/datum/config_entry/number/movedelay/sprint_speed_increase
+	config_entry_value = 1
+
 /////////////////////////////////////////////////Outdated move delay
 /datum/config_entry/number/outdated_movedelay
 	deprecated_by = /datum/config_entry/keyed_list/multiplicative_movespeed

--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -12,8 +12,11 @@
 
 /mob/living/carbon/human/movement_delay()
 	. = 0
-	if(!resting && m_intent == MOVE_INTENT_RUN && !sprinting)
-		. += 1
+	if(!resting && m_intent == MOVE_INTENT_RUN && sprinting)
+		var/static/datum/config_entry/number/movespeed/sprint_speed_increase/SSI
+		if(!SSI)
+			SSI = CONFIG_GET_ENTRY(number/movespeed/sprint_speed_increase)
+		. -= SSI.config_entry_value
 	if(wrongdirmovedelay)
 		. += 1
 	. += ..()

--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,9 +13,9 @@
 /mob/living/carbon/human/movement_delay()
 	. = 0
 	if(!resting && m_intent == MOVE_INTENT_RUN && sprinting)
-		var/static/datum/config_entry/number/movespeed/sprint_speed_increase/SSI
+		var/static/datum/config_entry/movespeed/sprint_speed_increase/SSI
 		if(!SSI)
-			SSI = CONFIG_GET_ENTRY(number/movespeed/sprint_speed_increase)
+			SSI = CONFIG_GET_ENTRY(movespeed/sprint_speed_increase)
 		. -= SSI.config_entry_value
 	if(wrongdirmovedelay)
 		. += 1

--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,9 +13,9 @@
 /mob/living/carbon/human/movement_delay()
 	. = 0
 	if(!resting && m_intent == MOVE_INTENT_RUN && sprinting)
-		var/static/datum/config_entry/movespeed/sprint_speed_increase/SSI
+		var/static/datum/config_entry/number/movespeed/sprint_speed_increase/SSI
 		if(!SSI)
-			SSI = CONFIG_GET_ENTRY(movespeed/sprint_speed_increase)
+			SSI = CONFIG_GET_ENTRY(number/movespeed/sprint_speed_increase)
 		. -= SSI.config_entry_value
 	if(wrongdirmovedelay)
 		. += 1

--- a/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human_movement.dm
@@ -13,9 +13,9 @@
 /mob/living/carbon/human/movement_delay()
 	. = 0
 	if(!resting && m_intent == MOVE_INTENT_RUN && sprinting)
-		var/static/datum/config_entry/number/movespeed/sprint_speed_increase/SSI
+		var/static/datum/config_entry/number/movedelay/sprint_speed_increase/SSI
 		if(!SSI)
-			SSI = CONFIG_GET_ENTRY(number/movespeed/sprint_speed_increase)
+			SSI = CONFIG_GET_ENTRY(number/movedelay/sprint_speed_increase)
 		. -= SSI.config_entry_value
 	if(wrongdirmovedelay)
 		. += 1

--- a/modular_citadel/code/modules/mob/living/living.dm
+++ b/modular_citadel/code/modules/mob/living/living.dm
@@ -19,9 +19,9 @@
 
 /mob/living/update_config_movespeed()
 	. = ..()
-	sprint_buffer_max = CONFIG_GET(number/movespeed/sprint_buffer_max)
-	sprint_buffer_regen_ds = CONFIG_GET(number/movespeed/sprint_buffer_regen_per_ds)
-	sprint_stamina_cost = CONFIG_GET(number/movespeed/sprint_stamina_cost)
+	sprint_buffer_max = CONFIG_GET(number/movedelay/sprint_buffer_max)
+	sprint_buffer_regen_ds = CONFIG_GET(number/movedelay/sprint_buffer_regen_per_ds)
+	sprint_stamina_cost = CONFIG_GET(number/movedelay/sprint_stamina_cost)
 
 /mob/living/movement_delay(ignorewalk = 0)
 	. = ..()

--- a/modular_citadel/code/modules/mob/living/living.dm
+++ b/modular_citadel/code/modules/mob/living/living.dm
@@ -17,6 +17,12 @@
 	var/sprint_stamina_cost = 0.70			//stamina loss per tile while insufficient sprint buffer.
 	//---End
 
+/mob/living/update_config_movespeed()
+	. = ..()
+	sprint_buffer_max = CONFIG_GET(number/movespeed/sprint_buffer_max)
+	sprint_buffer_regen_ds = CONFIG_GET(number/movespeed/sprint_buffer_regen_per_ds)
+	sprint_stamina_cost = CONFIG_GET(number/movespeed/sprint_stamina_cost)
+
 /mob/living/movement_delay(ignorewalk = 0)
 	. = ..()
 	if(resting)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

(will) includes: 
sprint speed
cost when buffer is empty
sprint buffer maximum
sprint buffer regeneration

HUMAN DELAY MUST BE INCREASED BY 1 PRIOR TO MERGE/TESTMERGE, ELSE EVERYONE WILL RUN AT THE SPEED OF LIGHT.

## Why It's Good For The Game

Easier to adjust this in the future via config.

## Changelog
tweak: Sprinting is now in general a config
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
