### PR TITLE
[Balance Patch - Tend Wounds Edition]

### DIFF
--- a/code/modules/surgery/healing.dm
+++ b/code/modules/surgery/healing.dm
@@ -25,7 +25,7 @@
 	name = "repair body"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 65, /obj/item/pen = 55)
 	repeatable = TRUE
-	time = 25
+	time = 15
 	var/brutehealing = 0
 	var/burnhealing = 0
 	var/missinghpbonus = 0 //heals an extra point of damager per X missing damage of type (burn damage for burn healing, brute for brute). Smaller Number = More Healing!
@@ -117,15 +117,15 @@
 /********************BRUTE STEPS********************/
 /datum/surgery_step/heal/brute/basic
 	name = "tend bruises"
-	brutehealing = 5
+	brutehealing = 10
 	missinghpbonus = 15
 
 /datum/surgery_step/heal/brute/upgraded
-	brutehealing = 5
+	brutehealing = 10
 	missinghpbonus = 10
 
 /datum/surgery_step/heal/brute/upgraded/femto
-	brutehealing = 5
+	brutehealing = 10
 	missinghpbonus = 5
 
 /***************************BURN***************************/
@@ -155,15 +155,15 @@
 /********************BURN STEPS********************/
 /datum/surgery_step/heal/burn/basic
 	name = "tend burn wounds"
-	burnhealing = 5
+	burnhealing = 10
 	missinghpbonus = 15
 
 /datum/surgery_step/heal/burn/upgraded
-	burnhealing = 5
+	burnhealing = 10
 	missinghpbonus = 10
 
 /datum/surgery_step/heal/burn/upgraded/femto
-	burnhealing = 5
+	burnhealing = 10
 	missinghpbonus = 5
 
 /***************************COMBO***************************/
@@ -193,19 +193,19 @@
 /********************COMBO STEPS********************/
 /datum/surgery_step/heal/combo
 	name = "tend physical wounds"
-	brutehealing = 3
-	burnhealing = 3
+	brutehealing = 6
+	burnhealing = 6
 	missinghpbonus = 15
-	time = 10
+	time = 6
 
 /datum/surgery_step/heal/combo/upgraded
-	brutehealing = 3
-	burnhealing = 3
+	brutehealing = 6
+	burnhealing = 6
 	missinghpbonus = 10
 
 /datum/surgery_step/heal/combo/upgraded/femto
-	brutehealing = 1
-	burnhealing = 1
+	brutehealing = 3
+	burnhealing = 3
 	missinghpbonus = 2.5
 
 /datum/surgery_step/heal/combo/upgraded/femto/failure(mob/user, mob/living/carbon/target, target_zone, obj/item/tool, datum/surgery/surgery)


### PR DESCRIPTION
Seriously why the fuck is this doing such little healing and taking so much time to do?

Like, it's literally useless with our synthflesh+silver sulf... meta

Fuckin hell, even bicardine/kelotane heals faster than this.

Not anymore.

Today, I'm dramatically improving the healing and giving a decent time reduction to doing this surgery.

I haven't touched the "nerf to healing" on dead people... maybe should if it's not enough... but that'll be for later after community tries it out.

--------

PATCH NOTES

- Doubled healing on all Tend Wounds

- Roughly around 40% reduction to time needed to do the step that actually heals.


===

Marked it so maintainers can edit if I have fucked up any code and I didn't see it.