### PR TITLE
nonlethal dueling pistols are now not access locked, lethal ones are now armory locked. also, dueling pistols show their duel datum id (which is added) for better finding when you have many pairs.

### DIFF
--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -370,6 +370,8 @@
 
 /obj/item/storage/lockbox/dueling/hugbox
 	gun_type = /obj/item/gun/energy/dueling/hugbox
+	req_access = list(ACCESS_ARMORY)
 
 /obj/item/storage/lockbox/dueling/hugbox/stamina
 	gun_type = /obj/item/gun/energy/dueling/hugbox/stamina
+	req_access = null

--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -22,6 +22,11 @@
 	var/list/fired = list()
 	var/countdown_length = 10
 	var/countdown_step = 0
+	var/static/next_id = 1
+	var/id
+
+/datum/duel/New()
+	id = next_id++
 
 /datum/duel/proc/try_begin()
 	//Check if both guns are held and if so begin.
@@ -156,6 +161,13 @@
 	. = ..()
 	setting_overlay = mutable_appearance(icon,setting_iconstate())
 	add_overlay(setting_overlay)
+
+/obj/item/gun/energy/dueling/examine(mob/user)
+	. = ..()
+	if(duel)
+		. += "Its linking number is [duel.id]."
+	else
+		. += "ERROR: No linking number on gun."
 
 /obj/item/gun/energy/dueling/proc/setting_iconstate()
 	switch(setting)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

kinda quirky i added something no one can use

## Changelog
:cl:
tweak: dueling pistol accesses have been changed to be more accessible.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
