### PR TITLE
Mining Update : Real update

### DIFF
--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -814,8 +814,11 @@
 /turf/open/floor/plating,
 /area/mine/production)
 "ou" = (
-/obj/effect/turf_decal/tile/purple{
+/obj/effect/turf_decal/tile/brown{
 	dir = 1
+	},
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
 	},
 /obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
@@ -1168,14 +1171,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"tJ" = (
-/obj/item/beacon,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/miner,
-/turf/open/floor/plasteel,
-/area/mine/production)
 "tK" = (
 /obj/structure/closet/crate,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -2235,6 +2230,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "KO" = (
@@ -2530,6 +2526,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Nk" = (
@@ -6608,9 +6605,9 @@ VT
 VT
 Cd
 Ed
-tJ
+Wf
 II
-ou
+Jo
 Ed
 Cd
 Cd
@@ -6671,7 +6668,7 @@ wX
 Wf
 YM
 GN
-II
+ou
 Nf
 mN
 Aj

--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -722,7 +722,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/production)
 "nm" = (
 /obj/effect/turf_decal/tile/red{
@@ -1300,16 +1301,6 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
-/obj/item/gun/energy/kinetic_accelerator,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "wj" = (
@@ -1581,7 +1572,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/production)
 "Be" = (
 /obj/machinery/light/small{
@@ -2119,9 +2111,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"JI" = (
-/turf/closed/wall/r_wall,
-/area/mine/production)
 "JJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2310,7 +2299,8 @@
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/production)
 "Le" = (
 /obj/structure/closet/crate/internals,
@@ -2380,7 +2370,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/mining/glass{
 	name = "Processing Area";
-	req_access_txt = "48"
+	req_access_txt = "48";
+	security_level = 6
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2390,10 +2381,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/machinery/door/airlock/highsecurity{
-	name = "Miner's Side, Shitters not allowed";
-	req_access_txt = "48"
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -3028,7 +3015,8 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/closed/wall/r_wall,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/production)
 "Vs" = (
 /obj/effect/turf_decal/tile/purple,
@@ -5471,7 +5459,7 @@ JY
 JY
 jJ
 jJ
-JY
+VT
 VT
 VT
 wz
@@ -5527,8 +5515,8 @@ JY
 JY
 JY
 JY
-JY
-JY
+VT
+VT
 VT
 VT
 wz
@@ -5582,9 +5570,9 @@ JY
 JY
 JY
 JY
-JY
-JY
-JY
+VT
+VT
+VT
 VT
 VT
 VT
@@ -5638,8 +5626,8 @@ JY
 JY
 JY
 JY
-JY
-JY
+VT
+VT
 VT
 VT
 VT
@@ -5694,8 +5682,8 @@ JY
 JY
 JY
 JY
-JY
-Lm
+VT
+VT
 VT
 VT
 VT
@@ -5750,8 +5738,8 @@ JY
 JY
 JY
 JY
-JY
-Lm
+VT
+VT
 VT
 VT
 VT
@@ -5806,8 +5794,8 @@ JY
 JY
 JY
 JY
-JY
-JY
+VT
+VT
 VT
 VT
 VT
@@ -5861,9 +5849,9 @@ JY
 Lm
 VT
 VT
-JY
-JY
-JY
+VT
+VT
+VT
 VT
 VT
 VT
@@ -5919,8 +5907,8 @@ VT
 VT
 VT
 VT
-Lm
-Lm
+VT
+VT
 VT
 VT
 Lm
@@ -6900,10 +6888,10 @@ vJ
 JW
 bg
 VP
-JI
-JI
+Cd
+Cd
 Bc
-JI
+Cd
 Bc
 es
 XN
@@ -6957,7 +6945,7 @@ Ex
 xv
 bg
 mI
-JI
+Cd
 OI
 sz
 gk
@@ -7013,8 +7001,8 @@ CV
 al
 lj
 bg
-JI
-JI
+Cd
+Cd
 mw
 es
 es

--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -716,14 +716,13 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mN" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/mine/production)
 "nm" = (
 /obj/effect/turf_decal/tile/red{
@@ -1301,6 +1300,16 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
+/obj/item/gun/energy/kinetic_accelerator,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "wj" = (
@@ -1569,11 +1578,10 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Bc" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/mine/production)
 "Be" = (
 /obj/machinery/light/small{
@@ -2111,6 +2119,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"JI" = (
+/turf/closed/wall/r_wall,
+/area/mine/production)
 "JJ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -2296,11 +2307,10 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "Lc" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/mine/production)
 "Le" = (
 /obj/structure/closet/crate/internals,
@@ -2380,6 +2390,10 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/door/airlock/highsecurity{
+	name = "Miner's Side, Shitters not allowed";
+	req_access_txt = "48"
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
@@ -3008,14 +3022,13 @@
 /turf/open/floor/plasteel,
 /area/mine/production)
 "Vo" = (
-/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/turf/open/floor/plating,
+/turf/closed/wall/r_wall,
 /area/mine/production)
 "Vs" = (
 /obj/effect/turf_decal/tile/purple,
@@ -6887,10 +6900,10 @@ vJ
 JW
 bg
 VP
-Cd
-Cd
+JI
+JI
 Bc
-Cd
+JI
 Bc
 es
 XN
@@ -6944,7 +6957,7 @@ Ex
 xv
 bg
 mI
-Cd
+JI
 OI
 sz
 gk
@@ -7000,8 +7013,8 @@ CV
 al
 lj
 bg
-Cd
-Cd
+JI
+JI
 mw
 es
 es

--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -327,6 +327,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "fU" = (
@@ -812,6 +813,13 @@
 	},
 /turf/open/floor/plating,
 /area/mine/production)
+"ou" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/obj/structure/closet/secure_closet/miner,
+/turf/open/floor/plasteel,
+/area/mine/production)
 "ow" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
@@ -1165,6 +1173,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/structure/closet/secure_closet/miner,
 /turf/open/floor/plasteel,
 /area/mine/production)
 "tK" = (
@@ -6601,7 +6610,7 @@ Cd
 Ed
 tJ
 II
-Jo
+ou
 Ed
 Cd
 Cd


### PR DESCRIPTION
This is a response about the "complains" that I got concerning the public mining base.

## About The Pull Request
I was told that people broke in the miner-only section of the mining base
I was told that shitty miners took more than 1 PKA, with 3 max being available roundstart

> So I stuffed 10 PKA in a crate on the miner's side.
> I put R-walls and a vault door to separate the miner's side.
> 
> There, now you have more PKA to yoink when someone take 2 PKA instead of one, and Shitters can't break in the miner's side to cause shit.

So, I calmed down from the stupidity that lead me to do that, and made real changes

- There are now 3 lockers down in the mining base, miner's side
- The door between mining's side and public's is now reinforced with plasteel, so people can't just hack in
- I also profited of this occasion to widen the moat between the Gulag and the Miner's landing pad, to make it harder to cross and use a fire extinguisher to put yourself out.

## Why It's Good For The Game
_**Less shitters complain, are you happy now?**_

## Changelog
:cl:
change: Mining is harder to shitters
/:cl:
