### PR TITLE
Status Display Fix: It's About Time

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -7850,7 +7850,7 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "asa" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -13716,7 +13716,7 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "aHu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white/corner{
@@ -16757,7 +16757,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "aPE" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/locker)
 "aPF" = (
@@ -16848,7 +16848,7 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -16880,7 +16880,7 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -18156,7 +18156,7 @@
 /area/hallway/secondary/exit)
 "aTl" = (
 /obj/machinery/vending/cola/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
@@ -18197,7 +18197,7 @@
 /area/hallway/secondary/exit)
 "aTr" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
@@ -21371,7 +21371,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "baZ" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	layer = 4;
 	pixel_y = 32
 	},
@@ -21528,7 +21528,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bbv" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable{
@@ -22164,7 +22164,7 @@
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -23065,7 +23065,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfw" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai_upload)
 "bfx" = (
@@ -25063,7 +25063,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/aug_manipulator,
@@ -27326,7 +27326,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bpw" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "bpx" = (
@@ -28634,7 +28634,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bsz" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white/side{
@@ -32596,7 +32596,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -35471,7 +35471,7 @@
 /area/medical/sleeper)
 "bIe" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -42591,7 +42591,7 @@
 /turf/open/floor/plating,
 /area/tcommsat/computer)
 "bZr" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/tcommsat/computer)
 "bZs" = (
@@ -49648,7 +49648,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuc" = (
 /obj/structure/rack,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/storage/box/donkpockets,
@@ -50228,7 +50228,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cvf" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "cvg" = (
@@ -50753,7 +50753,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/circuit,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -620,7 +620,7 @@
 /turf/open/space,
 /area/solar/starboard/fore)
 "acV" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -635,7 +635,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "acW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -655,7 +655,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "acX" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -667,7 +667,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "acY" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -684,7 +684,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "adb" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -701,7 +701,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "adc" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -998,7 +998,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "aeB" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/construction/mining/aux_base)
 "aeC" = (
@@ -1722,7 +1722,7 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "ahO" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -1735,7 +1735,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahP" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -1753,7 +1753,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahR" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -1766,7 +1766,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahS" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -1784,7 +1784,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/light{
@@ -1802,7 +1802,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "ahX" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -3055,7 +3055,7 @@
 /turf/open/floor/plasteel,
 /area/security/vacantoffice)
 "akC" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/vacantoffice)
 "akD" = (
@@ -3485,7 +3485,7 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "aly" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "alz" = (
@@ -4184,7 +4184,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/electronic_marketing_den)
 "amP" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -4217,7 +4217,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/electronic_marketing_den)
 "amU" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -4307,7 +4307,7 @@
 /turf/open/floor/carpet,
 /area/security/vacantoffice)
 "ang" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/structure/frame/computer,
@@ -4470,7 +4470,7 @@
 /obj/machinery/computer/prisoner/management{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -5433,7 +5433,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -5915,7 +5915,7 @@
 /area/crew_quarters/electronic_marketing_den)
 "apY" = (
 /obj/structure/frame/computer,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -9221,7 +9221,7 @@
 /turf/open/floor/plasteel,
 /area/janitor)
 "avA" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -9290,7 +9290,7 @@
 /area/janitor)
 "avD" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/clipboard,
@@ -9566,7 +9566,7 @@
 /turf/open/floor/plating,
 /area/engine/supermatter)
 "awi" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "awj" = (
@@ -10599,7 +10599,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/toilet/auxiliary)
 "ayd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -12334,7 +12334,7 @@
 	})
 "aBm" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/delivery,
@@ -13659,7 +13659,7 @@
 /area/hallway/secondary/service)
 "aDF" = (
 /obj/structure/bed,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/bedsheet/clown,
@@ -14298,7 +14298,7 @@
 /area/crew_quarters/bar)
 "aER" = (
 /obj/structure/closet/secure_closet/bar,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -14358,7 +14358,7 @@
 /area/crew_quarters/bar)
 "aEW" = (
 /obj/machinery/vending/boozeomat,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -14391,7 +14391,7 @@
 /area/crew_quarters/bar)
 "aEY" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/clipboard,
@@ -14830,7 +14830,7 @@
 	name = "Maintenance Garden"
 	})
 "aFM" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/delivery,
@@ -15204,7 +15204,7 @@
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
 "aGu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -15746,7 +15746,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
 "aHa" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/light,
@@ -16821,7 +16821,7 @@
 /area/hallway/secondary/service)
 "aIP" = (
 /obj/structure/bed,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/bedsheet/mime,
@@ -16906,7 +16906,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aIY" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/bar)
 "aIZ" = (
@@ -18124,7 +18124,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -18156,7 +18156,7 @@
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
 "aLd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
@@ -18353,7 +18353,7 @@
 	name = "Engineering Power Monitoring Console"
 	},
 /obj/structure/cable/white,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -19179,7 +19179,7 @@
 /area/hallway/secondary/service)
 "aNa" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/camera_film{
@@ -19243,7 +19243,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/easel,
@@ -19356,7 +19356,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "aNo" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/quartermaster/sorting)
 "aNp" = (
@@ -19913,7 +19913,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "aOh" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -20080,7 +20080,7 @@
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -22793,7 +22793,7 @@
 	dir = 4;
 	pixel_x = -23
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/reagent_containers/glass/bottle/morphine{
@@ -24043,7 +24043,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "aUs" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -25784,7 +25784,7 @@
 /turf/closed/wall,
 /area/engine/atmos)
 "aWK" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/atmos)
 "aWL" = (
@@ -26522,7 +26522,7 @@
 /area/security/prison)
 "aXM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/prison)
 "aXN" = (
@@ -27066,7 +27066,7 @@
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aYD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
 "aYE" = (
@@ -28509,7 +28509,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "baX" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/quartermaster/qm)
 "baY" = (
@@ -29246,7 +29246,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "bcr" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/quartermaster/office)
 "bcs" = (
@@ -29578,7 +29578,7 @@
 /obj/structure/closet/secure_closet/brig{
 	name = "Prisoner Locker"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -33053,7 +33053,7 @@
 /obj/machinery/computer/security{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -34463,7 +34463,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "bkY" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light/small{
@@ -34513,7 +34513,7 @@
 /area/maintenance/port/fore)
 "bld" = (
 /obj/machinery/hydroponics/constructable,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
@@ -34680,7 +34680,7 @@
 /area/crew_quarters/kitchen)
 "bls" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/vending/dinnerware,
@@ -35363,7 +35363,7 @@
 "bmB" = (
 /obj/structure/bed,
 /obj/item/bedsheet/hos,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -35888,7 +35888,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bnx" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/fore)
 "bny" = (
@@ -36362,7 +36362,7 @@
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plating,
@@ -36542,7 +36542,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hydroponics)
 "boE" = (
@@ -36856,7 +36856,7 @@
 /area/security/execution/transfer)
 "bpf" = (
 /obj/machinery/computer/shuttle/labor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39782,7 +39782,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/heads/hos)
 "btA" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -40141,7 +40141,7 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "buf" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
@@ -40254,7 +40254,7 @@
 /turf/open/floor/plating,
 /area/hallway/primary/central)
 "bur" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/primary/central)
 "bus" = (
@@ -41463,7 +41463,7 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
 "bwy" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bwz" = (
@@ -42212,7 +42212,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bxH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -42574,7 +42574,7 @@
 /area/bridge)
 "byn" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/storage/toolbox/mechanical,
@@ -43177,7 +43177,7 @@
 /obj/structure/table/reinforced,
 /obj/item/storage/toolbox/electrical,
 /obj/item/wrench/power,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -43309,7 +43309,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/break_room)
 "bzt" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/cable/white{
@@ -44096,7 +44096,7 @@
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bAx" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/ai)
 "bAy" = (
@@ -44284,7 +44284,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -45837,7 +45837,7 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/requests_console{
@@ -46136,7 +46136,7 @@
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bDu" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/storage/primary)
 "bDv" = (
@@ -47422,7 +47422,7 @@
 /area/hallway/primary/port)
 "bES" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48334,7 +48334,7 @@
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
 "bGe" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -48507,7 +48507,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bGr" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = 32
 	},
@@ -48707,7 +48707,7 @@
 /obj/structure/rack,
 /obj/item/airlock_painter,
 /obj/item/toner,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -49450,7 +49450,7 @@
 /area/engine/gravity_generator)
 "bHP" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -49544,7 +49544,7 @@
 /turf/closed/wall,
 /area/engine/break_room)
 "bHX" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/break_room)
 "bHY" = (
@@ -50064,7 +50064,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bIN" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/bridge)
 "bIO" = (
@@ -51288,7 +51288,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bKy" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/newscaster{
@@ -51457,7 +51457,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "bKS" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51998,7 +51998,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/transit_tube)
 "bLH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/transit_tube)
 "bLI" = (
@@ -52432,7 +52432,7 @@
 /area/storage/tech)
 "bMj" = (
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52458,7 +52458,7 @@
 	pixel_x = 3;
 	pixel_y = -3
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -53524,7 +53524,7 @@
 /obj/machinery/computer/card/minor/ce{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -53711,7 +53711,7 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "bOd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -54108,7 +54108,7 @@
 /obj/machinery/computer/telecomms/monitor{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -54372,7 +54372,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/carpet,
@@ -54654,7 +54654,7 @@
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPI" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPJ" = (
@@ -56117,7 +56117,7 @@
 /area/crew_quarters/heads/chief)
 "bSg" = (
 /obj/structure/dresser,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -57235,7 +57235,7 @@
 /obj/machinery/computer/station_alert{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -57942,7 +57942,7 @@
 /area/crew_quarters/heads/captain)
 "bUP" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/item/coin/adamantine{
@@ -60905,7 +60905,7 @@
 	pixel_x = 26;
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/recharger,
@@ -61752,7 +61752,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "cac" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -61895,7 +61895,7 @@
 "cal" = (
 /obj/structure/table/reinforced,
 /obj/item/paper_bin,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/pen,
@@ -62226,7 +62226,7 @@
 /area/crew_quarters/heads/hop)
 "caS" = (
 /obj/machinery/pdapainter,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -63159,7 +63159,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "ccz" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hop)
 "ccA" = (
@@ -64330,7 +64330,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -64591,7 +64591,7 @@
 /obj/structure/table/wood,
 /obj/item/folder/blue,
 /obj/item/pen/fourcolor,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -65289,7 +65289,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -66588,7 +66588,7 @@
 	pixel_x = -24;
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -67083,7 +67083,7 @@
 /area/lawoffice)
 "ciy" = (
 /obj/machinery/photocopier,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -67301,7 +67301,7 @@
 /area/security/brig)
 "ciL" = (
 /obj/structure/closet/secure_closet/security/sec,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -68044,7 +68044,7 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "ckd" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -68181,7 +68181,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai_upload)
 "cko" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32;
 	pixel_y = -32
 	},
@@ -68218,7 +68218,7 @@
 /turf/open/floor/circuit/green,
 /area/ai_monitored/turret_protected/ai_upload)
 "cks" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = -32
 	},
@@ -70115,7 +70115,7 @@
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cnD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
 "cnE" = (
@@ -70156,7 +70156,7 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cnH" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/engine/engineering)
 "cnI" = (
@@ -70506,7 +70506,7 @@
 /area/teleporter)
 "cor" = (
 /obj/machinery/teleport/station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -71327,7 +71327,7 @@
 /area/teleporter)
 "cpV" = (
 /obj/structure/table,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/paper_bin,
@@ -71766,7 +71766,7 @@
 /area/library)
 "cqU" = (
 /obj/machinery/libraryscanner,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -72058,7 +72058,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "crs" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/locker)
 "crt" = (
@@ -72935,7 +72935,7 @@
 	dir = 1;
 	name = "Jury"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -74329,7 +74329,7 @@
 /turf/open/floor/plasteel/grimy,
 /area/library)
 "cvk" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/library)
 "cvl" = (
@@ -74972,7 +74972,7 @@
 /obj/structure/cable/white{
 	icon_state = "1-2"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -75859,7 +75859,7 @@
 /area/engine/storage)
 "cxL" = (
 /obj/machinery/suit_storage_unit/engine,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -76343,7 +76343,7 @@
 /obj/machinery/gateway{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -76578,7 +76578,7 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cyW" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -77058,7 +77058,7 @@
 /obj/structure/table/wood,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -78070,7 +78070,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
 "cBu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -78615,7 +78615,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
@@ -78645,7 +78645,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -78951,7 +78951,7 @@
 	pixel_y = 3
 	},
 /obj/item/newspaper,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -79679,7 +79679,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cDR" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -79717,7 +79717,7 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -80011,7 +80011,7 @@
 "cEs" = (
 /obj/machinery/light,
 /obj/structure/dresser,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -80514,7 +80514,7 @@
 	},
 /area/crew_quarters/toilet/restrooms)
 "cFj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -80540,7 +80540,7 @@
 /area/crew_quarters/toilet/restrooms)
 "cFl" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/structure/cable/white{
@@ -81105,7 +81105,7 @@
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/eva)
 "cGm" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -81688,7 +81688,7 @@
 /area/engine/storage)
 "cHr" = (
 /obj/structure/reagent_dispensers/watertank,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -82182,7 +82182,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
 "cIo" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "cIp" = (
@@ -85300,7 +85300,7 @@
 /turf/open/floor/plasteel,
 /area/science/research)
 "cNs" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/science/research)
 "cNt" = (
@@ -85387,7 +85387,7 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cNB" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/medbay/central)
 "cNC" = (
@@ -86958,7 +86958,7 @@
 	dir = 4;
 	pixel_x = -24
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/extinguisher_cabinet{
@@ -87536,7 +87536,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/department/electrical)
 "cRE" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/maintenance/department/electrical)
 "cRF" = (
@@ -87699,7 +87699,7 @@
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/white{
@@ -88254,7 +88254,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cSM" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/reagent_dispensers/peppertank{
@@ -88626,7 +88626,7 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port)
 "cTm" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -89691,7 +89691,7 @@
 /obj/item/folder,
 /obj/item/pen,
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/paicard,
@@ -89712,7 +89712,7 @@
 "cUX" = (
 /obj/structure/bed,
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/spawner/lootdrop/bedsheet,
@@ -89749,7 +89749,7 @@
 	name = "trenchcoat"
 	},
 /obj/item/clothing/suit/toggle/lawyer/black,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/clothing/head/fedora,
@@ -89856,7 +89856,7 @@
 /turf/open/floor/plating,
 /area/crew_quarters/fitness/recreation)
 "cVj" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -90566,7 +90566,7 @@
 	},
 /obj/item/storage/box/syringes,
 /obj/item/gun/syringe,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/window/reinforced,
@@ -90619,7 +90619,7 @@
 	pixel_x = -3;
 	pixel_y = 2
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/firealarm{
@@ -91099,7 +91099,7 @@
 /obj/machinery/computer/camera_advanced/xenobio{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /turf/open/floor/circuit/green,
@@ -91250,7 +91250,7 @@
 /obj/structure/table,
 /obj/item/gps,
 /obj/item/assembly/flash/handheld,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -91870,7 +91870,7 @@
 "cYE" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/small,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -91893,7 +91893,7 @@
 "cYH" = (
 /obj/machinery/power/smes,
 /obj/machinery/light/small,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -93248,7 +93248,7 @@
 	dir = 1
 	},
 /obj/item/twohanded/required/kirbyplants/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -93616,7 +93616,7 @@
 /area/medical/medbay/central)
 "dbz" = (
 /obj/machinery/vending/cola/random,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/light{
@@ -94444,7 +94444,7 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -95332,7 +95332,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "der" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/chemistry)
 "des" = (
@@ -98493,7 +98493,7 @@
 /area/science/explab)
 "djG" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -98705,7 +98705,7 @@
 /obj/item/storage/toolbox/mechanical,
 /obj/item/stack/cable_coil/white,
 /obj/item/stack/cable_coil/white,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -99134,7 +99134,7 @@
 /area/medical/abandoned)
 "dkK" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/storage/firstaid/regular,
@@ -99165,7 +99165,7 @@
 /area/medical/abandoned)
 "dkM" = (
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/reagent_containers/blood/random,
@@ -99737,7 +99737,7 @@
 /turf/closed/wall,
 /area/medical/surgery)
 "dmb" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/surgery)
 "dmc" = (
@@ -100285,7 +100285,7 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -102730,7 +102730,7 @@
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "drL" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/science/explab)
 "drM" = (
@@ -103377,7 +103377,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dta" = (
 /obj/structure/table/wood,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/item/book/manual/wiki/engineering_hacking,
@@ -103584,7 +103584,7 @@
 /area/science/research)
 "dtw" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/bot,
@@ -104467,7 +104467,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "dvi" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/medical/genetics)
 "dvj" = (
@@ -105182,7 +105182,7 @@
 	dir = 8
 	},
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/keycard_auth{
@@ -106597,7 +106597,7 @@
 /obj/machinery/computer/crew{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -106665,7 +106665,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "dyJ" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -106854,7 +106854,7 @@
 /area/crew_quarters/abandoned_gambling_den)
 "dze" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
@@ -107749,7 +107749,7 @@
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/rd,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -109302,7 +109302,7 @@
 	pixel_y = 2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -109900,7 +109900,7 @@
 /area/medical/medbay/central)
 "dEg" = (
 /obj/structure/filingcabinet/chestdrawer,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -110678,7 +110678,7 @@
 "dFB" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/crowbar,
@@ -110763,7 +110763,7 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/stripes/corner,
@@ -112799,7 +112799,7 @@
 "dIR" = (
 /obj/structure/table/optable,
 /obj/effect/decal/cleanable/blood/old,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -114289,7 +114289,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/wood{
@@ -114340,7 +114340,7 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel/grimy,
@@ -116346,7 +116346,7 @@
 /obj/machinery/computer/med_data{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -116735,7 +116735,7 @@
 "dPQ" = (
 /obj/machinery/vending/cola/random,
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -118303,7 +118303,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/green{
@@ -118977,7 +118977,7 @@
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/machinery/portable_atmospherics/canister/air,
@@ -119222,7 +119222,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/snacks/grown/poppy,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -119278,7 +119278,7 @@
 	pixel_y = 3
 	},
 /obj/item/reagent_containers/food/snacks/grown/harebell,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -119705,7 +119705,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -121334,7 +121334,7 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "dYF" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "dYG" = (
@@ -121425,7 +121425,7 @@
 /area/medical/virology)
 "dYT" = (
 /obj/machinery/light,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -122739,7 +122739,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "ebx" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/medical/virology)
 "eby" = (
@@ -123476,7 +123476,7 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "ecT" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/chapel/main)
@@ -124214,7 +124214,7 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/escape)
 "eee" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/security/checkpoint/escape)
 "eef" = (
@@ -124430,7 +124430,7 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -125279,7 +125279,7 @@
 	name = "Chapel RC";
 	pixel_y = -32
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/camera{
@@ -125358,7 +125358,7 @@
 /obj/machinery/computer/security{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -126227,7 +126227,7 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "iwL" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/blue{

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -421,7 +421,7 @@
 	},
 /area/security/prison)
 "abr" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -2472,7 +2472,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "afj" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32;
 	pixel_y = 32
 	},
@@ -2501,7 +2501,7 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
 "afn" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32;
 	pixel_y = 32
 	},
@@ -15058,7 +15058,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -17819,7 +17819,7 @@
 /obj/structure/chair{
 	name = "Judge"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -19088,7 +19088,7 @@
 "aLO" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/machinery/portable_atmospherics/scrubber,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/delivery,
@@ -21087,7 +21087,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/camera{
@@ -21381,7 +21381,7 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/machinery/flasher{
@@ -23713,7 +23713,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVm" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -23740,7 +23740,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
 "aVq" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
@@ -23803,7 +23803,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -24135,7 +24135,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -24359,7 +24359,7 @@
 	pixel_x = -25;
 	pixel_y = 25
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/extinguisher_cabinet{
@@ -27493,7 +27493,7 @@
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -28332,7 +28332,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain/private)
 "bdI" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -30143,7 +30143,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bhk" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/folder/yellow{
@@ -30795,7 +30795,7 @@
 /obj/structure/chair/office/dark{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel/dark,
@@ -32463,7 +32463,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "blC" = (
 /obj/machinery/teleport/station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -32572,7 +32572,7 @@
 /area/ai_monitored/storage/satellite)
 "blK" = (
 /obj/machinery/recharge_station,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/cable/yellow{
@@ -33091,7 +33091,7 @@
 /area/crew_quarters/heads/captain/private)
 "bmJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/disposalpipe/segment,
@@ -34052,7 +34052,7 @@
 /obj/structure/displaycase/captain{
 	pixel_y = 5
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/wood,
@@ -35067,7 +35067,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "bqF" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -35947,7 +35947,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "bse" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/porta_turret/ai,
@@ -36179,7 +36179,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -36283,7 +36283,7 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hop)
 "bsP" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed/ian,
@@ -37933,7 +37933,7 @@
 /area/bridge)
 "bwu" = (
 /obj/machinery/holopad,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -39063,7 +39063,7 @@
 	},
 /area/engine/atmos)
 "byS" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -39533,7 +39533,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bzN" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot,
@@ -40057,7 +40057,7 @@
 "bAW" = (
 /obj/structure/table/wood,
 /obj/item/folder/blue,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 31
 	},
 /obj/item/folder/blue,
@@ -41121,7 +41121,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -41265,7 +41265,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
@@ -44514,7 +44514,7 @@
 /obj/machinery/gateway{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/bot_white,
@@ -45284,7 +45284,7 @@
 /area/maintenance/central)
 "bLH" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/machinery/camera{
@@ -49142,7 +49142,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -49213,7 +49213,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -52537,7 +52537,7 @@
 	pixel_y = 4
 	},
 /obj/item/pen,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light/small{
@@ -59310,7 +59310,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "cnC" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/table/glass,
@@ -62450,7 +62450,7 @@
 	},
 /area/crew_quarters/heads/hor)
 "ctc" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/landmark/xmastree/rdrod,
@@ -65398,7 +65398,7 @@
 "cyO" = (
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white/side,
@@ -73012,7 +73012,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cMU" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	layer = 4
 	},
 /turf/closed/wall,
@@ -76209,7 +76209,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 30
 	},
 /obj/machinery/photocopier{
@@ -78350,7 +78350,7 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "deD" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
 "deI" = (
@@ -79825,7 +79825,7 @@
 /area/maintenance/aft)
 "diD" = (
 /obj/machinery/vending/cigarette,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/sign/poster/official/random{

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3086,7 +3086,7 @@
 /area/security/main)
 "ajo" = (
 /obj/machinery/vending/coffee,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/red{
@@ -3427,7 +3427,7 @@
 "akc" = (
 /obj/structure/table/wood,
 /obj/machinery/recharger,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/machinery/light{
@@ -6882,7 +6882,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arK" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/item/folder/yellow{
@@ -9248,7 +9248,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -11380,7 +11380,7 @@
 /turf/open/floor/wood,
 /area/crew_quarters/heads/hop)
 "aBF" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/structure/bed/dogbed/ian,
@@ -14151,7 +14151,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 1
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -17493,7 +17493,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "aQt" = (
-/obj/machinery/status_display,
+/obj/machinery/status_display/evac,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
 "aQu" = (
@@ -24292,7 +24292,7 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
@@ -36929,7 +36929,7 @@
 /area/medical/surgery)
 "bHc" = (
 /obj/machinery/computer/med_data,
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/freezer,
@@ -48691,7 +48691,7 @@
 /turf/open/space,
 /area/space/nearstation)
 "cmu" = (
-/obj/machinery/status_display{
+/obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/structure/table,

--- a/code/game/machinery/status_display.dm
+++ b/code/game/machinery/status_display.dm
@@ -15,7 +15,7 @@
 #define SD_AI_EMOTE 1  // 1 = AI emoticon
 #define SD_AI_BSOD 2  // 2 = Blue screen of death
 
-/// Status display which can show images and scrolling text.
+/// Status display which can show images and scrolling text. !!!USE /obj/machinery/status_display/evac NOT THIS!!!
 /obj/machinery/status_display
 	name = "status display"
 	desc = null


### PR DESCRIPTION

## About The Pull Request

All Status Displays on all Current Rotation Maps are now subtype "evac" which fixes them not updating correctly.

## Why It's Good For The Game

This has been broken for ages, time to let people make stupid messages on the displays again.

## Changelog
:cl: Tupinambis
fix: Status Displays should now update correctly.
/:cl:
