### PR TITLE
Masks are now PROPERLY hidden my headgear that hides masks (Spacesuits, Hardsuits, Rad Hoods, Etc.)

### DIFF
--- a/code/modules/mob/living/carbon/human/update_icons.dm
+++ b/code/modules/mob/living/carbon/human/update_icons.dm
@@ -461,6 +461,8 @@ There are several things that need to be remembered:
 		var/alt_icon = M.alternate_worn_icon || 'icons/mob/mask.dmi'
 		var/muzzled = FALSE
 		var/variation_flag = NONE
+		if(head && (head.flags_inv & HIDEMASK))
+			return
 		if(("mam_snouts" in dna.species.default_features) && dna.features["mam_snouts"] != "None")
 			muzzled = TRUE
 		if(!muzzled && ("snout" in dna.species.default_features) && dna.features["snout"] != "None")


### PR DESCRIPTION

## About The Pull Request

Does what it says on the tin: Fixes a bug where masks would partially stick out of helmets when it shouldn't

## Why It's Good For The Game

Bug fixes always good. Ugly pixels sticking out of my EVA helmet bad.

## Changelog
:cl:
fix: masks no longer improperly stick out of helmets when they should be hidden.
/:cl:
