### PR TITLE
Made .editorconfig not auto-newline on txts

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,3 +6,6 @@ indent_size = 4
 [*.yml]
 indent_style = space
 indent_size = 2
+
+[*.txt]
+insert_final_newline = false


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Makes VSC not care about newlines for .txt files in particular.

## Why It's Good For The Game

I don't know if file2list will have an empty-string entry if there's a newline at the end but I don't want to temp it.

## Changelog
Not necessary.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
