### PR TITLE
fixes kevinz error with preferences.dm

### DIFF
--- a/modular_citadel/code/modules/client/preferences.dm
+++ b/modular_citadel/code/modules/client/preferences.dm
@@ -24,7 +24,7 @@
 	var/cit_toggles = TOGGLES_CITADEL
 
 	// stuff that was in base
-	max_save_slots = 10
+	max_save_slots = 16
 
 
 /datum/preferences/New(client/C)

--- a/modular_citadel/code/modules/client/preferences.dm
+++ b/modular_citadel/code/modules/client/preferences.dm
@@ -23,9 +23,6 @@
 	var/hound_sleeper = TRUE
 	var/cit_toggles = TOGGLES_CITADEL
 
-	// stuff that was in base
-	max_save_slots = 16
-
 
 /datum/preferences/New(client/C)
 	..()


### PR DESCRIPTION
## About The Pull Request

He edited max_save_slots to be 16 but forgot to do the same thing to the preferences.dm in modular_citadel.

## Why It's Good For The Game

fix

## Changelog
:cl:
fix: character slot amount
/:cl:
