### PR TITLE
A few consistencies for those "shoes" that don't actually cover feet.

### DIFF
--- a/code/modules/assembly/mousetrap.dm
+++ b/code/modules/assembly/mousetrap.dm
@@ -46,7 +46,7 @@
 			return FALSE
 		switch(type)
 			if("feet")
-				if(!H.shoes)
+				if(!H.shoes || !(H.shoes.body_parts_covered & FEET))
 					affecting = H.get_bodypart(pick(BODY_ZONE_L_LEG, BODY_ZONE_R_LEG))
 					H.Knockdown(60)
 			if(BODY_ZONE_PRECISE_L_HAND, BODY_ZONE_PRECISE_R_HAND)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -887,7 +887,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/barefoot/on_mob_life(mob/living/carbon/M)
 	if(ishuman(M)) //Barefoot causes the imbiber to quickly regenerate brute trauma if they're not wearing shoes.
 		var/mob/living/carbon/human/H = M
-		if(!H.shoes)
+		if(!H.shoes || !(H.shoes.body_parts_covered & FEET))
 			H.adjustBruteLoss(-3, 0)
 			. = 1
 	return ..() || .


### PR DESCRIPTION
## About The Pull Request
Consistency for mousetraps and the barefoot alcohol drink

## Why It's Good For The Game
This will close #10418.

## Changelog
:cl:
fix: The Barefoot drink and mousetraps will now work even if wearing certain "feet-less shoes".
/:cl:

