### PR TITLE
Makes "Meow Mix" bar sign actually appear

### DIFF
--- a/code/game/objects/structures/barsigns.dm
+++ b/code/game/objects/structures/barsigns.dm
@@ -305,7 +305,7 @@
 
 /datum/barsign/meow_mix
 	name = "Meow Mix"
-	icon = "meow_mix"
+	icon = "Meow Mix"
 	desc = "No, we don't serve catnip, officer!"
 
 /datum/barsign/hiddensigns


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. The icon_state is "Meow Mix", not "meow_mix". This has gone unnoticed for 7 months, somehow. Baffling.

## Why It's Good For The Game

Best the bar sign doesn't disappear when someone picks a very intentional sign.

## Changelog
:cl:
fix: Meow Mix bar sign works
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
