### PR TITLE
Gangs can now only tag with GANG spraycans, rather than lathed spraycans

### DIFF
--- a/code/game/objects/items/crayons.dm
+++ b/code/game/objects/items/crayons.dm
@@ -619,8 +619,7 @@
 	is_capped = TRUE
 	self_contained = FALSE // Don't disappear when they're empty
 	can_change_colour = TRUE
-	gang = TRUE //Gang check is true for all things upon the honored hierarchy of spraycans, except those that are FALSE.
-
+	
 	reagent_contents = list(/datum/reagent/fuel = 1, /datum/reagent/consumable/ethanol = 1)
 
 	pre_noise = TRUE
@@ -774,7 +773,6 @@
 	icon_capped = "deathcan2_cap"
 	icon_uncapped = "deathcan2"
 	use_overlays = FALSE
-	gang = FALSE
 
 	volume_multiplier = 25
 	charges = 100
@@ -789,7 +787,6 @@
 	icon_capped = "clowncan2_cap"
 	icon_uncapped = "clowncan2"
 	use_overlays = FALSE
-	gang = FALSE
 
 	reagent_contents = list(/datum/reagent/lube = 1, /datum/reagent/consumable/banana = 1)
 	volume_multiplier = 5
@@ -804,7 +801,6 @@
 	icon_capped = "mimecan_cap"
 	icon_uncapped = "mimecan"
 	use_overlays = FALSE
-	gang = FALSE
 
 	can_change_colour = FALSE
 	paint_color = "#FFFFFF" //RGB


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

I think it's better for gangs as a gamemode to have more of am emphasis on leaders (we also get an extra LT from /tg/ implementation back in the day btw) to have to pass out gear. If you want your influence points, hand out spraycans. The meta should not be to pen someone and leave them to lathe spraycans at public lathe and then go blasting with a sniper rifle.

## Changelog
:cl:
balance: Gangs can now only tag with a gang uplink bought spraycan.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
