### PR TITLE
Fixed and brutalized clown op slippery weapons a little.

### DIFF
--- a/code/__DEFINES/mobs.dm
+++ b/code/__DEFINES/mobs.dm
@@ -200,9 +200,11 @@
 #define NO_SLIP_WHEN_WALKING	(1<<0)
 #define SLIDE					(1<<1)
 #define GALOSHES_DONT_HELP		(1<<2)
-#define SLIDE_ICE				(1<<3)
-#define SLIP_WHEN_CRAWLING		(1<<4) //clown planet ruin
-#define SLIP_WHEN_JOGGING		(1<<5) //slips prevented by walking are also dodged if the mob is not sprinting or fatigued... unless this flag is on.
+#define FLYING_DOESNT_HELP		(1<<3)
+#define SLIDE_ICE				(1<<4)
+#define SLIP_WHEN_CRAWLING		(1<<5) //clown planet ruin amongst others
+#define SLIP_WHEN_JOGGING		(1<<6) //slips prevented by walking are also dodged if the mob is nor sprinting or fatigued... unless this flag is on.
+
 
 #define MAX_CHICKENS 50
 

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -9,7 +9,8 @@
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
-/datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
+/datum/component/slippery/proc/Slip(datum/source, atom/movable/AM, extra_flags = NONE)
 	var/mob/victim = AM
-	if(istype(victim) && !victim.is_flying() && victim.slip(intensity, parent, lube_flags) && callback)
+	var/lube = lube_flags | extra_flags
+	if(istype(victim) && victim.slip(intensity, parent, lube) && callback)
 		callback.Invoke(victim)

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -57,10 +57,8 @@
 /obj/item/melee/transforming/energy/sword/bananium
 	name = "bananium sword"
 	desc = "An elegant weapon, for a more civilized age."
-	force = 0
-	throwforce = 0
-	force_on = 0
-	throwforce_on = 0
+	force_on = 15
+	throwforce_on = 15
 	hitsound = null
 	attack_verb_on = list("slipped")
 	clumsy_check = FALSE
@@ -72,7 +70,7 @@
 
 /obj/item/melee/transforming/energy/sword/bananium/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
+	AddComponent(/datum/component/slippery, 81, GALOSHES_DONT_HELP)
 	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
 	slipper.signal_enabled = active
 
@@ -80,13 +78,13 @@
 	..()
 	if(active)
 		var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-		slipper.Slip(M)
+		slipper.Slip(src, M, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 
 /obj/item/melee/transforming/energy/sword/bananium/throw_impact(atom/hit_atom, throwingdatum)
 	. = ..()
 	if(active)
 		var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-		slipper.Slip(hit_atom)
+		slipper.Slip(src, hit_atom, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 
 /obj/item/melee/transforming/energy/sword/bananium/attackby(obj/item/I, mob/living/user, params)
 	if((world.time > next_trombone_allowed) && istype(I, /obj/item/melee/transforming/energy/sword/bananium))
@@ -109,7 +107,7 @@
 		transform_weapon(user, TRUE)
 	user.visible_message("<span class='suicide'>[user] is [pick("slitting [user.p_their()] stomach open with", "falling on")] [src]! It looks like [user.p_theyre()] trying to commit seppuku, but the blade slips off of [user.p_them()] harmlessly!</span>")
 	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-	slipper.Slip(user)
+	slipper.Slip(src, user, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 	return SHAME
 
 //BANANIUM SHIELD
@@ -129,7 +127,7 @@
 
 /obj/item/shield/energy/bananium/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 60, GALOSHES_DONT_HELP)
+	AddComponent(/datum/component/slippery, 81, GALOSHES_DONT_HELP)
 	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
 	slipper.signal_enabled = active
 
@@ -150,7 +148,7 @@
 		var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
 		if(iscarbon(hit_atom) && !caught)//if they are a carbon and they didn't catch it
 			var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-			slipper.Slip(hit_atom)
+			slipper.Slip(src, hit_atom, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 		if(thrownby && !caught)
 			throw_at(thrownby, throw_range+2, throw_speed, null, 1)
 	else
@@ -212,7 +210,7 @@
 				M.equip_to_slot_or_del(the_stash, SLOT_WEAR_MASK, TRUE, TRUE, TRUE, TRUE)
 
 /obj/item/clothing/mask/fakemoustache/sticky
-	var/unstick_time = 600
+	var/unstick_time = 2 MINUTES
 
 /obj/item/clothing/mask/fakemoustache/sticky/Initialize()
 	. = ..()

--- a/code/game/objects/items/grenades/grenade.dm
+++ b/code/game/objects/items/grenades/grenade.dm
@@ -34,12 +34,12 @@
 
 /obj/item/grenade/proc/clown_check(mob/living/carbon/human/user)
 	var/clumsy = HAS_TRAIT(user, TRAIT_CLUMSY)
-	if(clumsy && (clumsy_check == GRENADE_CLUMSY_FUMBLE))
-		if(prob(50))
+	if(clumsy)
+		if(clumsy_check == GRENADE_CLUMSY_FUMBLE && prob(50))
 			to_chat(user, "<span class='warning'>Huh? How does this thing work?</span>")
 			preprime(user, 5, FALSE)
 			return FALSE
-	else if(!clumsy && (clumsy_check == GRENADE_NONCLUMSY_FUMBLE))
+	else if(clumsy_check == GRENADE_NONCLUMSY_FUMBLE && !(user.mind && HAS_TRAIT(user.mind, TRAIT_CLOWN_MENTALITY)))
 		to_chat(user, "<span class='warning'>You pull the pin on [src]. Attached to it is a pink ribbon that says, \"<span class='clown'>HONK</span>\"</span>")
 		preprime(user, 5, FALSE)
 		return FALSE

--- a/code/game/turfs/open.dm
+++ b/code/game/turfs/open.dm
@@ -245,48 +245,47 @@
 	return TRUE
 
 /turf/open/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
-	if(C.movement_type & FLYING)
-		return 0
-	if(has_gravity(src))
-		var/obj/buckled_obj
-		if(C.buckled)
-			buckled_obj = C.buckled
-			if(!(lube&GALOSHES_DONT_HELP)) //can't slip while buckled unless it's lube.
-				return 0
-		else
-			if(!(lube&SLIP_WHEN_CRAWLING) && (C.lying || !(C.status_flags & CANKNOCKDOWN))) // can't slip unbuckled mob if they're lying or can't fall.
-				return 0
-			if(lube & NO_SLIP_WHEN_WALKING)
-				if(C.m_intent == MOVE_INTENT_WALK)
-					return 0
-				if(ishuman(C) && !(lube & SLIP_WHEN_JOGGING))
-					var/mob/living/carbon/human/H = C
-					if(!H.sprinting && H.getStaminaLoss() <= 20)
-						return 0
-		if(!(lube&SLIDE_ICE))
-			to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")
-			playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
+	if(!(lube & FLYING_DOESNT_HELP) && (C.movement_type & FLYING || !has_gravity(src)))
+		return FALSE
+	var/obj/buckled_obj
+	if(C.buckled)
+		buckled_obj = C.buckled
+		if(!(lube&GALOSHES_DONT_HELP)) //can't slip while buckled unless it's lube.
+			return FALSE
+	else
+		if(!(lube&SLIP_WHEN_CRAWLING) && (C.lying || !(C.status_flags & CANKNOCKDOWN))) // can't slip unbuckled mob if they're lying or can't fall.
+			return FALSE
+		if(lube & NO_SLIP_WHEN_WALKING)
+			if(C.m_intent == MOVE_INTENT_WALK)
+				return FALSE
+			if(ishuman(C) && !(lube & SLIP_WHEN_JOGGING))
+				var/mob/living/carbon/human/H = C
+				if(!H.sprinting && H.getStaminaLoss() <= 20)
+					return FALSE
+	if(!(lube&SLIDE_ICE))
+		to_chat(C, "<span class='notice'>You slipped[ O ? " on the [O.name]" : ""]!</span>")
+		playsound(C.loc, 'sound/misc/slip.ogg', 50, 1, -3)
 
-		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
-		for(var/obj/item/I in C.held_items)
-			C.accident(I)
+	SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "slipped", /datum/mood_event/slipped)
+	for(var/obj/item/I in C.held_items)
+		C.accident(I)
 
-		var/olddir = C.dir
-		if(!(lube & SLIDE_ICE))
-			C.Knockdown(knockdown_amount)
-			C.stop_pulling()
-		else
-			C.Stun(20)
+	var/olddir = C.dir
+	if(!(lube & SLIDE_ICE))
+		C.Knockdown(knockdown_amount)
+		C.stop_pulling()
+	else
+		C.Stun(20)
 
-		if(buckled_obj)
-			buckled_obj.unbuckle_mob(C)
-			lube |= SLIDE_ICE
+	if(buckled_obj)
+		buckled_obj.unbuckle_mob(C)
+		lube |= SLIDE_ICE
 
-		if(lube&SLIDE)
-			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 4), 1, FALSE, CALLBACK(C, /mob/living/carbon/.proc/spin, 1, 1))
-		else if(lube&SLIDE_ICE)
-			new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 1), 1, FALSE)	//spinning would be bad for ice, fucks up the next dir
-		return 1
+	if(lube&SLIDE)
+		new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 4), 1, FALSE, CALLBACK(C, /mob/living/carbon/.proc/spin, 1, 1))
+	else if(lube&SLIDE_ICE)
+		new /datum/forced_movement(C, get_ranged_target_turf(C, olddir, 1), 1, FALSE)	//spinning would be bad for ice, fucks up the next dir
+	return TRUE
 
 /turf/open/proc/MakeSlippery(wet_setting = TURF_WET_WATER, min_wet_time = 0, wet_time_to_add = 0, max_wet_time = MAXIMUM_WET_TIME, permanent)
 	AddComponent(/datum/component/wet_floor, wet_setting, min_wet_time, wet_time_to_add, max_wet_time, permanent)

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -88,7 +88,7 @@
 /turf/open/space/proc/CanBuildHere()
 	return TRUE
 
