### PR TITLE
...? ...? (masked human mob examine pet peeve)

### DIFF
--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -385,20 +385,17 @@
 	else if(isobserver(user) && traitstring)
 		. += "<span class='info'><b>Traits:</b> [traitstring]</span>"
 
-	if(print_flavor_text())
-		if(get_visible_name() == "Unknown")	//Are we sure we know who this is? Don't show flavor text unless we can recognize them. Prevents certain metagaming with impersonation.
-			. += "...?"
-		else if(skipface) //Sometimes we're not unknown, but impersonating someone in a hardsuit, let's not reveal our flavor text then either.
-			. += "...?"
-		else
-			. += "[print_flavor_text()]"
-	if(print_flavor_text_2())
-		if(get_visible_name() == "Unknown")	//Are we sure we know who this is? Don't show flavor text unless we can recognize them. Prevents certain metagaming with impersonation.
-			. += "...?"
-		else if(skipface) //Sometimes we're not unknown, but impersonating someone in a hardsuit, let's not reveal our flavor text then either.
-			. += "...?"
-		else
-			. += "[print_flavor_text_2()]"
+	//No flavor text unless the face can be seen. Prevents certain metagaming with impersonation.
+	var/invisible_man = skipface || get_visible_name() == "Unknown"
+	if(invisible_man)
+		. += "...?"
+	else
+		var/flavor = print_flavor_text()
+		if(flavor)
+			. += flavor
+		var/temp_flavor = print_flavor_text_2()
+		if(temp_flavor)
+			. += temp_flavor
 	. += "*---------*</span>"
 
 /mob/living/proc/status_effect_examines(pronoun_replacement) //You can include this in any mob's examine() to show the examine texts of status effects!


### PR DESCRIPTION
## About The Pull Request
Stops the ellipsis question mark from being displayed twice when examining masked/unknown folks.
Forces the ellipsis question mark onto every masked/unknown folk examine message, even if they have a flavor text to start with, to discourage possible meta a little.

## Why It's Good For The Game
Resolving some peeves with this dumb stuff. Who the ever-loving dang needs a second flavor text anyway?!

## Changelog
:cl:
fix: Stopped the ellipsis question mark from being displayed twice in the examine message for masked/unknown human mobs.
tweaks: Made the aforementioned ellipsis question mark display on flavor-text-less masked/unknown human mobs too for consistency.
/:cl:
