### PR TITLE
Shoving someone who is on the ground now always disarms their active held item. Punch stamina cost reduced. 

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1475,10 +1475,6 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		target.grabbedby(user)
 		return 1
 
-
-
-
-
 /datum/species/proc/harm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
 	if(!attacker_style && HAS_TRAIT(user, TRAIT_PACIFISM))
 		to_chat(user, "<span class='warning'>You don't want to harm [target]!</span>")
@@ -1507,7 +1503,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			else
 				user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)
 
-		user.adjustStaminaLossBuffered(5) //CITADEL CHANGE - makes punching cause staminaloss
+		user.adjustStaminaLossBuffered(3.5) //CITADEL CHANGE - makes punching cause staminaloss
 
 		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 
@@ -1837,7 +1833,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		user.visible_message("<span class='notice'>[user] forces [p_them()]self up to [p_their()] feet!</span>", "<span class='notice'>You force yourself up to your feet!</span>")
 		user.resting = 0
 		user.update_canmove()
-		user.adjustStaminaLossBuffered(user.stambuffer) //Rewards good stamina management by making it easier to instantly get up from resting
+		user.adjustStaminaLossBuffered(20) //Rewards good stamina management by making it easier to instantly get up from resting
 		playsound(user, 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 
 /datum/species/proc/altdisarm(mob/living/carbon/human/user, mob/living/carbon/human/target, datum/martial_art/attacker_style)
@@ -1850,6 +1846,12 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	if(attacker_style && attacker_style.disarm_act(user,target))
 		return TRUE
 	if(user.resting)
+		var/obj/item/target_disarm = target.get_active_held_item()
+		if(target_disarm)
+			target.dropItemToGround(target_disarm)
+			target.visible_message("<span class='warning'>[user] wrestles [target_disarm] out of [target]'s hand!</span>",
+			"<span class='userdanger'>[user] wrestles [target_disarm] out of your hand!</span>")
+			return TRUE
 		return FALSE
 	else
 		if(user == target)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Also makes shove-up cost constant rather than stambuffer

## Why It's Good For The Game

Made shove-up cost constant rather than staminabuffer as it's probably better that way if someone's staminabuffer is, say, edited for whatever reason, and without this the new cost would be impredictable. 

Anyways for the actual balance changes:
Shoving's horribly underpowered on Citadel, this makes shoving someone down more of a punishment/consequence than the current disarm which only applies if they have a gun and are standing up. And I guess you can argue that being down slows them but honestly that isn't too relevant for what you'd usually be using shoves for.
Also punch, with its average of 5 damage, is just outright terrible at a 1:1 average damage to stamina cost. Rage cages are nearly untenable and stamcritting from trying to fistfight one person is a load of why. This won't make it vastly more superior or anything, just makes it slightly better in a fight.

## Changelog
:cl:
balance: Shoving now always disarms if someone is down. Punching now takes 3.5 stam instead of 5 to do.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

### This is only intended for after taser removal.
