### PR TITLE
guns/ammo/projectiles now properly clean up while being deleted

### DIFF
--- a/code/modules/projectiles/ammunition/_ammunition.dm
+++ b/code/modules/projectiles/ammunition/_ammunition.dm
@@ -34,6 +34,11 @@
 	setDir(pick(GLOB.alldirs))
 	update_icon()
 
+/obj/item/ammo_casing/Destroy()
+	if(BB)
+		QDEL_NULL(BB)
+	return ..()
+
 /obj/item/ammo_casing/update_icon()
 	..()
 	icon_state = "[initial(icon_state)][BB ? "-live" : ""]"

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -76,6 +76,13 @@
 	if(zoomable)
 		azoom = new (src)
 
+/obj/item/gun/Destroy()
+	QDEL_NULL(pin)
+	QDEL_NULL(gun_light)
+	QDEL_NULL(bayonet)
+	QDEL_NULL(chambered)
+	return ..()
+
 /obj/item/gun/CheckParts(list/parts_list)
 	..()
 	var/obj/item/gun/G = locate(/obj/item/gun) in contents

--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -58,6 +58,7 @@
 
 /obj/item/gun/energy/Destroy()
 	QDEL_NULL(cell)
+	QDEL_LIST(ammo_type)
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -643,11 +643,11 @@
 			Bump(original)
 
 /obj/item/projectile/Destroy()
+	STOP_PROCESSING(SSprojectiles, src)
 	if(hitscan)
 		finalize_hitscan_and_generate_tracers()
-	STOP_PROCESSING(SSprojectiles, src)
 	cleanup_beam_segments()
-	qdel(trajectory)
+	QDEL_NULL(trajectory)
 	return ..()
 
 /obj/item/projectile/proc/cleanup_beam_segments()


### PR DESCRIPTION
Title, they should be deleting contents properly using QDEL_NULL instead of relying on the default atom/object behaviors for wiping contents.