### PR TITLE
Uplink Refresh Part 5: All the Nuke Op Bundle Content

### DIFF
--- a/code/game/objects/items/storage/backpack.dm
+++ b/code/game/objects/items/storage/backpack.dm
@@ -467,11 +467,9 @@
 	icon_state = "duffel-syndiemed"
 	item_state = "duffel-syndiemed"
 
-/obj/item/storage/backpack/duffelbag/syndie/surgery
+/obj/item/storage/backpack/duffelbag/syndie/med/surgery
 	name = "surgery duffel bag"
 	desc = "A suspicious looking duffel bag for holding surgery tools."
-	icon_state = "duffel-syndiemed"
-	item_state = "duffel-syndiemed"
 
 /obj/item/storage/backpack/duffelbag/syndie/surgery/PopulateContents()
 	new /obj/item/scalpel(src)
@@ -488,7 +486,7 @@
 	new /obj/item/implanter(src)
 	new /obj/item/reagent_containers/medspray/sterilizine(src)
 
-/obj/item/storage/backpack/duffelbag/syndie/surgery_adv
+/obj/item/storage/backpack/duffelbag/syndie/med/surgery_adv
 	name = "advanced surgery duffel bag"
 	desc = "A large duffel bag for holding surgical tools. Bears the logo of an advanced med-tech firm."
 
@@ -505,70 +503,6 @@
 	new /obj/item/implanter(src)
 	new /obj/item/reagent_containers/medspray/sterilizine(src)
 
-/obj/item/storage/backpack/duffelbag/syndie/ammo
-	name = "ammunition duffel bag"
-	desc = "A large duffel bag for holding extra weapons ammunition and supplies."
-	icon_state = "duffel-syndieammo"
-	item_state = "duffel-syndieammo"
-
-/obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun
-	desc = "A large duffel bag, packed to the brim with Bulldog shotgun drum magazines."
-
-/obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun/PopulateContents()
-	for(var/i in 1 to 6)
-		new /obj/item/ammo_box/magazine/m12g(src)
-	new /obj/item/ammo_box/magazine/m12g/stun(src)
-	new /obj/item/ammo_box/magazine/m12g/slug(src)
-	new /obj/item/ammo_box/magazine/m12g/dragon(src)
-
-/obj/item/storage/backpack/duffelbag/syndie/ammo/smg
-	desc = "A large duffel bag, packed to the brim with C-20r magazines."
-
-/obj/item/storage/backpack/duffelbag/syndie/ammo/smg/PopulateContents()
-	for(var/i in 1 to 9)
-		new /obj/item/ammo_box/magazine/smgm45(src)
-
-/obj/item/storage/backpack/duffelbag/syndie/c20rbundle
-	desc = "A large duffel bag containing a C-20r, some magazines, and a cheap looking suppressor."
-
-/obj/item/storage/backpack/duffelbag/syndie/c20rbundle/PopulateContents()
-	new /obj/item/ammo_box/magazine/smgm45(src)
-	new /obj/item/ammo_box/magazine/smgm45(src)
-	new /obj/item/gun/ballistic/automatic/c20r(src)
-	new /obj/item/suppressor/specialoffer(src)
-
-/obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
-	desc = "A large duffel bag containing a Bulldog, some drums, and a pair of thermal imaging glasses."
-
-/obj/item/storage/backpack/duffelbag/syndie/bulldogbundle/PopulateContents()
-	new /obj/item/ammo_box/magazine/m12g(src)
-	new /obj/item/gun/ballistic/automatic/shotgun/bulldog(src)
-	new /obj/item/ammo_box/magazine/m12g/stun(src)
-	new /obj/item/clothing/glasses/thermal/syndi(src)
-
-/obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle
-	desc = "A large duffel bag containing a tactical medkit, a Donksoft machine gun, a big jumbo box of riot darts, and a knock-off pair of magboots."
-
-/obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle/PopulateContents()
-	new /obj/item/clothing/shoes/magboots/syndie(src)
-	new /obj/item/storage/firstaid/tactical/nukeop(src)
-	new /obj/item/gun/ballistic/automatic/l6_saw/toy(src)
-	new /obj/item/ammo_box/foambox/riot(src)
-
-/obj/item/storage/backpack/duffelbag/syndie/med/bioterrorbundle
-	desc = "A large duffel bag containing deadly chemicals, a handheld chem sprayer, Bioterror foam grenade, a Donksoft assault rifle, box of riot grade darts, a dart pistol, and a box of syringes."
-
-/obj/item/storage/backpack/duffelbag/syndie/med/bioterrorbundle/PopulateContents()
-	new /obj/item/reagent_containers/spray/chemsprayer/bioterror(src)
-	new /obj/item/storage/box/syndie_kit/chemical(src)
-	new /obj/item/gun/syringe/syndicate(src)
-	new /obj/item/gun/ballistic/automatic/c20r/toy(src)
-	new /obj/item/storage/box/syringes(src)
-	new /obj/item/ammo_box/foambox/riot(src)
-	new /obj/item/grenade/chem_grenade/bioterrorfoam(src)
-	if(prob(5))
-		new /obj/item/reagent_containers/food/snacks/pizza/pineapple(src)
-
 /obj/item/storage/backpack/duffelbag/syndie/c4/PopulateContents()
 	for(var/i in 1 to 10)
 		new /obj/item/grenade/plastic/c4(src)
@@ -576,20 +510,6 @@
 /obj/item/storage/backpack/duffelbag/syndie/x4/PopulateContents()
 	for(var/i in 1 to 3)
 		new /obj/item/grenade/plastic/x4(src)
-
-/obj/item/storage/backpack/duffelbag/syndie/firestarter
-	desc = "A large duffel bag containing a New Russian pyro backpack sprayer, Elite hardsuit, a Stechkin APS pistol, minibomb, ammo, and other equipment."
-
-/obj/item/storage/backpack/duffelbag/syndie/firestarter/PopulateContents()
-	new /obj/item/clothing/under/syndicate/soviet(src)
-	new /obj/item/watertank/op(src)
-	new /obj/item/clothing/suit/space/hardsuit/syndi/elite(src)
-	new /obj/item/gun/ballistic/automatic/pistol/APS(src)
-	new /obj/item/ammo_box/magazine/pistolm9mm(src)
-	new /obj/item/ammo_box/magazine/pistolm9mm(src)
-	new /obj/item/reagent_containers/food/drinks/bottle/vodka/badminka(src)
-	new /obj/item/reagent_containers/syringe/stimulants(src)
-	new /obj/item/grenade/syndieminibomb(src)
 
 // For ClownOps.
 /obj/item/storage/backpack/duffelbag/clown/syndie/ComponentInitialize()
@@ -606,15 +526,175 @@
 	new /obj/item/bikehorn(src)
 	new /obj/item/implanter/sad_trombone(src)
 
-obj/item/storage/backpack/duffelbag/syndie/shredderbundle
-	desc = "A large duffel bag containing two CX Shredders, some magazines, an elite hardsuit, and a chest rig."
+// Nuke Op Bundles
+/obj/item/storage/backpack/duffelbag/syndie/assault
+	name = "assault trooper duffel bag"
+	desc = "A large duffel bag for holding combat equipment"
 
-/obj/item/storage/backpack/duffelbag/syndie/shredderbundle/PopulateContents()
-	new /obj/item/ammo_box/magazine/flechette/shredder(src)
-	new /obj/item/ammo_box/magazine/flechette/shredder(src)
-	new /obj/item/ammo_box/magazine/flechette/shredder(src)
-	new /obj/item/ammo_box/magazine/flechette/shredder(src)
-	new /obj/item/gun/ballistic/automatic/flechette/shredder(src)
-	new /obj/item/gun/ballistic/automatic/flechette/shredder(src)
-	new /obj/item/storage/belt/military(src)
+/obj/item/storage/backpack/duffelbag/syndie/assault/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/c20r(src)
+	new /obj/item/ammo_box/magazine/smgm10mm(src)
+	new /obj/item/ammo_box/magazine/smgm10mm(src)
+	new /obj/item/ammo_box/magazine/smgm10mm(src)
+	new /obj/item/ammo_box/magazine/smgm10mm/ap(src)
+	new /obj/item/ammo_box/magazine/smgm10mm/ap(src)
+	new /obj/item/grenade/syndieminibomb/concussion/frag(src)
+	new /obj/item/grenade/syndieminibomb/concussion/frag(src)
+	new /obj/item/grenade/flashbang(src)
+	new /obj/item/grenade/flashbang(src)
+	new /obj/item/grenade/plastic/c4(src)
+	new /obj/item/grenade/plastic/c4(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/shredder
+	name = "assault trooper duffel bag"
+	desc = "A large duffel bag for holding combat equipment"
+
+/obj/item/storage/backpack/duffelbag/syndie/shredder/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/flechette(src)
+	new /obj/item/ammo_box/magazine/flechette(src)
+	new /obj/item/ammo_box/magazine/flechette(src)
+	new /obj/item/ammo_box/magazine/flechette(src)
+	new /obj/item/ammo_box/magazine/flechette/s(src)
+	new /obj/item/ammo_box/magazine/flechette/s(src)
+	new /obj/item/reagent_containers/syringe/stimulants(src)
+	new /obj/item/soap/syndie(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/donk
+	name = "\improper Donk Co. duffel bag"
+	desc = "A large duffel bag for holding toys. There is a Donk Co. logo on the back."
+
+/obj/item/storage/backpack/duffelbag/syndie/donk/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/c20r/toy(src)
+	new /obj/item/ammo_box/foambox/riot(src)
+	new /obj/item/ammo_box/foambox/riot(src)
+	new /obj/item/ammo_box/foambox/riot(src)
+	new /obj/item/ammo_box/foambox/riot(src)
+	new /obj/item/ammo_box/foambox/riot(src)
+	new /obj/item/soap/syndie(src)
+	new /obj/item/grenade/clusterbuster/soap(src)
+	new /obj/item/grenade/chem_grenade/teargas/moustache(src)
+	new /obj/item/disk/nuclear/fake(src)
+	new /obj/item/slimepotion/slime/sentience/nuclear(src)
+	new /obj/item/storage/box/syndie_kit/chameleon/broken(src)
+	new /obj/item/toy/cards/deck/syndicate(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/bioterror
+	name = "bioterrorist duffel bag"
+	desc = "A large duffel bag for holding biohazardous material. Handle with extreme care"
+
+/obj/item/storage/backpack/duffelbag/syndie/bioterror/PopulateContents()
+	new /obj/item/clothing/suit/space/syndicate/black/med(src)
+	new /obj/item/clothing/head/helmet/space/syndicate/black/med(src)
+	new /obj/item/reagent_containers/spray/chemsprayer/bioterror(src)
+	new /obj/item/storage/box/syndie_kit/bioterror(src)
+	new /obj/item/storage/box/syndie_kit/tuberculosisgrenade(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/knight
+	name = "energy knight duffel bag"
+	desc = "A large duffel bag for holding electronic swordsman gear"
+
+/obj/item/storage/backpack/duffelbag/syndie/knight/PopulateContents()
+	new /obj/item/melee/transforming/energy/sword/saber(src)
+	new /obj/item/shield/energy(src)
+	new /obj/item/clothing/shoes/chameleon/noslip(src)
+	new /obj/item/autosurgeon/anti_stun(src)
+	new /obj/item/storage/box/syndie_kit/imp_adrenal(src)
+	new /obj/item/autosurgeon/thermal_eyes(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/cqc
+	name = "cqc duffel bag"
+	desc = "A large duffel bag for holding the secrets of hand to hand combat"
+
+/obj/item/storage/backpack/duffelbag/syndie/cqc/PopulateContents()
+	new /obj/item/book/granter/martial/cqc(src)
+	new /obj/item/clothing/gloves/rapid(src)
+	new /obj/item/soap/syndie(src)
+	new /obj/item/clothing/glasses/phantomthief/syndicate(src)
+	new /obj/item/card/emag(src)
+	new /obj/item/storage/box/syndie_kit/throwing_weapons(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/infiltrator/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/pistol(src)
+	new /obj/item/suppressor(src)
+	new /obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new /obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new /obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new /obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new /obj/item/ammo_box/magazine/m10mm/soporific(src)
+	new /obj/item/switchblade(src)
+	new /obj/item/grenade/smokebomb(src)
+	new /obj/item/grenade/smokebomb(src)
+	new /obj/item/card/emag(src)
+	new /obj/item/camera_bug(src)
+	new /obj/item/multitool/ai_detect(src)
+	new /obj/item/implanter/stealth(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/engineer
+	name = "combat engineer duffel bag"
+	desc = "A large duffel bag for holding a lot of engineering supplies"
+
+/obj/item/storage/backpack/duffelbag/syndie/engineer/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/shotgun/bulldog(src)
+	new /obj/item/ammo_box/magazine/m12g(src)
+	new /obj/item/ammo_box/magazine/m12g(src)
+	new /obj/item/ammo_box/magazine/m12g(src)
+	new /obj/item/ammo_box/magazine/m12g(src)
+	new /obj/item/clothing/head/helmet/space/syndicate/black/engie(src)
+	new /obj/item/clothing/suit/space/syndicate/black/engie(src)
+	new /obj/item/construction/rcd/industrial(src)
+	new /obj/item/storage/belt/military/engineer(src)
+	new /obj/item/clothing/shoes/magboots/syndie(src)
+	new /obj/item/encryptionkey/binary(src)
+	new /obj/item/grenade/spawnergrenade/manhacks(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/pyro
+	name = "pyromaniac duffel bag"
+	desc = "A large duffel bag for holding inflammatory supplies. Handle with care."
+
+/obj/item/storage/backpack/duffelbag/syndie/pyro/PopulateContents()
+	new /obj/item/flamethrower/full/tank(src)
+	new /obj/item/tank/internals/plasma(src)
+	new /obj/item/tank/internals/plasma(src)
+	new /obj/item/twohanded/fireaxe(src)
+	new /obj/item/clothing/suit/space/hardsuit/syndi/elite(src)
+	new /obj/item/grenade/chem_grenade/incendiary(src)
+	new /obj/item/grenade/chem_grenade/incendiary(src)
+	new /obj/item/grenade/chem_grenade/incendiary(src)
+	new /obj/item/grenade/chem_grenade/incendiary(src)
+	new /obj/item/grenade/chem_grenade/incendiary(src)
+	new /obj/item/grenade/chem_grenade/incendiary(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/med/combatmedic
+	name = "combat medic duffel bag"
+	desc = "A large duffel bag designed for carrying large amounts of military-grade medical supplies."
+
+/obj/item/storage/backpack/duffelbag/syndie/med/combatmedic/PopulateContents()
+	new /obj/item/gun/medbeam(src)
+	new /obj/item/clothing/suit/space/syndicate/black/med(src)
+	new /obj/item/clothing/head/helmet/space/syndicate/black/med(src)
+	new /obj/item/storage/firstaid/tactical(src)
+	new /obj/item/healthanalyzer/advanced(src)
+	new /obj/item/gun/ballistic/automatic/shotgun/bulldog(src)
+	new /obj/item/ammo_box/magazine/m12g/slug(src)
+	new /obj/item/ammo_box/magazine/m12g/slug(src)
+	new /obj/item/ammo_box/magazine/m12g/slug(src)
+	new /obj/item/ammo_box/magazine/m12g/slug(src)
+	new /obj/item/ammo_box/magazine/m12g/slug(src)
+	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
+
+/obj/item/storage/backpack/duffelbag/syndie/ammo
+	name = "ammunition duffel bag"
+	desc = "A large duffel bag for holding extra weapons ammunition and supplies."
+	icon_state = "duffel-syndieammo"
+	item_state = "duffel-syndieammo"
+
+/obj/item/storage/backpack/duffelbag/syndie/ammo/heavy
+	name = "heavy weapons specialist duffel bag"
+	desc = "A large duffel bag for holding heavy weaponry and ammunition."
+
+/obj/item/storage/backpack/duffelbag/syndie/ammo/heavy/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/l6_saw(src)
+	new /obj/item/ammo_box/magazine/mm195x129(src)
+	new /obj/item/ammo_box/magazine/mm195x129(src)
+	new /obj/item/storage/box/syndie_kit/flashbang(src)
 	new /obj/item/clothing/suit/space/hardsuit/syndi/elite(src)

--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -350,6 +350,19 @@
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
 	STR.max_w_class = WEIGHT_CLASS_SMALL
 
+/obj/item/storage/belt/military/engineer
+	name = "engineering chest rig"
+	desc = "A set of tactical webbing worn by combat engineers."
+
+/obj/item/storage/belt/military/engineer/PopulateContents()
+	new /obj/item/screwdriver/nuke(src)
+	new /obj/item/wrench(src)
+	new /obj/item/weldingtool/largetank(src)
+	new /obj/item/crowbar/red(src)
+	new /obj/item/wirecutters(src, "red")
+	new /obj/item/multitool(src)
+	new /obj/item/clothing/glasses/hud/diagnostic/night(src)
+
 /obj/item/storage/belt/military/snack
 	name = "tactical snack rig"
 

--- a/code/game/objects/items/storage/briefcase.dm
+++ b/code/game/objects/items/storage/briefcase.dm
@@ -82,11 +82,13 @@
 /obj/item/storage/briefcase/sniperbundle/PopulateContents()
 	..() // in case you need any paperwork done after your rampage
 	new /obj/item/gun/ballistic/automatic/sniper_rifle/syndicate(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
+	new /obj/item/ammo_box/magazine/sniper_rounds/penetrator(src)
 	new /obj/item/clothing/neck/tie/red(src)
 	new /obj/item/clothing/under/syndicate/sniper(src)
-	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
-	new /obj/item/ammo_box/magazine/sniper_rounds/soporific(src)
-	new /obj/item/suppressor/specialoffer(src)
 
 
 /obj/item/storage/briefcase/modularbundle

--- a/code/game/objects/items/tools/wrench.dm
+++ b/code/game/objects/items/tools/wrench.dm
@@ -23,6 +23,13 @@
 	playsound(loc, 'sound/weapons/genhit.ogg', 50, 1, -1)
 	return (BRUTELOSS)
 
+/obj/item/wrench/citadel
+	name = "rusty wrench"
+	desc = "A wrench with common uses. It seems unusually robust..."
+	toolspeed = 0.5
+	force = 20
+	throwforce = 24
+
 /obj/item/wrench/cyborg
 	name = "automatic wrench"
 	desc = "An advanced robotic wrench. Can be found in construction cyborgs."

--- a/code/modules/clothing/spacesuits/syndi.dm
+++ b/code/modules/clothing/spacesuits/syndi.dm
@@ -102,14 +102,19 @@
 
 //Black medical syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/med
-	name = "black space helmet"
+	name = "black medical space helmet"
+	desc = "A specialized space suit designed for use in biohazardous conditions. Lightweight and fully sealed."
 	icon_state = "syndicate-helm-black-med"
 	item_state = "syndicate-helm-black"
+	armor = list("melee" = 35, "bullet" = 40, "laser" = 30,"energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 60, "fire" = 50, "acid" = 100)
 
 /obj/item/clothing/suit/space/syndicate/black/med
-	name = "green space suit"
+	name = "black medical space suit"
+	desc = "A specialized space suit designed for use in biohazardous conditions. Lightweight and fully sealed."
 	icon_state = "syndicate-black-med"
 	item_state = "syndicate-black"
+	slowdown = 0
+	armor = list("melee" = 35, "bullet" = 40, "laser" = 30,"energy" = 15, "bomb" = 35, "bio" = 100, "rad" = 60, "fire" = 50, "acid" = 100)
 
 
 //Black-orange syndicate space suit
@@ -140,10 +145,14 @@
 //Black with yellow/red engineering syndicate space suit
 /obj/item/clothing/head/helmet/space/syndicate/black/engie
 	name = "black space helmet"
+	desc = "A specialized engineering space suit designed for use in hazardous environments. Resistant to explosives and fire."
 	icon_state = "syndicate-helm-black-engie"
 	item_state = "syndicate-helm-black"
+	armor = list("melee" = 40, "bullet" = 50, "laser" = 30,"energy" = 25, "bomb" = 90, "bio" = 100, "rad" = 50, "fire" = 90, "acid" = 85)
 
 /obj/item/clothing/suit/space/syndicate/black/engie
 	name = "black engineering space suit"
+	desc = "A specialized engineering space suit designed for use in hazardous environments. Resistant to explosives and fire."
 	icon_state = "syndicate-black-engie"
 	item_state = "syndicate-black"
+	armor = list("melee" = 40, "bullet" = 60, "laser" = 30,"energy" = 25, "bomb" = 90, "bio" = 100, "rad" = 50, "fire" = 90, "acid" = 85)

--- a/code/modules/uplink/uplink_items/uplink_bundles.dm
+++ b/code/modules/uplink/uplink_items/uplink_bundles.dm
@@ -7,76 +7,118 @@
 	When adding new entries to the file, please keep them sorted by category.
 */
 
-/datum/uplink_item/bundles_TC/chemical
-	name = "Bioterror bundle"
-	desc = "For the madman: Contains a handheld Bioterror chem sprayer, a Bioterror foam grenade, a box of lethal chemicals, a dart pistol, \
-			box of syringes, Donksoft assault rifle, and some riot darts. Remember: Seal suit and equip internals before use."
-	item = /obj/item/storage/backpack/duffelbag/syndie/med/bioterrorbundle
-	cost = 30 // normally 42
+/datum/uplink_item/bundles_TC/assault
+	name = "Assault Trooper Kit"
+	desc = "A brutally simple kit that is useful in every operation. Includes a c-20r with five spare magazines, two AP, two fragmentation grenades \
+			two flashbangs, and two C4 charges."
+	item = /obj/item/storage/backpack/duffelbag/syndie/assault
+	cost = 25
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/bundles_TC/bulldog
-	name = "Bulldog bundle"
-	desc = "Lean and mean: Optimized for people that want to get up close and personal. Contains the popular \
-			Bulldog shotgun, a 12g buckshot drum, a 12g taser slug drum and a pair of Thermal imaging goggles."
-	item = /obj/item/storage/backpack/duffelbag/syndie/bulldogbundle
-	cost = 13 // normally 16
+/datum/uplink_item/bundles_TC/shredder
+	name = "Shredder Kit"
+	desc = "An unquestionably unethical shredder of internal organs, the CX Shredder is banned by several intergalactic treaties. \
+			This kit contains one CX Shredder with an assortment of five assorted spare magazines, a stimpack, and a bar of soap to clean up the mess."
+	item = /obj/item/storage/backpack/duffelbag/syndie/shredder
+	cost = 25
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/bundles_TC/c20r
-	name = "C-20r bundle"
-	desc = "Old Faithful: The classic C-20r, bundled with two magazines, and a (surplus) suppressor at discount price."
-	item = /obj/item/storage/backpack/duffelbag/syndie/c20rbundle
-	cost = 14 // normally 16
+/datum/uplink_item/bundles_TC/donk
+	name = "Donksoft Kit"
+	desc = "A kit chalk full of harmless fun! Includes a toy riot submachine gun, with five extra boxes of riot darts, \
+			soap, a fake nuke disk, a syndicate sentience potion, playing cards, a broken chameleon kit, a cluster soap bomb, and the exclusive tearstache grenade!"
+	item = /obj/item/storage/backpack/duffelbag/syndie/donk
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/bundles_TC/knight
+	name = "Energy Knight Kit"
+	desc = "Hack and slash with close quarters energy weaponry. Includes an energy sword, an energy shield, no slips, an adrenals implanter, a CNS rebooter implant, \
+			and a thermal vision autosurgeon."
+	item = /obj/item/storage/backpack/duffelbag/syndie/knight
+	cost = 25
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/bundles_TC/cybernetics_bundle
-	name = "Cybernetic Implants Bundle"
-	desc = "A random selection of cybernetic implants. Guaranteed 5 high quality implants. Comes with an autosurgeon."
-	item = /obj/item/storage/box/cyber_implants
-	cost = 40
+/datum/uplink_item/bundles_TC/cqc
+	name = "Close Quarters Combat Kit"
+	desc = "Reign supreme in hand to hand combat with this kit. Includes a CQC manual, gloves of the north star, \
+			an adrenaline mask, throwing weapons, an emag, and a bar of soap."
+	item = /obj/item/storage/backpack/duffelbag/syndie/cqc
+	cost = 25
 	include_modes = list(/datum/game_mode/nuclear)
 
-/datum/uplink_item/bundles_TC/medical
-	name = "Medical bundle"
-	desc = "The support specialist: Aid your fellow operatives with this medical bundle. Contains a tactical medkit, \
-			a Donksoft LMG, a box of riot darts and a pair of magboots to rescue your friends in no-gravity environments."
-	item = /obj/item/storage/backpack/duffelbag/syndie/med/medicalbundle
-	cost = 15 // normally 20
+/datum/uplink_item/bundles_TC/sniper
+	name = "Sniper Kit"
+	desc = "A specialist kit for long ranged assassinations. Includes a syndicate .50 caliber sniper rifle, with an assortment of five magazines, \
+			six smoke grenades, and a sharp-looking tactical turtleneck suit and tie,"
+	item = /obj/item/storage/briefcase/sniperbundle
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/infiltrator
+	name = "Infiltration Kit"
+	desc = "Sneak behind enemy lines and get your hands dirty when you need to. Includes a stechkin pistol, suppressor, five soporific 10mm magazines, \
+			a switchblade, two smoke grenades, a cryptographic sequencer, a camera bug, an AI detector, and a stealth implanter."
+	item = /obj/item/storage/backpack/duffelbag/syndie/infiltrator
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/medic
+	name = "Combat Medic Kit"
+	desc = "Keep your allies in the fight with this medical kit. Includes a medibeam gun, an advanced health analyzer, \
+			a bulldog with five spare slug drums, omnizine laced cigarettes, a tactical medkit, and a light weight medical space suit."
+	item = /obj/item/storage/backpack/duffelbag/syndie/med/combatmedic
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/engineer
+	name = "Combat Engineer Kit"
+	desc = "Keep yourself and your silicon allies alive with this specialized engineering kit. Includes a chest rig full of engineering goodies, \
+			a Bulldog with four additional buckshot drums, an high performance industrial RCD, a grenade full of manhacks, and a specialized hazard suit."
+	item = /obj/item/storage/backpack/duffelbag/syndie/engineer
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/grenadier
+	name = "Grenadier's Belt"
+	desc = "KABOOM BABY! Includes a grenade belt jam packed with a serious arsenal of explosives. Includes 10 fragmentation grenades, two minibombs \
+			two flashbangs, two emp grenades, two incendiary grenades, four smoke grenades, four gluon grenades, an acid grenades, and a screwdriver and multitool \
+			for modifying them. An EXCEPTIONAL value."
+	item = /obj/item/storage/belt/grenade/full
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/heavy
+	name = "Heavy Weapons Specialist Kit"
+	desc = "Provide your allies with covering fire with this specialist kit. Includes the L6 SAW along with two box magazines, a box of flashbangs for crowd control \
+			and an elite syndicate hardsuit for soaking up damage."
+	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/heavy
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/bioterror
+	name = "Bioterrorist Kit"
+	desc = "An incredibly dangerous kit for biological warfare. Handle with care. Includes a handheld bioterror chem sprayer, a bioterror kit, \
+			the terrifying Fungal Tuberculosis kit, and a light weight medical space suit. Seal suit and internals before use."
+	item = /obj/item/storage/backpack/duffelbag/syndie/bioterror
+	cost = 25
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/bundles_TC/pyro
+	name = "Pyromaniac Kit"
+	desc = "Set the station on fire with this dangerous kit. Includes a plasma flamethrower with two spare tanks, \
+			six incendiary grenades for setting the world on fire, the legendary fire axe, \
+			and a fireproof elite syndicate hardsuit to keep you safe from the flames. We are not responsible for any friendly fire that results from the purchase of this kit."
+	item = /obj/item/storage/backpack/duffelbag/syndie/pyro
+	cost = 25
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/modular
 	name = "Modular Pistol Kit"
-	desc = "A heavy briefcase containing one modular pistol (chambered in 10mm), one supressor, and spare ammunition, including a box of soporific ammo. \
-		Includes a suit jacket that is padded with a robust liner."
+	desc = "A heavy briefcase containing one modular pistole (chambered in 10mm), one suppressor, and spare ammunition, \
+			including a box of soporific ammo. Includes a suit jacket padded with robust liner."
 	item = /obj/item/storage/briefcase/modularbundle
 	cost = 12
-
-/datum/uplink_item/bundles_TC/shredder
-	name = "Shredder bundle"
-	desc = "A truly horrific weapon designed simply to maim its victim, the CX Shredder is banned by several intergalactic treaties. \
-			You'll get two of them with this. And spare ammo to boot. And we'll throw in an extra elite hardsuit and chest rig to hold them all!"
-	item = /obj/item/storage/backpack/duffelbag/syndie/shredderbundle
-	cost = 30 // normally 41
-	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/bundles_TC/sniper
-	name = "Sniper bundle"
-	desc = "Elegant and refined: Contains a collapsed sniper rifle in an expensive carrying case, \
-			two soporific knockout magazines, a free surplus supressor, and a sharp-looking tactical turtleneck suit. \
-			We'll throw in a free red tie if you order NOW."
-	item = /obj/item/storage/briefcase/sniperbundle
-	cost = 20 // normally 26
-	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/bundles_TC/firestarter
-	name = "Spetsnaz Pyro bundle"
-	desc = "For systematic suppression of carbon lifeforms in close quarters: Contains a lethal New Russian backpack spray, Elite hardsuit, \
-			Stechkin APS pistol, two magazines, a minibomb and a stimulant syringe. \
-			Order NOW and comrade Boris will throw in an extra tracksuit."
-	item = /obj/item/storage/backpack/duffelbag/syndie/firestarter
-	cost = 30
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/bundles_TC/bundle
 	name = "Syndicate Bundle"
@@ -85,8 +127,7 @@
 			you will receive. May contain discontinued and/or exotic items."
 	item = /obj/item/storage/box/syndicate
 	cost = 20
-	exclude_modes = list(/datum/game_mode/nuclear)
-	cant_discount = TRUE
+	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
 /datum/uplink_item/bundles_TC/surplus
 	name = "Syndicate Surplus Crate"
@@ -96,7 +137,6 @@
 	cost = 20
 	player_minimum = 25
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-	cant_discount = TRUE
 	var/starting_crate_value = 50
 
 /datum/uplink_item/bundles_TC/surplus/super
@@ -134,7 +174,6 @@
 	desc = "Picking this will purchase a random item. Useful if you have some TC to spare or if you haven't decided on a strategy yet."
 	item = /obj/effect/gibspawner/generic // non-tangible item because techwebs use this path to determine illegal tech
 	cost = 0
-	cant_discount = TRUE
 
 /datum/uplink_item/bundles_TC/random/purchase(mob/user, datum/component/uplink/U)
 	var/list/uplink_items = U.uplink_items
@@ -161,7 +200,6 @@
 	item = /obj/item/stack/telecrystal
 	cost = 1
 	surplus = 0
-	cant_discount = TRUE
 	// Don't add telecrystals to the purchase_log since
 	// it's just used to buy more items (including itself!)
 	purchase_log_vis = FALSE


### PR DESCRIPTION
## About The Pull Request

Adds a bunch of specialized 25 TC bundles/kits that can help fill proper roles, and give newer op players and easy option to just pick up and use without worrying about wasting TC.

## Why It's Good For The Game

It's good for new players, it helps people actually fill roles and work as a team, and more importantly, it gives some fun and unique "classes" to choose and specialize in. 

## Changelog
:cl: Tupinambis
delete: Most old nuke op bundles.
add: Goon style 25 TC specialized kits to fill various roles. 
/:cl:
