### PR TITLE
Playback device spam peeve.

### DIFF
--- a/code/modules/assembly/playback.dm
+++ b/code/modules/assembly/playback.dm
@@ -25,7 +25,7 @@
 	listening = FALSE
 	languages = message_language
 	say("The recorded message is '[recorded]'.", language = message_language)
-	next_activate = max(round(length(recorded) * 0.5), 3 SECONDS)
+	activate_cooldown = max(round(length(recorded) * 0.5), 3 SECONDS)
 
 /obj/item/assembly/playback/activate()
 	. = ..()

--- a/code/modules/assembly/playback.dm
+++ b/code/modules/assembly/playback.dm
@@ -25,12 +25,13 @@
 	listening = FALSE
 	languages = message_language
 	say("The recorded message is '[recorded]'.", language = message_language)
+	next_activate = max(round(length(recorded) * 0.5), 3 SECONDS)
 
 /obj/item/assembly/playback/activate()
-	if(recorded == "") // Why say anything when there isn't anything to say
+	. = ..()
+	if(!. || !recorded) // Why say anything when there isn't anything to say
 		return FALSE
 	say("[recorded]", language = languages) // Repeat the message in the language it was said in
-	return TRUE
 
 /obj/item/assembly/playback/proc/record()
 	if(!secured || holder)


### PR DESCRIPTION
## About The Pull Request
The cooldown of the playback device now increases with messages longer than 60 characters (3 seconds is the default assembly cooldown).
Also makes the device properly call parent on `activate()`.

## Why It's Good For The Game
Mildens the playback device potential spam a little.

## Changelog
:cl:
tweak: The playback device's cooldown now proportionally increases with messages longer than 60 characters (3 seconds is the default assembly cooldown).
/:cl:
