### PR TITLE
Makes quick item usage (click-dragging unequipped item) require combat mode

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -400,12 +400,14 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		return usr.client.Click(src, src_location, src_control, params)
 	var/list/directaccess = usr.DirectAccess()	//This, specifically, is what requires the copypaste. If this were after the adjacency check, then it'd be impossible to use items in your inventory, among other things.
 												//If this were before the above checks, then trying to click on items would act a little funky and signal overrides wouldn't work.
-	if((usr.CanReach(src) || (src in directaccess)) && (usr.CanReach(over) || (over in directaccess)))
-		if(!usr.get_active_held_item())
-			usr.UnarmedAttack(src, TRUE)
-			if(usr.get_active_held_item() == src)
-				melee_attack_chain(usr, over)
-			return TRUE //returning TRUE as a "is this overridden?" flag
+	if(iscarbon(usr))
+		var/mob/living/carbon/C = usr
+		if(C.combatmode && ((C.CanReach(src) || (src in directaccess)) && (C.CanReach(over) || (over in directaccess))))
+			if(!C.get_active_held_item())
+				C.UnarmedAttack(src, TRUE)
+				if(C.get_active_held_item() == src)
+					melee_attack_chain(C, over)
+				return TRUE //returning TRUE as a "is this overridden?" flag
 	if(!Adjacent(usr) || !over.Adjacent(usr))
 		return // should stop you from dragging through windows
 


### PR DESCRIPTION
## About The Pull Request
This PR does more or less what it says on the tin. It makes it so that quick item usage (the thing that happens when you click and drag an unequipped item onto something else) requires combat mode enabled in order for it to actually happen. This allows this behavior to exist for its primary purpose (quickly reloading firearms, deconstructing structures, and more) in a way that allows legacy clickdrag override behavior to coexist. It makes sense for the clickdrag behavior to be a combat mode feature due to the utility being useful primarily during active combat and other stressful situations, where every decisecond counts. Also let's face it, dragging shells into a shotgun feels a lot better than clicking the shell, then clicking the shotgun.

## Changelog
:cl: Bhijn
tweak: Click-dragging will now only perform the quick item usage behavior if you're in combat mode.
/:cl:
