### PR TITLE
Energy crossbow changed from RNG to static effects

### DIFF
--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -107,10 +107,11 @@
 	name = "energy crossbow"
 	desc = "A reverse engineered weapon using syndicate technology."
 	icon_state = "crossbowlarge"
-	w_class = WEIGHT_CLASS_NORMAL
+	w_class = WEIGHT_CLASS_BULKY
 	materials = list(MAT_METAL=4000)
 	suppressed = null
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
+	weapon_weight = WEAPON_HEAVY
 	pin = null
 
 /obj/item/gun/energy/plasmacutter

--- a/code/modules/projectiles/guns/energy/special.dm
+++ b/code/modules/projectiles/guns/energy/special.dm
@@ -105,7 +105,7 @@
 
 /obj/item/gun/energy/kinetic_accelerator/crossbow/large
 	name = "energy crossbow"
-	desc = "A reverse engineered weapon using syndicate technology."
+	desc = "A reverse engineered weapon using syndicate technology. This thing seems incredibly unwieldly, and seems to be using similar internals to the Proto-Kinetic Accelerator. It might not play nice when brought near weapons similar to it."
 	icon_state = "crossbowlarge"
 	w_class = WEIGHT_CLASS_BULKY
 	materials = list(MAT_METAL=4000)
@@ -113,6 +113,7 @@
 	ammo_type = list(/obj/item/ammo_casing/energy/bolt/large)
 	weapon_weight = WEAPON_HEAVY
 	pin = null
+	unique_frequency = FALSE
 
 /obj/item/gun/energy/plasmacutter
 	name = "plasma cutter"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -6,8 +6,10 @@
 	nodamage = 0
 	stamina = 60
 	eyeblur = 10
-	knockdown = 10
 	slur = 5
+	var/hardstun_ds = 0
+	var/softstun_ds = 1
+	var/stam_dmg = 0
 
 /obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
 	. = ..()
@@ -16,6 +18,7 @@
 		var/obj/item/I = C.get_active_held_item()
 		if(I && C.dropItemToGround(I))
 			to_chat(C, "<span class ='notice'>Your arm goes limp, and you drop what you're holding!</span>")
+		C.Knockdown(softstun_ds, TRUE, FALSE, hardstun_ds, stam_dmg)
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -4,21 +4,11 @@
 	damage = 15
 	damage_type = TOX
 	nodamage = 0
-	stamina = 60
 	eyeblur = 10
 	slur = 5
-	var/hardstun_ds = 0
-	var/softstun_ds = 1
-	var/stam_dmg = 0
-
-/obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if(iscarbon(target))
-		var/mob/living/carbon/C = target
-		var/obj/item/I = C.get_active_held_item()
-		if(I && C.dropItemToGround(I))
-			to_chat(C, "<span class ='notice'>Your arm goes limp, and you drop what you're holding!</span>")
-		C.Knockdown(softstun_ds, TRUE, FALSE, hardstun_ds, stam_dmg)
+	knockdown = 160
+	stamina = 0
+	knockdown_stamoverride = 60
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -1,7 +1,7 @@
 /obj/item/projectile/energy/bolt //ebow bolts
 	name = "bolt"
 	icon_state = "cbbolt"
-	damage = 8
+	damage = 15
 	damage_type = TOX
 	nodamage = 0
 	stamina = 60

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -4,9 +4,18 @@
 	damage = 8
 	damage_type = TOX
 	nodamage = 0
-	knockdown = 100
-	stutter = 5
-	drowsy = 50
+	stamina = 60
+	eyeblur = 10
+	knockdown = 10
+	slur = 5
+
+/obj/item/projectile/energy/bolt/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		var/obj/item/I = C.get_active_held_item()
+		if(I && C.dropItemToGround(I))
+			to_chat(C, "<span class ='notice'>Your arm goes limp, and you drop what you're holding!</span>")
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"

--- a/code/modules/projectiles/projectile/energy/ebow.dm
+++ b/code/modules/projectiles/projectile/energy/ebow.dm
@@ -7,8 +7,8 @@
 	eyeblur = 10
 	slur = 5
 	knockdown = 160
-	stamina = 0
-	knockdown_stamoverride = 60
+	stamina = 60
+	knockdown_stamoverride = 0
 
 /obj/item/projectile/energy/bolt/halloween
 	name = "candy corn"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Energy crossbows are kind of absolutely terrible using RNG mechanics. Hopefully I've somehow managed to make them less RNG! This is largely a port of a similar change over on /tg/station, but with some effects to hopefully allow for disarms without making the knockdown too intense.

**WHAT SHOULD BE HAPPENING WHEN SHOT WITH AN EBOW:**
1. You flop to the floor for a 1 second knockdown. So not very intense.
2. You drop items in your hand.
3. You take 60 stamina damage and 15 toxin damage.
4. You slur your speech, which makes it harder to scream out for help.
5. Your vision is blurred.

Large ebows have all this and retain the higher damage (15 -> 20 toxin).

## Why It's Good For The Game

I really, really dislike RNG based mechanics, and the current state of the ebow on /tg/station is easily my favourite iteration due to the considerably higher skill ceiling for it's use while being a reliable and dependable tool for keeping people floored, kidnapping people, and fighting off security. 

I would have altered the price but another PR is currently open that is touching the ebow price.

~~There are some concerns I have with the fact that the large ebows are mass-printable and these can be dual-wielded. But I think that is a problem more with the fact that they can be printed so easily and illegal tech acquired so readily over whether ebows should or shouldn't be altered. Essentially, different problem that needs a different solution. (I have some ideas)~~

I've implemented those ideas. Large energy crossbows are both bulky weapons and heavy weapons.

## Changelog
:cl:
add: Ebows now disarm people hit by them.
add: Ebows now do 60 stamina damage on hit.
del: Ebows no longer inflict drowsiness
balance: Miniature ebows do 15 toxin damage, up from 8.
balance: Ebows have considerably shorter knockdowns.
balance: Ebows now make you slur rather than stutter.
balance: Large ebows are now heavy and bulky.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
