### PR TITLE
Comments out meteor defense tech node

### DIFF
--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -203,14 +203,16 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 	export_price = 5000
 
-//datum/techweb_node/basic_meteor_defense
-	//id = "basic_meteor_defense"
-	//display_name = "Meteor Defense Research"
-	//description = "Unlock the potential of the mysterious of why CC decided to not build these around the station themselves."
-	//prereq_ids = list("adv_engi", "high_efficiency")
-	//design_ids = list("meteor_defence", "meteor_console")
-	//research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	//export_price = 5000
+/*
+/datum/techweb_node/basic_meteor_defense
+	id = "basic_meteor_defense"
+	display_name = "Meteor Defense Research"
+	description = "Unlock the potential of the mysterious of why CC decided to not build these around the station themselves."
+	prereq_ids = list("adv_engi", "high_efficiency")
+	design_ids = list("meteor_defence", "meteor_console")
+	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	export_price = 5000
+*/
 
 //datum/techweb_node/adv_meteor_defense
 	//id = "adv_meteor_defense"

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -203,14 +203,14 @@
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 3000)
 	export_price = 5000
 
-/datum/techweb_node/basic_meteor_defense
-	id = "basic_meteor_defense"
-	display_name = "Meteor Defense Research"
-	description = "Unlock the potential of the mysterious of why CC decided to not build these around the station themselves."
-	prereq_ids = list("adv_engi", "high_efficiency")
-	design_ids = list("meteor_defence", "meteor_console")
-	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
-	export_price = 5000
+//datum/techweb_node/basic_meteor_defense
+	//id = "basic_meteor_defense"
+	//display_name = "Meteor Defense Research"
+	//description = "Unlock the potential of the mysterious of why CC decided to not build these around the station themselves."
+	//prereq_ids = list("adv_engi", "high_efficiency")
+	//design_ids = list("meteor_defence", "meteor_console")
+	//research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 5000)
+	//export_price = 5000
 
 //datum/techweb_node/adv_meteor_defense
 	//id = "adv_meteor_defense"


### PR DESCRIPTION
## About The Pull Request

Comments out meteor defense tech node, what it says on the tin.

## Why It's Good For The Game

Meteor shields, with being able to be created as of right now, are too powerful. These were originally designed as a station goal, requiring cargo to purchase them, engineering to set them up, and a sat shield to properly manage them. The benefit being that it reduces the chance for meteors to spawn, as well as having an absurd 14 tile radius of instantly destroying any and all meteors that dare go into their range forever with no recharge or degradation over time.

Now, they can be easily mass produced from engineering needing just mostly metal and glass, the cheapest of materials, where you can literally find stacks of fifty of both in maintenance multiple times over. They don't even require a computer to manage anymore, just click on them and they turn on.  It completely preemptively negates an entire event (which, unless I'm mistaken, no other events can be straight up removed like this).

They were added to the engineering lathe without reducing the power level, and should considered as such.

## Changelog
:cl:
del: Removed meteor defense tech node
/:cl:
