### PR TITLE
Fixes chainsaw force being set to 0 on drop.

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -25,8 +25,8 @@
  */
 /obj/item/twohanded
 	var/wielded = 0
-	var/force_unwielded = 0
-	var/force_wielded = 0
+	var/force_unwielded // default to null, the number force will be set to on unwield()
+	var/force_wielded // same as above but for wield()
 	var/wieldsound = null
 	var/unwieldsound = null
 	var/slowdown_wielded = 0
@@ -73,7 +73,7 @@
 		to_chat(user, "<span class='warning'>You don't have enough intact hands.</span>")
 		return
 	wielded = 1
-	if(force_wielded)
+	if(!isnull(force_wielded))
 		force = force_wielded
 	name = "[name] (Wielded)"
 	update_icon()
@@ -738,7 +738,7 @@
 	on = !on
 	to_chat(user, "As you pull the starting cord dangling from [src], [on ? "it begins to whirr." : "the chain stops moving."]")
 	force = on ? force_on : initial(force)
-	throwforce = on ? force_on : initial(force)
+	throwforce = on ? force_on : force
 	icon_state = "chainsaw_[on ? "on" : "off"]"
 	var/datum/component/butchering/butchering = src.GetComponent(/datum/component/butchering)
 	butchering.butchering_enabled = on


### PR DESCRIPTION
## About The Pull Request
Fixing a discrepancy that forced people to set force_wielded for twohanded/required subtypes.

## Why It's Good For The Game
This will close #10491.

## Changelog
:cl: Fixes chainsaw force being set to 0 on drop.
/:cl:
