### PR TITLE
Updates Virus Symptom Stats to Match TG

### DIFF
--- a/code/datums/diseases/advance/symptoms/choking.dm
+++ b/code/datums/diseases/advance/symptoms/choking.dm
@@ -22,7 +22,7 @@ Bonus
 	stealth = -3
 	resistance = -2
 	stage_speed = -2
-	transmittable = -4
+	transmittable = -2
 	level = 3
 	severity = 3
 	base_message_chance = 15

--- a/code/datums/diseases/advance/symptoms/fire.dm
+++ b/code/datums/diseases/advance/symptoms/fire.dm
@@ -19,9 +19,9 @@ Bonus
 
 	name = "Spontaneous Combustion"
 	desc = "The virus turns fat into an extremely flammable compound, and raises the body's temperature, making the host burst into flames spontaneously."
-	stealth = 1
+	stealth = -1
 	resistance = -4
-	stage_speed = -4
+	stage_speed = -3
 	transmittable = -4
 	level = 6
 	severity = 5

--- a/code/datums/diseases/advance/symptoms/flesh_eating.dm
+++ b/code/datums/diseases/advance/symptoms/flesh_eating.dm
@@ -22,7 +22,7 @@ Bonus
 	stealth = -3
 	resistance = -4
 	stage_speed = 0
-	transmittable = -4
+	transmittable = -3
 	level = 6
 	severity = 5
 	base_message_chance = 50

--- a/code/datums/diseases/advance/symptoms/hallucigen.dm
+++ b/code/datums/diseases/advance/symptoms/hallucigen.dm
@@ -18,7 +18,7 @@ Bonus
 /datum/symptom/hallucigen
 	name = "Hallucigen"
 	desc = "The virus stimulates the brain, causing occasional hallucinations."
-	stealth = -2
+	stealth = -1
 	resistance = -3
 	stage_speed = -3
 	transmittable = -1

--- a/code/datums/diseases/advance/symptoms/narcolepsy.dm
+++ b/code/datums/diseases/advance/symptoms/narcolepsy.dm
@@ -18,7 +18,7 @@ Bonus
 	stealth = -1
 	resistance = -2
 	stage_speed = -3
-	transmittable = -4
+	transmittable = 0
 	level = 6
 	symptom_delay_min = 15
 	symptom_delay_max = 80

--- a/code/datums/diseases/advance/symptoms/shivering.dm
+++ b/code/datums/diseases/advance/symptoms/shivering.dm
@@ -20,7 +20,7 @@ Bonus
 	desc = "The virus inhibits the body's thermoregulation, cooling the body down."
 	stealth = 0
 	resistance = 2
-	stage_speed = 2
+	stage_speed = 3
 	transmittable = 2
 	level = 2
 	severity = 2

--- a/code/datums/diseases/advance/symptoms/viral.dm
+++ b/code/datums/diseases/advance/symptoms/viral.dm
@@ -26,7 +26,7 @@ BONUS
 //////////////////////////////////////
 Viral evolution
 
-	Moderate stealth reductopn.
+	Moderate stealth reduction.
 	Major decreases to resistance.
 	increases stage speed.
 	increase to transmission

--- a/code/datums/diseases/advance/symptoms/vomit.dm
+++ b/code/datums/diseases/advance/symptoms/vomit.dm
@@ -25,8 +25,8 @@ Bonus
 	desc = "The virus causes nausea and irritates the stomach, causing occasional vomit."
 	stealth = -2
 	resistance = -1
-	stage_speed = 0
-	transmittable = 1
+	stage_speed = -1
+	transmittable = 2
 	level = 3
 	severity = 3
 	base_message_chance = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This makes our virus symptoms' stats match TG's.

Full list of Changes
- Choking Transmission increased from -4 to -2
- Spontaneous Combustion Stealth decreased from 1 to -1
- Spontaneous Combustion Stage Speed increased from -4 to -3
- Autophagocytosis Necrosis Transission increased from -4 to -3
- Hallucigen Stealth increased from -2 to -1
- Narcolepsy Transmission increased from -4 to 0
- Shivering Stage Speed increased from 2 to 3
- Vomiting Stage Speed decreased from 0 to -1
- Vomiting Transmission increased from 1 to 2

I also fixed a typo in the comments for Viral Evolutionary Acceleration because it was bugging me.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
This PR does 3 main things: First, it makes properly minmaxing Virology a little more accessible by making virus stats match our best available source of documentation.  Second, the change to Shivering makes a few beneficial symptom combinations that were previously impossible to fully buff possible.  Third, it serves as a minor buff to some of the less popular harmful symptom options.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Minor stat changes to Choking, Spontaneous Combustion, Autophagocytosis Necrosis, Hallucigen, Narcolepsy, Shivering, and Vomiting symptoms.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
