### PR TITLE
Spinfusors are no longer purchasable from cargo

### DIFF
--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -201,22 +201,6 @@
 		var/item = pick(contains)
 		new item(C)
 
-/datum/supply_pack/security/armory/spinfusor
-	name = "Stormhammer Spinfusor Crate"
-	cost = 14000
-	desc = "Got yourself a code red? Blob, nukies or even worst knocking on your door? Well with the Stormhammer Spinfusor you can stop crime in one shot, dont miss! Contains two Stormhammer Spinfusors (Note, guns may or may not be loaded). Requires Armory access to open."
-	contains = list(/obj/item/gun/ballistic/automatic/spinfusor,
-					/obj/item/gun/ballistic/automatic/spinfusor)
-	crate_name = "spinfusor crate"
-
-/datum/supply_pack/security/armory/spinfusorammo
-	name = "Spinfusor Disk Crate"
-	cost = 7000
-	desc = "Need more ammo for a Stormhammer? Well we got some for a price! Contains two boxes of Spinfusor disks. Requires Armory access to open."
-	contains = list(/obj/item/ammo_box/aspinfusor,
-					/obj/item/ammo_box/aspinfusor)
-	crate_name = "spinfusor disk crate"
-
 /datum/supply_pack/security/armory/swat
 	name = "SWAT Crate"
 	desc = "Contains two fullbody sets of tough, fireproof, pressurized suits designed in a joint effort by IS-ERI and Nanotrasen. Each set contains a suit, helmet, mask, combat belt, and combat gloves. Requires Armory access to open."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There is no amount of number tweaks that will fix the spinfusor. As I'm told, the only reason why they exist was to counter the obscenely powerful flight suit that has long since been phased out of the code.

Now, they only serve to oneshot everything you point them at. This isn't something regular crewmen should get without a lot of effort. The grenade launcher in space, while not exactly a GOOD item balance wise, is supposed to be reasonably unique.

Spinfusors are still in the game for admemery. You just otherwise can't acquire them via cargo. Because Tribes memes are still genuinely funny to me, even if the part that made it funny isn't a thing anymore, which is the super fast flight suits that would have paired with the gun.

![13359033171319](https://user-images.githubusercontent.com/40847847/73145823-96447e80-4103-11ea-97a0-836215c1dd18.png)

## Why It's Good For The Game

A mass shipment of grenade launchers is not really all that balanced and I don't particularly think this is a hard thing to justify.

## Changelog
:cl:
del: You can no longer order spinfusors or their ammo from cargo. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
