### PR TITLE
buffs door crushing

### DIFF
--- a/code/game/machinery/doors/door.dm
+++ b/code/game/machinery/doors/door.dm
@@ -288,9 +288,10 @@
 				return
 
 	operating = TRUE
-
 	do_animate("closing")
 	layer = closingLayer
+	if(!safe)
+		crush()
 	sleep(5)
 	density = TRUE
 	sleep(5)
@@ -302,8 +303,6 @@
 	update_freelook_sight()
 	if(safe)
 		CheckForMobs()
-	else
-		crush()
 	return 1
 
 /obj/machinery/door/proc/CheckForMobs()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Door crushing now happens on the moment it starts to close instead of after it's done closing.

**It might be a good idea to make this only happen for user triggered (whether by AI or signaller or a person doing it) and make the old behavior for something like automatic closes to make this less obnoxious.**

## Why It's Good For The Game

This was necessary when doorcrushing was an outright hardstun and an AI could game over you by just clipping you with a door. This is no longer necessary with stamina combat and it'd be nice to make this relevant for rogue AIs and similar again.

## Changelog
:cl:
balance: Doorcrushes are once again instant.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
