### PR TITLE
RPD icon reorder, less building pixelhunting

### DIFF
--- a/code/game/objects/items/RPD.dm
+++ b/code/game/objects/items/RPD.dm
@@ -7,35 +7,35 @@ RPD
 #define DISPOSALS_CATEGORY 1
 #define TRANSIT_CATEGORY 2
 
-#define BUILD_MODE 1
-#define WRENCH_MODE 2
-#define DESTROY_MODE 4
-#define PAINT_MODE 8
+#define BUILD_MODE (1<<0)
+#define WRENCH_MODE (1<<1)
+#define DESTROY_MODE (1<<2)
+#define PAINT_MODE (1<<3)
 
 
 GLOBAL_LIST_INIT(atmos_pipe_recipes, list(
 	"Pipes" = list(
 		new /datum/pipe_info/pipe("Pipe",				/obj/machinery/atmospherics/pipe/simple),
 		new /datum/pipe_info/pipe("Manifold",			/obj/machinery/atmospherics/pipe/manifold),
-		new /datum/pipe_info/pipe("Manual Valve",		/obj/machinery/atmospherics/components/binary/valve),
-		new /datum/pipe_info/pipe("Digital Valve",		/obj/machinery/atmospherics/components/binary/valve/digital),
-		new /datum/pipe_info/pipe("Relief Valve",		/obj/machinery/atmospherics/components/binary/relief_valve),
 		new /datum/pipe_info/pipe("4-Way Manifold",		/obj/machinery/atmospherics/pipe/manifold4w),
 		new /datum/pipe_info/pipe("Layer Manifold",		/obj/machinery/atmospherics/pipe/layer_manifold),
 	),
 	"Devices" = list(
 		new /datum/pipe_info/pipe("Connector",			/obj/machinery/atmospherics/components/unary/portables_connector),
-		new /datum/pipe_info/pipe("Unary Vent",			/obj/machinery/atmospherics/components/unary/vent_pump),
-		new /datum/pipe_info/pipe("Relief Valve",		/obj/machinery/atmospherics/components/unary/relief_valve),
 		new /datum/pipe_info/pipe("Gas Pump",			/obj/machinery/atmospherics/components/binary/pump),
-		new /datum/pipe_info/pipe("Passive Gate",		/obj/machinery/atmospherics/components/binary/passive_gate),
 		new /datum/pipe_info/pipe("Volume Pump",		/obj/machinery/atmospherics/components/binary/volume_pump),
-		new /datum/pipe_info/pipe("Scrubber",			/obj/machinery/atmospherics/components/unary/vent_scrubber),
-		new /datum/pipe_info/pipe("Injector",			/obj/machinery/atmospherics/components/unary/outlet_injector),
-		new /datum/pipe_info/meter("Meter"),
 		new /datum/pipe_info/pipe("Gas Filter",			/obj/machinery/atmospherics/components/trinary/filter),
 		new /datum/pipe_info/pipe("Gas Mixer",			/obj/machinery/atmospherics/components/trinary/mixer),
+		new /datum/pipe_info/pipe("Passive Gate",		/obj/machinery/atmospherics/components/binary/passive_gate),
+		new /datum/pipe_info/pipe("Injector",			/obj/machinery/atmospherics/components/unary/outlet_injector),
+		new /datum/pipe_info/pipe("Scrubber",			/obj/machinery/atmospherics/components/unary/vent_scrubber),
+		new /datum/pipe_info/pipe("Unary Vent",			/obj/machinery/atmospherics/components/unary/vent_pump),
 		new /datum/pipe_info/pipe("Passive Vent",		/obj/machinery/atmospherics/components/unary/passive_vent),
+		new /datum/pipe_info/pipe("Manual Valve",		/obj/machinery/atmospherics/components/binary/valve),
+		new /datum/pipe_info/pipe("Digital Valve",		/obj/machinery/atmospherics/components/binary/valve/digital),
+		new /datum/pipe_info/pipe("Relief Valve (Binary)",		/obj/machinery/atmospherics/components/binary/relief_valve),
+		new /datum/pipe_info/pipe("Relief Valve (Unary)",		/obj/machinery/atmospherics/components/unary/relief_valve),
+		new /datum/pipe_info/meter("Meter"),
 	),
 	"Heat Exchange" = list(
 		new /datum/pipe_info/pipe("Pipe",				/obj/machinery/atmospherics/pipe/heat_exchanging/simple),
@@ -102,22 +102,22 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			dirs = list("[NORTH]" = "Vertical", "[EAST]" = "Horizontal")
 			if(dirtype == PIPE_BENDABLE)
 				dirs += list("[NORTHWEST]" = "West to North", "[NORTHEAST]" = "North to East",
-							 "[SOUTHWEST]" = "South to West", "[SOUTHEAST]" = "East to South")
+							"[SOUTHWEST]" = "South to West", "[SOUTHEAST]" = "East to South")
 		if(PIPE_TRINARY)
-			dirs = list("[NORTH]" = "West South East", "[EAST]" = "North West South",
-						"[SOUTH]" = "East North West", "[WEST]" = "South East North")
+			dirs = list("[NORTH]" = "West South East", "[SOUTH]" = "East North West",
+						"[EAST]" = "North West South", "[WEST]" = "South East North")
 		if(PIPE_TRIN_M)
-			dirs = list("[NORTH]" = "North East South", "[EAST]" = "East South West",
-						"[SOUTH]" = "South West North", "[WEST]" = "West North East",
-						"[SOUTHEAST]" = "West South East", "[NORTHEAST]" = "South East North",
-						"[NORTHWEST]" = "East North West", "[SOUTHWEST]" = "North West South")
+			dirs = list("[NORTH]" = "North East South", "[SOUTHWEST]" = "North West South",
+						"[NORTHEAST]" = "South East North", "[SOUTH]" = "South West North",
+						"[WEST]" = "West North East", "[SOUTHEAST]" = "West South East",
+						"[NORTHWEST]" = "East North West", "[EAST]" = "East South West",)
 		if(PIPE_UNARY)
-			dirs = list("[NORTH]" = "North", "[EAST]" = "East", "[SOUTH]" = "South", "[WEST]" = "West")
+			dirs = list("[NORTH]" = "North", "[SOUTH]" = "South", "[WEST]" = "West", "[EAST]" = "East")
 		if(PIPE_ONEDIR)
 			dirs = list("[SOUTH]" = name)
 		if(PIPE_UNARY_FLIPPABLE)
-			dirs = list("[NORTH]" = "North", "[NORTHEAST]" = "North Flipped", "[EAST]" = "East", "[SOUTHEAST]" = "East Flipped",
-						"[SOUTH]" = "South", "[SOUTHWEST]" = "South Flipped", "[WEST]" = "West", "[NORTHWEST]" = "West Flipped")
+			dirs = list("[NORTH]" = "North", "[EAST]" = "East", "[SOUTH]" = "South", "[WEST]" = "West",
+						"[NORTHEAST]" = "North Flipped", "[SOUTHEAST]" = "East Flipped", "[SOUTHWEST]" = "South Flipped", "[NORTHWEST]" = "West Flipped")
 
 
 	var/list/rows = list()
@@ -208,7 +208,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/datum/pipe_info/first_atmos
 	var/static/datum/pipe_info/first_disposal
 	var/static/datum/pipe_info/first_transit
-	var/mode = BUILD_MODE | PAINT_MODE | DESTROY_MODE | WRENCH_MODE
+	var/mode = BUILD_MODE | DESTROY_MODE | WRENCH_MODE
 
 /obj/item/pipe_dispenser/New()
 	. = ..()
@@ -249,7 +249,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 		var/datum/asset/assets = get_asset_datum(/datum/asset/spritesheet/pipes)
 		assets.send(user)
 
-		ui = new(user, src, ui_key, "rpd", name, 300, 550, master_ui, state)
+		ui = new(user, src, ui_key, "rpd", name, 425, 515, master_ui, state)
 		ui.open()
 
 /obj/item/pipe_dispenser/ui_data(mob/user)
@@ -342,11 +342,13 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 	var/static/list/make_pipe_whitelist
 	if(!make_pipe_whitelist)
 		make_pipe_whitelist = typecacheof(list(/obj/structure/lattice, /obj/structure/girder, /obj/item/pipe, /obj/structure/window, /obj/structure/grille))
+	if(istype(A, /obj/machinery/atmospherics) && (mode & BUILD_MODE && !(mode & PAINT_MODE))) //Reduces pixelhunt when coloring is off.
+		A = get_turf(A)
 	var/can_make_pipe = (isturf(A) || is_type_in_typecache(A, make_pipe_whitelist))
 
 	. = FALSE
 
-	if((mode&DESTROY_MODE) && istype(A, /obj/item/pipe) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod) || istype(A, /obj/item/pipe_meter))
+	if((mode & DESTROY_MODE) && istype(A, /obj/item/pipe) || istype(A, /obj/structure/disposalconstruct) || istype(A, /obj/structure/c_transit_tube) || istype(A, /obj/structure/c_transit_tube_pod) || istype(A, /obj/item/pipe_meter))
 		to_chat(user, "<span class='notice'>You start destroying a pipe...</span>")
 		playsound(get_turf(src), 'sound/machines/click.ogg', 50, 1)
 		if(do_after(user, destroy_speed, target = A))
@@ -354,7 +356,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 			qdel(A)
 		return
 
-	if((mode&PAINT_MODE))
+	if((mode & PAINT_MODE))
 		if(istype(A, /obj/machinery/atmospherics/pipe) && !istype(A, /obj/machinery/atmospherics/pipe/layer_manifold))
 			var/obj/machinery/atmospherics/pipe/P = A
 			to_chat(user, "<span class='notice'>You start painting \the [P] [paint_color]...</span>")
@@ -372,7 +374,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 				user.visible_message("<span class='notice'>[user] paints \the [A] [paint_color].</span>","<span class='notice'>You paint \the [A] [paint_color].</span>")
 			return
 
-	if(mode&BUILD_MODE)
+	if(mode & BUILD_MODE)
 		switch(category) //if we've gotten this var, the target is valid
 			if(ATMOS_CATEGORY) //Making pipes
 				if(!can_make_pipe)
@@ -388,7 +390,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 						activate()
 						var/obj/item/pipe_meter/PM = new /obj/item/pipe_meter(A)
 						PM.setAttachLayer(piping_layer)
-						if(mode&WRENCH_MODE)
+						if(mode & WRENCH_MODE)
 							PM.wrench_act(user, src)
 				else
 					to_chat(user, "<span class='notice'>You start building a pipe...</span>")
@@ -407,7 +409,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 						P.setPipingLayer(piping_layer)
 						if(findtext("[queued_p_type]", "/obj/machinery/atmospherics/pipe") && !findtext("[queued_p_type]", "layer_manifold"))
 							P.add_atom_colour(GLOB.pipe_paint_colors[paint_color], FIXED_COLOUR_PRIORITY)
-						if(mode&WRENCH_MODE)
+						if(mode & WRENCH_MODE)
 							P.wrench_act(user, src)
 
 			if(DISPOSALS_CATEGORY) //Making disposals pipes
@@ -431,7 +433,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 
 					C.add_fingerprint(usr)
 					C.update_icon()
-					if(mode&WRENCH_MODE)
+					if(mode & WRENCH_MODE)
 						C.wrench_act(user, src)
 					return
 
@@ -453,7 +455,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 					if(queued_p_type == /obj/structure/c_transit_tube_pod)
 						var/obj/structure/c_transit_tube_pod/pod = new /obj/structure/c_transit_tube_pod(A)
 						pod.add_fingerprint(usr)
-						if(mode&WRENCH_MODE)
+						if(mode & WRENCH_MODE)
 							pod.wrench_act(user, src)
 
 					else
@@ -465,7 +467,7 @@ GLOBAL_LIST_INIT(transit_tube_recipes, list(
 							tube.simple_rotate_flip()
 
 						tube.add_fingerprint(usr)
-						if(mode&WRENCH_MODE)
+						if(mode & WRENCH_MODE)
 							tube.wrench_act(user, src)
 					return
 


### PR DESCRIPTION
Port https://github.com/tgstation/tgstation/pull/48605 , the rest of the PR is a copy-paste of the original

## About The Pull Request
Reordered the tab sub categories, from a hearty jumble to similar stuff bunched together.
Reordered preview icons to something I think makes more sense, most notably binary/basic trinary is now ordered like this:
![71780966-7f5db100-2fc9-11ea-9377-06651b71ae8c](https://user-images.githubusercontent.com/50276533/73412606-21c23900-42d7-11ea-88f2-3a32f36652ff.png)
And advanced trinary like this:
![71781170-e8462880-2fcb-11ea-8fe1-1b05208c71f2](https://user-images.githubusercontent.com/50276533/73412616-2850b080-42d7-11ea-98ef-97abd2d92fb0.png)
Made the RPD start with the paint setting off, meaning it wont by default repaint pipes you hit with it. Instead, if build is on and paint is off it will target the turf underneath. Much, much less pixelhunting around heat pipes and similar.
![71781011-07dc5180-2fca-11ea-8aa5-5b43d2bc1fda](https://user-images.githubusercontent.com/50276533/73412637-38689000-42d7-11ea-975a-d854065a4303.gif)

## Why It's Good For The Game
Further improves the RPD UI by applying sane ordering, qol RPD change.

## Changelog
:cl:
tweak: RPD subcategories and preview icons reorganized.
add: RPD now starts with painting turned off, hitting pipes with build and no paint will target the turf underneath instead. Bye bye turf pixelhunting.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
