### PR TITLE
[DNM] Makes sanitize_hexcolor use all 6 digits instead of repeating 3

### DIFF
--- a/code/__HELPERS/sanitize_values.dm
+++ b/code/__HELPERS/sanitize_values.dm
@@ -38,7 +38,7 @@
 				return default
 	return default
 
-/proc/sanitize_hexcolor(color, desired_format=3, include_crunch=0, default)
+/proc/sanitize_hexcolor(color, desired_format=6, include_crunch=0, default)
 	var/crunch = include_crunch ? "#" : ""
 	if(!istext(color))
 		color = ""


### PR DESCRIPTION
## About The Pull Request

this makes colours like #3B3024 (which is a dark shade of brown) not turn into #333322 (which is an unacceptable puke green colour)

## Why It's Good For The Game

can't think of anything other than making my spaceman look good
