### PR TITLE
Made ghost cafe mobs dust upon leaving, allowed ghost cafe bans

### DIFF
--- a/code/__DEFINES/role_preferences.dm
+++ b/code/__DEFINES/role_preferences.dm
@@ -37,7 +37,7 @@
 #define ROLE_GANG					"gangster"
 #define ROLE_BLOODSUCKER			"bloodsucker"
 //#define ROLE_MONSTERHUNTER			"monster hunter" Disabled for now
-
+#define ROLE_GHOSTCAFE				"ghostcafe"
 //Missing assignment means it's not a gamemode specific role, IT'S NOT A BUG OR ERROR.
 //The gamemode specific ones are just so the gamemodes can query whether a player is old enough
 //(in game days played) to play that role

--- a/code/datums/elements/dusts_on_leaving_area.dm
+++ b/code/datums/elements/dusts_on_leaving_area.dm
@@ -1,6 +1,6 @@
 /datum/element/dusts_on_leaving_area
 	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
-	id_arg_index = 1
+	id_arg_index = 2
 	var/list/attached_mobs = list()
 	var/list/area_types = list()
 

--- a/code/datums/elements/dusts_on_leaving_area.dm
+++ b/code/datums/elements/dusts_on_leaving_area.dm
@@ -1,0 +1,28 @@
+/datum/element/dusts_on_leaving_area
+	element_flags = ELEMENT_DETACH | ELEMENT_BESPOKE
+	id_arg_index = 1
+	var/list/attached_mobs = list()
+	var/list/area_types = list()
+
+/datum/element/dusts_on_leaving_area/Attach(datum/target,types)
+	. = ..()
+	if(!ismob(target))
+		return ELEMENT_INCOMPATIBLE
+	attached_mobs += target
+	area_types = types
+	START_PROCESSING(SSprocessing,src)
+
+/datum/element/dusts_on_leaving_area/Detach(mob/M)
+	. = ..()
+	if(M in attached_mobs)
+		attached_mobs -= M
+	if(!attached_mobs.len)
+		STOP_PROCESSING(SSprocessing,src)
+
+/datum/element/dusts_on_leaving_area/process()
+	for(var/m in attached_mobs)
+		var/mob/M = m
+		var/area/A = get_area(M)
+		if(!(A.type in area_types))
+			M.dust(force = TRUE)
+			Detach(M)

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -619,7 +619,7 @@
 	assignedrole = "Ghost Cafe Visitor"
 	flavour_text = "Is this what life after death is like?"
 	skip_reentry_check = TRUE
-	banType = "ghostcafe"
+	banType = ROLE_GHOSTCAFE
 
 /datum/action/toggle_dead_chat_mob
 	icon_icon = 'icons/mob/mob.dmi'
@@ -642,12 +642,14 @@
 /obj/effect/mob_spawn/human/ghostcafe/special(mob/living/carbon/human/new_spawn)
 	if(new_spawn.client)
 		new_spawn.client.prefs.copy_to(new_spawn)
+		var/area/A = get_area(src)
 		var/datum/outfit/O = new /datum/outfit/ghostcafe()
 		O.equip(new_spawn, FALSE, new_spawn.client)
 		SSjob.equip_loadout(null, new_spawn, FALSE)
 		SSquirks.AssignQuirks(new_spawn, new_spawn.client, TRUE, TRUE, null, FALSE, new_spawn)
 		new_spawn.AddElement(/datum/element/ghost_role_eligibility)
 		new_spawn.AddElement(/datum/element/dusts_on_catatonia)
+		new_spawn.AddElement(/datum/element/dusts_on_leaving_area,list(A.type,/area/hilbertshotel))
 		ADD_TRAIT(new_spawn, TRAIT_SIXTHSENSE, GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn,TRAIT_EXEMPT_HEALTH_EVENTS,GHOSTROLE_TRAIT)
 		ADD_TRAIT(new_spawn,TRAIT_PACIFISM,GHOSTROLE_TRAIT)

--- a/code/modules/admin/topic.dm
+++ b/code/modules/admin/topic.dm
@@ -845,7 +845,11 @@
 			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_LAVALAND];jobban4=[REF(M)]'><font color=red>Lavaland</font></a></td>"
 		else
 			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_LAVALAND];jobban4=[REF(M)]'>Lavaland</a></td>"
-
+		// Ghost cafe
+		if(jobban_isbanned(M,ROLE_GHOSTCAFE))
+			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_GHOSTCAFE];jobban4=[REF(M)]'><font color=red>Lavaland</font></a></td>"
+		else
+			dat += "<td width='20%'><a href='?src=[REF(src)];[HrefToken()];jobban3=[ROLE_GHOSTCAFE];jobban4=[REF(M)]'>Lavaland</a></td>"
 		dat += "</tr></table>"
 
 	//Antagonist (Orange)

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -475,6 +475,7 @@
 #include "code\datums\elements\_element.dm"
 #include "code\datums\elements\cleaning.dm"
 #include "code\datums\elements\dusts_on_catatonia.dm"
+#include "code\datums\elements\dusts_on_leaving_area.dm"
 #include "code\datums\elements\earhealing.dm"
 #include "code\datums\elements\ghost_role_eligibility.dm"
 #include "code\datums\elements\wuv.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. 

## Why It's Good For The Game

Less exploits are always good. This limits exploit potential massively.

## Changelog
:cl:
tweak: Ghost cafe mobs are super duper attached to the ghost cafe.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
