### PR TITLE
Relief valve fixes

### DIFF
--- a/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
@@ -5,6 +5,7 @@
 	icon_state = "relief_valve-t-map"
 	can_unwrench = TRUE
 	construction_type = /obj/item/pipe/binary
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE
 	var/opened = FALSE
 	var/open_pressure = ONE_ATMOSPHERE * 3
 	var/close_pressure = ONE_ATMOSPHERE
@@ -50,8 +51,9 @@
 	if(!is_operational())
 		return
 
-	var/datum/gas_mixture/air_contents = airs[1]
-	var/our_pressure = air_contents.return_pressure()
+	var/datum/gas_mixture/air_one = airs[1]
+	var/datum/gas_mixture/air_two = airs[2]
+	var/our_pressure = abs(air_one.return_pressure() - air_two.return_pressure())
 	if(opened && our_pressure < close_pressure)
 		close()
 	else if(!opened && our_pressure >= open_pressure)

--- a/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/binary_devices/relief_valve.dm
@@ -5,7 +5,7 @@
 	icon_state = "relief_valve-t-map"
 	can_unwrench = TRUE
 	construction_type = /obj/item/pipe/binary
-	interaction_flags_machine = INTERACT_MACHINE_OFFLINE
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 	var/opened = FALSE
 	var/open_pressure = ONE_ATMOSPHERE * 3
 	var/close_pressure = ONE_ATMOSPHERE
@@ -53,8 +53,9 @@
 
 	var/datum/gas_mixture/air_one = airs[1]
 	var/datum/gas_mixture/air_two = airs[2]
-	var/our_pressure = abs(air_one.return_pressure() - air_two.return_pressure())
-	if(opened && our_pressure < close_pressure)
+	var/air_one_pressure = air_one.return_pressure()
+	var/our_pressure = abs(air_one_pressure - air_two.return_pressure())
+	if(opened && air_one_pressure < close_pressure)
 		close()
 	else if(!opened && our_pressure >= open_pressure)
 		open()

--- a/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
@@ -4,7 +4,7 @@
 	icon = 'icons/obj/atmospherics/components/relief_valve.dmi'
 	icon_state = "relief_valve-e-map"
 	can_unwrench = TRUE
-	interaction_flags_machine = INTERACT_MACHINE_OFFLINE
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE | INTERACT_MACHINE_WIRES_IF_OPEN | INTERACT_MACHINE_ALLOW_SILICON | INTERACT_MACHINE_OPEN_SILICON | INTERACT_MACHINE_SET_MACHINE
 	var/opened = FALSE
 	var/open_pressure = ONE_ATMOSPHERE * 3
 	var/close_pressure = ONE_ATMOSPHERE

--- a/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
+++ b/code/modules/atmospherics/machinery/components/unary_devices/relief_valve.dm
@@ -4,6 +4,7 @@
 	icon = 'icons/obj/atmospherics/components/relief_valve.dmi'
 	icon_state = "relief_valve-e-map"
 	can_unwrench = TRUE
+	interaction_flags_machine = INTERACT_MACHINE_OFFLINE
 	var/opened = FALSE
 	var/open_pressure = ONE_ATMOSPHERE * 3
 	var/close_pressure = ONE_ATMOSPHERE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Binary relief valves were only checking one side's pressure instead of the pressure difference to open up meaning they basically didn't work 50% of the time (yikes!) and neither version were able to be interacted with without power even though neither actually require it.

## Why It's Good For The Game

It's best these things work.

## Changelog
:cl:
fix: Fixed a few relief valve behaviors
/:cl: