### PR TITLE
Fix HE Manifold's sprites

### DIFF
--- a/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
+++ b/code/modules/atmospherics/machinery/pipes/heat_exchange/manifold.dm
@@ -1,6 +1,6 @@
 //3-Way Manifold
 /obj/machinery/atmospherics/pipe/heat_exchanging/manifold
-	icon_state = "manifold"
+	icon_state = "manifold-2"
 
 	name = "pipe manifold"
 	desc = "A manifold composed of regular pipes."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
So, when I ported TG's Pipes, it changed the name of the icons to also indicate the layer, and I forgot to change the name of the icon for the HE pipe manifold.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
I would like to see that pipe, thank you very much.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: fixed a sprite
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
