### PR TITLE
heck suit resistances - goliath resistance and also acid-proof

### DIFF
--- a/code/modules/mining/equipment/explorer_gear.dm
+++ b/code/modules/mining/equipment/explorer_gear.dm
@@ -70,7 +70,7 @@
 	item_state = "hostile_env"
 	clothing_flags = THICKMATERIAL //not spaceproof
 	max_heat_protection_temperature = FIRE_IMMUNITY_MAX_TEMP_PROTECT
-	resistance_flags = FIRE_PROOF | LAVA_PROOF
+	resistance_flags = FIRE_PROOF | LAVA_PROOF | ACID_PROOF | GOLIATH_RESISTANCE
 	mutantrace_variation = STYLE_DIGITIGRADE|STYLE_SNEK_TAURIC|STYLE_PAW_TAURIC
 	slowdown = 0
 	armor = list("melee" = 70, "bullet" = 40, "laser" = 10, "energy" = 10, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 100, "acid" = 100)


### PR DESCRIPTION
## About The Pull Request
see title
## Why It's Good For The Game
goliath resistance: you went through the trouble of fragging big fella bubblegum you might as well have a(nother) suit better than the roundstarts
acid_proof: its already got 100 acid armor i dunno if this is really necessary but the ash drake armor has the same shit?
## Changelog
:cl:
tweak: The H.E.C.K. suit is now goliath tentacle resistant and probably better for acid resistance.
/:cl: