### PR TITLE
crushing magboots for tators

### DIFF
--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -80,7 +80,7 @@
 
 /obj/item/clothing/shoes/magboots/crushing/equipped(mob/user,slot)
 	. = ..()
-	if (slot == SLOT_SHOES)
+	if (slot == SLOT_SHOES && magpulse)
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED,.proc/crush)
 
 /obj/item/clothing/shoes/magboots/crushing/dropped(mob/user)

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -71,12 +71,17 @@
 			to_chat(A,"<span class='userdanger'>[user]'s magboots press down on you, crushing you!</span>")
 			A.emote("scream")
 
+/obj/item/clothing/shoes/magboots/crushing/attack_self(mob/user)
+	. = ..()
+	if (magpulse)
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED,.proc/crush)
+	else
+		UnregisterSignal(user,COMSIG_MOVABLE_MOVED)
+
 /obj/item/clothing/shoes/magboots/crushing/equipped(mob/user,slot)
 	. = ..()
 	if (slot == SLOT_SHOES)
 		RegisterSignal(user, COMSIG_MOVABLE_MOVED,.proc/crush)
-	else
-		UnregisterSignal(user,COMSIG_MOVABLE_MOVED)
 
 /obj/item/clothing/shoes/magboots/crushing/dropped(mob/user)
 	. = ..()

--- a/code/modules/clothing/shoes/magboots.dm
+++ b/code/modules/clothing/shoes/magboots.dm
@@ -57,3 +57,27 @@
 	name = "blood-red magboots"
 	icon_state = "syndiemag0"
 	magboot_state = "syndiemag"
+
+/obj/item/clothing/shoes/magboots/crushing
+	desc = "Normal looking magboots that are altered to increase magnetic pull to crush anything underfoot."
+
+/obj/item/clothing/shoes/magboots/crushing/proc/crush(mob/living/user)
+	if (!isturf(user.loc) || !magpulse)
+		return
+	var/turf/T = user.loc
+	for (var/mob/living/A in T)
+		if (A != user && A.lying)
+			A.adjustBruteLoss(rand(10,13))
+			to_chat(A,"<span class='userdanger'>[user]'s magboots press down on you, crushing you!</span>")
+			A.emote("scream")
+
+/obj/item/clothing/shoes/magboots/crushing/equipped(mob/user,slot)
+	. = ..()
+	if (slot == SLOT_SHOES)
+		RegisterSignal(user, COMSIG_MOVABLE_MOVED,.proc/crush)
+	else
+		UnregisterSignal(user,COMSIG_MOVABLE_MOVED)
+
+/obj/item/clothing/shoes/magboots/crushing/dropped(mob/user)
+	. = ..()
+	UnregisterSignal(user,COMSIG_MOVABLE_MOVED)

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -224,3 +224,10 @@
 	cost = 5 //Low ammo, and deals same as 10mm but emp-able
 	item = /obj/item/gun/energy/emitter
 	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+
+/datum/uplink_item/role_restricted/crushmagboots
+	name = "Crushing Magboots"
+	desc = "A pair of extra-strength magboots that crush anyone you walk over."
+	cost = 2
+	item = /obj/item/clothing/shoes/magboots/crushing
+	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")


### PR DESCRIPTION
## About The Pull Request

Crushing magboots for traitors, only engineers + atmos techs, crushes anyone you walk over while the magpulse is enabled.

## Why It's Good For The Game

more traitor items + fun times.

## Changelog
:cl:
add: crushing magboots
/:cl: