### PR TITLE
fixes spacemen going at lightspeed on local/testing servers

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -39,7 +39,7 @@ WALK_DELAY 4
 ## Entries completely override all subtypes. Later entries have precedence over earlier entries.
 ## This means if you put /mob 0 on the last entry, it will null out all changes, while if you put /mob as the first entry and
 ## /mob/living/carbon/human on the last entry, the last entry will override the first.
-##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 0
+MULTIPLICATIVE_MOVESPEED /mob/living/carbon/human 1
 ##MULTIPLICATIVE_MOVESPEED /mob/living/silicon/robot 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/monkey 0
 ##MULTIPLICATIVE_MOVESPEED /mob/living/carbon/alien 0


### PR DESCRIPTION
This is just a config change that's required for movement to function as of #10648 . I'd really like to be able to test things with the most recent commit of the code without things being hilariously broken because someone forgot to make config changes that are required for a given PR to function properly.

## Changelog
:cl:
fix: Spacemen no longer run at lightspeed on local servers.
/:cl:
