### PR TITLE
FIXES FANCY SWITCHBLADES

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -315,6 +315,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	var/extended_force = 20
 	var/extended_throwforce = 23
 	var/extended_icon_state = "switchblade_ext"
+	var/retracted_icon_state = "switchblade"
 
 /obj/item/switchblade/attack_self(mob/user)
 	extended = !extended
@@ -331,7 +332,7 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 		force = initial(force)
 		w_class = WEIGHT_CLASS_SMALL
 		throwforce = initial(throwforce)
-		icon_state = initial(icon_state)
+		icon_state = retracted_icon_state
 		attack_verb = list("stubbed", "poked")
 		hitsound = 'sound/weapons/genhit.ogg'
 		sharpness = IS_BLUNT
@@ -348,12 +349,14 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	extended_force = 15
 	extended_throwforce = 18
 	extended_icon_state = "switchblade_ext_ms"
+	retracted_icon_state = "switchblade_ms"
 
 /obj/item/switchblade/crafted/attackby(obj/item/I, mob/user, params)
 	. = ..()
 	if(istype(I, /obj/item/stack/sheet/mineral/silver))
 		icon_state = extended ? "switchblade_ext_msf" : "switchblade_msf"
 		extended_icon_state = "switchblade_ext_msf"
+		retracted_icon_state = "switchblade_msf"
 		icon_state = "switchblade_msf"
 		to_chat(user, "<span class='notice'>You use part of the silver to improve your Switchblade. Stylish!</span>")
 


### PR DESCRIPTION
ONCE, AND FOR ALL MAYBE HOPEFULLY FINALLY. FUCK!!!

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
**THE FINAL FIX. THESE SHOULD WORK ONCE AND FOR ALL.**
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
**GODDAMN IT I'VE SPENT TOO MUCH TIME ON THESE _FUCKING_ SWITCHBLADES.**
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
Fix: Switchblades no longer regain their old Makeshift sprite after retracting if you've made them fancy with Silver.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
