### PR TITLE
Makes Disco Inferno locked behind emag only, similar to Gorilla shuttle.

### DIFF
--- a/code/datums/shuttles.dm
+++ b/code/datums/shuttles.dm
@@ -229,9 +229,14 @@
 /datum/map_template/shuttle/emergency/discoinferno
 	suffix = "discoinferno"
 	name = "Disco Inferno"
-	description = "The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
+	description = "(Emag Only)The glorious results of centuries of plasma research done by Nanotrasen employees. This is the reason why you are here. Get on and dance like you're on fire, burn baby burn!"
 	admin_notes = "Flaming hot. The main area has a dance machine as well as plasma floor tiles that will be ignited by players every single time."
 	credit_cost = 10000
+	
+/datum/map_template/shuttle/emergency/discoinferno/prerequisites_met()
+	if("emagged" in SSshuttle.shuttle_purchase_requirements_met)
+		return TRUE
+	return FALSE
 
 /datum/map_template/shuttle/emergency/arena
 	suffix = "arena"


### PR DESCRIPTION
Admin notes literally paint this as a grief shuttle. There is zero legitimate reason to actually purchase this given the huge risk it has to everyone evacuating.

The floors/statues take one hit from a welder and the entire shuttle is lit on fire, with zero heat protection to anyone in the top and bottom.

Gorilla shuttle was locked behind an emag, why this hasn't been locked behind one makes no sense.