### PR TITLE
Make the radiation hardsuit a voidsuit instead

### DIFF
--- a/code/modules/cargo/packs/engineering.dm
+++ b/code/modules/cargo/packs/engineering.dm
@@ -67,14 +67,15 @@
 	crate_name = "atmospherics hardsuit"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 
-/datum/supply_pack/engineering/radhardsuit
-	name = "Radiation Hardsuit"
+/datum/supply_pack/engineering/radvoidsuit
+	name = "Radiation Voidsuit"
 	desc = "The Singulo is loose? Do you need to do a few changes to its containment and don't want to spent the rest of the shift under the shower? Get this Radiation Hardsuit! It protect from radiations and space only."
 	cost = 3500
 	access = ACCESS_ENGINE
 	contains = list(/obj/item/tank/internals/air,
 					/obj/item/clothing/mask/gas,
-					/obj/item/clothing/suit/space/hardsuit/engine/rad)
+					/obj/item/clothing/suit/space/rad,
+					/obj/item/clothing/head/helmet/space/rad)
 	crate_name = "radiation hardsuit"
 	crate_type = /obj/structure/closet/crate/secure/engineering
 

--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -203,32 +203,6 @@
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/atmos
 
-	//Radiation
-/obj/item/clothing/head/helmet/space/hardsuit/engine/rad
-	name = "radiation hardsuit helmet"
-	desc = "A special helmet that protects against radiation and space. Not much else unfortunately."
-	icon_state = "cespace_helmet"
-	item_state = "nothing"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
-	item_color = "engineering"
-	resistance_flags = FIRE_PROOF
-	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-	actions_types = list()
-
-/obj/item/clothing/suit/space/hardsuit/engine/rad
-	name = "radiation hardsuit"
-	desc = "A special suit that protects against radiation and space. Not much else unfortunately."
-	icon_state = "hardsuit-rad"
-	item_state = "nothing"
-	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
-	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/engine/rad
-	resistance_flags = FIRE_PROOF
-	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
-	mutantrace_variation = NONE
-
-/obj/item/clothing/head/helmet/space/hardsuit/engine/rad/attack_self()
-	return //Sprites required for flashlight
-
 	//Chief Engineer's hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/engine/elite
 	name = "advanced hardsuit helmet"

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -11,6 +11,7 @@ Contains:
  - ERT hardsuit: Command, Sec, Engi, Med
  - ERT High Alarm - Command, Sec, Engi, Med
  - EVA spacesuit
+ - Radiation Spacesuit
  - Freedom's spacesuit (freedom from vacuum's oppression)
  - Carp hardsuit
 */
@@ -312,6 +313,31 @@ Contains:
 	flash_protect = 0
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 20, "fire" = 50, "acid" = 65)
 
+//Radiation
+/obj/item/clothing/head/helmet/space/rad
+	name = "radiation voidsuit helmet"
+	desc = "A special helmet that protects against radiation and space. Not much else unfortunately."
+	icon_state = "cespace_helmet"
+	item_state = "nothing"
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
+	item_color = "engineering"
+	resistance_flags = FIRE_PROOF
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	actions_types = list()
+
+/obj/item/clothing/suit/space/rad
+	name = "radiation voidsuit"
+	desc = "A special suit that protects against radiation and space. Not much else unfortunately."
+	icon_state = "hardsuit-rad"
+	item_state = "nothing"
+	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 0, "bio" = 100, "rad" = 100, "fire" = 0, "acid" = 0)
+	resistance_flags = FIRE_PROOF
+	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
+	mutantrace_variation = NONE
+/*
+/obj/item/clothing/head/helmet/space/hardsuit/engine/rad/attack_self()
+	return //Sprites required for flashlight
+*/
 /obj/item/clothing/head/helmet/space/freedom
 	name = "eagle helmet"
 	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle."

--- a/code/modules/clothing/spacesuits/miscellaneous.dm
+++ b/code/modules/clothing/spacesuits/miscellaneous.dm
@@ -334,10 +334,7 @@ Contains:
 	resistance_flags = FIRE_PROOF
 	rad_flags = RAD_PROTECT_CONTENTS | RAD_NO_CONTAMINATE
 	mutantrace_variation = NONE
-/*
-/obj/item/clothing/head/helmet/space/hardsuit/engine/rad/attack_self()
-	return //Sprites required for flashlight
-*/
+
 /obj/item/clothing/head/helmet/space/freedom
 	name = "eagle helmet"
 	desc = "An advanced, space-proof helmet. It appears to be modeled after an old-world eagle."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This change the radiation hardsuit that I added into a radiation voidsuit,
The main differences being the lack of helmet light (already done, so no changes there), the lack of a retractable helmet and the addition of the helmet in the Radiation Hardsuit crate, now renamed Radiation Voidsuit crate.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I was told it look more like a softsuit or a voidsuit than a hardsuit, and I agree with that, so it is now a voidsuit, like the NASA Voidsuit or the EVA Space Suit.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
change: Made the radiation hardsuit a voidsuit and added the helmet in the crate
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