-/turf/open/space/handle_slip()
+/turf/open/space/handle_slip(mob/living/carbon/C, knockdown_amount, obj/O, lube)
 	if(lube & FLYING_DOESNT_HELP)
 		return ..()
 

--- a/code/game/turfs/space/space.dm
+++ b/code/game/turfs/space/space.dm
@@ -89,7 +89,8 @@
 	return TRUE
 
 /turf/open/space/handle_slip()
-	return
+	if(lube & FLYING_DOESNT_HELP)
+		return ..()
 
 /turf/open/space/attackby(obj/item/C, mob/user, params)
 	..()

--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -13,8 +13,8 @@
 		. += SOFTCRIT_ADD_SLOWDOWN
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube)
-	if(movement_type & FLYING)
-		return 0
+	if(movement_type & FLYING && !(lube & FLYING_DOESNT_HELP))
+		return FALSE
 	if(!(lube&SLIDE_ICE))
 		log_combat(src, (O ? O : get_turf(src)), "slipped on the", null, ((lube & SLIDE) ? "(LUBE)" : null))
 	return loc.handle_slip(src, knockdown_amount, O, lube)


### PR DESCRIPTION
## About The Pull Request
Fixed bananium energy sword/shield slips, buffed them to also mercilessly slip flying/crawling dudes, made the bananium e-sword a little more harmful. Fixed the clumsiness check for mustache nade and doubled the sticky 'staches effect timer.

## Why It's Good For The Game
Fix and slight clown ops buff.

## Changelog
:cl:
balance: rebalanced something
fix: Fixed bananium energy sword/shield slips.
balance: Buffed said slips to ignore no-grav/crawling/flying as well as adding some deadly force to the e-sword.
fix: Fixed the 'stache grenade anti-non-clumsy user check.
balance: Doubled the timer for the sticky mustaches effect from the above grenade (from 1 to 2 minutes)
/:cl:
