### PR TITLE
Buffs carps again

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -21,7 +21,9 @@
 	health = 35
 	spacewalk = TRUE
 
-	var/regen_cooldown = 0 //Used for Mega carp and Cayenne
+	var/regen = FALSE //Can it heal over time or not?
+	var/regen_cooldown = 0 //Used for how long it takes before a healing will take place default in 60 seconds
+	var/heal_amout = 0 //How much is healed pre regen cooldown
 
 	harm_intent_damage = 8
 	obj_damage = 50
@@ -30,6 +32,20 @@
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
 	speak_emote = list("gnashes")
+
+	//Some carps heal over time
+
+/mob/living/simple_animal/hostile/carp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
+	. = ..()
+	if(regen != TRUE)
+		return
+	else
+		regen_cooldown = world.time + REGENERATION_DELAY
+
+/mob/living/simple_animal/hostile/carp/Life()
+	. = ..()
+	if(regen_cooldown < world.time)
+		heal_overall_damage(heal_amout)
 
 	//Space carp aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
@@ -61,6 +77,10 @@
 	icon_living = "megacarp"
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
+
+	heal_amout = 6
+	regen = TRUE
+
 	maxHealth = 30
 	health = 30
 	pixel_x = -16
@@ -78,40 +98,24 @@
 	maxHealth += rand(40,60)
 	move_to_delay = rand(3,7)
 
-/mob/living/simple_animal/hostile/carp/megacarp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	. = ..()
-	if(.)
-		regen_cooldown = world.time + REGENERATION_DELAY
-
-/mob/living/simple_animal/hostile/carp/megacarp/Life()
-	. = ..()
-	if(regen_cooldown < world.time)
-		heal_overall_damage(4)
-
 /mob/living/simple_animal/hostile/carp/cayenne
 	name = "Cayenne"
 	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
 	gender = FEMALE
+
+	regen = TRUE
+	heal_amout = 8
+
 	speak_emote = list("squeaks")
 	maxHealth = 90
 	health = 90
 	gold_core_spawnable = NO_SPAWN
-	faction = list(ROLE_SYNDICATE)
+	faction = list(ROLE_SYNDICATE, "carp") //They are still a carp
 	AIStatus = AI_OFF
 
 	harm_intent_damage = 12
 	obj_damage = 70
 	melee_damage_lower = 15
 	melee_damage_upper = 18
-
-/mob/living/simple_animal/hostile/carp/cayenne/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	. = ..()
-	if(.)
-		regen_cooldown = world.time + REGENERATION_DELAY
-
-/mob/living/simple_animal/hostile/carp/cayenne/Life()
-	. = ..()
-	if(regen_cooldown < world.time)
-		heal_overall_damage(8)
 
 #undef REGENERATION_DELAY

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -21,6 +21,8 @@
 	health = 35
 	spacewalk = TRUE
 
+	var/regen_cooldown = 0 //Used for Mega carp and Cayenne
+
 	harm_intent_damage = 8
 	obj_damage = 50
 	melee_damage_lower = 15
@@ -67,8 +69,6 @@
 	obj_damage = 80
 	melee_damage_lower = 20
 	melee_damage_upper = 20
-
-	var/regen_cooldown = 0
 
 /mob/living/simple_animal/hostile/carp/megacarp/Initialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -17,8 +17,8 @@
 	emote_taunt = list("gnashes")
 	taunt_chance = 30
 	speed = 0
-	maxHealth = 25
-	health = 25
+	maxHealth = 35
+	health = 35
 	spacewalk = TRUE
 
 	harm_intent_damage = 8
@@ -59,8 +59,8 @@
 	icon_living = "megacarp"
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
-	maxHealth = 20
-	health = 20
+	maxHealth = 30
+	health = 30
 	pixel_x = -16
 	mob_size = MOB_SIZE_LARGE
 
@@ -73,9 +73,9 @@
 /mob/living/simple_animal/hostile/carp/megacarp/Initialize()
 	. = ..()
 	name = "[pick(GLOB.megacarp_first_names)] [pick(GLOB.megacarp_last_names)]"
-	melee_damage_lower += rand(2, 10)
+	melee_damage_lower += rand(4, 10)
 	melee_damage_upper += rand(10,20)
-	maxHealth += rand(30,60)
+	maxHealth += rand(40,60)
 	move_to_delay = rand(3,7)
 
 /mob/living/simple_animal/hostile/carp/megacarp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
@@ -103,5 +103,15 @@
 	obj_damage = 70
 	melee_damage_lower = 15
 	melee_damage_upper = 18
+
+/mob/living/simple_animal/hostile/carp/cayenne/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
+	. = ..()
+	if(.)
+		regen_cooldown = world.time + REGENERATION_DELAY
+
+/mob/living/simple_animal/hostile/carp/cayenne/Life()
+	. = ..()
+	if(regen_cooldown < world.time)
+		heal_overall_damage(8)
 
 #undef REGENERATION_DELAY

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -20,11 +20,6 @@
 	maxHealth = 35
 	health = 35
 	spacewalk = TRUE
-
-	var/regen = FALSE //Can it heal over time or not?
-	var/regen_cooldown = 0 //Used for how long it takes before a healing will take place default in 60 seconds
-	var/heal_amout = 0 //How much is healed pre regen cooldown
-
 	harm_intent_damage = 8
 	obj_damage = 50
 	melee_damage_lower = 15
@@ -32,19 +27,6 @@
 	attacktext = "bites"
 	attack_sound = 'sound/weapons/bite.ogg'
 	speak_emote = list("gnashes")
-
-	//Some carps heal over time
-
-/mob/living/simple_animal/hostile/carp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
-	. = ..()
-	if(regen)
-		regen_cooldown = world.time + REGENERATION_DELAY
-
-/mob/living/simple_animal/hostile/carp/Life()
-	. = ..()
-	if(regen && regen_cooldown < world.time)
-		heal_overall_damage(heal_amout)
-
 	//Space carp aren't affected by cold.
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
 	minbodytemp = 0
@@ -53,6 +35,19 @@
 	movement_type = FLYING
 	pressure_resistance = 200
 	gold_core_spawnable = HOSTILE_SPAWN
+	//some carps heal over time
+	var/regen_cooldown = 0 //Used for how long it takes before a healing will take place default in 60 seconds
+	var/regen_amount = 0 //How much is healed pre regen cooldown
+
+/mob/living/simple_animal/hostile/carp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
+	. = ..()
+	if(regen_amount)
+		regen_cooldown = world.time + REGENERATION_DELAY
+
+/mob/living/simple_animal/hostile/carp/Life()
+	. = ..()
+	if(regen_amount && regen_cooldown < world.time)
+		heal_overall_damage(regen_amount)
 
 /mob/living/simple_animal/hostile/carp/AttackingTarget()
 	. = ..()
@@ -76,8 +71,7 @@
 	icon_dead = "megacarp_dead"
 	icon_gib = "megacarp_gib"
 
-	heal_amout = 6
-	regen = TRUE
+	regen_amount = 6
 
 	maxHealth = 30
 	health = 30
@@ -101,8 +95,7 @@
 	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
 	gender = FEMALE
 
-	regen = TRUE
-	heal_amout = 8
+	regen_amout = 8
 
 	speak_emote = list("squeaks")
 	maxHealth = 90

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -37,14 +37,12 @@
 
 /mob/living/simple_animal/hostile/carp/adjustHealth(amount, updating_health = TRUE, forced = FALSE)
 	. = ..()
-	if(regen != TRUE)
-		return
-	else
+	if(regen)
 		regen_cooldown = world.time + REGENERATION_DELAY
 
 /mob/living/simple_animal/hostile/carp/Life()
 	. = ..()
-	if(regen_cooldown < world.time)
+	if(regen && regen_cooldown < world.time)
 		heal_overall_damage(heal_amout)
 
 	//Space carp aren't affected by cold.

--- a/code/modules/mob/living/simple_animal/hostile/carp.dm
+++ b/code/modules/mob/living/simple_animal/hostile/carp.dm
@@ -95,7 +95,7 @@
 	desc = "A failed Syndicate experiment in weaponized space carp technology, it now serves as a lovable mascot."
 	gender = FEMALE
 
-	regen_amout = 8
+	regen_amount = 8
 
 	speak_emote = list("squeaks")
 	maxHealth = 90


### PR DESCRIPTION
## About The Pull Request

Normal and Mega carps have 10~ 20~ more HP
Mega carps lower damage add on is now 4 to 10 rather then 2 to 10
The Nukie carp now can regen passively 
## Why It's Good For The Game

The nukie carp is a ghost role that will likely take a few hits and then die, or sit on the shuttle/space well the team dies/wins the game mode. Having it stuck in a "man if only they would heal me" mode kinda sucks and makes them more usefull - Note it takes 11 mins to fully regen from 2 hp to full

As for carp hp buffs, they go down in 2-3 hits with a spear/tool box and are not that much of a threat to anyone in space. 

Mega carps are buffed a bit more so that they are less of a hit it /4 to 5!/ times and have them bit a less squishy for being a massive mob that can mess you up if you dont prepare for the fight

## Changelog
:cl:
add: Carps have evolved to take more damage
/:cl:
