### PR TITLE
Tweaking Chef Vendor, Blood Crate, and Cake Recipe

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -142,6 +142,9 @@
 	new /obj/item/reagent_containers/blood/OMinus(src)
 	new /obj/item/reagent_containers/blood/OPlus(src)
 	new /obj/item/reagent_containers/blood/lizard(src)
+	new /obj/item/reagent_containers/blood/jellyblood(src)
+	new /obj/item/reagent_containers/blood/insect(src)
+	new /obj/item/reagent_containers/blood/synthetics(src)
 	for(var/i in 1 to 3)
 		new /obj/item/reagent_containers/blood/random(src)
 

--- a/code/modules/food_and_drinks/food/condiment.dm
+++ b/code/modules/food_and_drinks/food/condiment.dm
@@ -310,7 +310,13 @@
 	originalname = "astrotame"
 	list_reagents = list(/datum/reagent/consumable/astrotame = 5)
 
+//Other Sauce
 /obj/item/reagent_containers/food/condiment/pack/bbqsauce
 	name = "bbq sauce pack"
 	originalname = "bbq sauce"
 	list_reagents = list(/datum/reagent/consumable/bbqsauce = 10)
+
+/obj/item/reagent_containers/food/condiment/pack/soysauce
+	name = "soy sauce pack"
+	originalname = "soy sauce"
+	list_reagents = list(/datum/reagent/consumable/soysauce = 10)

--- a/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
+++ b/code/modules/food_and_drinks/recipes/tablecraft/recipes_cake.dm
@@ -69,9 +69,9 @@
 /datum/crafting_recipe/food/birthdaycake
 	name = "Birthday cake"
 	reqs = list(
-		/datum/reagent/consumable/sugar = 10,
+		/datum/reagent/consumable/sugar = 5,
+		/datum/reagent/consumable/caramel =2,
 		/obj/item/candle = 1,
-		/obj/item/reagent_containers/food/snacks/grown/vanillapod = 2,
 		/obj/item/reagent_containers/food/snacks/store/cake/plain = 1
 	)
 	result = /obj/item/reagent_containers/food/snacks/store/cake/birthday

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -14,6 +14,8 @@
 					/obj/item/reagent_containers/food/condiment/pack/mustard = 5,
 					/obj/item/reagent_containers/food/condiment/pack/hotsauce = 5,
 					/obj/item/reagent_containers/food/condiment/pack/astrotame = 5,
+					/obj/item/reagent_containers/food/condiment/pack/bbqsauce = 5,
+					/obj/item/reagent_containers/food/condiment/pack/soysauce = 5,
 					/obj/item/reagent_containers/food/condiment/saltshaker = 5,
 					/obj/item/reagent_containers/food/condiment/peppermill = 5,
 					/obj/item/reagent_containers/glass/bowl = 30)
@@ -23,7 +25,6 @@
 					/obj/item/reagent_containers/syringe = 3)
 	premium = list(
 					/obj/item/reagent_containers/food/condiment/enzyme = 1,
-					/obj/item/reagent_containers/food/condiment/soysauce = 1,
 					/obj/item/reagent_containers/glass/bottle/cryoxadone = 2) // Bartender can literally make this with upgraded parts, or it gets stolen from medical.
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION
Added additional blood types to blood crate.
Added Soy Sauce packet.
Added Soy Sauce and BBQ packet to chef vendor.
Changed Birthday Cake recipe to mirror TG.

## About The Pull Request

Just some tiny tweaks I thought of.

## Why It's Good For The Game

Chefs don't do enough work as-is, giving the ones who actually make real meals some starter condiments is nice. We also have caramel now, so might as well let the birthday cake reflect that.

## Changelog
:cl:
tweak: Blood Crate now has all of the current blood types.
tweak: Birthday Cake Recipe is now the same as TG.
tweak: Added Soy Sauce and BBQ Packets to Dinnerware Vendor.
/:cl:
