### PR TITLE
Makes meteor shields cheaper, and lower on the tech tree

### DIFF
--- a/code/modules/research/designs/misc_designs.dm
+++ b/code/modules/research/designs/misc_designs.dm
@@ -532,7 +532,7 @@
 	desc = "A blue print of a early model of the Meteor defence turret."
 	id = "meteor_defence"
 	build_type = PROTOLATHE
-	materials = list(MAT_METAL = 50000, MAT_GLASS = 50000, MAT_SILVER = 8500, MAT_GOLD = 8500, MAT_TITANIUM = 7500, MAT_URANIUM = 7500)
+	materials = list(MAT_METAL = 20000, MAT_GLASS = 20000, MAT_SILVER = 2500, MAT_GOLD = 2500, MAT_TITANIUM = 2500, MAT_URANIUM = 2500)
 	build_path = /obj/machinery/satellite/meteor_shield/sci
 	category = list("Equipment")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -235,10 +235,10 @@
 	id = "basic_meteor_defense"
 	display_name = "Meteor Defense Research"
 	description = "Unlock the potential of the mysterious of why CC decided to not build these around the station themselves."
-	prereq_ids = list("adv_engi", "high_efficiency")
+	prereq_ids = list("engineering")
 	design_ids = list("meteor_defence", "meteor_console")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	export_price = 5000
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2000)
+	export_price = 2000
 
 //datum/techweb_node/adv_meteor_defense
 	//id = "adv_meteor_defense"


### PR DESCRIPTION
Want to keep the meteor shields at 1 minute? Then this is the balance to keeping them at just that.

Current rate of tech points usage makes everything but fringe things like this actually purchased unless it's needed. This PR sets the meteor shields to base tier, and allows them to be purchased off the bat so engineering can preemptively set them up.

Cost is lowered significantly (about 66%)
Tech point is only 2k and at basic engineering tier rather than behind a much larger amount of tiers before you can unlock it.

I encourage you to read the discussions from the actual engineering mains on the last PR pertaining this,