### PR TITLE
Fixing chaplain armaments beacon edge case.

### DIFF
--- a/code/game/objects/items/holy_weapons.dm
+++ b/code/game/objects/items/holy_weapons.dm
@@ -72,20 +72,21 @@
 		display_names += list(initial(A.name) = A)
 
 	var/choice = input(M,"What holy armor kit would you like to order?","Holy Armor Theme") as null|anything in display_names
-	if(QDELETED(src) || !choice || M.stat || !in_range(M, src) || M.restrained() || !M.canmove || GLOB.holy_armor_type)
+	var/turf/T = get_turf(M)
+	if(!T || QDELETED(src) || !choice || M.stat || !in_range(M, src) || M.restrained() || !M.canmove || GLOB.holy_armor_type)
 		return
 
 	var/index = display_names.Find(choice)
 	var/A = holy_armor_list[index]
 
 	GLOB.holy_armor_type = A
-	var/holy_armor_box = new A
+	var/holy_armor_box = new A(T)
 
 	SSblackbox.record_feedback("tally", "chaplain_armor", 1, "[choice]")
 
 	if(holy_armor_box)
 		qdel(src)
-		M.put_in_active_hand(holy_armor_box)///YOU COMPILED
+		M.put_in_hands(holy_armor_box)
 
 /obj/item/storage/box/holy
 	name = "Templar Kit"


### PR DESCRIPTION
## About The Pull Request
Stops the box from staying in nullspace if it fails to land onto the user's active hand

## Why It's Good For The Game
This will close #10822, and gosh the updated beacons (such as curator's, musician) need to be ported too one day.

## Changelog
:cl:
fix: Fixed an edge case with the chaplain armaments beacon spawning the box in nullspace.
/:cl:

