### PR TITLE
Further buff and fix to the clown ops' tearstache grenade.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -174,6 +174,7 @@
 #define TRAIT_CLOWN_MENTALITY	"clown_mentality" // The future is now, clownman.
 #define TRAIT_FREESPRINT		"free_sprinting"
 #define TRAIT_NO_TELEPORT		"no-teleport" //you just can't
+#define TRAIT_NO_INTERNALS		"no-internals"
 #define TRAIT_NO_ALCOHOL		"alcohol_intolerance"
 
 // common trait sources

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -291,7 +291,7 @@
 		icon_state = "internal0"
 	else
 		if(!C.getorganslot(ORGAN_SLOT_BREATHING_TUBE))
-			if(HAS_TRAIT(src, TRAIT_NO_INTERNALS))
+			if(HAS_TRAIT(C, TRAIT_NO_INTERNALS))
 				to_chat(C, "<span class='warning'>Due to cumbersome equipment or anatomy, you are currently unable to use internals!</span>")
 				return
 			var/obj/item/clothing/check

--- a/code/_onclick/hud/screen_objects.dm
+++ b/code/_onclick/hud/screen_objects.dm
@@ -291,6 +291,9 @@
 		icon_state = "internal0"
 	else
 		if(!C.getorganslot(ORGAN_SLOT_BREATHING_TUBE))
+			if(HAS_TRAIT(src, TRAIT_NO_INTERNALS))
+				to_chat(C, "<span class='warning'>Due to cumbersome equipment or anatomy, you are currently unable to use internals!</span>")
+				return
 			var/obj/item/clothing/check
 			var/internals = FALSE
 

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -201,9 +201,13 @@
 	clumsy_check = GRENADE_NONCLUMSY_FUMBLE
 
 /obj/item/grenade/chem_grenade/teargas/moustache/prime()
-	var/myloc = get_turf(src)
+	var/list/check_later = list()
+	for(var/mob/living/carbon/M in get_turf(src))
+		check_later += M
 	. = ..()
-	for(var/mob/living/carbon/M in view(6, myloc))
+	if(!.) //grenade did not properly prime.
+		return
+	for(var/M in check_later)
 		if(!istype(M.wear_mask, /obj/item/clothing/mask/gas/clown_hat) && !istype(M.wear_mask, /obj/item/clothing/mask/gas/mime) )
 			if(!M.wear_mask || M.dropItemToGround(M.wear_mask))
 				var/obj/item/clothing/mask/fakemoustache/sticky/the_stash = new /obj/item/clothing/mask/fakemoustache/sticky()
@@ -215,10 +219,16 @@
 /obj/item/clothing/mask/fakemoustache/sticky/Initialize()
 	. = ..()
 	ADD_TRAIT(src, TRAIT_NODROP, STICKY_MOUSTACHE_TRAIT)
-	addtimer(CALLBACK(src, .proc/unstick), unstick_time)
+	addtimer(TRAIT_CALLBACK_REMOVE(src, TRAIT_NODROP, STICKY_MOUSTACHE_TRAIT), unstick_time)
 
-/obj/item/clothing/mask/fakemoustache/sticky/proc/unstick()
-	ADD_TRAIT(src, TRAIT_NODROP, STICKY_MOUSTACHE_TRAIT)
+/obj/item/clothing/mask/fakemoustache/sticky/equipped(mob/user, slot)
+	. = ..()
+	if(slot = SLOT_WEAR_MASK)
+		ADD_TRAIT(user, TRAIT_NO_INTERNALS, STICKY_MOUSTACHE_TRAIT)
+
+/obj/item/clothing/mask/fakemoustache/sticky/dropped(mob/user)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_NO_INTERNALS, STICKY_MOUSTACHE_TRAIT)
 
 //DARK H.O.N.K. AND CLOWN MECH WEAPONS
 

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -202,16 +202,17 @@
 
 /obj/item/grenade/chem_grenade/teargas/moustache/prime()
 	var/list/check_later = list()
-	for(var/mob/living/carbon/M in get_turf(src))
-		check_later += M
+	for(var/mob/living/carbon/C in get_turf(src))
+		check_later += C
 	. = ..()
 	if(!.) //grenade did not properly prime.
 		return
 	for(var/M in check_later)
-		if(!istype(M.wear_mask, /obj/item/clothing/mask/gas/clown_hat) && !istype(M.wear_mask, /obj/item/clothing/mask/gas/mime) )
-			if(!M.wear_mask || M.dropItemToGround(M.wear_mask))
+		var/mob/living/carbon/C = M
+		if(!istype(C.wear_mask, /obj/item/clothing/mask/gas/clown_hat) && !istype(C.wear_mask, /obj/item/clothing/mask/gas/mime))
+			if(!C.wear_mask || C.dropItemToGround(C.wear_mask))
 				var/obj/item/clothing/mask/fakemoustache/sticky/the_stash = new /obj/item/clothing/mask/fakemoustache/sticky()
-				M.equip_to_slot_or_del(the_stash, SLOT_WEAR_MASK, TRUE, TRUE, TRUE, TRUE)
+				C.equip_to_slot_or_del(the_stash, SLOT_WEAR_MASK, TRUE, TRUE, TRUE, TRUE)
 
 /obj/item/clothing/mask/fakemoustache/sticky
 	var/unstick_time = 2 MINUTES

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -224,7 +224,7 @@
 
 /obj/item/clothing/mask/fakemoustache/sticky/equipped(mob/user, slot)
 	. = ..()
-	if(slot = SLOT_WEAR_MASK)
+	if(slot == SLOT_WEAR_MASK)
 		ADD_TRAIT(user, TRAIT_NO_INTERNALS, STICKY_MOUSTACHE_TRAIT)
 
 /obj/item/clothing/mask/fakemoustache/sticky/dropped(mob/user)

--- a/code/game/objects/items/grenades/chem_grenade.dm
+++ b/code/game/objects/items/grenades/chem_grenade.dm
@@ -177,7 +177,7 @@
 
 /obj/item/grenade/chem_grenade/prime()
 	if(stage != READY)
-		return
+		return FALSE
 
 	var/list/datum/reagents/reactants = list()
 	for(var/obj/item/reagent_containers/glass/G in beakers)
@@ -192,7 +192,7 @@
 				O.forceMove(drop_location())
 			beakers = list()
 		stage_change(EMPTY)
-		return
+		return FALSE
 
 	if(nadeassembly)
 		var/mob/M = get_mob_by_ckey(assemblyattacher)
@@ -205,6 +205,7 @@
 	update_mob()
 
 	qdel(src)
+	return TRUE
 
 //Large chem grenades accept slime cores and use the appropriately.
 /obj/item/grenade/chem_grenade/large
@@ -219,7 +220,7 @@
 
 /obj/item/grenade/chem_grenade/large/prime()
 	if(stage != READY)
-		return
+		return FALSE
 
 	for(var/obj/item/slime_extract/S in beakers)
 		if(S.Uses)
@@ -237,7 +238,7 @@
 				else
 					S.forceMove(get_turf(src))
 					no_splash = TRUE
-	..()
+	return ..()
 
 	//I tried to just put it in the allowed_containers list but
 	//if you do that it must have reagents.  If you're going to
@@ -288,7 +289,7 @@
 
 /obj/item/grenade/chem_grenade/adv_release/prime()
 	if(stage != READY)
-		return
+		return FALSE
 
 	var/total_volume = 0
 	for(var/obj/item/reagent_containers/RC in beakers)
@@ -296,7 +297,7 @@
 	if(!total_volume)
 		qdel(src)
 		qdel(nadeassembly)
-		return
+		return FALSE
 	var/fraction = unit_spread/total_volume
 	var/datum/reagents/reactants = new(unit_spread)
 	reactants.my_atom = src
@@ -313,6 +314,7 @@
 	else
 		addtimer(CALLBACK(src, .proc/prime), det_time)
 	log_game("A grenade detonated at [AREACOORD(DT)]")
+	return TRUE
 
 
 

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -33,7 +33,7 @@
 		H.update_internals_hud_icon(0)
 	else
 		if(!H.getorganslot(ORGAN_SLOT_BREATHING_TUBE))
-			if(HAS_TRAIT(src, TRAIT_NO_INTERNALS))
+			if(HAS_TRAIT(H, TRAIT_NO_INTERNALS))
 				to_chat(H, "<span class='warning'>Due to cumbersome equipment or anatomy, you are currently unable to use internals!</span>")
 				return
 			var/obj/item/clothing/check

--- a/code/game/objects/items/tanks/tanks.dm
+++ b/code/game/objects/items/tanks/tanks.dm
@@ -33,6 +33,9 @@
 		H.update_internals_hud_icon(0)
 	else
 		if(!H.getorganslot(ORGAN_SLOT_BREATHING_TUBE))
+			if(HAS_TRAIT(src, TRAIT_NO_INTERNALS))
+				to_chat(H, "<span class='warning'>Due to cumbersome equipment or anatomy, you are currently unable to use internals!</span>")
+				return
 			var/obj/item/clothing/check
 			var/internals = FALSE
 

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -230,7 +230,7 @@
 
 	dat += "<BR><B>Back:</B> <A href='?src=[REF(src)];item=[SLOT_BACK]'>[back ? back : "Nothing"]</A>"
 
-	if(istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/tank))
+	if(!HAS_TRAIT(src, TRAIT_NO_INTERNALS) && istype(wear_mask, /obj/item/clothing/mask) && istype(back, /obj/item/tank))
 		dat += "<BR><A href='?src=[REF(src)];internal=1'>[internal ? "Disable Internals" : "Set Internals"]</A>"
 
 	if(handcuffed)
@@ -249,7 +249,7 @@
 	..()
 	//strip panel
 	if(usr.canUseTopic(src, BE_CLOSE, NO_DEXTERY))
-		if(href_list["internal"])
+		if(href_list["internal"] && !HAS_TRAIT(src, TRAIT_NO_INTERNALS))
 			var/slot = text2num(href_list["internal"])
 			var/obj/item/ITEM = get_item_by_slot(slot)
 			if(ITEM && istype(ITEM, /obj/item/tank) && wear_mask && (wear_mask.clothing_flags & ALLOWINTERNALS))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -334,9 +334,10 @@
 	var/obj/item/clothing/check
 	var/internals = FALSE
 
-	for(check in GET_INTERNAL_SLOTS(src))
-		if(CHECK_BITFIELD(check.clothing_flags, ALLOWINTERNALS))
-			internals = TRUE
+	if(!HAS_TRAIT(src, TRAIT_NO_INTERNALS))
+		for(check in GET_INTERNAL_SLOTS(src))
+			if(CHECK_BITFIELD(check.clothing_flags, ALLOWINTERNALS))
+				internals = TRUE
 	if(internal)
 		if(internal.loc != src)
 			internal = null

--- a/code/modules/uplink/uplink_items/uplink_explosives.dm
+++ b/code/modules/uplink/uplink_items/uplink_explosives.dm
@@ -145,7 +145,7 @@
 /datum/uplink_item/explosives/tearstache
 	name = "Teachstache Grenade"
 	desc = "A teargas grenade that launches sticky moustaches onto the face of anyone not wearing a clown or mime mask. The moustaches will \
-		remain attached to the face of all targets for one minute, preventing the use of breath masks and other such devices."
+		remain attached to the face of all targets for two minutes, preventing the use of breath masks and other such devices."
 	item = /obj/item/grenade/chem_grenade/teargas/moustache
 	cost = 3
 	surplus = 0


### PR DESCRIPTION
## About The Pull Request
Now the moustachening actually works and is not anymore blocked by its own tear gas smoke.
Also it stops internals more effectively, thus can't be bypassed with the space helmet powercreep anymore (breathing implant still works).
Additional few lines for return values to make sure the tearstache nade can't be exploited.

## Why It's Good For The Game
Fixes and a buff.

## Changelog
:cl:
fix: Fixed the tearstache nade not properly working.
balance: Buffed it against space helmet internals.
/:cl:
