### PR TITLE
Fixes slipping.

### DIFF
--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -9,8 +9,7 @@
 	callback = _callback
 	RegisterSignal(parent, list(COMSIG_MOVABLE_CROSSED, COMSIG_ATOM_ENTERED), .proc/Slip)
 
-/datum/component/slippery/proc/Slip(datum/source, atom/movable/AM, extra_flags = NONE)
+/datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	var/lube = lube_flags | extra_flags
 	if(istype(victim) && victim.slip(intensity, parent, lube) && callback)
 		callback.Invoke(victim)

--- a/code/datums/components/slippery.dm
+++ b/code/datums/components/slippery.dm
@@ -11,5 +11,5 @@
 
 /datum/component/slippery/proc/Slip(datum/source, atom/movable/AM)
 	var/mob/victim = AM
-	if(istype(victim) && victim.slip(intensity, parent, lube) && callback)
+	if(istype(victim) && victim.slip(intensity, parent, lube_flags) && callback)
 		callback.Invoke(victim)

--- a/code/game/gamemodes/clown_ops/clown_weapons.dm
+++ b/code/game/gamemodes/clown_ops/clown_weapons.dm
@@ -67,24 +67,26 @@
 	heat = 0
 	light_color = "#ffff00"
 	var/next_trombone_allowed = 0
+	var/datum/component/slippery/slipper
 
 /obj/item/melee/transforming/energy/sword/bananium/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 81, GALOSHES_DONT_HELP)
-	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
+	slipper = LoadComponent(/datum/component/slippery, 81, GALOSHES_DONT_HELP)
 	slipper.signal_enabled = active
 
 /obj/item/melee/transforming/energy/sword/bananium/attack(mob/living/M, mob/living/user)
 	..()
 	if(active)
-		var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-		slipper.Slip(src, M, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
+		slipper.lube_flags |= FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING
+		slipper.Slip(src, M)
+		slipper.lube_flags &= ~(FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 
 /obj/item/melee/transforming/energy/sword/bananium/throw_impact(atom/hit_atom, throwingdatum)
 	. = ..()
 	if(active)
-		var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-		slipper.Slip(src, hit_atom, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
+		slipper.lube_flags |= FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING
+		slipper.Slip(src, hit_atom)
+		slipper.lube_flags &= ~(FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 
 /obj/item/melee/transforming/energy/sword/bananium/attackby(obj/item/I, mob/living/user, params)
 	if((world.time > next_trombone_allowed) && istype(I, /obj/item/melee/transforming/energy/sword/bananium))
@@ -96,7 +98,6 @@
 
 /obj/item/melee/transforming/energy/sword/bananium/transform_weapon(mob/living/user, supress_message_text)
 	..()
-	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
 	slipper.signal_enabled = active
 
 /obj/item/melee/transforming/energy/sword/bananium/ignition_effect(atom/A, mob/user)
@@ -106,8 +107,9 @@
 	if(!active)
 		transform_weapon(user, TRUE)
 	user.visible_message("<span class='suicide'>[user] is [pick("slitting [user.p_their()] stomach open with", "falling on")] [src]! It looks like [user.p_theyre()] trying to commit seppuku, but the blade slips off of [user.p_them()] harmlessly!</span>")
-	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-	slipper.Slip(src, user, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
+	slipper.lube_flags |= FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING
+	slipper.Slip(src, user)
+	slipper.lube_flags &= ~(FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 	return SHAME
 
 //BANANIUM SHIELD
@@ -124,16 +126,15 @@
 	on_force = 0
 	on_throwforce = 0
 	on_throw_speed = 1
+	var/datum/component/slippery/slipper
 
 /obj/item/shield/energy/bananium/Initialize()
 	. = ..()
-	AddComponent(/datum/component/slippery, 81, GALOSHES_DONT_HELP)
-	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
+	slipper = LoadComponent(/datum/component/slippery, 81, GALOSHES_DONT_HELP)
 	slipper.signal_enabled = active
 
 /obj/item/shield/energy/bananium/attack_self(mob/living/carbon/human/user)
 	..()
-	var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
 	slipper.signal_enabled = active
 
 /obj/item/shield/energy/bananium/throw_at(atom/target, range, speed, mob/thrower, spin=1, diagonals_first = 0, datum/callback/callback)
@@ -147,8 +148,9 @@
 	if(active)
 		var/caught = hit_atom.hitby(src, FALSE, FALSE, throwingdatum=throwingdatum)
 		if(iscarbon(hit_atom) && !caught)//if they are a carbon and they didn't catch it
-			var/datum/component/slippery/slipper = GetComponent(/datum/component/slippery)
-			slipper.Slip(src, hit_atom, FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
+			slipper.lube_flags |= FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING
+			slipper.Slip(src, hit_atom)
+			slipper.lube_flags &= ~(FLYING_DOESNT_HELP|SLIP_WHEN_CRAWLING)
 		if(thrownby && !caught)
 			throw_at(thrownby, throw_range+2, throw_speed, null, 1)
 	else


### PR DESCRIPTION
## About The Pull Request
Damnit, I had a moment of deficiency and forgot the component signals may carry on additional args and that signal procs args shouldn't be messed in such a singular hacky way.

Making too many web edit PRs but my pc is pretty slow at times and this is high priority.

## Why It's Good For The Game
Fixing the game. Also makes the  `slipper` an actual bananium shield/sword variable instead of using GetComponent everytime.

## Changelog
:cl:
fix: Fixed slipping.
/:cl:

