### PR TITLE
fixes a very likely race condition in dueling pistols

### DIFF
--- a/code/modules/projectiles/guns/energy/dueling.dm
+++ b/code/modules/projectiles/guns/energy/dueling.dm
@@ -316,7 +316,7 @@
 		if(DUEL_HUGBOX_NONE)
 			var/obj/item/bodypart/B = L.get_bodypart(BODY_ZONE_HEAD)
 			B.dismember()
-			qdel(B)
+			QDEL_IN(B, 1)
 		if(DUEL_HUGBOX_LETHAL)
 			L.adjustBruteLoss(180)
 			L.death()				//Die, powergamers.


### PR DESCRIPTION
what title says, pretty sure that's causing your mind's active to be set to 1 when you are removed from the round/your body is deleted.