### PR TITLE
Stunbaton Balance Adjustments 2.0 (Unfucked Edition)

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -15,7 +15,7 @@
 	attack_verb = list("beaten")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-	var/stunforce = 140
+	var/stunforce = 70
 	var/status = FALSE
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 1000
@@ -188,8 +188,8 @@
 		stunpwr *= round(stuncharge/hitcost, 0.1)
 
 
-	L.Knockdown(stunpwr)
-	L.adjustStaminaLoss(stunpwr*0.1)//CIT CHANGE - makes stunbatons deal extra staminaloss. Todo: make this also deal pain when pain gets implemented.
+	L.Knockdown(stunpwr, override_stamdmg = 0)
+	L.apply_damage(stunpwr*0.55, STAMINA, user.zone_selected)
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)
@@ -274,7 +274,7 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 3
 	throwforce = 5
-	stunforce = 100
+	stunforce = 60
 	hitcost = 2000
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK


### PR DESCRIPTION

## About The Pull Request

(I fucked up with my last PR #10741, this unfucks things.)

Who would win? A heavily armed series of antags with various amounts of stun resistance and rapid stamina regen, or one zappy stick.

It's always the zappy stick, this nerfs stunbaton stamina damage from 49 (3 hits to hardcrit) to 38.5 (4 hits to hard crit) with the stunprod taking an extra hit to stamcrit. Additionally, stunbatons no longer disarm.

Zappy stick now does limb based damage and disables limbs in two hits.

## Why It's Good For The Game

Getting hit a single time with a stunbaton should not consistently game over people. As of now if you get stunbatonned once you have pretty much no chance to fight back.

The removal of the disarm should make energy swords ( and melee weapons in general) significantly more useful as an antag than they currently are, and the stamina damage nerf should hopefully give people on the recieving end of a stunbaton more time to react and fight back.

Limb based damage adds strategy and such.

## Changelog
:cl: Tupinambis
balance: stunbatons now take 4 hits to inflict hard crit, up from 3.
balance: stunbatons no longer disarm targets.
/:cl:
