### PR TITLE
Corrects Box'es caps office + some other tweaks

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -173,19 +173,6 @@
 "aay" = (
 /turf/open/floor/plating,
 /area/security/prison)
-"aaz" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 3;
-	name = "Docking Beacon";
-	picked_color = "Burgundy"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
 "aaA" = (
 /obj/machinery/seed_extractor,
 /turf/open/floor/plasteel,
@@ -247,46 +234,10 @@
 /obj/structure/chair/stool,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaK" = (
-/obj/structure/lattice/catwalk,
-/obj/item/stack/marker_beacon{
-	anchored = 1;
-	icon_state = "markerburgundy-on";
-	light_color = "#FA644B";
-	light_power = 3;
-	light_range = 3;
-	name = "Docking Beacon";
-	picked_color = "Burgundy"
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"aaL" = (
-/obj/machinery/photocopier,
-/turf/open/floor/wood,
-/area/library)
-"aaM" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "aaN" = (
 /obj/structure/chair/sofa/right,
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaO" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "aaP" = (
 /obj/machinery/computer/cryopod{
 	dir = 8;
@@ -297,12 +248,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaQ" = (
-/obj/structure/sign/poster/contraband/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "aaR" = (
 /obj/structure/lattice,
 /obj/structure/sign/warning/securearea{
@@ -340,15 +285,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"aaY" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/obj/item/poster/random_official,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "aaZ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/security/armory)
@@ -569,11 +505,6 @@
 "abF" = (
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
-"abG" = (
-/obj/structure/door_assembly/door_assembly_mai,
-/obj/item/electronics/airlock,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
 "abH" = (
 /obj/structure/table,
 /obj/item/storage/box/chemimp{
@@ -1634,10 +1565,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
-"adO" = (
-/obj/effect/spawner/structure/window/shuttle,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
 "adP" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -2052,34 +1979,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"aeD" = (
-/obj/structure/grille/broken,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"aeE" = (
-/obj/structure/girder,
-/turf/open/floor/plating/airless,
-/area/space/nearstation)
-"aeF" = (
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/computer/station_alert{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "aeG" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -2458,12 +2357,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"afn" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "afo" = (
 /obj/machinery/door/airlock/external{
 	name = "Escape Pod Three"
@@ -2484,39 +2377,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"afq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"afr" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
-"afs" = (
-/obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -31
-	},
-/obj/machinery/computer/monitor{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "aft" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 5
@@ -2827,15 +2687,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/general/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"age" = (
-/obj/structure/chair/office/dark{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "agf" = (
 /obj/structure/table,
 /obj/item/stack/sheet/metal,
@@ -2985,10 +2836,6 @@
 /obj/machinery/suit_storage_unit/security,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"agv" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "agw" = (
 /obj/structure/table,
 /obj/machinery/syndicatebomb/training,
@@ -3118,14 +2965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
-"agH" = (
-/obj/machinery/bluespace_beacon,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "agI" = (
 /obj/machinery/airalarm{
 	pixel_y = 23
@@ -3255,12 +3094,6 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/security/warden)
-"agX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "agY" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -3501,16 +3334,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"ahw" = (
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ahx" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4651,16 +4474,6 @@
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"ajC" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/grimy,
-/area/ai_monitored/turret_protected/aisat_interior)
 "ajD" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -4869,18 +4682,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/solars/port/fore)
-"ajX" = (
-/obj/machinery/computer/teleporter{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat_interior)
-"ajY" = (
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/atmos)
 "ajZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
@@ -5164,18 +4965,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"akz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/holopad,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/landmark/start/cyborg,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat_interior)
 "akA" = (
 /obj/structure/chair{
 	dir = 8;
@@ -6276,14 +6065,6 @@
 /turf/open/floor/plasteel,
 /area/security/processing)
 "anu" = (
-/obj/machinery/button/door{
-	desc = "A remote control switch for the exit.";
-	id = "laborexit";
-	name = "exit button";
-	normaldoorcontrol = 1;
-	pixel_x = 26;
-	pixel_y = -6
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -6432,10 +6213,8 @@
 /area/space)
 "anP" = (
 /obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/security{
-	id_tag = "laborexit";
-	name = "Labor Shuttle";
-	req_access_txt = "63"
+/obj/machinery/door/airlock/security/glass{
+	name = "Labor Camp Shuttle Airlock"
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -16138,6 +15917,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"aNV" = (
+/obj/machinery/photocopier,
+/turf/open/floor/wood,
+/area/library)
 "aNW" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Chapel Office";
@@ -22009,7 +21792,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/wood,
+/turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "bcR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -22128,6 +21911,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/machinery/computer/arcade/minesweeper,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bdj" = (
@@ -23115,7 +22899,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 5
 	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
 "bfD" = (
 /obj/structure/cable{
@@ -26705,6 +26489,7 @@
 /area/crew_quarters/heads/captain)
 "boa" = (
 /obj/structure/toilet{
+	contents = newlist(/obj/item/toy/snappop/phoenix);
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -30020,6 +29805,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
+"bvG" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
 "bvH" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
@@ -30190,6 +29981,21 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
+"bwc" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/brown,
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "bwd" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
@@ -48366,6 +48172,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"coh" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"coi" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/turf/open/floor/plasteel,
+/area/security/brig)
 "cop" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/incinerator_input{
 	dir = 1
@@ -48524,6 +48340,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"coI" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hydroponics)
 "coJ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable/yellow{
@@ -48754,6 +48574,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cpF" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/sign/poster/official/space_cops{
+	pixel_x = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "cpG" = (
 /obj/structure/table/optable,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
@@ -49488,9 +49317,46 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ctu" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctv" = (
 /turf/closed/wall/r_wall,
 /area/space/nearstation)
+"ctw" = (
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/computer/station_alert{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"ctx" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
+"cty" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctz" = (
 /obj/machinery/door/poddoor/shutters{
 	id = "teledoor";
@@ -49535,6 +49401,41 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ctG" = (
+/obj/structure/chair/office/dark{
+	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
+"ctH" = (
+/obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = -31
+	},
+/obj/machinery/computer/monitor{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"ctI" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctJ" = (
 /obj/machinery/holopad,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -49558,6 +49459,14 @@
 	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
+"ctM" = (
+/obj/machinery/bluespace_beacon,
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctN" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 10
@@ -49565,6 +49474,12 @@
 /obj/structure/lattice,
 /turf/open/space,
 /area/space/nearstation)
+"ctP" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctQ" = (
 /obj/structure/table,
 /obj/machinery/microwave{
@@ -49590,6 +49505,26 @@
 /obj/structure/sign/warning/radiation/rad_area,
 /turf/closed/wall,
 /area/engine/engineering)
+"ctS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
+"ctT" = (
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/ai_monitored/turret_protected/aisat_interior)
 "ctU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -49611,6 +49546,12 @@
 	},
 /obj/structure/chair,
 /turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"ctW" = (
+/obj/machinery/computer/teleporter{
+	dir = 8
+	},
+/turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat_interior)
 "ctX" = (
 /obj/machinery/camera{
@@ -49892,6 +49833,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/atmos)
+"cuC" = (
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/start/cyborg,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/atmos)
 "cuD" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -49938,6 +49885,18 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat_interior)
+"cuG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/holopad,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
 "cuH" = (
@@ -50882,14 +50841,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
-"cwP" = (
-/obj/structure/fireplace,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
 "cwT" = (
 /obj/machinery/camera{
 	c_tag = "Arrivals Escape Pod 2";
@@ -51199,14 +51150,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"czi" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
 "czk" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -52077,6 +52020,15 @@
 /obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
+"cCt" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
+	},
+/obj/item/poster/random_official,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "cCB" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -52238,6 +52190,36 @@
 /obj/structure/closet/radiation,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"cEo" = (
+/obj/structure/closet/boxinggloves,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"cGz" = (
+/obj/structure/table/wood,
+/obj/item/instrument/violin,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"cHf" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 20
+	},
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 20
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/item/reagent_containers/food/drinks/britcup,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
 "cHD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -52548,27 +52530,10 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"cJn" = (
-/obj/structure/reagent_dispensers/watertank/high,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/box,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cMk" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+"cIv" = (
+/obj/structure/sign/poster/official/cohiba_robusto_ad,
+/turf/closed/wall,
+/area/lawoffice)
 "cMC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -52599,6 +52564,10 @@
 	},
 /turf/open/floor/plasteel/airless/solarpanel,
 /area/solar/starboard/aft)
+"cMS" = (
+/obj/item/chair/wood,
+/turf/open/floor/plating,
+/area/maintenance/port)
 "cNa" = (
 /obj/structure/cable,
 /obj/machinery/power/solar{
@@ -52752,6 +52721,10 @@
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"cPn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
 "cPA" = (
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 4
@@ -52794,47 +52767,25 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cRz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+"cQF" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 8;
+	name = "8maintenance loot spawner"
 	},
-/obj/machinery/button/door{
-	id = "holoprivacy";
-	name = "Holodeck Privacy";
-	pixel_y = 24
+/obj/item/radio/intercom{
+	pixel_y = 25
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"cRD" = (
-/obj/machinery/light/small{
-	dir = 8
-	},
-/obj/structure/dresser,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
-	dir = 8;
-	name = "Theatre APC";
-	pixel_x = -25
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
-"cSn" = (
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"cQT" = (
+/obj/structure/filingcabinet,
 /obj/machinery/light{
-	dir = 1
+	dir = 8;
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "cSA" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -53196,6 +53147,12 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
+"cTT" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
 "cTX" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -53218,952 +53175,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
+"cUx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge/meeting_room)
 "cVb" = (
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"cVp" = (
-/obj/structure/window/reinforced/tinted{
-	dir = 8
-	},
-/obj/structure/window/reinforced/tinted{
-	dir = 4
-	},
-/obj/structure/curtain,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"cVu" = (
-/obj/machinery/camera{
-	c_tag = "Locker Room South";
-	dir = 8
-	},
-/obj/structure/closet/secure_closet/personal,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
+"cVs" = (
+/obj/machinery/vending/coffee,
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
 "cVK" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"cXx" = (
-/obj/machinery/door/airlock/security{
-	name = "Labor Shuttle";
-	req_access_txt = "2"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/processing)
-"dbn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
-"dbM" = (
-/turf/open/floor/plating,
-/area/space/nearstation)
-"dcG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/closet/wardrobe/pjs,
-/obj/item/clothing/under/maid,
-/obj/item/clothing/under/maid,
-/obj/item/clothing/under/janimaid,
-/obj/item/clothing/under/janimaid,
-/obj/item/clothing/accessory/maidapron,
-/obj/item/clothing/accessory/maidapron,
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"dfh" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/circuit";
-	name = "Circuitry Lab APC";
-	pixel_x = 30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"dfI" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/departments/evac{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"dfL" = (
-/obj/structure/reagent_dispensers/keg/gargle,
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"dgh" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/machinery/camera{
-	c_tag = "VR Sleepers";
-	dir = 1
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/fitness)
-"dgz" = (
-/turf/closed/wall,
-/area/crew_quarters/cryopod)
-"dhx" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 25
-	},
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"dok" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"doP" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
-"dqu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"dtE" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"dvc" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"dvO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall,
-/area/science/circuit)
-"dwc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"dxB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"dzi" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"dzy" = (
-/obj/machinery/door/airlock{
-	name = "Shower Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/toilet)
-"dHb" = (
-/obj/structure/chair/comfy/black{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"dKP" = (
-/turf/closed/wall,
-/area/maintenance/bar)
-"dKV" = (
-/obj/structure/chair/stool/bar,
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"dMu" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"dMX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/obj/structure/chair/comfy/brown,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"dMZ" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"dRC" = (
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"dSv" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/abandoned_gambling_den";
-	name = "Abandoned Gambling Den APC";
-	pixel_y = -24
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"dTe" = (
-/obj/structure/chair/comfy/beige{
-	dir = 8
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel/grimy,
-/area/hallway/secondary/entry)
-"dTJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/heads/captain)
-"eaI" = (
-/obj/structure/table/reinforced,
-/obj/item/radio/intercom{
-	pixel_x = -30
-	},
-/obj/item/stock_parts/cell/high,
-/obj/item/stock_parts/cell/high,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"edH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"ego" = (
-/obj/machinery/atmospherics/components/binary/valve,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"egQ" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/bluecherrycupcake{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"egS" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/obj/item/reagent_containers/food/snacks/burger/plain,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"elw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
+"cXU" = (
 /obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	light_color = "#c9d3e8"
+	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"epV" = (
-/obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm6";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
-"eqm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"est" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/computer/shuttle/mining/common{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
-"evR" = (
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"ewZ" = (
-/obj/structure/chair/sofa/right,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"eyM" = (
-/obj/machinery/mineral/ore_redemption{
-	input_dir = 2;
-	output_dir = 1
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"eHI" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
-"eLH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
-"eMQ" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/carpet,
-/area/library)
-"eND" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"eNK" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"eNW" = (
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"eOv" = (
-/obj/effect/landmark/event_spawn,
-/turf/closed/wall,
-/area/crew_quarters/fitness)
-"eOy" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ePO" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"eRk" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"eRn" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/quartermaster/warehouse)
-"eRz" = (
-/obj/structure/lattice,
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
-"eUd" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"eVC" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopod)
-"eVL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch{
-	pixel_y = 28
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningdock)
-"eXm" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"fbm" = (
-/obj/structure/chair/comfy/brown{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"fby" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"fcG" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/science/mixing)
-"fhP" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"fjy" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/crew_quarters/heads/captain)
-"flc" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/fancy/donut_box,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"fnC" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"fnJ" = (
-/obj/structure/sign/mining{
-	pixel_y = 7
-	},
-/turf/closed/wall,
-/area/quartermaster/miningdock)
-"frE" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/crew_quarters/fitness)
-"ftv" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"fuo" = (
-/obj/item/reagent_containers/glass/bucket,
-/turf/open/floor/grass,
-/area/security/prison)
-"fvk" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"fvW" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"fvY" = (
-/obj/machinery/computer/cryopod{
-	pixel_y = 26
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"fxa" = (
-/obj/structure/chair/wood/normal,
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/maintenance/bar)
-"fyq" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 5
-	},
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
-"fyM" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/item/radio/headset/headset_cargo,
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"fzd" = (
-/turf/closed/wall,
-/area/crew_quarters/abandoned_gambling_den)
-"fGf" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
-/obj/structure/table,
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"fGl" = (
-/obj/effect/landmark/event_spawn,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"fGC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/door/airlock/vault,
-/obj/effect/mapping_helpers/airlock/locked,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"fHK" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"fIn" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/obj/machinery/meter,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"fJa" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"fKl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"fLd" = (
-/obj/structure/table/wood,
-/obj/machinery/requests_console{
-	department = "Theatre";
-	name = "theatre RC";
-	pixel_x = -32
-	},
-/obj/item/reagent_containers/food/snacks/baguette,
-/obj/item/toy/dummy,
-/obj/item/lipstick/random{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/lipstick/random{
-	pixel_x = -2;
-	pixel_y = -2
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
-"fOc" = (
-/obj/structure/bed,
-/obj/item/bedsheet/random,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"fPs" = (
-/obj/structure/table/reinforced,
-/obj/machinery/door/firedoor,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "kitchen";
-	name = "kitchen shutters"
-	},
-/obj/item/reagent_containers/food/snacks/cheesynachos{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"fQF" = (
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	dir = 5;
-	icon_state = "roomnum";
-	name = "Room Number 7";
-	pixel_y = 24
-	},
-/obj/structure/chair/sofa/right,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"fSr" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/trunk{
-	dir = 4
-	},
-/obj/machinery/disposal/bin,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"fTg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"fVU" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
-"fZD" = (
-/obj/structure/filingcabinet,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"gbq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plating,
-/area/construction)
-"gbT" = (
-/obj/structure/table,
-/obj/item/stack/sheet/metal/fifty,
-/obj/item/stack/sheet/glass/fifty,
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
-"gdu" = (
-/obj/structure/toilet{
-	dir = 4
-	},
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 25
-	},
-/obj/machinery/button/door{
-	id = "LockerShitter2";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 14;
-	pixel_y = 38;
-	specialfunctions = 4
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet/locker)
-"gfD" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"ggg" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable,
-/turf/open/space,
-/area/solar/starboard/aft)
-"ghs" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/light,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ghJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/sign/warning/fire{
-	desc = "A sign that states the labeled room's number.";
-	icon_state = "roomnum";
-	name = "Room Number 1";
-	pixel_x = -30;
-	pixel_y = -7
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"ghY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"gjf" = (
-/obj/machinery/vending/coffee,
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"gjl" = (
-/turf/closed/wall,
-/area/quartermaster/warehouse)
-"gjC" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"gtL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"gwd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"gwi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"gBo" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"gCe" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"gFD" = (
-/obj/structure/table/wood/fancy/royalblue,
-/obj/item/crowbar/red,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"gIO" = (
-/obj/structure/bed,
-/obj/effect/spawner/lootdrop/bedsheet,
-/turf/open/floor/plating,
-/area/security/prison)
-"gJg" = (
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
-"gKk" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
-"gLH" = (
-/obj/machinery/door/airlock/external{
-	name = "External Access";
-	req_access_txt = "13"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/fore)
-"gMl" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"gOZ" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"gQn" = (
-/obj/machinery/light/small,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"gSH" = (
-/obj/structure/grille,
-/turf/closed/wall/r_wall,
-/area/space/nearstation)
-"gVX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
-"gVY" = (
+"daI" = (
 /obj/structure/reagent_dispensers/foamtank,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -54178,488 +53214,20 @@
 /obj/effect/turf_decal/stripes/box,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"gWd" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/construction)
-"gXs" = (
-/obj/structure/lattice,
-/turf/open/space/basic,
-/area/space/nearstation)
-"gZG" = (
-/obj/structure/closet/crate/freezer/surplus_limbs,
-/obj/item/reagent_containers/glass/beaker/synthflesh,
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/medical/sleeper)
-"haz" = (
-/obj/machinery/autolathe{
-	name = "public autolathe"
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"haX" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"hcd" = (
-/obj/machinery/smartfridge/organ/preloaded,
-/turf/closed/wall,
-/area/medical/sleeper)
-"hdb" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"hdp" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 3;
-	name = "3maintenance loot spawner"
-	},
+"dbU" = (
 /obj/structure/light_construct{
-	dir = 8
+	dir = 1
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"hfe" = (
-/obj/structure/sign/poster/contraband/smoke{
-	desc = "This poster reminds us all that the Detective is a parasite. Year after year, they must get replacement lungs because of their addiction. ";
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
-"hgX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"dce" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
-/obj/machinery/light/small,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 1
-	},
-/area/crew_quarters/fitness)
-"hik" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/space,
-/area/solar/starboard/aft)
-"hjw" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"hkg" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"hlY" = (
-/obj/machinery/door/airlock{
-	name = "Recharging Station"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"hoo" = (
-/obj/effect/landmark/carpspawn,
-/turf/open/space/basic,
-/area/space)
-"htr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"hvS" = (
-/obj/effect/landmark/stationroom/box/engine,
-/turf/open/space/basic,
-/area/space)
-"hwu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
-"hzw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/window{
-	dir = 1
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"hzR" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"hKF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plating,
-/area/storage/tech)
-"hMx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"hRa" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/machinery/cell_charger{
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"hRz" = (
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hRT" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/department/electrical)
-"hRX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"hSU" = (
-/obj/structure/chair/sofa/left,
-/obj/structure/window{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"hVw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"hWn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"hYW" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 2;
-	name = "2maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"hZH" = (
-/obj/machinery/hydroponics/constructable,
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_x = 29
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
-"idX" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iep" = (
-/obj/structure/mirror{
-	pixel_y = 32
-	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 25
-	},
-/obj/structure/toilet{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"ier" = (
-/obj/machinery/button/door{
-	id = "Room Two";
-	name = "Door Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_x = 7;
-	pixel_y = -24;
-	specialfunctions = 4
-	},
-/obj/structure/chair/comfy/brown{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"igT" = (
-/obj/structure/table/wood/poker,
-/obj/item/toy/cards/deck{
-	pixel_y = 5
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"ihm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/junction/flip,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ihC" = (
-/obj/item/chair/wood,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"iiW" = (
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"ilJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	light_color = "#c9d3e8"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"imH" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"ioB" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/obj/effect/landmark/start/mime,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
-"ioG" = (
-/obj/machinery/vending/cola/red,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"ioX" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"ipc" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engine_smes)
-"ipA" = (
-/turf/open/floor/plating,
-/area/maintenance/department/medical/morgue)
-"iqw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"isy" = (
-/obj/structure/urinal{
-	pixel_y = 32
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
-"itG" = (
-/obj/structure/table/reinforced,
-/obj/item/paper_bin,
-/obj/item/pen,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"itT" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ium" = (
-/mob/living/simple_animal/bot/cleanbot{
-	name = "C.L.E.A.N."
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"ivF" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"iyC" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-06"
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
-/area/hallway/secondary/entry)
-"izv" = (
-/obj/machinery/vending/clothing,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"iEx" = (
-/obj/structure/table/wood,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/item/instrument/trombone,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"iEI" = (
-/obj/machinery/vending/autodrobe/all_access,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"iEJ" = (
-/obj/machinery/door/airlock/external{
-	name = "Escape Pod One"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"iES" = (
-/obj/structure/fireplace,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"iFL" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"iMG" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-14"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"iNn" = (
-/obj/machinery/camera{
-	c_tag = "Kitchen Cold Room"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/reagent_dispensers/cooking_oil,
-/turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
-"iOt" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/sign/poster/contraband/free_drone{
-	pixel_y = 32
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"iOV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/light_construct{
-	dir = 4
-	},
+/obj/machinery/meter,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"iRJ" = (
+"dev" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -54680,150 +53248,67 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"iVU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window,
-/obj/machinery/door/firedoor,
-/turf/open/floor/plating,
-/area/crew_quarters/cryopod)
-"iWa" = (
-/obj/structure/closet/crate,
-/obj/item/book/manual/wiki/telescience,
-/obj/item/book/manual/wiki/engineering_guide,
-/obj/item/book/manual/wiki/engineering_construction,
-/obj/item/book/manual/wiki/atmospherics,
-/obj/item/book/manual/wiki/detective,
-/obj/item/book/manual/wiki/tcomms,
-/obj/item/book/manual/wiki/engineering_singulo_tesla,
-/obj/item/book/manual/wiki/experimentor,
-/obj/item/book/manual/wiki/research_and_development,
-/obj/item/book/manual/wiki/robotics_cyborgs,
-/obj/item/book/manual/wiki/security_space_law,
-/obj/item/book/manual/wiki/medicine,
-/obj/item/book/manual/wiki/medical_cloning,
-/obj/item/book/manual/wiki/infections,
-/obj/item/book/manual/ripley_build_and_repair,
-/obj/item/book/manual/hydroponics_pod_people,
-/obj/item/book/manual/wiki/toxins,
-/obj/item/book/manual/wiki/grenades,
-/obj/item/book{
-	desc = "An undeniably handy book.";
-	icon_state = "bookknock";
-	name = "A Simpleton's Guide to Safe-cracking with Stethoscopes"
-	},
-/turf/open/floor/wood,
-/area/library)
-"iWk" = (
-/obj/structure/bookcase{
-	name = "Forbidden Knowledge"
-	},
-/turf/open/floor/carpet,
-/area/library)
-"iYz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/theatre)
-"jaa" = (
-/obj/machinery/hydroponics/constructable,
-/obj/machinery/light{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
-"jbf" = (
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+"dfh" = (
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/service";
-	dir = 1;
-	name = "Service Hall APC";
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"jdT" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"jeR" = (
-/obj/structure/chair/sofa/left,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jeT" = (
-/obj/machinery/vending/clothing,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"jgm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
+	areastring = "/area/science/circuit";
+	name = "Circuitry Lab APC";
+	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 4
 	},
-/obj/machinery/camera{
-	c_tag = "Circuitry Lab";
-	dir = 8;
-	network = list("ss13","rd")
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"jgv" = (
-/obj/structure/chair/comfy/brown{
-	color = "#596479";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jhF" = (
-/obj/effect/turf_decal/stripes/line{
+"dfL" = (
+/obj/structure/reagent_dispensers/keg/gargle,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"dgz" = (
+/turf/closed/wall,
+/area/crew_quarters/cryopod)
+"dgO" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/turf/open/floor/plasteel,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"jiR" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+"diq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"dly" = (
+/obj/machinery/door/window/southright{
+	name = "Target Storage"
+	},
+/obj/item/target/alien,
+/obj/item/target/alien,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
+"dml" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"dqb" = (
+/obj/structure/bed,
+/obj/item/bedsheet/random,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/window,
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"jlm" = (
-/obj/machinery/rnd/production/techfab/department/cargo,
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"jly" = (
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"dqu" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
+"dsC" = (
 /obj/structure/chair/stool{
 	pixel_y = 8
 	},
@@ -54834,65 +53319,273 @@
 	icon_state = "carpetsymbol"
 	},
 /area/crew_quarters/theatre)
-"jmC" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space/nearstation)
-"jnm" = (
-/obj/machinery/power/smes{
-	charge = 5e+006
+"dtx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/sink{
+	dir = 4;
+	pixel_x = 11
+	},
+/obj/structure/mirror{
+	pixel_x = 25
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"dvc" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"dvO" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall,
+/area/science/circuit)
+"dyS" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dzi" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"dBm" = (
+/obj/machinery/portable_atmospherics/scrubber,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"dCV" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/recharger,
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dKP" = (
+/turf/closed/wall,
+/area/maintenance/bar)
+"dKV" = (
+/obj/structure/chair/stool/bar,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"dLG" = (
+/obj/machinery/door/airlock/security{
+	name = "Firing Range";
+	req_access_txt = "2"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"jnX" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
-"job" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/door/window/westright{
-	name = "Red Corner"
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"jqv" = (
-/obj/structure/chair/wood/normal{
-	dir = 1
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
-	},
-/area/maintenance/bar)
-"jrE" = (
+/area/security/prison)
+"dMZ" = (
 /obj/structure/sign/poster/official/random{
-	pixel_x = 32
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"jsy" = (
+"dPk" = (
+/obj/structure/closet{
+	name = "Costume Closet"
+	},
+/obj/item/clothing/head/russobluecamohat,
+/obj/item/clothing/head/russobluecamohat,
+/obj/item/clothing/head/helmet/rus_ushanka,
+/obj/item/clothing/head/helmet/rus_ushanka,
+/obj/item/clothing/head/helmet/rus_ushanka,
+/obj/item/clothing/head/helmet/rus_ushanka,
+/obj/item/clothing/under/mw2_russian_para,
+/obj/item/clothing/under/mw2_russian_para,
+/obj/item/clothing/under/mw2_russian_para,
+/obj/item/clothing/under/mw2_russian_para,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/obj/item/clothing/shoes/jackboots,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"dTI" = (
+/obj/structure/urinal{
+	pixel_y = 32
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"dVU" = (
+/turf/open/floor/plating,
+/area/space/nearstation)
+"dXq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"eaI" = (
+/obj/structure/table/reinforced,
+/obj/item/radio/intercom{
+	pixel_x = -30
+	},
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"eaR" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/space,
+/area/solar/starboard/fore)
+"edA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-04"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"efO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"egt" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/machinery/requests_console{
+	department = "Bar";
+	departmentType = 2;
+	pixel_x = -30;
+	pixel_y = 45;
+	receive_ore_updates = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"eih" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"elh" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"enB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall,
+/area/security/execution/transfer)
+"epC" = (
+/obj/machinery/door/airlock{
+	desc = "To keep the station within regulations, space IKEA requires one storage cupboard for their Nanotrasen partnership to continue.";
+	id_tag = "MaintDorm1";
+	name = "Furniture Storage"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/port)
+"epD" = (
+/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/structure/chair/sofa/right{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"eqd" = (
+/obj/item/electropack/shockcollar,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/security/prison)
+"eqA" = (
+/obj/machinery/shower{
+	dir = 8
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"esZ" = (
+/obj/machinery/door/airlock{
+	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
+	id_tag = "PrivateStudy";
+	name = "Private Study"
+	},
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/wood,
+/area/library)
+"evR" = (
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"ewu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"exP" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-14"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"eyM" = (
+/obj/machinery/mineral/ore_redemption{
+	input_dir = 2;
+	output_dir = 1
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningdock)
+"eAJ" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"eBX" = (
+/obj/machinery/vending/cola/space_up,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"eCr" = (
 /obj/structure/closet{
 	name = "Suit Closet"
 	},
@@ -54916,61 +53609,1168 @@
 /obj/item/clothing/under/lawyer/really_black,
 /obj/item/clothing/under/lawyer/red,
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"jtk" = (
-/obj/structure/chair/comfy/black{
+/area/crew_quarters/fitness)
+"eCR" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"eEe" = (
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"eFW" = (
+/obj/effect/spawner/structure/window/shuttle,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"eHI" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
+"eHU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"eJa" = (
+/obj/structure/table/wood/poker,
+/obj/item/toy/cards/deck{
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"eQb" = (
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"eRz" = (
+/obj/structure/lattice,
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"eSe" = (
+/obj/structure/closet/secure_closet/personal/cabinet{
+	desc = "Swipe your ID on the closet to claim it. First come first serve, this one is wooden and fancy. Store your stuff here.";
+	name = "Personal ID-Locked Closet";
+	pixel_y = 15
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"eVC" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopod)
+"eVL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/machinery/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"jtU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/closed/wall,
-/area/security/execution/transfer)
-"jvN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
+/area/quartermaster/miningdock)
+"fcn" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/nuke_storage)
+"fcG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/effect/turf_decal/tile/blue,
+/turf/closed/wall/r_wall,
+/area/science/mixing)
+"fde" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"jwi" = (
+/area/security/brig)
+"feE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
+/area/maintenance/starboard/fore)
+"feG" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"jzi" = (
+/area/crew_quarters/bar)
+"fgG" = (
+/obj/structure/table/wood,
+/obj/machinery/requests_console{
+	department = "Theatre";
+	name = "theatre RC";
+	pixel_x = -32
+	},
+/obj/item/reagent_containers/food/snacks/baguette,
+/obj/item/toy/dummy,
+/obj/item/lipstick/random{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/lipstick/random{
+	pixel_x = -2;
+	pixel_y = -2
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
+"fjS" = (
+/obj/structure/closet/radiation,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"flc" = (
+/obj/structure/table/reinforced,
+/obj/item/storage/fancy/donut_box,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"flE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"fne" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/effect/landmark/start/mime,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
+"fnC" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
+"fpl" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"fpI" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-06"
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
+"fsj" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/security/main";
+	dir = 4;
+	name = "Firing Range APC";
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ftE" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fup" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"fvY" = (
+/obj/machinery/computer/cryopod{
+	pixel_y = 26
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"fxa" = (
+/obj/structure/chair/wood/normal,
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
+/area/maintenance/bar)
+"fxe" = (
+/obj/structure/chair/sofa,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"fxV" = (
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central)
+"fzd" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"fAj" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/love_ian{
+	pixel_x = 32;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fBy" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"fCx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "holoprivacy";
+	name = "Holodeck Privacy";
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"fFA" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"fGf" = (
+/obj/machinery/smartfridge/disks{
+	pixel_y = 2
+	},
+/obj/structure/table,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"fHG" = (
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"fIs" = (
 /obj/structure/grille,
 /obj/structure/lattice,
 /turf/open/floor/plating,
 /area/space/nearstation)
-"jzD" = (
-/obj/structure/piano{
-	icon_state = "piano"
+"fKl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/landmark/event_spawn,
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"fMZ" = (
+/obj/item/radio/intercom{
+	dir = 4;
+	name = "Station Intercom (General)";
+	pixel_x = 27
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"fOA" = (
+/obj/machinery/door/airlock{
+	name = "Theatre Backstage";
+	req_access_txt = "46"
 	},
 /turf/open/floor/wood,
-/area/crew_quarters/bar)
-"jAD" = (
-/obj/structure/grille,
-/turf/open/floor/plating/airless,
+/area/crew_quarters/theatre)
+"fOI" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-18"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"fTg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/firealarm{
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"fTC" = (
+/obj/structure/filingcabinet,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"fZm" = (
+/obj/structure/chair/sofa/left,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"gbd" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"gbh" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
+"gbq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plating,
+/area/construction)
+"gbu" = (
+/obj/structure/bed,
+/obj/effect/spawner/lootdrop/bedsheet,
+/turf/open/floor/plating,
+/area/security/prison)
+"gbT" = (
+/obj/structure/table,
+/obj/item/stack/sheet/metal/fifty,
+/obj/item/stack/sheet/glass/fifty,
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"gcF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/light_construct{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"gfr" = (
+/obj/structure/bed,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"gfC" = (
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"gfD" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"ghq" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 3;
+	name = "Docking Beacon";
+	picked_color = "Burgundy"
+	},
+/turf/open/floor/plating,
 /area/space/nearstation)
-"jBZ" = (
+"ghD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"gjl" = (
+/turf/closed/wall,
+/area/quartermaster/warehouse)
+"gnf" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/sign/departments/custodian{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gpD" = (
+/obj/machinery/light_switch{
+	pixel_y = 28
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
+"grA" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
+"gwd" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"gxc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"gzf" = (
+/obj/structure/window/reinforced/tinted{
+	dir = 8
+	},
+/obj/structure/window/reinforced/tinted{
+	dir = 4
+	},
+/obj/structure/curtain,
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"gBo" = (
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"gCC" = (
+/obj/structure/sign/poster/contraband/tools,
+/turf/closed/wall,
+/area/storage/primary)
+"gDl" = (
+/obj/effect/landmark/carpspawn,
+/turf/open/space/basic,
+/area/space)
+"gIU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"gJi" = (
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
+/area/space/nearstation)
+"gLH" = (
+/obj/machinery/door/airlock/external{
+	name = "External Access";
+	req_access_txt = "13"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/fore)
+"gMl" = (
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"gNC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/wood,
+/area/bridge/meeting_room)
+"gOZ" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"gQX" = (
+/obj/machinery/button/door{
+	desc = "Alright, GAMER! Want to take your PWRGAME addiction to the MAX? Just smash this button with your chubby chetto encrusted hands an- oh, you broke the switch. Good job, idiot.";
+	id = "RIPFUN";
+	name = "Powerful Gamer Toggle";
+	normaldoorcontrol = 1;
+	pixel_x = -24;
+	pixel_y = 7;
+	specialfunctions = 4
+	},
+/obj/structure/table_frame/wood,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"gRZ" = (
+/obj/structure/bookcase{
+	name = "Forbidden Knowledge"
+	},
+/turf/open/floor/carpet,
+/area/library)
+"gTx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
+"gUu" = (
+/obj/structure/lattice,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"gWd" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/construction)
+"gXs" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space/nearstation)
+"gZG" = (
+/obj/structure/closet/crate/freezer/surplus_limbs,
+/obj/item/reagent_containers/glass/beaker/synthflesh,
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/medical/sleeper)
+"haL" = (
+/obj/structure/lattice,
+/turf/open/space/basic,
+/area/space)
+"haM" = (
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_y = -29
+	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"hcb" = (
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"hcA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"hew" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-4"
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"hgO" = (
+/obj/structure/table,
+/obj/item/storage/pill_bottle/dice{
+	pixel_x = 4;
+	pixel_y = 4
+	},
+/obj/item/reagent_containers/food/snacks/cherrycupcake,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"hiV" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/department/electrical)
+"hlV" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall,
+/area/crew_quarters/dorms)
+"hnl" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/closed/wall,
+/area/maintenance/port)
+"hnU" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"hrF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space,
+/area/solar/port/aft)
+"hsb" = (
+/obj/structure/table/wood,
+/obj/item/book/codex_gigas,
+/obj/item/clothing/under/suit_jacket/red,
+/obj/structure/destructible/cult/tome,
+/turf/open/floor/carpet,
+/area/library)
+"hse" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"hBA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/table,
+/obj/item/storage/firstaid/regular{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"hGH" = (
+/obj/machinery/door/airlock{
+	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
+	id_tag = "PrivateStudy";
+	name = "Private Study"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/wood,
+/area/library)
+"hHQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"hIL" = (
+/obj/structure/sign/poster/contraband/space_up{
+	pixel_x = -32;
+	pixel_y = 32
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"hIM" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"hOv" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	pixel_y = 5
+	},
+/obj/item/reagent_containers/food/snacks/burger/plain,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"hPs" = (
+/obj/structure/fireplace,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 23
+	},
+/turf/open/floor/plating,
+/area/maintenance/port)
+"hPP" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/quartermaster/warehouse)
+"hRa" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"hRI" = (
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"hSZ" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"hWd" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"idK" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"iiW" = (
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"ijG" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/structure/window,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"ikk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"ikm" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"imH" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"inR" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/crew_quarters/theatre)
+"iou" = (
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"ipA" = (
+/turf/open/floor/plating,
+/area/maintenance/department/medical/morgue)
+"itG" = (
+/obj/structure/table/reinforced,
+/obj/item/paper_bin,
+/obj/item/pen,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"itK" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 3;
+	name = "3maintenance loot spawner"
+	},
+/obj/structure/light_construct{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"itQ" = (
+/obj/machinery/door/window/southleft{
+	name = "Target Storage"
+	},
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target,
+/obj/item/target,
+/turf/open/floor/plating,
+/area/security/prison)
+"ium" = (
+/mob/living/simple_animal/bot/cleanbot{
+	name = "C.L.E.A.N."
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"iuR" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"iwB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/maintenance/port)
+"izv" = (
+/obj/machinery/vending/clothing,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"iDo" = (
+/obj/structure/grille,
+/turf/open/space/basic,
+/area/space/nearstation)
+"iDS" = (
+/obj/docking_port/stationary{
+	dir = 8;
+	dwidth = 3;
+	height = 5;
+	id = "commonmining_home";
+	name = "SS13: Common Mining Dock";
+	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
+	width = 7
+	},
+/turf/open/space/basic,
+/area/space)
+"iEJ" = (
+/obj/machinery/door/airlock/external{
+	name = "Escape Pod One"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"iHk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"iNn" = (
+/obj/machinery/camera{
+	c_tag = "Kitchen Cold Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/reagent_dispensers/cooking_oil,
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/kitchen)
+"iTq" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/crew_quarters/theatre)
+"iTU" = (
+/obj/structure/piano{
+	icon_state = "piano"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"iVU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/spawner/structure/window,
+/obj/machinery/door/firedoor,
+/turf/open/floor/plating,
+/area/crew_quarters/cryopod)
+"iWx" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"jaF" = (
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"jaH" = (
+/obj/structure/door_assembly/door_assembly_mai,
+/obj/item/electronics/airlock,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"jbf" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/service";
+	dir = 1;
+	name = "Service Hall APC";
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
+"jex" = (
+/obj/machinery/smartfridge/organ/preloaded,
+/turf/closed/wall,
+/area/medical/sleeper)
+"jez" = (
+/obj/effect/landmark/blobstart,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"jgm" = (
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/machinery/camera{
+	c_tag = "Circuitry Lab";
+	dir = 8;
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"jgA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"jjC" = (
+/obj/structure/table/wood,
+/obj/item/toy/cards/deck,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"jkx" = (
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/computer/slot_machine,
+/obj/item/coin/iron,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"jkz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"jlm" = (
+/obj/machinery/rnd/production/techfab/department/cargo,
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"jls" = (
+/obj/machinery/door/airlock/security{
+	name = "Labor Shuttle";
+	req_access_txt = "2"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/processing)
+"jmV" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/item/reagent_containers/food/drinks/britcup{
+	desc = "Kingston's personal cup.";
+	pixel_x = 5;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"jqv" = (
+/obj/structure/chair/wood/normal{
+	dir = 1
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/bar)
+"jrE" = (
+/obj/structure/sign/poster/official/random{
+	pixel_x = 32
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"juG" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/bluecherrycupcake{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"jvd" = (
+/obj/structure/closet/athletic_mixed,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"jxF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/reagent_dispensers/fueltank,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"jAD" = (
+/obj/structure/grille,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"jAN" = (
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 8
+	},
+/area/crew_quarters/fitness)
+"jBi" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/public/glass{
+	name = "Holodeck Door"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/fitness)
+"jBA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
 "jCq" = (
 /obj/structure/disposalpipe/segment{
 	dir = 5
@@ -54983,22 +54783,46 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jDY" = (
-/obj/structure/chair{
+"jEc" = (
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"jFy" = (
-/obj/machinery/door/airlock{
-	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
-	id_tag = "PrivateStudy";
-	name = "Private Study"
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/wood,
-/area/library)
+/area/crew_quarters/fitness)
+"jFH" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"jGW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/trunk{
+	dir = 4
+	},
+/obj/machinery/disposal/bin,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"jHh" = (
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
 "jHt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/disposalpipe/segment{
@@ -55012,10 +54836,23 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jHM" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/security/prison)
+"jIs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space,
+/area/solar/starboard/fore)
+"jJg" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	pixel_y = 5
+	},
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "jJF" = (
 /obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
@@ -55023,51 +54860,40 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/port/aft)
-"jLM" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
+"jKP" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore)
-"jMK" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"jNo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"jRy" = (
-/obj/machinery/door/airlock{
-	name = "Instrument Storage"
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/fore)
-"jSa" = (
-/obj/item/electropack/shockcollar,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/security/prison)
-"jSD" = (
-/obj/machinery/door/airlock/security{
-	name = "Firing Range";
-	req_access_txt = "2"
+/area/maintenance/fore/secondary)
+"jLn" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engine_smes)
+"jLT" = (
+/obj/machinery/button/door{
+	id = "Room Two";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 7;
+	pixel_y = -24;
+	specialfunctions = 4
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"jRw" = (
+/obj/machinery/computer/arcade/minesweeper{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
@@ -55089,64 +54915,70 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"jXg" = (
-/obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/nuke_storage";
-	dir = 1;
-	name = "Vault APC";
-	pixel_y = 25
-	},
+"jZT" = (
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
-	dir = 1
+/obj/machinery/door/poddoor/preopen{
+	id = "maint2"
 	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"kaq" = (
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
+"kdP" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
-"jYI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ker" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"keM" = (
+/obj/machinery/light/small{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/machinery/washing_machine,
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"kfv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating,
+/area/storage/tech)
+"kfX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"kay" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/snacks/bluecherrycupcake{
-	pixel_y = 5
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"kcj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
+"kgr" = (
+/obj/machinery/light/small{
+	brightness = 3;
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"kdm" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/plating,
-/area/security/prison)
-"kel" = (
-/obj/effect/landmark/blobstart,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"kfE" = (
-/obj/machinery/computer/libraryconsole/bookmanagement,
-/obj/structure/table,
-/turf/open/floor/plasteel,
 /area/security/prison)
 "khb" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
@@ -55158,22 +54990,6 @@
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"khA" = (
-/obj/structure/table,
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/obj/item/instrument/eguitar{
-	pixel_x = 5
-	},
-/obj/item/instrument/violin,
-/obj/item/instrument/trombone,
-/obj/item/instrument/saxophone,
-/obj/item/instrument/piano_synth,
-/obj/item/instrument/recorder,
-/obj/item/instrument/accordion,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
 "khB" = (
 /obj/machinery/door/airlock/external{
 	req_access_txt = "13"
@@ -55183,10 +54999,37 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"klu" = (
+"khV" = (
+/obj/machinery/vending/cola/red,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"kls" = (
 /obj/structure/lattice,
-/turf/open/space/basic,
-/area/space)
+/obj/structure/lattice,
+/turf/open/space,
+/area/space/nearstation)
+"kmw" = (
+/obj/structure/chair/comfy/black{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"kmS" = (
+/obj/item/flashlight/lamp/green{
+	pixel_x = -3;
+	pixel_y = 22
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4;
+	pixel_y = 5
+	},
+/obj/structure/dresser{
+	desc = "There's plenty of clothes here to change into! It has a surprising amount of variety, too.";
+	name = "Dresser";
+	pixel_y = 7
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "knx" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Central Access"
@@ -55215,75 +55058,57 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"ksn" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
+"kqI" = (
 /obj/structure/window,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"ktP" = (
+/obj/machinery/power/smes{
+	charge = 5e+006
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"ktS" = (
+/turf/open/space/basic,
+/area/space/nearstation)
+"kvl" = (
+/obj/structure/grille,
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
+"kvL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"kuY" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "maint2"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"kvb" = (
-/obj/structure/shuttle/engine/heater{
-	dir = 1
-	},
-/turf/closed/wall/mineral/titanium,
-/area/space/nearstation)
-"kvZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"kwy" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/machinery/requests_console{
-	department = "Bar";
-	departmentType = 2;
-	pixel_x = -30;
-	pixel_y = 45;
-	receive_ore_updates = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"kxc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"kyi" = (
-/obj/structure/bed,
-/obj/machinery/button/door{
-	id = "Dorm5";
-	name = "Cabin Bolt Control";
-	normaldoorcontrol = 1;
-	pixel_y = -25;
-	specialfunctions = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/obj/effect/spawner/lootdrop/bedsheet,
 /turf/open/floor/wood,
-/area/crew_quarters/dorms)
+/area/bridge/meeting_room)
+"kxf" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
 "kyF" = (
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/wood,
@@ -55292,91 +55117,83 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/science/mixing)
-"kCk" = (
-/obj/structure/mirror{
-	pixel_y = 32
+"kAH" = (
+/obj/machinery/camera{
+	c_tag = "Bar West";
+	dir = 4
 	},
-/obj/structure/sink{
-	dir = 1;
-	pixel_y = 25
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
-"kCW" = (
-/obj/machinery/portable_atmospherics/scrubber,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"kDD" = (
-/obj/structure/lattice,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/nuke_storage)
-"kHJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 6
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"kHK" = (
-/obj/machinery/button/door{
-	desc = "Bolts the doors to the Private Study.";
-	id = "PrivateStudy";
-	name = "Private Study Lock";
-	pixel_x = 25;
-	pixel_y = 25;
-	req_access_txt = "";
-	req_one_access_txt = "28;63"
+/obj/machinery/computer/arcade/orion_trail,
+/obj/structure/sign/poster/official/foam_force_ad{
+	pixel_x = -32
 	},
 /turf/open/floor/wood,
-/area/library)
-"kJr" = (
-/obj/effect/turf_decal/stripes/line{
+/area/crew_quarters/bar)
+"kAJ" = (
+/obj/machinery/portable_atmospherics/pump,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"kAO" = (
+/obj/structure/chair/sofa{
+	dir = 1
+	},
+/obj/structure/window,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"kCo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/security/prison)
-"kJY" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -3;
-	pixel_y = 22
-	},
-/obj/structure/dresser{
-	desc = "There's plenty of clothes here to change into! It has a surprising amount of variety, too.";
-	name = "Dresser";
-	pixel_y = 7
-	},
-/turf/open/floor/plating,
-/area/maintenance/port)
-"kKw" = (
-/obj/structure/lattice/catwalk,
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
+"kEY" = (
+/obj/effect/landmark/stationroom/box/engine,
+/turf/open/space/basic,
+/area/space)
+"kGJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/turf/open/space,
-/area/solar/port/aft)
-"kLR" = (
-/obj/machinery/door/poddoor/shutters/preopen{
-	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
-	id = "PrivateStudy1";
-	name = "Private Study Privacy Shutters"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/obj/effect/spawner/structure/window,
-/turf/open/floor/wood,
-/area/library)
-"kOf" = (
-/obj/structure/chair{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"kMt" = (
+/obj/structure/lattice,
+/turf/closed/wall,
+/area/security/prison)
+"kNv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/sign/poster/contraband/free_drone{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
 "kPd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/cable{
@@ -55384,6 +55201,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"kPj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/junction/flip,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "kQk" = (
 /obj/structure/rack,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -55393,254 +55217,32 @@
 /obj/item/storage/toolbox/electrical,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"kQZ" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
+"kQO" = (
+/obj/structure/reagent_dispensers/keg/semen,
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"kRk" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/structure/chair/sofa/right{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"kRw" = (
-/obj/effect/landmark/start/roboticist,
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
+/area/maintenance/bar)
 "kSb" = (
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/miningdock)
-"kSh" = (
-/obj/item/radio/intercom{
-	name = "Station Intercom (General)";
-	pixel_y = -29
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"kSB" = (
-/obj/machinery/atmospherics/components/unary/tank/air{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"kTz" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
-"kWI" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/window{
+"kWp" = (
+/obj/structure/shuttle/engine/heater{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/locker)
-"lhg" = (
-/obj/machinery/vending/clothing,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/turf/closed/wall/mineral/titanium,
+/area/space/nearstation)
+"kYk" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/departments/evac{
+	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"lmi" = (
-/obj/structure/door_assembly/door_assembly_mai,
-/obj/item/electronics/airlock,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"lnu" = (
-/obj/structure/chair/wood/normal{
-	dir = 4
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
-	},
-/area/maintenance/bar)
-"lwj" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = 5;
-	pixel_y = 7
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"lwp" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
-"lwY" = (
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	icon_state = "right";
-	name = "Unisex Showers"
-	},
-/turf/open/floor/plasteel/freezer,
+/area/hallway/primary/starboard)
+"laq" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/plasteel,
 /area/security/prison)
-"lxx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/crew_quarters/bar)
-"lAB" = (
-/obj/structure/sign/nanotrasen,
-/turf/closed/wall,
-/area/science/circuit)
-"lBE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"lCi" = (
-/obj/docking_port/stationary/public_mining_dock{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
-"lCB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"lCL" = (
-/turf/open/space/basic,
-/area/space/nearstation)
-"lFl" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"lLt" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"lLI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"lMg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"lMx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/crew_quarters/dorms)
-"lMY" = (
-/obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/sparsegrass,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/effect/spawner/structure/window,
-/turf/open/floor/grass,
-/area/crew_quarters/bar)
-"lNB" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"lQG" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/science/circuit)
-"lTq" = (
-/obj/structure/table,
-/obj/item/folder/blue,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"lYU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/structure/sign/departments/security{
-	pixel_x = -32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"lYZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/disposalpipe/junction,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"maC" = (
-/obj/structure/table,
-/obj/item/storage/pill_bottle/dice{
-	pixel_x = 4;
-	pixel_y = 4
-	},
-/obj/item/reagent_containers/food/snacks/cherrycupcake,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"mbD" = (
+"lip" = (
 /obj/structure/closet{
 	name = "Suit Closet"
 	},
@@ -55664,108 +55266,142 @@
 /obj/item/clothing/under/lawyer/really_black,
 /obj/item/clothing/under/lawyer/red,
 /turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"lnu" = (
+/obj/structure/chair/wood/normal{
+	dir = 4
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
+	},
+/area/maintenance/bar)
+"lsk" = (
+/obj/machinery/vending/autodrobe/all_access,
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"mfb" = (
-/obj/structure/toilet{
+"ltK" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"lva" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"lyR" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/plating,
+/area/security/prison)
+"lAB" = (
+/obj/structure/sign/nanotrasen,
+/turf/closed/wall,
+/area/science/circuit)
+"lCi" = (
+/obj/docking_port/stationary/public_mining_dock{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/construction/mining/aux_base)
+"lGV" = (
+/obj/machinery/button/door{
+	id = "maintdiy";
+	name = "Shutters Control Button";
+	pixel_x = -6;
+	pixel_y = 24
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"lMg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"lOe" = (
+/obj/machinery/shower{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/blue,
 /area/crew_quarters/dorms)
+"lPr" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "applebush"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/port)
+"lQG" = (
+/obj/effect/spawner/structure/window,
+/turf/open/floor/plating,
+/area/science/circuit)
+"lSa" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"lUS" = (
+/obj/structure/table/wood/fancy/black,
+/obj/machinery/light/small,
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"lXE" = (
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	dir = 5;
+	icon_state = "roomnum";
+	name = "Room Number 7";
+	pixel_y = 24
+	},
+/obj/structure/chair/sofa/right,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"lZl" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/gold,
+/obj/item/coin/gold,
+/obj/item/coin/gold,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"mbU" = (
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/crew_quarters/fitness)
+"mcp" = (
+/obj/structure/target_stake,
+/obj/item/target/syndicate,
+/turf/open/floor/plating,
+/area/security/prison)
 "mjr" = (
 /obj/structure/reagent_dispensers/keg/milk,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"mlr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/light_construct{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"moq" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"mpI" = (
-/obj/structure/table/wood,
-/turf/open/floor/wood{
-	icon_state = "wood-broken5"
-	},
-/area/maintenance/bar)
-"mqa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"mqZ" = (
-/obj/structure/reagent_dispensers/keg/aphro/strong,
-/obj/item/reagent_containers/glass/beaker,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"mrR" = (
-/obj/effect/spawner/lootdrop/keg,
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"mte" = (
-/obj/structure/extinguisher_cabinet,
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
-"mwO" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"myt" = (
-/obj/structure/closet/secure_closet/personal/cabinet{
-	desc = "Swipe your ID on the closet to claim it. First come first serve, this one is wooden and fancy. Store your stuff here.";
-	name = "Personal ID-Locked Closet";
-	pixel_y = 15
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"mCq" = (
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"mEN" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"mHC" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"mIS" = (
-/obj/structure/table,
-/obj/item/clothing/gloves/boxing/yellow,
-/obj/item/clothing/gloves/boxing/green,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing/blue,
-/obj/item/clothing/gloves/boxing,
-/obj/item/clothing/gloves/boxing,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"mNi" = (
-/obj/machinery/light_switch{
-	pixel_x = -20
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"mPE" = (
-/obj/machinery/chem_dispenser/drinks,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"mQR" = (
+"mkv" = (
 /obj/machinery/camera{
 	c_tag = "Gravity Generator Room";
 	dir = 8
@@ -55776,6 +55412,211 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
+"mkO" = (
+/obj/machinery/door/airlock{
+	name = "Shower Room"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/toilet)
+"mnC" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"moD" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/snacks/bluecherrycupcake{
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"mps" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"mpI" = (
+/obj/structure/table/wood,
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
+/area/maintenance/bar)
+"mqZ" = (
+/obj/structure/reagent_dispensers/keg/aphro/strong,
+/obj/item/reagent_containers/glass/beaker,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"mrR" = (
+/obj/effect/spawner/lootdrop/keg,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"mse" = (
+/obj/machinery/airalarm{
+	pixel_y = 23
+	},
+/obj/structure/chair/sofa/left,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"mvt" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"myh" = (
+/obj/structure/piano,
+/obj/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"mzB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/window,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"mAH" = (
+/obj/machinery/atmospherics/components/unary/tank/air{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"mGw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"mHU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/light_construct{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"mIZ" = (
+/obj/structure/falsewall,
+/turf/open/floor/plating,
+/area/security/prison)
+"mJo" = (
+/obj/structure/door_assembly/door_assembly_mai,
+/obj/item/electronics/airlock,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"mJG" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"mNi" = (
+/obj/machinery/light_switch{
+	pixel_x = -20
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"mNW" = (
+/obj/structure/sign/poster/official/fruit_bowl{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/primary/starboard)
+"mOB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/engineering/glass{
+	name = "Gravity Generator";
+	req_access_txt = "11"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/engine/gravity_generator)
+"mOO" = (
+/obj/structure/chair/sofa/left{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"mPk" = (
+/obj/structure/bed,
+/obj/machinery/button/door{
+	id = "Dorm5";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/spawner/lootdrop/bedsheet,
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
+"mPr" = (
+/obj/structure/rack,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/tank/internals/emergency_oxygen,
+/obj/item/clothing/mask/breath,
+/obj/item/clothing/mask/breath,
+/obj/effect/decal/cleanable/cobweb,
+/obj/item/clothing/under/color/grey,
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"mPt" = (
+/obj/structure/table,
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/glasses/sunglasses{
+	pixel_x = 3;
+	pixel_y = 3
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/item/clothing/ears/earmuffs{
+	pixel_x = -3;
+	pixel_y = -2
+	},
+/obj/machinery/firealarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"mPE" = (
+/obj/machinery/chem_dispenser/drinks,
+/obj/structure/table/wood,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"mQS" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "mRe" = (
 /obj/machinery/light{
 	dir = 8
@@ -55783,134 +55624,109 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"mTp" = (
-/obj/structure/chair/sofa/left,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
+"mRQ" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"mXB" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"ncj" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/structure/sign/poster/contraband/fun_police{
-	pixel_x = 32
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"mTG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"ndC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
 /obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"nea" = (
-/obj/machinery/recharge_station,
-/turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"neb" = (
-/obj/item/radio/intercom{
-	pixel_y = 25
+/area/crew_quarters/locker)
+"nbT" = (
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/preopen{
+	id = "bridge blast";
+	name = "bridge blast door"
+	},
+/turf/open/floor/plating,
 /area/hallway/primary/central)
-"nel" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
+"ndq" = (
 /turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"new" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/plating,
-/area/security/prison)
-"neC" = (
+/area/crew_quarters/abandoned_gambling_den)
+"nez" = (
 /obj/structure/table/wood,
-/obj/item/toy/cards/deck,
-/turf/open/floor/plasteel,
-/area/security/prison)
+/obj/item/instrument/piano_synth,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "nfm" = (
 /obj/machinery/vending/autodrobe,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"nie" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
+"ngs" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
-"nlt" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"nmx" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"nmS" = (
-/obj/structure/closet/athletic_mixed,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"nrR" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"nsJ" = (
-/obj/machinery/door/airlock{
-	desc = "Private study room where nerds are probably playing Dungeons and Dragons 13e, or a place for blood cult rituals.";
-	id_tag = "PrivateStudy";
-	name = "Private Study"
-	},
-/obj/machinery/door/firedoor,
 /turf/open/floor/wood,
-/area/library)
-"ntf" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/area/crew_quarters/theatre)
+"ngV" = (
+/obj/structure/table/wood,
+/obj/item/instrument/guitar,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"nhY" = (
+/obj/structure/closet,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
 	},
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"nuV" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
+"nkP" = (
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 8;
+	name = "8maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"noy" = (
+/obj/structure/sign/poster/contraband/smoke{
+	desc = "This poster reminds us all that the Detective is a parasite. Year after year, they must get replacement lungs because of their addiction. ";
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
+"noF" = (
+/obj/machinery/door/airlock{
+	name = "Instrument Storage"
+	},
+/turf/open/floor/plasteel/dark,
+/area/maintenance/starboard/fore)
+"nsA" = (
+/turf/closed/wall,
+/area/crew_quarters/abandoned_gambling_den)
+"nuw" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 4;
+	name = "4maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"nwX" = (
+/obj/structure/grille/broken,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
 "nxv" = (
 /obj/machinery/power/apc{
 	areastring = "/area/construction";
@@ -55922,13 +55738,13 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
-"nyH" = (
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
+"nGf" = (
+/obj/machinery/hydroponics/constructable,
+/obj/machinery/light{
+	dir = 1
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
 "nGt" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -55940,51 +55756,74 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"nGS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
+"nGI" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Shuttle Bay"
 	},
-/obj/effect/turf_decal/tile/blue{
-	alpha = 255;
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"nIE" = (
-/obj/structure/sign/poster/contraband/tools,
-/turf/closed/wall,
-/area/storage/primary)
-"nLf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
 	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
-"nMx" = (
-/obj/effect/mapping_helpers/airlock/locked,
-/obj/machinery/door/airlock/vault,
-/obj/structure/cable{
-	icon_state = "1-2"
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"nLu" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"nLw" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/window{
+	dir = 1
+	},
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"nQi" = (
+/obj/machinery/recharge_station,
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"nRG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"nSt" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"nUV" = (
+/obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"nXE" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
 /turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"nOS" = (
+/area/hallway/primary/central)
+"nYe" = (
 /obj/structure/safe,
 /obj/item/clothing/head/bearpelt,
 /obj/item/reagent_containers/food/drinks/drinkingglass/shotglass,
@@ -56004,196 +55843,108 @@
 /obj/item/gun/ballistic/revolver/nagant,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/nuke_storage)
-"nQr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall,
-/area/maintenance/port)
-"nRG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"nTE" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"nWq" = (
-/obj/machinery/door/airlock/engineering{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
+"nZE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"nXa" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
+/area/crew_quarters/dorms)
+"oax" = (
+/obj/structure/table/wood/fancy,
+/obj/machinery/light,
+/obj/item/reagent_containers/food/condiment/saltshaker{
+	pixel_x = -3;
+	pixel_y = 20
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
+/obj/item/reagent_containers/food/condiment/peppermill{
+	dir = 1;
+	pixel_x = 3;
+	pixel_y = 20
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	pixel_y = 5
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"obc" = (
+/obj/structure/chair/sofa/right,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
 "oce" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"ocv" = (
+/obj/structure/table,
+/obj/item/clothing/gloves/boxing/yellow,
+/obj/item/clothing/gloves/boxing/green,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing/blue,
+/obj/item/clothing/gloves/boxing,
+/obj/item/clothing/gloves/boxing,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "odx" = (
 /obj/machinery/vending/kink,
 /turf/open/floor/plating,
 /area/maintenance/bar)
-"oeJ" = (
-/obj/structure/table/wood,
-/obj/item/instrument/violin,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"oeQ" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"ohX" = (
-/obj/structure/table/wood,
-/obj/machinery/airalarm{
-	dir = 1;
-	pixel_y = -22
-	},
-/turf/open/floor/wood,
-/area/security/vacantoffice)
-"olr" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"olv" = (
-/obj/machinery/atmospherics/pipe/manifold4w/scrubbers,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"olw" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 4;
-	name = "4maintenance loot spawner"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"oma" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"ofU" = (
+/obj/structure/chair/comfy/black{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"orw" = (
-/obj/structure/table,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
+"old" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/recharger,
-/obj/item/gun/energy/laser/practice,
-/obj/item/gun/energy/laser/practice,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"ory" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"otF" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/extinguisher_cabinet{
-	pixel_x = 5;
+/obj/structure/sign/departments/security{
+	pixel_x = -32;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ouD" = (
-/obj/structure/reagent_dispensers/keg/semen,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"oBp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/reagent_dispensers/fueltank,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"oDy" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-04"
-	},
+/area/hallway/primary/fore)
+"olr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"oFk" = (
-/obj/structure/closet/boxinggloves,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"oHU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
 /area/science/circuit)
-"oKh" = (
-/obj/structure/chair/wood/normal{
-	dir = 8
+"omY" = (
+/obj/item/flashlight/lamp/green{
+	pixel_x = -3;
+	pixel_y = 22
 	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"oMY" = (
-/obj/machinery/button/door{
-	desc = "Alright, GAMER! Want to take your PWRGAME addiction to the MAX? Just smash this button with your chubby chetto encrusted hands an- oh, you broke the switch. Good job, idiot.";
-	id = "RIPFUN";
-	name = "Powerful Gamer Toggle";
-	normaldoorcontrol = 1;
-	pixel_x = -24;
-	pixel_y = 7;
-	specialfunctions = 4
+/obj/structure/dresser{
+	desc = "There's plenty of clothes here to change into! It has a surprising amount of variety, too.";
+	name = "Dresser";
+	pixel_y = 7
 	},
-/obj/structure/table_frame/wood,
 /turf/open/floor/plating,
 /area/maintenance/port)
-"oNb" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
+"oqj" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
 	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"oqO" = (
 /obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"oNQ" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /obj/machinery/light{
 	dir = 4;
@@ -56201,69 +55952,119 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"oOb" = (
-/obj/structure/sign/poster/official/cohiba_robusto_ad,
-/turf/closed/wall,
-/area/lawoffice)
-"oSO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+"ouQ" = (
+/obj/structure/table,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fountain,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"oxm" = (
+/obj/structure/flora/ausbushes/fullgrass,
+/obj/structure/flora/ausbushes/sparsegrass,
+/obj/structure/flora/ausbushes/ppflowers,
+/obj/structure/flora/ausbushes/ywflowers,
+/obj/structure/flora/ausbushes/brflowers,
+/obj/effect/spawner/structure/window,
+/turf/open/floor/grass,
+/area/crew_quarters/bar)
+"oyl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/structure/chair/sofa,
-/obj/item/radio/intercom{
-	pixel_y = 25
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"oUh" = (
-/obj/structure/disposalpipe/trunk{
+/obj/effect/turf_decal/tile/blue,
+/obj/machinery/door/window/eastleft{
+	name = "Blue Corner"
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/disposal/bin,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"oXL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oYc" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"phu" = (
+/area/crew_quarters/locker)
+"oyz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4;
 	pixel_y = 5
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"phH" = (
-/turf/open/floor/grass,
-/area/security/prison)
-"phY" = (
+"oyN" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/space/nearstation)
+"oyX" = (
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 4;
+	name = "Air In"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"oAb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
+/turf/closed/wall,
+/area/crew_quarters/bar)
+"oAB" = (
+/obj/structure/fireplace,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"oDN" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"oEZ" = (
+/obj/effect/spawner/lootdrop/keg,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"oHB" = (
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"oHU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"pjh" = (
+/area/science/circuit)
+"oIJ" = (
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"oIW" = (
+/obj/structure/toilet{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"oKh" = (
+/obj/structure/chair/wood/normal{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"oLl" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -56272,9 +56073,95 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/abandoned_gambling_den)
-"poa" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+"oLn" = (
+/obj/machinery/light/small{
 	dir = 4
+	},
+/obj/structure/rack,
+/obj/effect/spawner/lootdrop/maintenance{
+	lootcount = 2;
+	name = "2maintenance loot spawner"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"oTW" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/crew_quarters/theatre)
+"oUh" = (
+/obj/structure/disposalpipe/trunk{
+	dir = 1
+	},
+/obj/machinery/disposal/bin,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"oZl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/structure/closet/wardrobe/pjs,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/under/janimaid,
+/obj/item/clothing/accessory/maidapron,
+/obj/item/clothing/accessory/maidapron,
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"pem" = (
+/obj/machinery/button/door{
+	desc = "Bolts the doors to the Private Study.";
+	id = "PrivateStudy";
+	name = "Private Study Lock";
+	pixel_x = 25;
+	pixel_y = 25;
+	req_access_txt = "";
+	req_one_access_txt = "28;63"
+	},
+/turf/open/floor/wood,
+/area/library)
+"pfm" = (
+/obj/structure/sign/poster/official/twelve_gauge,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
+"pgf" = (
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"pgn" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"plm" = (
+/obj/structure/reagent_dispensers/watertank/high,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/box,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"plC" = (
+/obj/machinery/door/airlock/maintenance{
+	req_access_txt = "12"
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
@@ -56287,85 +56174,71 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"ppY" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/love_ian{
-	pixel_x = 32;
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pqR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"prP" = (
-/obj/structure/grille,
-/turf/open/space/basic,
-/area/space/nearstation)
-"prU" = (
-/obj/item/radio/intercom{
+"pou" = (
+/obj/machinery/light{
 	dir = 4;
-	name = "Station Intercom (General)";
-	pixel_x = 27
+	light_color = "#e8eaff"
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"ptV" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"puG" = (
-/obj/structure/rack,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/tank/internals/emergency_oxygen,
-/obj/item/clothing/mask/breath,
-/obj/item/clothing/mask/breath,
-/obj/effect/decal/cleanable/cobweb,
-/obj/item/clothing/under/color/grey,
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
-"pxD" = (
+/area/crew_quarters/abandoned_gambling_den)
+"pqe" = (
 /obj/structure/chair/sofa,
 /obj/structure/window{
 	dir = 1
 	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"pzk" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
+"pqs" = (
+/obj/machinery/vending/clothing,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/obj/structure/table,
-/obj/item/coin/gold,
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"pAl" = (
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/tank/air{
+/area/crew_quarters/locker)
+"psk" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge/meeting_room)
+"pst" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/vault,
+/obj/effect/mapping_helpers/airlock/locked,
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
+"puh" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"pFt" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
+/obj/machinery/light/small,
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
 	},
-/turf/open/space,
-/area/solar/starboard/aft)
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/fitness)
+"pBp" = (
+/obj/effect/landmark/event_spawn,
+/turf/closed/wall,
+/area/crew_quarters/fitness)
+"pFX" = (
+/obj/structure/table/wood/fancy,
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
 "pHl" = (
 /obj/structure/table,
 /obj/item/storage/box/beakers{
@@ -56392,12 +56265,31 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
-"pHo" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+"pHO" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/structure/sign/poster/contraband/fun_police{
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/hallway/primary/fore)
+"pIf" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/theatre)
+"pJR" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
 "pLn" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
@@ -56405,88 +56297,7 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/disposal)
-"pLt" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/power/apc{
-	areastring = "/area/security/main";
-	dir = 4;
-	name = "Firing Range APC";
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pNH" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/door/window,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"pNI" = (
-/obj/effect/turf_decal/bot,
-/obj/structure/sign/poster/official/pda_ad{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pPE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/machinery/door/window/eastleft{
-	name = "Blue Corner"
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"pQr" = (
-/obj/structure/table,
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/glasses/sunglasses{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/item/clothing/ears/earmuffs{
-	pixel_x = -3;
-	pixel_y = -2
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"pQD" = (
-/obj/structure/sign/poster/official/ion_rifle,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory)
-"pSf" = (
+"pPi" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -56498,361 +56309,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"pTn" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/terminal,
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"pTR" = (
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pUl" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Command Access To Vault";
-	req_access = "19"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
-"pZv" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"qbx" = (
-/obj/structure/table/wood/fancy,
-/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
-	pixel_x = -3;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"qeQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"qje" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qkC" = (
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard/fore";
-	dir = 1;
-	name = "Starboard Bow Maintenance APC";
-	pixel_y = 24
-	},
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"qlr" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/window{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"qlF" = (
-/obj/structure/lattice,
-/turf/closed/wall,
-/area/security/prison)
-"qmM" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"qoP" = (
-/obj/machinery/airalarm{
-	pixel_y = 23
-	},
-/obj/structure/chair/sofa/left,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"qpA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/sign/poster/official/cohiba_robusto_ad{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
-"qux" = (
-/obj/structure/chair/sofa/left{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"quT" = (
-/obj/structure/lattice,
-/obj/structure/grille/broken,
-/turf/open/space/basic,
-/area/space/nearstation)
-"qvM" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/circuit,
-/area/ai_monitored/nuke_storage)
-"qwe" = (
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
-"qwB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/engineering/glass{
-	name = "Gravity Generator";
-	req_access_txt = "11"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
-"qxc" = (
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/obj/machinery/computer/slot_machine,
-/obj/item/coin/iron,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"qAQ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/table,
-/obj/item/storage/firstaid/regular{
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"qBc" = (
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"qBe" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
+"pPI" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
-	dir = 8
-	},
-/turf/open/floor/carpet,
-/area/bridge/meeting_room)
-"qEv" = (
-/obj/structure/table/wood/fancy,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/item/reagent_containers/food/drinks/britcup{
-	desc = "Kingston's personal cup.";
-	pixel_x = 5;
-	pixel_y = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"qHB" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
-"qIf" = (
-/obj/machinery/door/airlock{
-	name = "Unisex Restrooms"
-	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"qIw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"qJZ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"qMu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/obj/machinery/light/small{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"qNs" = (
-/obj/structure/table/wood,
-/obj/item/flashlight/lamp/green{
-	on = 0;
-	pixel_x = -7;
-	pixel_y = 12
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"qOf" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"qQJ" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/theatre)
-"qUm" = (
-/obj/structure/filingcabinet/employment,
-/turf/open/floor/wood,
-/area/crew_quarters/heads/captain)
-"qXH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"rcD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
-/area/science/circuit)
-"reZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/closed/wall/r_wall,
-/area/engine/engine_smes)
-"rfW" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/maintenance/disposal/incinerator)
-"rgF" = (
-/obj/structure/rack,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"rhb" = (
-/obj/machinery/vending/cola/space_up,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"riA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/machinery/camera{
-	c_tag = "Firing Range";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"riB" = (
-/obj/machinery/door/firedoor,
-/obj/structure/sign/departments/evac{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rmX" = (
-/obj/structure/table,
-/obj/item/reagent_containers/food/drinks/beer,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"rsv" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space,
-/area/solar/starboard/fore)
-"rsX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rtT" = (
-/obj/structure/chair/comfy/brown{
-	color = "#66b266";
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rvZ" = (
-/obj/structure/target_stake,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/prison)
-"rzg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"rBq" = (
-/obj/item/clothing/head/kitty,
-/obj/item/clothing/under/maid,
-/obj/item/clothing/mask/muzzle,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"rEV" = (
+/area/engine/gravity_generator)
+"pQp" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/shutters/preopen{
@@ -56861,56 +56324,410 @@
 	},
 /turf/open/floor/plating,
 /area/crew_quarters/fitness)
-"rFc" = (
-/obj/machinery/door/airlock{
-	desc = "To keep the station within regulations, space IKEA requires one storage cupboard for their Nanotrasen partnership to continue.";
-	id_tag = "MaintDorm1";
-	name = "Furniture Storage"
+"pRs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port)
-"rHa" = (
-/obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 3;
-	height = 5;
-	id = "commonmining_home";
-	name = "SS13: Common Mining Dock";
-	roundstart_template = /datum/map_template/shuttle/mining_common/meta;
-	width = 7
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
 	},
-/turf/open/space/basic,
-/area/space)
-"rKc" = (
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"pTB" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /turf/open/space,
-/area/solar/port/fore)
+/area/solar/starboard/aft)
+"qaY" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"qcm" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
+"qeb" = (
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/abandoned_gambling_den";
+	name = "Abandoned Gambling Den APC";
+	pixel_y = -24
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"qeQ" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"qfk" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/structure/window,
+/obj/structure/window{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"qfD" = (
+/obj/machinery/door/poddoor/shutters/preopen{
+	desc = "Privacy shutters for the Private Study. Stops people spying in on your game.";
+	id = "PrivateStudy1";
+	name = "Private Study Privacy Shutters"
+	},
+/obj/effect/spawner/structure/window,
+/turf/open/floor/wood,
+/area/library)
+"qje" = (
+/obj/structure/sign/mining{
+	pixel_y = 7
+	},
+/turf/closed/wall,
+/area/quartermaster/miningdock)
+"qmn" = (
+/obj/machinery/computer/libraryconsole/bookmanagement,
+/obj/structure/table,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qqs" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"qus" = (
+/obj/structure/table/reinforced,
+/obj/machinery/door/firedoor,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "kitchen";
+	name = "kitchen shutters"
+	},
+/obj/item/reagent_containers/food/snacks/cheesynachos{
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"quT" = (
+/obj/structure/lattice,
+/obj/structure/grille/broken,
+/turf/open/space/basic,
+/area/space/nearstation)
+"qAm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"qBi" = (
+/obj/structure/lattice,
+/turf/closed/wall/r_wall,
+/area/crew_quarters/heads/captain)
+"qIw" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"qJr" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space,
+/area/solar/port/aft)
+"qLR" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"qOc" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/machinery/camera{
+	c_tag = "VR Sleepers";
+	dir = 1
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/white/side{
+	dir = 1
+	},
+/area/crew_quarters/fitness)
+"qOB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
+"qTG" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"qTV" = (
+/obj/item/twohanded/required/kirbyplants{
+	icon_state = "plant-22"
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"qVP" = (
+/obj/effect/spawner/structure/window,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"qXg" = (
+/obj/structure/chair/sofa/left,
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rcD" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"rdG" = (
+/obj/machinery/hydroponics/constructable,
+/obj/item/radio/intercom{
+	name = "Station Intercom (General)";
+	pixel_x = 29
+	},
+/turf/open/floor/plasteel/dark,
+/area/hydroponics)
+"reA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/machinery/vending/kink,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"rfW" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
+/turf/open/floor/plasteel,
+/area/maintenance/disposal/incinerator)
+"rjQ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"rmN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/obj/structure/chair/comfy/brown,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"rmX" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/beer,
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"rnt" = (
+/obj/structure/chair/comfy/black{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
+	dir = 8
+	},
+/turf/open/floor/carpet,
+/area/bridge/meeting_room)
+"rnK" = (
+/obj/structure/shuttle/engine/propulsion{
+	dir = 1
+	},
+/turf/open/space/basic,
+/area/space/nearstation)
+"rqf" = (
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rqk" = (
+/obj/structure/reagent_dispensers/water_cooler,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"rqE" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"rqW" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/obj/structure/dresser,
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
+	dir = 8;
+	name = "Theatre APC";
+	pixel_x = -25
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/theatre)
+"rrM" = (
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
+/obj/structure/closet/wardrobe/black,
+/obj/item/clothing/under/skirt/black,
+/obj/item/clothing/head/beret/black,
+/obj/item/clothing/head/beret/black,
+/obj/item/clothing/under/trendy_fit,
+/obj/item/clothing/under/trendy_fit,
+/obj/item/clothing/under/sundress,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"rtl" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
+	},
+/obj/machinery/camera{
+	c_tag = "Bar Backroom"
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"ruo" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"rvr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"rvS" = (
+/obj/structure/chair/comfy/brown{
+	color = "#66b266";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"ryr" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"rBq" = (
+/obj/item/clothing/head/kitty,
+/obj/item/clothing/under/maid,
+/obj/item/clothing/mask/muzzle,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"rGq" = (
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"rIA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
 "rKP" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
 /turf/open/floor/plating,
 /area/construction)
-"rLr" = (
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"rLR" = (
-/obj/structure/sign/poster/contraband/space_up{
-	pixel_x = -32;
-	pixel_y = 32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"rMc" = (
-/obj/structure/table/wood/fancy/black,
-/obj/machinery/light/small,
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "rMN" = (
 /obj/structure/bed,
 /obj/item/tank/internals/anesthetic,
@@ -56933,38 +56750,32 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"rOm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 23
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
-"rTQ" = (
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+"rPU" = (
+/turf/open/floor/plasteel/white/side{
 	dir = 4
 	},
+/area/crew_quarters/theatre)
+"rTu" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/airlock/command{
+	name = "Command Access To Vault";
+	req_access = "19"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge/meeting_room)
+"rXl" = (
+/obj/structure/chair/office/light,
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
+	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 1
+	dir = 9
 	},
-/turf/open/floor/plasteel/white/side{
-	dir = 8
-	},
-/area/crew_quarters/fitness)
-"rUQ" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "saK" = (
 /obj/structure/closet/crate,
 /obj/item/target/alien,
@@ -56977,60 +56788,54 @@
 /obj/item/gun/energy/laser/practice,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"sdL" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
+"saU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
+"saX" = (
+/obj/item/reagent_containers/glass/bucket,
+/turf/open/floor/grass,
+/area/security/prison)
+"sci" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/side{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
+"seP" = (
+/obj/structure/cable{
+	icon_state = "0-4"
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
-"sfa" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/machinery/door/poddoor/preopen{
+	id = "Secure Gate";
+	name = "brig shutters"
+	},
+/obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
 	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"sgV" = (
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 4;
-	name = "Air In"
-	},
+/turf/open/floor/plating,
+/area/security/brig)
+"shR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /turf/open/floor/plating,
-/area/maintenance/fore/secondary)
-"sjm" = (
-/obj/structure/table/wood,
-/obj/item/instrument/piano_synth,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"sjw" = (
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/structure/closet/wardrobe/black,
-/obj/item/clothing/under/skirt/black,
-/obj/item/clothing/head/beret/black,
-/obj/item/clothing/head/beret/black,
-/obj/item/clothing/under/trendy_fit,
-/obj/item/clothing/under/trendy_fit,
-/obj/item/clothing/under/sundress,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"sjT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
+/area/space/nearstation)
 "slk" = (
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
@@ -57043,86 +56848,45 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper,
 /turf/open/floor/plating,
 /area/maintenance/department/medical/morgue)
-"slp" = (
-/obj/effect/turf_decal/tile/blue{
-	alpha = 255
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	alpha = 255;
+"spu" = (
+/obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/blue{
+/obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"smn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"sqp" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/machinery/light,
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"snG" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/space,
-/area/solar/port/aft)
-"spX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/command{
+	name = "Captain's Vault Access";
+	req_access_txt = "20"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
-"sqa" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "applebush"
+"srG" = (
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/port)
-"srq" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel/dark,
-/area/bridge/meeting_room)
-"ssL" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
-/turf/open/space,
-/area/solar/starboard/fore)
-"suI" = (
-/obj/machinery/door/window/southleft{
-	name = "Target Storage"
-	},
-/obj/item/target/clown,
-/obj/item/target/clown,
-/obj/item/target,
-/obj/item/target,
 /turf/open/floor/plating,
-/area/security/prison)
-"svw" = (
-/obj/structure/chair{
+/area/crew_quarters/abandoned_gambling_den)
+"ssB" = (
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/green{
 	dir = 4
 	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/area/hallway/primary/starboard)
 "sxs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/structure/table,
@@ -57136,16 +56900,88 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
-"sxX" = (
+"syJ" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"szG" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"sAM" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken6"
 	},
-/area/maintenance/starboard/fore)
-"sAI" = (
+/area/maintenance/bar)
+"sEi" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
+"sEt" = (
+/turf/open/floor/wood{
+	icon_state = "wood-broken7"
+	},
+/area/maintenance/bar)
+"sEM" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"sFW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/sign/departments/restroom{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"sHx" = (
+/obj/structure/table,
+/obj/item/book/manual/hydroponics_pod_people{
+	pixel_x = -4;
+	pixel_y = 5
+	},
+/obj/item/paper/guides/jobs/hydroponics{
+	pixel_x = -5;
+	pixel_y = 3
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"sJx" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"sJI" = (
 /obj/structure/table/wood/fancy,
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -3;
@@ -57158,30 +56994,31 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"sAM" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken6"
+"sLa" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/area/maintenance/bar)
-"sEt" = (
-/turf/open/floor/wood{
-	icon_state = "wood-broken7"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
 	},
-/area/maintenance/bar)
-"sIe" = (
-/obj/structure/sign/poster/official/fruit_bowl{
-	pixel_y = 32
+/obj/structure/window{
+	dir = 4
 	},
-/turf/open/floor/plasteel/white/corner{
+/obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/area/hallway/primary/starboard)
-"sLr" = (
-/obj/structure/table,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/silver,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"sLj" = (
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
 "sLv" = (
 /obj/structure/closet,
 /obj/effect/spawner/lootdrop/maintenance,
@@ -57190,17 +57027,13 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"sMa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
+"sNK" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/vending/kink,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
 "sOs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -57208,9 +57041,38 @@
 /obj/machinery/door/airlock/maintenance/abandoned,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
+"sOA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
+"sPT" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"sPY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/turf/closed/wall/r_wall,
+/area/engine/engine_smes)
 "sQX" = (
 /turf/open/floor/plating,
 /area/space)
+"sRH" = (
+/obj/machinery/autolathe{
+	name = "public autolathe"
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
 "sRT" = (
 /obj/machinery/vending/cola/random,
 /turf/open/floor/wood,
@@ -57242,52 +57104,56 @@
 /obj/machinery/vending/boozeomat/all_access,
 /turf/closed/wall,
 /area/maintenance/bar)
-"sYv" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
+"sYR" = (
+/obj/machinery/door/airlock{
+	name = "Unisex Restrooms"
 	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
-"sZa" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/machinery/camera{
-	c_tag = "Bar Backroom"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"sZR" = (
-/obj/structure/lattice,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/bar)
 "tal" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall,
 /area/hallway/secondary/service)
-"tdF" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/light{
+"tgH" = (
+/obj/structure/filingcabinet/employment,
+/turf/open/floor/wood,
+/area/crew_quarters/heads/captain)
+"tif" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"tkq" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"tkB" = (
+/obj/structure/sign/poster/official/help_others{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "tkU" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
+"tmO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/security/prison)
 "tqg" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -57297,20 +57163,98 @@
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
-"tqt" = (
-/obj/structure/disposalpipe/segment,
-/obj/structure/chair/comfy/brown{
-	dir = 1
+"tqB" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 5
 	},
-/turf/open/floor/wood,
-/area/library)
+/turf/open/floor/plating,
+/area/space/nearstation)
 "trb" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"tru" = (
+"ttL" = (
+/obj/structure/sign/poster/contraband/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"ttX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/camera{
+	c_tag = "Firing Range";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tur" = (
+/obj/item/restraints/handcuffs/fake,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"tvi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"txm" = (
+/obj/structure/table/wood/fancy/royalblue,
+/obj/item/crowbar/red,
+/turf/open/floor/plating,
+/area/maintenance/port)
+"tyX" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
+"tzQ" = (
+/obj/machinery/shower{
+	dir = 4
+	},
+/obj/item/soap,
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"tCa" = (
+/obj/structure/table/wood,
+/obj/item/instrument/guitar{
+	pixel_x = -7
+	},
+/obj/item/instrument/eguitar{
+	pixel_x = 5
+	},
+/obj/item/instrument/violin,
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"tCd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue{
+	alpha = 255;
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"tJi" = (
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
@@ -57332,248 +57276,106 @@
 /obj/item/megaphone/clown,
 /turf/open/floor/plasteel,
 /area/crew_quarters/theatre)
-"trY" = (
-/obj/structure/sign/poster/contraband/lizard{
-	pixel_x = -32
-	},
-/obj/structure/sign/poster/contraband/lizard{
-	pixel_x = -32
-	},
-/obj/structure/sign/poster/contraband/lizard{
-	pixel_x = -32
+"tJK" = (
+/obj/machinery/door/airlock/engineering{
+	name = "Gravity Generator";
+	req_access_txt = "11"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"tsr" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
-"tuj" = (
-/obj/structure/light_construct{
-	dir = 1
-	},
+/area/engine/gravity_generator)
+"tJS" = (
+/obj/effect/spawner/lootdrop/keg,
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
-"tur" = (
-/obj/item/restraints/handcuffs/fake,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"tuN" = (
-/obj/structure/chair/sofa,
-/obj/structure/window{
+"tKk" = (
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"tAb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/door/airlock/command{
-	name = "Captain's Vault Access";
-	req_access_txt = "20"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/heads/captain)
-"tAE" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/table/wood,
-/obj/item/reagent_containers/food/condiment/saltshaker{
-	pixel_x = -3;
-	pixel_y = 20
-	},
-/obj/item/reagent_containers/food/condiment/peppermill{
-	dir = 1;
-	pixel_x = 3;
-	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/reagent_containers/food/drinks/britcup,
+/obj/structure/sign/warning/fire{
+	desc = "A sign that states the labeled room's number.";
+	icon_state = "roomnum";
+	name = "Room Number 1";
+	pixel_x = -30;
+	pixel_y = -7
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
-"tAV" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"tCi" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
-"tFt" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"tGG" = (
-/obj/structure/table/wood,
-/obj/item/book/codex_gigas,
-/obj/item/clothing/under/suit_jacket/red,
-/obj/structure/destructible/cult/tome,
-/turf/open/floor/carpet,
-/area/library)
-"tHx" = (
-/obj/machinery/computer/arcade/minesweeper{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tIk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "maintdiy";
-	name = "Security Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"tIC" = (
-/obj/structure/table/wood,
-/obj/item/instrument/guitar{
-	pixel_x = -7
-	},
-/obj/item/instrument/eguitar{
-	pixel_x = 5
-	},
-/obj/item/instrument/violin,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"tLl" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
 "tMl" = (
 /obj/effect/turf_decal/loading_area,
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
-"tMS" = (
-/obj/structure/table,
-/obj/item/paper_bin{
-	pixel_y = 6
+"tNF" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
 	},
-/obj/item/pen/fountain,
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/central)
-"tNJ" = (
-/obj/effect/spawner/structure/window,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"tOd" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 5
-	},
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/security/prison)
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "tOq" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"tOU" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
 "tPT" = (
 /obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table/wood,
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"tQk" = (
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
 "tRe" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
+"tRB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
 "tRF" = (
 /obj/machinery/light/small{
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"tTW" = (
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"tUm" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
+"tWj" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 4;
+	pixel_y = 5
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"tUw" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/open/floor/carpet,
+/turf/open/floor/wood,
 /area/crew_quarters/theatre)
-"tWs" = (
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"tWR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
 "tXL" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"tZe" = (
+/obj/effect/turf_decal/bot,
+/obj/structure/sign/poster/official/pda_ad{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uaj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "uaw" = (
 /obj/machinery/power/apc{
 	areastring = "/area/storage/art";
@@ -57586,37 +57388,380 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"udi" = (
+"ubj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/machinery/door/window/westright{
+	name = "Red Corner"
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"ucq" = (
+/obj/structure/sign/poster/contraband/red_rum{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ufD" = (
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/green,
+/obj/effect/turf_decal/tile/green{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 4
+	},
+/area/crew_quarters/fitness)
+"ugu" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"uhm" = (
+/obj/machinery/door/airlock{
+	name = "Recharging Station"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore/secondary)
+"ujv" = (
+/obj/structure/sign/departments/restroom,
+/turf/closed/wall,
+/area/crew_quarters/toilet)
+"ujF" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"ujS" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 6
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"unA" = (
+/obj/machinery/light{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"unW" = (
+/obj/effect/landmark/event_spawn,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uoB" = (
+/obj/structure/table/reinforced,
+/obj/item/multitool,
+/obj/item/screwdriver,
+/obj/machinery/camera{
+	c_tag = "Circuitry Lab North";
+	network = list("ss13","rd")
+	},
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"uoG" = (
+/obj/machinery/power/apc{
+	areastring = "/area/security/detectives_office";
+	dir = 4;
+	name = "Detective's Office APC";
+	pixel_x = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
+"usO" = (
+/obj/machinery/vending/snack/random,
+/obj/machinery/light/small{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"uua" = (
+/obj/machinery/atmospherics/components/binary/valve,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"uuG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"uve" = (
+/obj/structure/table,
+/obj/effect/spawner/lootdrop/maintenance,
+/obj/item/coin/silver,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"uvZ" = (
+/obj/structure/mineral_door/wood,
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"uxY" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/disposalpipe/junction,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"uBa" = (
+/obj/structure/table,
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = 5;
+	pixel_y = 7
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/dr_gibb{
+	pixel_x = -3;
+	pixel_y = 2
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"uDO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/space,
+/area/solar/port/fore)
+"uEI" = (
 /obj/structure/chair/comfy/brown{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uFp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
+	},
+/obj/structure/sign/poster/official/cohiba_robusto_ad{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/detectives_office)
+"uGI" = (
+/turf/open/floor/grass,
+/area/security/prison)
+"uIO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 10
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"uJx" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"uNu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/line,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"uOJ" = (
+/obj/effect/mapping_helpers/airlock/locked,
+/obj/machinery/door/airlock/vault,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
+"uPT" = (
+/obj/machinery/atmospherics/pipe/simple/general/visible,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
+"uQS" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+	dir = 1;
+	pixel_x = 5
+	},
+/obj/machinery/light/small,
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"uRd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/terminal,
+/turf/closed/wall/r_wall,
+/area/engine/gravity_generator)
+"uRS" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
+	},
+/turf/open/floor/carpet{
+	icon_state = "carpetsymbol"
+	},
+/area/crew_quarters/theatre)
+"uVS" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 9
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
+"vae" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/space/nearstation)
+"vbi" = (
+/obj/structure/table,
+/obj/item/instrument/guitar{
+	pixel_x = -7
+	},
+/obj/item/instrument/eguitar{
+	pixel_x = 5
+	},
+/obj/item/instrument/violin,
+/obj/item/instrument/trombone,
+/obj/item/instrument/saxophone,
+/obj/item/instrument/piano_synth,
+/obj/item/instrument/recorder,
+/obj/item/instrument/accordion,
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"vbD" = (
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command/glass{
+	name = "EVA Storage";
+	req_access_txt = "18"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/ai_monitored/storage/eva)
+"vcN" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"vda" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	dir = 4;
+	icon_state = "right";
+	name = "Shooting Range"
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"vdu" = (
+/obj/structure/table/wood,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
 	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"ued" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
+/turf/open/floor/wood,
+/area/security/vacantoffice)
+"vhb" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
+/obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -22
+/obj/structure/window{
+	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"uhm" = (
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/locker)
+"viF" = (
+/obj/structure/table/wood,
+/obj/item/instrument/trumpet,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"vjm" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/rag,
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/maintenance/bar)
+"vmQ" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "holoprivacy";
+	name = "Holodeck Shutters"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/fitness)
+"vnI" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment,
 /obj/structure/cable{
@@ -57633,305 +57778,50 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port)
-"ujF" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"uko" = (
+"vob" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
 /turf/open/floor/plasteel,
-/area/security/brig)
-"ukP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"ukS" = (
-/obj/machinery/shower{
-	dir = 4
-	},
-/obj/item/soap,
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/dorms)
-"unl" = (
-/obj/item/flashlight/lamp/green{
-	pixel_x = -3;
-	pixel_y = 22
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 4;
-	pixel_y = 5
-	},
-/obj/structure/dresser{
-	desc = "There's plenty of clothes here to change into! It has a surprising amount of variety, too.";
-	name = "Dresser";
-	pixel_y = 7
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/dorms)
-"unu" = (
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/structure/window/reinforced{
-	dir = 8
-	},
-/obj/machinery/washing_machine,
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
-"unE" = (
-/obj/structure/fans/tiny/invisible,
-/turf/open/space/basic,
-/area/space)
-"unY" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/structure/sign/departments/custodian{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"uoB" = (
-/obj/structure/table/reinforced,
-/obj/item/multitool,
-/obj/item/screwdriver,
-/obj/machinery/camera{
-	c_tag = "Circuitry Lab North";
-	network = list("ss13","rd")
-	},
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"upX" = (
-/obj/structure/chair/stool{
-	pixel_y = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/crew_quarters/theatre)
-"usO" = (
-/obj/machinery/vending/snack/random,
-/obj/machinery/light/small{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"uuG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
-"uvZ" = (
-/obj/structure/mineral_door/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"uya" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/sign/departments/restroom{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"uzk" = (
-/obj/structure/sign/departments/restroom,
-/turf/closed/wall,
-/area/crew_quarters/toilet)
-"uDW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"uNu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"uPT" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"uTq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"uVq" = (
-/obj/machinery/light{
-	dir = 1;
-	light_color = "#d1dfff"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"uVt" = (
-/obj/machinery/light/small{
-	brightness = 3;
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/security/prison)
-"uVS" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"uYE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"uZM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/space_cops{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"vbD" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/command/glass{
-	name = "EVA Storage";
-	req_access_txt = "18"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/ai_monitored/storage/eva)
-"vbY" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/green,
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
-"vdz" = (
-/obj/machinery/shower{
-	dir = 8
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
-"vdH" = (
-/obj/structure/bed,
-/turf/open/floor/plating,
-/area/maintenance/port)
-"vgp" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 9
-	},
-/turf/closed/wall/r_wall,
 /area/engine/gravity_generator)
-"vjm" = (
-/obj/structure/table/wood,
-/obj/item/reagent_containers/rag,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/maintenance/bar)
-"vjq" = (
-/obj/structure/table/reinforced,
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/tile/bar{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/bar)
-"vpm" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"vpz" = (
-/obj/structure/sign/poster/official/twelve_gauge,
-/turf/closed/wall/r_wall,
-/area/ai_monitored/security/armory)
 "vpY" = (
 /obj/structure/closet/lasertag/blue,
 /obj/item/clothing/under/pj/blue,
 /obj/item/clothing/under/pj/blue,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"vrM" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 10
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-18"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "vsM" = (
 /obj/machinery/power/apc/auto_name/south,
 /obj/structure/cable,
 /turf/open/floor/carpet,
 /area/crew_quarters/cryopod)
+"vsT" = (
+/obj/structure/closet/crate,
+/obj/item/book/manual/wiki/telescience,
+/obj/item/book/manual/wiki/engineering_guide,
+/obj/item/book/manual/wiki/engineering_construction,
+/obj/item/book/manual/wiki/atmospherics,
+/obj/item/book/manual/wiki/detective,
+/obj/item/book/manual/wiki/tcomms,
+/obj/item/book/manual/wiki/engineering_singulo_tesla,
+/obj/item/book/manual/wiki/experimentor,
+/obj/item/book/manual/wiki/research_and_development,
+/obj/item/book/manual/wiki/robotics_cyborgs,
+/obj/item/book/manual/wiki/security_space_law,
+/obj/item/book/manual/wiki/medicine,
+/obj/item/book/manual/wiki/medical_cloning,
+/obj/item/book/manual/wiki/infections,
+/obj/item/book/manual/ripley_build_and_repair,
+/obj/item/book/manual/hydroponics_pod_people,
+/obj/item/book/manual/wiki/toxins,
+/obj/item/book/manual/wiki/grenades,
+/obj/item/book{
+	desc = "An undeniably handy book.";
+	icon_state = "bookknock";
+	name = "A Simpleton's Guide to Safe-cracking with Stethoscopes"
+	},
+/turf/open/floor/wood,
+/area/library)
 "vxh" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/maintenance{
@@ -57940,23 +57830,10 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"vys" = (
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white/side{
-	dir = 4
-	},
-/area/crew_quarters/fitness)
+"vyp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/closed/wall,
+/area/crew_quarters/dorms)
 "vzp" = (
 /obj/structure/table/reinforced,
 /obj/machinery/firealarm{
@@ -57973,35 +57850,42 @@
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
-"vzS" = (
-/obj/structure/table,
-/obj/item/book/manual/hydroponics_pod_people{
-	pixel_x = -4;
-	pixel_y = 5
+"vBa" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
 	},
-/obj/item/paper/guides/jobs/hydroponics{
-	pixel_x = -5;
-	pixel_y = 3
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
+/turf/open/floor/plasteel/dark,
+/area/bridge/meeting_room)
 "vCb" = (
 /obj/machinery/rnd/production/techfab/department/service,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/service)
+"vCn" = (
+/obj/structure/chair{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
 "vCt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"vDq" = (
-/obj/effect/turf_decal/stripes/line,
+"vCy" = (
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/starboard/fore";
+	dir = 1;
+	name = "Starboard Bow Maintenance APC";
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
-/area/space/nearstation)
-"vFt" = (
-/obj/machinery/portable_atmospherics/pump,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
-"vGX" = (
+/area/maintenance/starboard/fore)
+"vDR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/structure/closet/secure_closet/personal/cabinet{
 	desc = "Swipe your ID on the closet to claim it. First come first serve, this one is wooden and fancy. Store your stuff here.";
@@ -58010,6 +57894,38 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
+"vEi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/extinguisher_cabinet{
+	pixel_x = 5;
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vEp" = (
+/obj/structure/sign/poster/contraband/lizard{
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/contraband/lizard{
+	pixel_x = -32
+	},
+/obj/structure/sign/poster/contraband/lizard{
+	pixel_x = -32
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/maintenance/starboard/fore)
+"vFr" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "vHj" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Cryogenics "
@@ -58020,108 +57936,311 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/crew_quarters/cryopod)
-"vHv" = (
-/obj/structure/closet{
-	name = "Costume Closet"
-	},
-/obj/item/clothing/head/russobluecamohat,
-/obj/item/clothing/head/russobluecamohat,
-/obj/item/clothing/head/helmet/rus_ushanka,
-/obj/item/clothing/head/helmet/rus_ushanka,
-/obj/item/clothing/head/helmet/rus_ushanka,
-/obj/item/clothing/head/helmet/rus_ushanka,
-/obj/item/clothing/under/mw2_russian_para,
-/obj/item/clothing/under/mw2_russian_para,
-/obj/item/clothing/under/mw2_russian_para,
-/obj/item/clothing/under/mw2_russian_para,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/obj/item/clothing/shoes/jackboots,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
-"vHM" = (
-/obj/machinery/vr_sleeper{
+"vHz" = (
+/obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
 	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white/corner{
-	dir = 1
-	},
+/turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"vHT" = (
+/obj/machinery/door/firedoor,
+/obj/structure/sign/departments/evac{
+	pixel_y = -32
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "vHY" = (
 /turf/open/floor/plating,
 /area/science/mixing)
-"vLD" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 10
-	},
+"vIi" = (
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/light,
-/obj/machinery/camera/motion{
-	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/nuke_storage)
-"vNh" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
+/turf/open/floor/plasteel,
+/area/security/prison)
+"vJu" = (
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
-/turf/open/floor/carpet,
-/area/crew_quarters/theatre)
-"vOq" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/obj/item/coin/gold,
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"vPs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/turf/open/space,
+/area/solar/starboard/aft)
 "vPE" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"vRr" = (
-/obj/effect/turf_decal/stripes/line{
+"vZA" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable,
+/turf/open/space,
+/area/solar/starboard/aft)
+"vZR" = (
+/obj/structure/chair/comfy/brown{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/library)
+"wbE" = (
+/obj/effect/turf_decal/tile/blue{
+	alpha = 255
+	},
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/obj/machinery/door/window/westleft{
-	base_state = "right";
-	dir = 4;
-	icon_state = "right";
-	name = "Shooting Range"
+/obj/effect/turf_decal/tile/blue{
+	alpha = 255;
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"wcB" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
+"wdv" = (
+/obj/structure/fans/tiny/invisible,
+/turf/open/space/basic,
+/area/space)
+"weM" = (
+/obj/structure/girder,
+/turf/open/floor/plating/airless,
+/area/space/nearstation)
+"wfR" = (
+/obj/item/electropack/shockcollar,
+/obj/item/assembly/signaler,
+/turf/open/floor/plating,
+/area/maintenance/bar)
+"wig" = (
+/obj/structure/table/wood,
+/obj/item/flashlight/lamp/green{
+	on = 0;
+	pixel_x = -7;
+	pixel_y = 12
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/turf/open/floor/carpet,
+/area/crew_quarters/dorms)
+"wkN" = (
+/turf/closed/wall,
+/area/science/circuit)
+"woR" = (
+/obj/machinery/cryopod{
+	dir = 1
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/cryopod)
+"wph" = (
+/obj/docking_port/stationary{
+	area_type = /area/construction/mining/aux_base;
+	dheight = 4;
+	dir = 8;
+	dwidth = 4;
+	height = 9;
+	id = "aux_base_zone";
+	name = "aux base zone";
+	roundstart_template = /datum/map_template/shuttle/aux_base/default;
+	width = 9
 	},
 /turf/open/floor/plating,
-/area/security/prison)
-"vRX" = (
-/obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
-	dir = 4;
-	name = "Detective's Office APC";
-	pixel_x = 24
+/area/construction/mining/aux_base)
+"wql" = (
+/obj/structure/extinguisher_cabinet,
+/turf/closed/wall/r_wall,
+/area/hallway/primary/central)
+"wqF" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair/comfy/brown{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/airalarm{
+	dir = 1;
+	pixel_y = -22
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"wrp" = (
+/obj/machinery/light{
+	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/grimy,
-/area/security/detectives_office)
-"vUR" = (
-/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
+"wvX" = (
+/obj/structure/table/reinforced,
+/obj/machinery/light,
+/obj/item/stack/sheet/metal/ten,
+/turf/open/floor/plasteel/white,
+/area/science/circuit)
+"wxT" = (
+/obj/structure/chair/sofa/left,
+/obj/structure/window{
+	dir = 1
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/bar)
+"wBd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 6
+	},
+/turf/closed/wall,
+/area/hallway/secondary/service)
+"wHz" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 5
+	},
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
+"wIG" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"wKe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "maintdiy";
+	name = "Security Shutters"
+	},
 /turf/open/floor/plating,
+/area/crew_quarters/abandoned_gambling_den)
+"wTf" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wUg" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -22
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"wUr" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/turf/open/floor/carpet,
+/area/crew_quarters/theatre)
+"wUY" = (
+/obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/hand_labeler,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/service)
+"wWT" = (
+/obj/effect/landmark/start/roboticist,
+/turf/open/floor/plasteel/white,
+/area/science/robotics/lab)
+"wXl" = (
+/obj/structure/mirror{
+	pixel_y = 32
+	},
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
+/obj/structure/toilet{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/dorms)
+"wYc" = (
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
 /area/security/prison)
-"vVP" = (
+"wZI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/heads/captain)
+"xbn" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 9
+	},
+/obj/structure/table,
+/obj/item/coin/gold,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"xfS" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/machinery/computer/shuttle/mining/common{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white/corner{
+	dir = 1
+	},
+/area/hallway/secondary/entry)
+"xgk" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/maintenance/port/aft)
+"xgC" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -58147,325 +58266,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"vWw" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"vYa" = (
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness)
-"vZs" = (
-/obj/structure/lattice,
-/obj/structure/lattice,
-/turf/open/space,
-/area/space/nearstation)
-"wcy" = (
-/obj/structure/reagent_dispensers/water_cooler,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"wfR" = (
-/obj/item/electropack/shockcollar,
-/obj/item/assembly/signaler,
-/turf/open/floor/plating,
-/area/maintenance/bar)
-"wgb" = (
-/obj/structure/falsewall,
-/turf/open/floor/plating,
-/area/security/prison)
-"wkN" = (
-/turf/closed/wall,
-/area/science/circuit)
-"woR" = (
-/obj/machinery/cryopod{
-	dir = 1
-	},
-/turf/open/floor/carpet,
-/area/crew_quarters/cryopod)
-"woX" = (
-/obj/machinery/door/window/southright{
-	name = "Target Storage"
-	},
-/obj/item/target/alien,
-/obj/item/target/alien,
-/obj/item/target/syndicate,
-/turf/open/floor/plating,
-/area/security/prison)
-"wph" = (
-/obj/docking_port/stationary{
-	area_type = /area/construction/mining/aux_base;
-	dheight = 4;
-	dir = 8;
-	dwidth = 4;
-	height = 9;
-	id = "aux_base_zone";
-	name = "aux base zone";
-	roundstart_template = /datum/map_template/shuttle/aux_base/default;
-	width = 9
-	},
-/turf/open/floor/plating,
-/area/construction/mining/aux_base)
-"wpo" = (
-/obj/machinery/camera{
-	c_tag = "Bar West";
-	dir = 4
-	},
-/obj/machinery/computer/arcade/orion_trail,
-/obj/structure/sign/poster/official/foam_force_ad{
-	pixel_x = -32
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"wrp" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"wuB" = (
-/obj/structure/chair/comfy/brown{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/library)
-"wvX" = (
-/obj/structure/table/reinforced,
-/obj/machinery/light,
-/obj/item/stack/sheet/metal/ten,
-/turf/open/floor/plasteel/white,
-/area/science/circuit)
-"wwn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"wwB" = (
-/turf/closed/wall/r_wall,
-/area/hallway/primary/central)
-"wwC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/sink{
-	dir = 4;
-	pixel_x = 11
-	},
-/obj/structure/mirror{
-	pixel_x = 25
-	},
-/turf/open/floor/mineral/titanium/blue,
-/area/crew_quarters/toilet)
-"wyM" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"wAB" = (
-/obj/structure/chair/office/light,
-/obj/machinery/firealarm{
-	dir = 4;
-	pixel_x = -24
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"wBd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/closed/wall,
-/area/hallway/secondary/service)
-"wCa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "holoprivacy";
-	name = "Holodeck Shutters"
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness)
-"wDR" = (
-/obj/structure/sign/poster/official/help_others{
-	pixel_y = -32
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wEp" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/hallway/primary/central)
-"wFk" = (
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wFX" = (
-/obj/machinery/door/firedoor,
-/obj/machinery/door/airlock/public/glass{
-	name = "Holodeck Door"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/fitness)
-"wGP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 10
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel,
-/area/crew_quarters/dorms)
-"wHz" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 5
-	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
-"wJz" = (
-/obj/machinery/light{
-	dir = 8
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"wLT" = (
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/closed/wall,
-/area/maintenance/port)
-"wNM" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"wOT" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"wUY" = (
-/obj/structure/table,
-/obj/item/stack/packageWrap,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/service)
-"wVs" = (
-/obj/structure/table/wood,
-/obj/item/instrument/trumpet,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"wXP" = (
-/obj/machinery/button/door{
-	id = "maintdiy";
-	name = "Shutters Control Button";
-	pixel_x = -6;
-	pixel_y = 24
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"wZB" = (
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"xbu" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"xcg" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 9
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"xdb" = (
-/obj/structure/closet,
-/obj/effect/spawner/lootdrop/maintenance{
-	lootcount = 8;
-	name = "8maintenance loot spawner"
-	},
-/obj/item/radio/intercom{
-	pixel_y = 25
-	},
-/turf/open/floor/plating,
-/area/crew_quarters/abandoned_gambling_den)
-"xdV" = (
-/obj/machinery/door/airlock{
-	name = "Theatre Backstage";
-	req_access_txt = "46"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
 "xgF" = (
 /obj/structure/chair/stool/bar,
 /turf/open/floor/wood{
 	icon_state = "wood-broken5"
 	},
 /area/maintenance/bar)
-"xhx" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+"xhS" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/turf/open/floor/wood,
-/area/bridge/meeting_room)
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
 "xhV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -58475,6 +58291,14 @@
 	},
 /turf/open/floor/plating,
 /area/construction)
+"xib" = (
+/obj/machinery/door/window/westleft{
+	base_state = "right";
+	icon_state = "right";
+	name = "Unisex Showers"
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
 "xiw" = (
 /obj/machinery/door/airlock{
 	name = "Service Hall";
@@ -58486,142 +58310,310 @@
 	},
 /turf/open/floor/plating,
 /area/hallway/secondary/service)
-"xkk" = (
-/obj/structure/piano,
-/obj/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/turf/open/floor/wood,
-/area/crew_quarters/theatre)
-"xlN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+"xkd" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"xls" = (
+/obj/effect/turf_decal/stripes/line,
+/turf/open/floor/plating,
+/area/security/prison)
+"xmo" = (
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"xmS" = (
+/obj/structure/chair/comfy/beige{
+	dir = 8
+	},
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/plasteel/grimy,
+/area/hallway/secondary/entry)
+"xqG" = (
+/obj/structure/table/reinforced,
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/tile/bar{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 10
+	},
+/obj/item/reagent_containers/food/drinks/soda_cans/starkist{
+	pixel_x = -3;
+	pixel_y = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/bar)
+"xrN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/crew_quarters/dorms)
+"xtP" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
+"xxi" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
-"xpx" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
+/area/maintenance/fore)
+"xzd" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
+/obj/structure/chair/sofa,
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xqW" = (
-/obj/structure/cable{
-	icon_state = "0-4"
+"xzj" = (
+/obj/machinery/light{
+	dir = 1;
+	light_color = "#d1dfff"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"xAk" = (
+/obj/structure/chair/stool{
+	pixel_y = 8
 	},
-/obj/machinery/door/poddoor/preopen{
-	id = "Secure Gate";
-	name = "brig shutters"
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plating,
-/area/security/brig)
-"xzh" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/plating,
-/area/space/nearstation)
-"xzy" = (
-/obj/effect/turf_decal/stripes/corner{
+/area/maintenance/starboard/fore)
+"xAv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/hydroponics)
+/area/crew_quarters/dorms)
+"xBk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 23
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet)
+"xBw" = (
+/obj/structure/closet/wardrobe/cargotech,
+/obj/item/radio/headset/headset_cargo,
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"xDM" = (
+/obj/machinery/camera{
+	c_tag = "Locker Room South";
+	dir = 8
+	},
+/obj/structure/closet/secure_closet/personal,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
 "xEu" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
 	},
 /turf/closed/wall/r_wall,
 /area/maintenance/disposal/incinerator)
+"xEB" = (
+/obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/nuke_storage";
+	dir = 1;
+	name = "Vault APC";
+	pixel_y = 25
+	},
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/circuit,
+/area/ai_monitored/nuke_storage)
+"xEE" = (
+/obj/item/radio/intercom{
+	pixel_y = 25
+	},
+/obj/machinery/vending/wardrobe/curator_wardrobe,
+/turf/open/floor/carpet,
+/area/library)
 "xIa" = (
 /obj/structure/table,
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"xIn" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"xLZ" = (
-/obj/structure/closet/radiation,
-/turf/open/floor/plasteel,
-/area/engine/gravity_generator)
-"xMl" = (
-/obj/structure/chair/sofa{
-	dir = 1
-	},
-/obj/structure/window,
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
-"xNY" = (
-/obj/structure/shuttle/engine/propulsion{
-	dir = 1
+"xLX" = (
+/obj/structure/lattice/catwalk,
+/obj/item/stack/marker_beacon{
+	anchored = 1;
+	icon_state = "markerburgundy-on";
+	light_color = "#FA644B";
+	light_power = 3;
+	light_range = 3;
+	name = "Docking Beacon";
+	picked_color = "Burgundy"
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
-"xXY" = (
+"xOx" = (
+/obj/structure/chair/comfy/brown{
+	color = "#596479";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xPk" = (
+/obj/structure/bed,
+/obj/machinery/button/door{
+	id = "Dorm6";
+	name = "Cabin Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_y = -25;
+	specialfunctions = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/effect/spawner/lootdrop/bedsheet,
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
+"xPY" = (
+/obj/structure/table/wood,
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/item/instrument/trombone,
+/turf/open/floor/wood,
+/area/crew_quarters/theatre)
+"xQG" = (
+/obj/machinery/door/airlock/external{
+	name = "Common Mining Shuttle Bay"
+	},
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/hallway/secondary/entry)
+"xTy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/engine/gravity_generator)
+"xUe" = (
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/security/prison)
+"xUL" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 10
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/light,
+/obj/machinery/camera/motion{
+	c_tag = "Vault";
+	dir = 1;
+	network = list("vault")
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/nuke_storage)
+"xXi" = (
+/obj/machinery/vending/clothing,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness)
+"xZD" = (
 /obj/structure/closet/lasertag/red,
 /obj/item/clothing/under/pj/red,
 /obj/item/clothing/under/pj/red,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
-"xYO" = (
-/obj/structure/sign/poster/contraband/red_rum{
+"ybj" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 6
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/security/prison)
+"ycd" = (
+/obj/structure/toilet{
+	dir = 4
+	},
+/obj/structure/mirror{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+/obj/structure/sink{
+	dir = 1;
+	pixel_y = 25
+	},
+/obj/machinery/button/door{
+	id = "LockerShitter2";
+	name = "Door Bolt Control";
+	normaldoorcontrol = 1;
+	pixel_x = 14;
+	pixel_y = 38;
+	specialfunctions = 4
+	},
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/blue,
+/area/crew_quarters/toilet/locker)
 "ycu" = (
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"ycF" = (
-/obj/machinery/door/airlock/external{
-	name = "Common Mining Shuttle Bay"
-	},
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
 "ydD" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/suit_storage_unit/rd,
 /turf/open/floor/plasteel,
 /area/science/mixing)
-"yiN" = (
-/obj/effect/turf_decal/tile/green{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/green{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
+"yhz" = (
+/obj/structure/table,
+/obj/item/folder/blue,
+/turf/open/floor/plasteel/dark,
+/area/hallway/primary/central)
+"yiY" = (
+/obj/structure/sign/poster/official/ion_rifle,
+/turf/closed/wall/r_wall,
+/area/ai_monitored/security/armory)
 
 (1,1,1) = {"
 aaa
@@ -64643,15 +64635,11 @@ aaa
 aaa
 aaa
 aaa
-aaK
+ghq
 aaa
 aaa
 aaa
-aaK
-aaa
-aaa
-aaa
-aaa
+ghq
 aaa
 aaa
 aaa
@@ -64660,7 +64648,11 @@ aaa
 aaa
 aaa
 aaa
-hoo
+aaa
+aaa
+aaa
+aaa
+gDl
 aaa
 aaa
 aaa
@@ -64894,13 +64886,9 @@ aaa
 aaa
 aaa
 aaa
-aaK
+ghq
 aaa
-aaK
-aaa
-aaa
-aaa
-gXs
+ghq
 aaa
 aaa
 aaa
@@ -64908,9 +64896,13 @@ gXs
 aaa
 aaa
 aaa
-aaK
+gXs
 aaa
-aaK
+aaa
+aaa
+ghq
+aaa
+ghq
 aaa
 aaa
 aaa
@@ -65157,11 +65149,11 @@ gXs
 aaa
 aaa
 gXs
-jmC
+gJi
 gXs
 gXs
 gXs
-jmC
+gJi
 gXs
 aaa
 aaa
@@ -65407,11 +65399,11 @@ aaa
 aaa
 aaa
 aaa
-jmC
-jmC
+gJi
+gJi
 gXs
 aag
-jmC
+gJi
 gXs
 gXs
 aaa
@@ -65421,11 +65413,11 @@ aaa
 aaa
 gXs
 gXs
-jmC
-jmC
-klu
+gJi
+gJi
+haL
 aag
-jmC
+gJi
 aaa
 aaa
 aaa
@@ -65664,11 +65656,11 @@ aaa
 aaa
 aaa
 aaa
-xcg
-lLt
+gIU
+shR
 aaa
-lLt
-jNo
+shR
+hse
 gXs
 aoV
 aaa
@@ -65678,11 +65670,11 @@ aaa
 aaa
 aaa
 gXs
-xcg
-lLt
+gIU
+shR
 aaa
-lLt
-jNo
+shR
+hse
 aaa
 aaa
 aaa
@@ -65921,11 +65913,11 @@ aaa
 aaa
 aaa
 aaa
-xzh
+bvG
 aaa
 cpe
 aaa
-vDq
+oyN
 aaa
 aaa
 aaa
@@ -65935,11 +65927,11 @@ aaa
 aaa
 aaa
 aaa
-xzh
+bvG
 aaa
 cwV
 aaa
-vDq
+oyN
 aaa
 aaa
 aaa
@@ -66177,7 +66169,7 @@ aaa
 aaa
 aaa
 aae
-lCL
+ktS
 gXs
 aaa
 aaa
@@ -66434,7 +66426,7 @@ aaa
 aaa
 aaa
 aaa
-lCL
+ktS
 gXs
 aaa
 aaa
@@ -66691,7 +66683,7 @@ aaa
 aaa
 aaa
 aaa
-lCL
+ktS
 gXs
 aaa
 aaa
@@ -66948,7 +66940,7 @@ aaa
 aaa
 aaa
 aaa
-lCL
+ktS
 gXs
 aaa
 cqq
@@ -66975,7 +66967,7 @@ aaa
 aaa
 aoV
 aaa
-rHa
+iDS
 aaa
 aaa
 aoV
@@ -67205,7 +67197,7 @@ aaf
 aaf
 aaf
 aaa
-lCL
+ktS
 arB
 asE
 cyb
@@ -67232,7 +67224,7 @@ aaa
 aaa
 asE
 asE
-ycF
+nGI
 asE
 asE
 aoV
@@ -67492,7 +67484,7 @@ awW
 auP
 awW
 aaf
-vZs
+kls
 aaa
 aaa
 aaa
@@ -67746,7 +67738,7 @@ aaa
 aaa
 arB
 arB
-jnX
+xQG
 asE
 aAC
 aaf
@@ -67978,7 +67970,7 @@ apN
 apN
 apN
 apJ
-iyC
+fpI
 ayk
 awW
 aAD
@@ -68002,7 +67994,7 @@ aaa
 aaa
 aaa
 arB
-est
+xfS
 ayk
 awW
 aAD
@@ -69278,7 +69270,7 @@ aaa
 awW
 aOh
 ayl
-tTW
+jHh
 aRY
 awW
 aaa
@@ -70574,7 +70566,7 @@ awW
 arB
 awZ
 aym
-vrM
+fOI
 awW
 aaf
 aaa
@@ -71855,7 +71847,7 @@ aUO
 aUy
 aWm
 aWf
-ohX
+vdu
 czK
 bhN
 bcl
@@ -72873,7 +72865,7 @@ aHy
 ayl
 aKk
 aLA
-dTe
+xmS
 aNf
 aLA
 aQD
@@ -74899,7 +74891,7 @@ ady
 ady
 ady
 ady
-rKc
+uDO
 ajq
 ajW
 akB
@@ -74943,7 +74935,7 @@ aXQ
 aXQ
 aPz
 aPz
-rFc
+epC
 aPz
 bhQ
 bjj
@@ -75197,11 +75189,11 @@ aPA
 aXQ
 aZt
 aXQ
-gdu
+ycd
 aPz
-kJY
-ihC
-oMY
+omY
+cMS
+gQX
 bhQ
 bjj
 bkF
@@ -75457,10 +75449,10 @@ aXQ
 bbL
 aPz
 bdJ
-gFD
+txm
 bgr
-nQr
-tUm
+iwB
+hew
 bkF
 aaa
 aaa
@@ -75715,7 +75707,7 @@ aZw
 aPz
 bct
 bfa
-vdH
+gfr
 bhQ
 bjk
 bkE
@@ -75970,10 +75962,10 @@ baO
 aZo
 baw
 aPz
-cwP
+hPs
 cBn
 bgs
-wLT
+hnl
 bjk
 bkF
 aaa
@@ -76274,7 +76266,7 @@ ccb
 ccb
 ccb
 aaa
-snG
+qJr
 aaa
 ccb
 ccb
@@ -76469,7 +76461,7 @@ bxk
 aDo
 aDo
 aIX
-nIE
+gCC
 aLE
 aLE
 aOp
@@ -76483,7 +76475,7 @@ aQN
 aQN
 aQN
 aQN
-kWI
+vhb
 bbO
 aPA
 bgt
@@ -76531,7 +76523,7 @@ aaa
 aaf
 aaa
 aaa
-kKw
+hrF
 aaa
 aaa
 aaf
@@ -76546,7 +76538,7 @@ aaa
 aaa
 aaa
 aaa
-hoo
+gDl
 aaa
 aaa
 aaa
@@ -76735,7 +76727,7 @@ aQN
 aQN
 aTz
 aUp
-job
+ubj
 aXr
 aZx
 aQN
@@ -76788,7 +76780,7 @@ aaf
 aaf
 aaf
 aaf
-kKw
+hrF
 aaf
 aaf
 aaf
@@ -76997,7 +76989,7 @@ aXv
 aYS
 aQN
 aQN
-kWI
+vhb
 bbO
 aPA
 aSg
@@ -77240,18 +77232,18 @@ aDo
 aDo
 aDo
 aIY
-nIE
+gCC
 aLE
 aLE
 aOl
 aPA
-lhg
+pqs
 aQN
 aTC
 aUs
-phY
+mTG
 aXt
-ksn
+ijG
 aQN
 aQN
 aPA
@@ -77506,9 +77498,9 @@ aQV
 aQN
 aTC
 aUu
-eRk
+gxc
 aXt
-ksn
+ijG
 aQN
 aQN
 aZB
@@ -77761,11 +77753,11 @@ aOl
 aPA
 aQU
 aQN
-hzw
-qlr
-pPE
+nLw
+sLa
+oyl
 aXw
-jiR
+qfk
 aQN
 aQN
 aZA
@@ -78273,10 +78265,10 @@ aLm
 aLE
 aOl
 aPA
-xIn
+vJu
 aQN
 aTD
-mIS
+ocv
 aUZ
 aYU
 aYU
@@ -78517,14 +78509,14 @@ aaf
 avY
 axo
 arP
-fLd
-cRD
+fgG
+rqW
 aGD
-tru
+tJi
 aCr
-qBc
-iFL
-qBc
+hcb
+qTG
+hcb
 aKu
 aLM
 aLF
@@ -78534,14 +78526,14 @@ aPG
 aPG
 aPG
 aPG
-jsy
+lip
 aQW
 aQW
 aQW
 aQW
-cVu
+xDM
 aPA
-oBp
+jxF
 aYb
 aZE
 bjp
@@ -78774,14 +78766,14 @@ aaa
 avY
 axo
 arP
-qwe
-ioB
+rPU
+fne
 aGr
 aHI
-xdV
-ePO
-phu
-qBc
+fOA
+tWj
+oyz
+hcb
 aKu
 aLL
 bDe
@@ -79032,13 +79024,13 @@ avY
 axo
 arP
 aCh
-qQJ
-iYz
+pIf
+kCo
 aHK
 aCr
-tUw
-mqa
-qBc
+uJx
+ikk
+hcb
 aKu
 aLN
 aLE
@@ -79052,13 +79044,13 @@ aWu
 aYc
 aZD
 aZD
-uhm
+vnI
 aZD
 aZD
 bff
-iRJ
+dev
 aZE
-fyM
+xBw
 bjr
 ama
 bmh
@@ -79117,18 +79109,18 @@ bLv
 bLv
 bLv
 aaa
-prP
-prP
-prP
-prP
-prP
-prP
-prP
-prP
-prP
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
 aaa
 aaa
-hoo
+gDl
 aaa
 aaa
 aaa
@@ -79289,13 +79281,13 @@ avZ
 axp
 ayC
 azH
-wyM
+eEe
 aGv
 aCr
 aCr
-tUw
-mqa
-qBc
+uJx
+ikk
+hcb
 aKu
 aLN
 aLE
@@ -79306,7 +79298,7 @@ aRa
 aTF
 aPG
 aSX
-eRn
+hPP
 aZF
 aZF
 aZF
@@ -79374,7 +79366,7 @@ cqK
 crl
 bLv
 aaa
-prP
+iDo
 ctv
 ctv
 ctv
@@ -79382,7 +79374,7 @@ ctv
 ctv
 ctv
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -79543,14 +79535,14 @@ aGh
 aqR
 aqR
 awb
-eLH
+xtP
 ayA
-fHK
-hRX
+sNK
+xmo
 aBV
-pNH
-sfa
-ioX
+mzB
+mJG
+szG
 aHG
 aJe
 aKw
@@ -79631,15 +79623,15 @@ cAQ
 crm
 bLv
 aaa
-prP
-prP
-prP
-prP
-prP
-prP
-prP
-prP
-prP
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
+iDo
 aaa
 aaa
 aaa
@@ -79803,13 +79795,13 @@ awa
 axq
 ayD
 azI
-gwi
+rjQ
 aBU
-xkk
-upX
-qJZ
-doP
-qBc
+myh
+inR
+wUr
+iTq
+hcb
 aKu
 aLN
 aMQ
@@ -79856,7 +79848,7 @@ aoV
 bCq
 bHE
 bHE
-puG
+mPr
 cdb
 bCq
 bVE
@@ -79898,9 +79890,9 @@ gXs
 aaa
 aaa
 aaa
-prP
-prP
-prP
+iDo
+iDo
+iDo
 aaa
 aaa
 aaa
@@ -80057,16 +80049,16 @@ aaa
 aaa
 aag
 avY
-jLM
+xxi
 ayD
-oeJ
+cGz
 aMr
-qOf
+ngs
 aDv
-lwp
-tUw
-jly
-qBc
+uRS
+uJx
+dsC
+hcb
 aKu
 aLN
 aMS
@@ -80155,9 +80147,9 @@ gXs
 aaa
 aaa
 aaa
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -80314,21 +80306,21 @@ aaa
 aaa
 aag
 avY
-jLM
+xxi
 ayD
-wVs
+viF
 aMr
 aMr
 aOH
-lwp
-vNh
-qHB
-qBc
+uRS
+lSa
+oTW
+hcb
 aKu
 aLN
 aMS
 aOi
-sqa
+lPr
 aPK
 aSl
 aTH
@@ -80383,7 +80375,7 @@ mrR
 dKP
 odx
 rBq
-ouD
+kQO
 bCq
 bUs
 bLv
@@ -80402,19 +80394,19 @@ aaf
 aaa
 aaf
 gXs
-sYv
+gUu
 crn
 bij
 bij
 bij
 bij
 bij
-hWn
+jkz
 btG
 aaa
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -80573,14 +80565,14 @@ aag
 avY
 axs
 ayD
-sjm
-eNK
-iEx
+nez
+ngV
+xPY
 aOH
-qBc
-qBc
-tAV
-qBc
+hcb
+hcb
+syJ
+hcb
 aKu
 aLN
 aMS
@@ -80610,7 +80602,7 @@ bbR
 btu
 bbR
 bOL
-fnJ
+qje
 byF
 bwW
 bGm
@@ -80652,26 +80644,26 @@ cjJ
 cjJ
 cjJ
 cjJ
-gVX
-reZ
-reZ
+kfX
+saU
+saU
 bij
 crn
 bij
 bij
-sZR
-ued
+eCR
+wUg
 bnT
 bph
 bsc
-fhP
+mQS
 bsc
-eXm
+tNF
 btG
 gXs
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -80912,12 +80904,12 @@ cov
 cpj
 cpS
 cjJ
-xLZ
-ivF
+fjS
+sPT
 btG
-wAB
-vVP
-mwO
+rXl
+xgC
+ugu
 bnV
 bph
 bih
@@ -80926,9 +80918,9 @@ bii
 bsc
 btG
 aaa
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -81104,8 +81096,8 @@ aPK
 aSn
 aTK
 aPK
-vRX
-hwu
+uoG
+sOA
 asW
 baW
 bLE
@@ -81123,7 +81115,7 @@ bpB
 bpB
 brR
 bsV
-aaM
+bwc
 bxA
 bvI
 bwX
@@ -81168,14 +81160,14 @@ cnN
 cox
 cpl
 cpU
-ipc
-edH
-edH
-nWq
-edH
-wZB
-fby
-qwB
+jLn
+xTy
+xTy
+tJK
+xTy
+vob
+xhS
+mOB
 bph
 big
 bgN
@@ -81183,9 +81175,9 @@ bkZ
 bsc
 btG
 aaa
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -81322,7 +81314,7 @@ aaa
 acd
 acd
 acd
-jHM
+xUe
 acd
 acd
 aaa
@@ -81366,7 +81358,7 @@ aYi
 aqW
 aqW
 bbQ
-qpA
+uFp
 apd
 aZH
 aZK
@@ -81426,12 +81418,12 @@ cow
 cpk
 cpT
 cjJ
-xLZ
-oNQ
+fjS
+dXq
 btG
-sZa
-jhF
-qmM
+rtl
+oqO
+vFr
 bnV
 bph
 bii
@@ -81440,9 +81432,9 @@ bih
 bsc
 btG
 aaa
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -81577,10 +81569,10 @@ abc
 abc
 afu
 abc
-suI
-qMu
-kJr
-dxB
+itQ
+pgn
+tmO
+eHU
 acd
 aaa
 aaa
@@ -81681,25 +81673,25 @@ clG
 cnP
 coz
 cpn
-dbn
-dbn
+sPY
+sPY
 bgO
-hjw
+dgO
 bgO
-nTE
-pTn
-jnm
+pPI
+uRd
+ktP
 bnW
 bph
 bsc
-mQR
+mkv
 bsc
-wNM
+jFH
 btG
 gXs
-prP
+iDo
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -81834,11 +81826,11 @@ aea
 aeH
 aft
 abc
-woX
-kdm
-rvZ
-vUR
-jHM
+dly
+mnC
+mcp
+xls
+xUe
 aaa
 aaa
 aiU
@@ -81944,19 +81936,19 @@ aaf
 aaa
 aaa
 gXs
-gtL
+iHk
 bgO
 bgO
 bgO
 bgO
 bgO
 bgO
-vgp
+jBA
 btG
 aaa
-gSH
+kvl
 ctv
-prP
+iDo
 aaa
 aaa
 aaa
@@ -82080,7 +82072,7 @@ aaa
 aaa
 gXs
 gXs
-dbM
+dVU
 abc
 abu
 abu
@@ -82092,10 +82084,10 @@ aeJ
 afw
 abc
 abc
-kdm
+mnC
 aay
-vUR
-qlF
+xls
+kMt
 aaf
 aaf
 aiU
@@ -82163,7 +82155,7 @@ bCq
 bHD
 bJe
 bCq
-czi
+nkP
 bHE
 bHE
 bHE
@@ -82211,7 +82203,7 @@ aaa
 aaa
 aaa
 aaa
-prP
+iDo
 ctv
 aaT
 aaa
@@ -82349,9 +82341,9 @@ aeI
 afv
 agf
 abc
-kdm
+mnC
 aay
-vUR
+xls
 aiT
 aiT
 aiV
@@ -82384,7 +82376,7 @@ aKA
 aLN
 aMS
 aOz
-iMG
+exP
 aPQ
 aSa
 aSr
@@ -82394,7 +82386,7 @@ aYZ
 bLE
 aqW
 aqW
-hfe
+noy
 apd
 beA
 bqp
@@ -82402,7 +82394,7 @@ cNG
 cNJ
 bLF
 aZK
-haz
+sRH
 bbR
 bqt
 cBq
@@ -82468,8 +82460,8 @@ aaa
 aaa
 aaa
 aaa
-prP
-prP
+iDo
+iDo
 aaT
 aaa
 aaa
@@ -82593,8 +82585,8 @@ aaa
 aaa
 aaa
 aai
-jSa
-uVt
+eqd
+kgr
 abe
 abw
 acc
@@ -82606,9 +82598,9 @@ aeL
 afy
 agh
 abc
-tOd
-vRr
-tLl
+hnU
+vda
+ybj
 aiT
 ajs
 akb
@@ -82850,7 +82842,7 @@ aaa
 aaa
 gXs
 aai
-gIO
+gbu
 aay
 abd
 abv
@@ -82863,9 +82855,9 @@ aeK
 afx
 agg
 abc
-orw
-jMK
-riA
+dCV
+idK
+ttX
 aiU
 ajr
 aka
@@ -83108,9 +83100,9 @@ aaf
 aaf
 aai
 acd
-wgb
+mIZ
 abg
-jtU
+enB
 aby
 aby
 aby
@@ -83120,10 +83112,10 @@ aeN
 afA
 afA
 abc
-vWw
-wFk
-oXL
-cXx
+laq
+kdP
+mGw
+jls
 aju
 akd
 akK
@@ -83190,14 +83182,14 @@ bCn
 bGq
 bGq
 bGq
-tdF
+rGq
 bLw
 bGq
 bGq
 bGq
 bLw
 bGq
-tdF
+rGq
 bTD
 bUx
 bVI
@@ -83212,7 +83204,7 @@ bVI
 bVI
 bVI
 bTA
-xlN
+xgk
 bHE
 bHE
 bHE
@@ -83245,7 +83237,7 @@ aaa
 aaa
 aaa
 aaa
-hvS
+kEY
 aaa
 aaa
 aaa
@@ -83366,7 +83358,7 @@ aai
 aai
 abf
 aat
-tHx
+jRw
 abx
 acd
 acC
@@ -83375,12 +83367,12 @@ adF
 aef
 aeM
 afz
-jSD
+dLG
 aav
-sjT
-pLt
-pQr
-new
+vIi
+fsj
+mPt
+lyR
 ajt
 akc
 akJ
@@ -83693,7 +83685,7 @@ bqw
 aJq
 aJq
 aYl
-ppY
+fAj
 aLX
 aJq
 aJq
@@ -83877,7 +83869,7 @@ aai
 aan
 aaw
 aaB
-kfE
+qmn
 aaJ
 aat
 abh
@@ -84132,7 +84124,7 @@ aag
 aaa
 aak
 aap
-fuo
+saX
 aaD
 aau
 aat
@@ -84207,7 +84199,7 @@ bqy
 cBr
 bqy
 buK
-pNI
+tZe
 aJw
 aJq
 aJq
@@ -84239,7 +84231,7 @@ bWB
 bWB
 cec
 bVI
-iOt
+kNv
 ccw
 chY
 ciX
@@ -84646,7 +84638,7 @@ aag
 aaa
 aal
 aar
-phH
+uGI
 aaF
 aat
 aat
@@ -84725,7 +84717,7 @@ bwi
 bmr
 aMm
 aJq
-otF
+vEi
 bCs
 bCs
 bEY
@@ -84903,12 +84895,12 @@ aag
 aaf
 aaj
 aaq
-eOy
+dyS
 aaE
 aat
 aaN
 aaV
-rtT
+rvS
 aat
 acd
 abL
@@ -84987,7 +84979,7 @@ bCs
 bDv
 bEX
 bFb
-hKF
+kfv
 bFa
 bKt
 bLx
@@ -85163,9 +85155,9 @@ aat
 aat
 aat
 aat
-jeR
-neC
-jgv
+qXg
+jjC
+xOx
 abD
 acd
 acd
@@ -85183,9 +85175,9 @@ agj
 auj
 akl
 akO
-uko
-uko
-xqW
+fde
+fde
+seP
 anw
 anz
 aox
@@ -85421,7 +85413,7 @@ aat
 aat
 aat
 aat
-hRz
+uEI
 aat
 abC
 acd
@@ -85465,7 +85457,7 @@ aGq
 aHO
 aJl
 ayW
-neb
+ftE
 aJq
 aOE
 aJn
@@ -85478,7 +85470,7 @@ aYq
 aZO
 aZC
 baK
-qBe
+rnt
 bbC
 bdI
 bgK
@@ -85735,10 +85727,10 @@ aYs
 aZQ
 bbi
 bde
-nLf
+kvL
 bcd
 bcd
-xhx
+gNC
 bcd
 bcd
 bcd
@@ -85930,14 +85922,14 @@ aaa
 aag
 aaf
 aai
-cMk
-cMk
+wYc
+wYc
 aaG
-cMk
+wYc
 aaP
 aaX
-unu
-lwY
+keM
+xib
 acd
 acD
 acY
@@ -85993,7 +85985,7 @@ aZP
 bbh
 bcc
 bdd
-gjf
+cVs
 bfr
 bgM
 bif
@@ -86211,9 +86203,9 @@ aiz
 ajg
 akl
 akR
-uko
-uko
-xqW
+fde
+fde
+seP
 anz
 anz
 aov
@@ -86252,19 +86244,19 @@ bbk
 bfu
 bbk
 bfs
-pUl
+rTu
 aZM
 aZM
 aaf
 aaf
-lCL
+ktS
 aaf
-lCL
+ktS
 aaf
-lCL
+ktS
 aaf
-lCL
-wwB
+ktS
+fxV
 aXf
 aJq
 bBi
@@ -86451,7 +86443,7 @@ aaa
 aaf
 aai
 abi
-vdz
+eqA
 ach
 acK
 adf
@@ -86509,19 +86501,19 @@ bce
 bdf
 beb
 aYv
-kTz
-kDD
+cUx
+fcn
 aaf
 aaf
-lCL
-lCL
+ktS
+ktS
 aaf
-wwB
-wwB
-wwB
-wwB
-wwB
-wwB
+fxV
+fxV
+fxV
+fxV
+fxV
+fxV
 aXf
 aJq
 byU
@@ -86766,19 +86758,19 @@ aZR
 bbm
 bec
 bfu
-sdL
+vBa
 aBa
 aBa
 aBa
 aBa
 aBa
 aBa
-wwB
+fxV
 bsb
-lTq
-tMS
-eND
-wEp
+yhz
+ouQ
+cQT
+nbT
 aXf
 aJq
 bBi
@@ -86972,7 +86964,7 @@ cpg
 acv
 adi
 adi
-pQD
+yiY
 aeW
 agQ
 ahv
@@ -86989,7 +86981,7 @@ anz
 anz
 aov
 aph
-oOb
+cIv
 ard
 ard
 ard
@@ -87023,7 +87015,7 @@ aZR
 aZR
 aZR
 bft
-srq
+psk
 aBa
 aBT
 aDs
@@ -87032,13 +87024,13 @@ aGb
 aBa
 bqD
 bsa
-oeQ
+vCn
 bsa
 bsa
-wEp
+nbT
 byS
 aJq
-idX
+wTf
 bCs
 bCs
 bCs
@@ -87229,7 +87221,7 @@ acl
 cxA
 acL
 adi
-vpz
+pfm
 agp
 agT
 ahx
@@ -87239,12 +87231,12 @@ ajc
 ajI
 akl
 akT
-fGl
-uko
-xqW
+unW
+fde
+seP
 anw
 anz
-lYU
+old
 apk
 anw
 anw
@@ -87255,7 +87247,7 @@ avj
 awl
 axC
 ayY
-uZM
+cpF
 azZ
 azZ
 azZ
@@ -87280,16 +87272,16 @@ bbm
 bdh
 bee
 bfv
-vLD
+xUL
 aBb
-cSn
+gpD
 aDr
 aEM
 aGa
 aHF
 bqF
 bsa
-nmx
+nXE
 buQ
 buQ
 bxI
@@ -87359,7 +87351,7 @@ cgI
 cgI
 cgI
 aaa
-hoo
+gDl
 aaa
 aaa
 aaa
@@ -87537,13 +87529,13 @@ bcf
 bdg
 bed
 bfv
-kvZ
-fGC
-qvM
+tyX
+pst
+cTT
 alu
 aEM
 aGd
-nMx
+uOJ
 bqE
 bqE
 bqE
@@ -87769,7 +87761,7 @@ avk
 awk
 axE
 ayZ
-ncj
+pHO
 aBu
 aAa
 aAa
@@ -87794,18 +87786,18 @@ bbm
 bdh
 bef
 bfv
-smn
+gTx
 aBc
-jXg
+xEB
 aDt
 aEO
 aGc
 aHF
 aKG
 bsf
-kxc
-kxc
-kxc
+dml
+dml
+dml
 bxK
 bwh
 bAh
@@ -88015,7 +88007,7 @@ aml
 amT
 anw
 anz
-ilJ
+cXU
 apl
 aqc
 aqc
@@ -88051,19 +88043,19 @@ aZR
 aZR
 aZR
 bfw
-rzg
+wZI
 aBa
 aBW
 bjy
 aEP
-nOS
+nYe
 aBa
 bqG
 bsa
-jDY
+eih
 bsa
 bsa
-wEp
+nbT
 bwb
 aJq
 bBr
@@ -88272,7 +88264,7 @@ amn
 amV
 anw
 anz
-rsX
+gfC
 aod
 aqf
 ahT
@@ -88308,19 +88300,19 @@ aZR
 bbm
 beh
 bfx
-spX
+qcm
 aBa
 aBa
 aBa
 aBa
 aBa
 aBa
-mte
+wql
 bsg
-lTq
-tMS
-fZD
-wEp
+yhz
+ouQ
+fTC
+nbT
 aJq
 aJq
 bBu
@@ -88565,19 +88557,19 @@ bcg
 aZU
 beg
 aYB
-ptV
-fjy
+qOB
+qBi
 aaf
 aaf
-lCL
-lCL
+ktS
+ktS
 aaf
-wwB
-wwB
-wwB
-wwB
-wwB
-wwB
+fxV
+fxV
+fxV
+fxV
+fxV
+fxV
 aJq
 aJq
 bBt
@@ -88782,9 +88774,9 @@ ajJ
 akr
 akX
 alC
-iqw
+wIG
 amX
-elw
+spu
 anz
 aoB
 aod
@@ -88822,19 +88814,19 @@ bbp
 bfx
 bbp
 bfz
-tAb
+sqp
 aZV
 aZV
 aaf
 aaf
-lCL
+ktS
 aaf
-lCL
+ktS
 aaf
-lCL
+ktS
 aaf
-lCL
-wwB
+ktS
+fxV
 aJq
 aJq
 aXf
@@ -89041,9 +89033,9 @@ akW
 aiG
 amo
 amW
-uYE
+uaj
 anz
-rsX
+gfC
 aod
 aqe
 arf
@@ -89094,7 +89086,7 @@ bsh
 bqH
 aJq
 aJq
-unY
+gnf
 bCv
 bDJ
 bCt
@@ -89333,7 +89325,7 @@ aYD
 aZX
 baf
 bdk
-jwi
+mRQ
 bek
 bfB
 bgU
@@ -89576,7 +89568,7 @@ vHj
 eVC
 dgz
 aJv
-ioG
+khV
 aMg
 bHt
 aOE
@@ -89806,13 +89798,13 @@ ahC
 aia
 aiP
 aiR
-olv
+coi
 akv
 ala
 aww
 afM
 aiX
-uVq
+xzj
 anz
 aoF
 apo
@@ -89823,8 +89815,8 @@ atj
 aul
 auR
 atj
-kcj
-ghJ
+mps
+tKk
 atj
 aAX
 azc
@@ -89847,7 +89839,7 @@ aPR
 aZV
 baq
 baQ
-dTJ
+wcB
 bcQ
 bfC
 bgV
@@ -90083,8 +90075,8 @@ avt
 axL
 bbl
 azT
-nlt
-dwc
+nZE
+ker
 aDG
 aFd
 auk
@@ -90137,7 +90129,7 @@ bOV
 bQj
 bRw
 bSF
-gVY
+daI
 bTP
 bRA
 bWQ
@@ -90336,11 +90328,11 @@ arf
 arf
 arf
 arf
-ukP
-oma
+ltK
+xAv
 awr
 awr
-wwn
+ruo
 aAh
 aAh
 aAh
@@ -90377,7 +90369,7 @@ btL
 buY
 buY
 bqH
-neb
+ftE
 aJq
 aXf
 bCv
@@ -90394,7 +90386,7 @@ bOV
 bQo
 bRz
 bSH
-cJn
+plm
 bTP
 bRA
 bWQ
@@ -90597,7 +90589,7 @@ avv
 awu
 awr
 aAd
-uDW
+tkq
 aAh
 aDL
 aAh
@@ -90651,7 +90643,7 @@ bOV
 bQj
 bRy
 bSG
-gVY
+daI
 bUK
 bVT
 bWR
@@ -90854,7 +90846,7 @@ awp
 axN
 awr
 awr
-kSh
+haM
 aAh
 aDQ
 aAh
@@ -90862,7 +90854,7 @@ aGl
 aAh
 aBy
 aAh
-pTR
+rqf
 aJq
 aOE
 aJn
@@ -90875,7 +90867,7 @@ aYF
 aZV
 bbw
 bcn
-qUm
+tgH
 ben
 bfE
 bgX
@@ -91105,13 +91097,13 @@ aqe
 arf
 ari
 asu
-kyi
+mPk
 aun
 avR
-oma
-dHb
+xAv
+ofU
 awr
-uya
+sFW
 aAh
 aDM
 aGx
@@ -91364,18 +91356,18 @@ arf
 arf
 arf
 arf
-ukP
+ltK
 axP
 azb
 aAi
-wGP
+uIO
 aCn
-rOm
-wwC
+xBk
+dtx
 aGm
 aHV
 aDM
-nrR
+hIM
 aJq
 aJq
 aJq
@@ -91406,9 +91398,9 @@ bva
 bwu
 bwu
 bwu
-ihm
+kPj
 bBB
-rhb
+eBX
 bzs
 bFp
 bGJ
@@ -91624,8 +91616,8 @@ arf
 awq
 axO
 aza
-jtk
-pqR
+kmw
+xrN
 aAh
 aAh
 aAh
@@ -91874,7 +91866,7 @@ ajo
 aps
 aqk
 arf
-vGX
+vDR
 blU
 aHw
 avn
@@ -91882,14 +91874,14 @@ awv
 axX
 aze
 awr
-hMx
+flE
 aAh
 aDU
 aBz
 aBz
 aAh
-isy
-uzk
+dTI
+ujv
 aJq
 aJq
 aJq
@@ -92133,7 +92125,7 @@ aqj
 arf
 ark
 asu
-epV
+xPk
 aun
 awt
 awr
@@ -92142,10 +92134,10 @@ azX
 aAZ
 aCe
 aDT
-mEN
-mEN
-dzy
-fyq
+cPn
+cPn
+mkO
+uQS
 aAh
 aJC
 aJC
@@ -92402,18 +92394,18 @@ aDP
 aBx
 aBx
 aAh
-kCk
-qIf
+qqs
+sYR
 aMq
 adq
 aQb
 aPZ
 aRu
-wpo
+kAH
 aKR
-tIC
+tCa
 aXi
-maC
+hgO
 baa
 aJC
 bcq
@@ -92653,7 +92645,7 @@ awy
 awr
 awr
 avG
-udi
+wqF
 aAh
 aAh
 aAh
@@ -92663,13 +92655,13 @@ aAh
 aAh
 aKR
 aKR
-pxD
+fxe
 aPY
-xMl
+kAO
 aRx
 aKR
-jzD
-tuN
+iTU
+pqe
 aPY
 aZZ
 aQg
@@ -92910,24 +92902,24 @@ awA
 axT
 axW
 aAl
-tAE
+cHf
 aJC
 aDR
 aFl
-rLr
+kqI
 aHZ
 aJC
 aKJ
-rLR
+hIL
 aKR
-hSU
-kay
+wxT
+moD
 aQd
 aQa
 aKR
-xbu
-hSU
-lwj
+elh
+wxT
+uBa
 bac
 aJC
 aYV
@@ -93151,7 +93143,7 @@ aif
 aif
 aif
 bkV
-fvk
+jKP
 alK
 aif
 aif
@@ -93159,19 +93151,19 @@ anc
 anD
 aoI
 arf
-myt
+eSe
 asN
 aur
 avy
-tWR
+nSt
 axS
 azk
 aAk
-eUd
+tvi
 aJC
 aDY
 aDY
-rLr
+kqI
 aKR
 aJk
 aKR
@@ -93187,7 +93179,7 @@ aKR
 aKR
 bab
 aJC
-xYO
+ucq
 aYV
 ber
 bfF
@@ -93399,13 +93391,13 @@ abp
 afo
 abp
 abp
-hlY
+uhm
 ahn
 aiA
 aiA
 aiA
 ahn
-hYW
+oLn
 anF
 aod
 ahn
@@ -93416,15 +93408,15 @@ ahn
 ahn
 ahn
 arf
-iES
-jdT
+oAB
+eQb
 aut
 arf
 aXF
 awr
 awr
 aAn
-wcy
+rqk
 aJC
 aEc
 aFk
@@ -93434,19 +93426,19 @@ aJC
 aKr
 aKR
 aKR
-fbm
-fbm
-hzR
+sLj
+sLj
+vcN
 aKR
 aKR
 aKR
-fbm
+sLj
 aKR
 aKR
 bbx
 aYV
 aYV
-wDR
+tkB
 bfF
 bhd
 bis
@@ -93652,11 +93644,11 @@ aaf
 aaf
 aaf
 abp
-unE
+wdv
 afp
-unE
+wdv
 abp
-nea
+nQi
 ahn
 aaa
 aaf
@@ -93666,39 +93658,39 @@ ahn
 anE
 aod
 aoK
-sgV
+oyX
 aqp
 ahn
-ukS
-tQk
-cVp
-jdT
-jdT
-jdT
-rMc
+tzQ
+pgf
+gzf
+eQb
+eQb
+eQb
+lUS
 aun
 avz
 awr
 awr
 aAn
-fSr
+jGW
 aJC
 aJC
-gjC
-lxx
+plC
+oAb
 aJC
 aJC
 aKq
 aKR
 aNF
-egS
-ghs
-lMY
+hOv
+oax
+oxm
 aSH
 aKR
-dMX
-igT
-moq
+rmN
+eJa
+hSZ
 aKR
 aQg
 aYV
@@ -93724,7 +93716,7 @@ bvj
 bvj
 bvd
 bFu
-hcd
+jex
 bvj
 bvd
 bKH
@@ -93926,19 +93918,19 @@ aoL
 apy
 aqq
 ahn
-dhx
-mfb
+qLR
+oIW
 arf
-unl
+kmS
 ast
-jdT
+eQb
 auv
 arf
 avA
 axW
 azo
 aAp
-lYZ
+uxY
 aBC
 aCt
 aEA
@@ -93949,13 +93941,13 @@ aKN
 aKR
 aKR
 aOJ
-fvW
-dtE
+oIJ
+unA
 aKR
 aKR
 aUg
 bFC
-moq
+hSZ
 aKR
 bbx
 aYV
@@ -93963,9 +93955,9 @@ aYV
 bet
 bfH
 bhf
-slp
+wbE
 bhh
-slp
+wbE
 bmJ
 bof
 bpu
@@ -94191,11 +94183,11 @@ arf
 arf
 arf
 arf
-hkg
-eNW
+hlV
+oHB
 azf
 aAo
-lMx
+vyp
 aBB
 aBB
 aBB
@@ -94205,12 +94197,12 @@ cNE
 aKM
 aMu
 aMu
-poa
-hdb
+feG
+tif
 aMu
 aMu
 aMu
-uTq
+jgA
 aSq
 aKR
 bad
@@ -94222,7 +94214,7 @@ bfG
 bhe
 bit
 bjS
-nGS
+tCd
 bli
 boe
 bli
@@ -94437,24 +94429,24 @@ aag
 aag
 aag
 arf
-iep
-gQn
+wXl
+iou
 arf
-myt
-qNs
-lMx
-sjw
+eSe
+wig
+vyp
+rrM
 clO
 asZ
 aua
-dcG
+oZl
 awB
 att
 azh
-vYa
-vYa
-gKk
-vbY
+fHG
+fHG
+kxf
+ufD
 alP
 aGI
 aId
@@ -94468,7 +94460,7 @@ aMx
 aMx
 aMx
 aMx
-eqm
+rqE
 aKR
 aZb
 aJC
@@ -94679,11 +94671,11 @@ aaa
 aaa
 aaa
 aaa
-xzh
+bvG
 aaa
 aqG
 aaa
-vDq
+oyN
 aaa
 aaa
 aaa
@@ -94694,24 +94686,24 @@ aaa
 aaa
 aaa
 arf
-pZv
-tQk
-cVp
-jdT
-ier
+lOe
+pgf
+gzf
+eQb
+jLT
 arf
 arm
-vYa
+fHG
 aya
-vYa
-vYa
+fHG
+fHG
 auB
 atZ
 azg
 azp
-vYa
+fHG
 aCu
-dgh
+qOc
 alP
 aGH
 aIc
@@ -94936,11 +94928,11 @@ aaa
 aaa
 aaa
 aaa
-lCB
-lNB
+tqB
+vae
 aaa
-lNB
-rUQ
+vae
+efO
 aaa
 aaa
 aaa
@@ -94954,21 +94946,21 @@ arf
 arf
 arf
 arf
-iES
-jYI
+oAB
+ujS
 aqs
-hVw
-vYa
-vYa
-vYa
-vYa
-pSf
-vYa
+coh
+fHG
+fHG
+fHG
+fHG
+pPi
+fHG
 ayb
-ndC
-vYa
+hWd
+fHG
 aCv
-frE
+mbU
 alP
 aGJ
 aIe
@@ -94982,7 +94974,7 @@ aXj
 aVy
 aSY
 aVy
-oNb
+xqG
 acN
 bah
 aJC
@@ -95193,11 +95185,11 @@ aaa
 aaa
 aaa
 aaa
-jmC
-jmC
+gJi
+gJi
 gXs
-jmC
-jmC
+gJi
+gJi
 aaa
 aaa
 aaa
@@ -95210,22 +95202,22 @@ aaa
 aaa
 aaa
 arf
-ewZ
-jdT
-tOU
+obc
+eQb
+qAm
 arf
-fQF
-qbx
-qux
-vYa
-vYa
-pSf
-vYa
+lXE
+pFX
+mOO
+fHG
+fHG
+pPi
+fHG
 ayb
-ndC
-vYa
-vys
-tCi
+hWd
+fHG
+sci
+sEi
 alP
 aGJ
 aIe
@@ -95235,11 +95227,11 @@ aKQ
 aNu
 aJC
 aPw
-kwy
+egt
 aQc
 aSZ
 aQc
-vjq
+qaY
 acN
 bag
 aJC
@@ -95467,22 +95459,22 @@ aaa
 aaa
 aaa
 arf
-qoP
-prU
-fOc
+mse
+fMZ
+dqb
 arf
-oSO
-sAI
-fJa
-vYa
-svw
-ntf
-jvN
-lBE
-xpx
-vYa
+xzd
+sJI
+jJg
+fHG
+eAJ
+rvr
+nLu
+hcA
+ryr
+fHG
 aCu
-hgX
+puh
 alP
 aGA
 aHS
@@ -95504,7 +95496,7 @@ aYV
 aYV
 bet
 bfH
-dok
+qTV
 bhh
 bhg
 bln
@@ -95708,9 +95700,9 @@ aaa
 aaa
 aaa
 aaa
-aaz
+xLX
 aaa
-aaz
+xLX
 aaa
 aaa
 aaa
@@ -95728,18 +95720,18 @@ arf
 arf
 arf
 arf
-mTp
-qEv
-kRk
-mXB
-qAQ
-pzk
-vYa
-sMa
-iEI
-jeT
-rTQ
-vHM
+fZm
+jmV
+epD
+ghD
+hBA
+xbn
+fHG
+reA
+lsk
+xXi
+jAN
+jEc
 alP
 aGL
 aHM
@@ -95984,18 +95976,18 @@ aaa
 aaa
 aaa
 gXs
-kHJ
-rEV
-rEV
-kQZ
-fVU
-vpm
-vpm
-fVU
-nel
-wCa
-wCa
-lFl
+ewu
+pQp
+pQp
+oqj
+jBi
+fpl
+fpl
+jBi
+oDN
+sEM
+sEM
+pRs
 arj
 alP
 aGL
@@ -96092,7 +96084,7 @@ aaf
 ctZ
 cui
 cuq
-ajY
+cuC
 cuO
 cuz
 cvm
@@ -96270,7 +96262,7 @@ aVz
 aVz
 aYJ
 aJI
-sIe
+mNW
 aYV
 aYV
 aYV
@@ -96600,8 +96592,8 @@ czk
 cti
 cua
 cua
-aeF
-afs
+ctw
+ctH
 ctQ
 cuc
 cuj
@@ -96787,7 +96779,7 @@ baj
 bbz
 aYV
 bdp
-itT
+mvt
 bfK
 bfK
 bfK
@@ -96857,9 +96849,9 @@ ctb
 cth
 cua
 ctr
-afn
-age
-agX
+ctu
+ctG
+ctP
 cub
 cuj
 cur
@@ -97040,7 +97032,7 @@ aVD
 aVE
 aXm
 aVz
-egQ
+juG
 bbz
 aYV
 bdp
@@ -97114,13 +97106,13 @@ ctc
 ctc
 cto
 ctt
-afq
+cty
 ctJ
-ahw
+ctT
 cue
 cul
 cuu
-akz
+cuG
 cuS
 cve
 cvo
@@ -97371,9 +97363,9 @@ ctb
 ctj
 ctk
 cts
-afr
-agv
-ajC
+ctx
+ctI
+ctS
 cud
 cuk
 cus
@@ -97526,17 +97518,17 @@ aaa
 aaa
 aaa
 aaa
-haX
-rEV
-rEV
-rEV
-nie
-vpm
-vpm
-wFX
-wCa
-wCa
-wCa
+vmQ
+pQp
+pQp
+pQp
+grA
+fpl
+fpl
+gbh
+sEM
+sEM
+sEM
 aCy
 arj
 alP
@@ -97554,7 +97546,7 @@ aTO
 cCq
 aVz
 aVz
-fPs
+qus
 bbz
 aYV
 bdp
@@ -97787,14 +97779,14 @@ aaa
 aaa
 aaa
 arj
-cRz
+fCx
 avD
 awC
 ayb
-mbD
-nmS
-oFk
-xXY
+eCr
+jvd
+cEo
+xZD
 vpY
 alP
 aGJ
@@ -97840,7 +97832,7 @@ bCR
 bqQ
 bGX
 bCR
-oDy
+edA
 bRN
 bIK
 bPq
@@ -98046,13 +98038,13 @@ aaf
 arj
 auz
 avC
-kOf
+vHz
 aya
-vYa
-vYa
-oYc
-vYa
-vYa
+fHG
+fHG
+xkd
+fHG
+fHG
 gOZ
 aGJ
 avI
@@ -98143,7 +98135,7 @@ aaa
 aaf
 cua
 ctF
-agH
+ctM
 ctX
 cuf
 cum
@@ -98303,7 +98295,7 @@ alO
 arj
 arj
 arj
-eOv
+pBp
 gOZ
 cVb
 cVb
@@ -98401,7 +98393,7 @@ aaf
 cua
 ctE
 ctL
-ajX
+ctW
 cuf
 cum
 cuw
@@ -98815,10 +98807,10 @@ cxW
 anf
 aqv
 ayf
-fIn
-ego
+dce
+uua
 awE
-dMu
+tRB
 cVb
 vCb
 wUY
@@ -99071,8 +99063,8 @@ aag
 alO
 anf
 alO
-kSB
-pAl
+mAH
+jaF
 alP
 anf
 aCG
@@ -99088,11 +99080,11 @@ aIq
 aKK
 aMy
 aIp
-jaa
+nGf
 aQm
-wOT
-htr
-htr
+fzd
+fFA
+fFA
 aVK
 aRJ
 aRJ
@@ -99334,10 +99326,10 @@ alP
 awF
 aCG
 alP
-olw
+nhY
 aBE
 aCz
-trY
+vEp
 aCJ
 aGT
 aIn
@@ -99347,10 +99339,10 @@ aMt
 aIp
 aOW
 aQm
-dRC
+coI
 aSS
 aUj
-pHo
+sJx
 aRJ
 aYQ
 cBg
@@ -99584,7 +99576,7 @@ aoN
 apA
 aof
 arq
-hdp
+itK
 atv
 auD
 alP
@@ -99604,14 +99596,14 @@ aMA
 aIp
 aOX
 aQm
-dRC
+coI
 aST
 aUk
-pHo
+sJx
 aRJ
 aYQ
 bam
-yiN
+ssB
 aYV
 aYV
 aYV
@@ -99828,10 +99820,10 @@ adU
 adU
 adU
 adU
-ssL
-rsv
-rsv
-rsv
+eaR
+jIs
+jIs
+jIs
 acx
 amv
 ane
@@ -99861,14 +99853,14 @@ aMz
 aNQ
 aOX
 aQm
-tFt
-tsr
-tsr
-xzy
+lva
+nUV
+nUV
+gbd
 aRJ
 aYR
 ban
-qje
+ikm
 aYV
 aYV
 bez
@@ -100112,7 +100104,7 @@ aaa
 aFq
 aGX
 aIp
-vzS
+sHx
 aKU
 aME
 aNN
@@ -100125,7 +100117,7 @@ aXo
 aXo
 aYO
 bap
-qje
+ikm
 aYV
 bci
 beB
@@ -100354,7 +100346,7 @@ aof
 aof
 aof
 aof
-qkC
+vCy
 aoP
 atw
 auF
@@ -100362,7 +100354,7 @@ alP
 aoP
 auF
 azr
-kel
+jez
 atw
 alP
 alP
@@ -100376,13 +100368,13 @@ aNQ
 aOZ
 aOX
 aOX
-hZH
+rdG
 aUz
 aVM
 aOX
 aYT
 bam
-ory
+iuR
 baR
 bcb
 bdl
@@ -100439,7 +100431,7 @@ bAw
 bAw
 clp
 aag
-jmC
+gJi
 aaa
 aaa
 aaa
@@ -100617,7 +100609,7 @@ aty
 auF
 alP
 aAt
-kuY
+jZT
 alP
 alP
 alP
@@ -100868,7 +100860,7 @@ aaa
 aaa
 apC
 anf
-kel
+jez
 alP
 atx
 auF
@@ -100877,7 +100869,7 @@ auD
 auF
 apE
 aAs
-khA
+vbi
 alP
 aCG
 aFr
@@ -101130,12 +101122,12 @@ alP
 apE
 auG
 alP
-rgF
+iWx
 auF
 apE
 anf
 anf
-jRy
+noF
 aCG
 aDZ
 aFu
@@ -101399,8 +101391,8 @@ bbE
 aIr
 bav
 aLf
-aaL
-kLR
+aNV
+qfD
 aRO
 aQp
 aRN
@@ -101464,11 +101456,11 @@ cQB
 czY
 cOT
 aaa
-jmC
-jmC
-jmC
-jmC
-jmC
+gJi
+gJi
+gJi
+gJi
+gJi
 aaa
 aaa
 aaa
@@ -101641,12 +101633,12 @@ apC
 alP
 alP
 alP
-tuj
+dbU
 auH
 avF
 awI
 ayc
-mlr
+gcF
 asw
 asw
 aCD
@@ -101657,7 +101649,7 @@ aIu
 aJQ
 aIt
 aIt
-kLR
+qfD
 aRO
 aIt
 aRN
@@ -101912,9 +101904,9 @@ anf
 aFu
 aIs
 aJP
-wuB
+vZR
 aIt
-nsJ
+hGH
 aYW
 aYW
 aYW
@@ -101982,9 +101974,9 @@ aaa
 aaa
 aaa
 aaH
-adO
-aeD
-aeE
+eFW
+nwX
+weM
 aaa
 aaa
 aaa
@@ -102169,9 +102161,9 @@ aFu
 aFu
 aIw
 aJS
-tqt
+pJR
 aNP
-jFy
+esZ
 aOS
 aOS
 aOS
@@ -102235,14 +102227,14 @@ cQB
 cAa
 cOT
 gXs
-xNY
-kvb
+rnK
+kWp
 aaa
 aaa
 aaH
 aaH
 aaH
-aeE
+weM
 aaa
 aaa
 aaa
@@ -102419,7 +102411,7 @@ awJ
 anf
 alP
 aAv
-gCe
+tJS
 aCE
 aDZ
 aFu
@@ -102428,7 +102420,7 @@ aIv
 aJR
 aIt
 aIt
-kLR
+qfD
 aRO
 aIt
 aPd
@@ -102492,14 +102484,14 @@ czU
 czZ
 cOT
 aaa
-jmC
+gJi
 aaH
 aaH
 aaH
 aaH
 aaH
 aaH
-adO
+eFW
 aaa
 aaa
 aaa
@@ -102685,7 +102677,7 @@ aIx
 aJF
 aQq
 aNS
-kLR
+qfD
 aRO
 aIt
 aPd
@@ -102749,14 +102741,14 @@ cgm
 czY
 cOT
 gXs
-xNY
-kvb
-gJg
+rnK
+kWp
+kaq
 aaH
 aaH
 aaa
 aaa
-gJg
+kaq
 aaa
 aaa
 aaa
@@ -102946,12 +102938,12 @@ aFu
 aPf
 aQq
 aRP
-kHK
+pem
 aIt
 aIt
 aWd
 aXV
-iWa
+vsT
 bbD
 aYV
 aXq
@@ -102959,7 +102951,7 @@ aYV
 bfV
 bhw
 cHM
-kRw
+wWT
 blB
 blF
 cHS
@@ -103008,9 +103000,9 @@ cNW
 aaa
 aaa
 aaa
-gJg
-gJg
-adO
+kaq
+kaq
+eFW
 aaH
 gXs
 aaa
@@ -103182,8 +103174,8 @@ alO
 anf
 anf
 arw
-ftv
-sLr
+nuw
+uve
 anf
 alP
 awL
@@ -103456,7 +103448,7 @@ aIy
 aJG
 cAz
 aFw
-iWk
+gRZ
 aPg
 aQr
 aFu
@@ -103523,10 +103515,10 @@ aaa
 aaa
 aaa
 aaa
-jmC
-jmC
-jmC
-jmC
+gJi
+gJi
+gJi
+gJi
 aaa
 aaa
 aaa
@@ -103693,10 +103685,10 @@ aaa
 aaa
 gXs
 alP
-qxc
+jkx
 ayf
-nuV
-iOV
+xAk
+mHU
 aFn
 aFn
 aBB
@@ -103713,7 +103705,7 @@ aFw
 aLo
 aLb
 aFw
-eMQ
+xEE
 aYW
 aYW
 aRQ
@@ -103947,13 +103939,13 @@ aaa
 aaa
 aaa
 aaa
-fzd
-fzd
-fzd
-fzd
-tNJ
-fzd
-fzd
+nsA
+nsA
+nsA
+nsA
+qVP
+nsA
+nsA
 atB
 alP
 alP
@@ -103970,7 +103962,7 @@ aIz
 aJM
 aLa
 aFw
-tGG
+hsb
 aYW
 aQs
 aFu
@@ -104204,21 +104196,21 @@ aaa
 aaa
 aaa
 aaa
-fzd
-xdb
-mCq
-wJz
-mHC
-tWs
-lmi
-ghY
-sxX
-ghY
-jBZ
+nsA
+cQF
+ndq
+rIA
+fBy
+hRI
+jaH
+hHQ
+feE
+hHQ
+kGJ
 avI
 asA
 apE
-vHv
+dPk
 aCG
 aEf
 aFw
@@ -104461,12 +104453,12 @@ aaa
 aaa
 aaa
 aaa
-tIk
-mCq
-mCq
-mCq
-mCq
-pjh
+wKe
+ndq
+ndq
+ndq
+ndq
+oLl
 asB
 asB
 asB
@@ -104557,7 +104549,7 @@ cOe
 cBT
 aag
 gXs
-jmC
+gJi
 aaa
 aaa
 aaa
@@ -104718,12 +104710,12 @@ aaa
 aaa
 aaa
 aaa
-tIk
-mCq
-mCq
-mCq
-mCq
-dSv
+wKe
+ndq
+ndq
+ndq
+ndq
+qeb
 asB
 atD
 auJ
@@ -104975,12 +104967,12 @@ aaa
 aaa
 aaa
 aaa
-fzd
-mCq
-mCq
-mCq
-mCq
-mCq
+nsA
+ndq
+ndq
+ndq
+ndq
+ndq
 asB
 atC
 auI
@@ -105064,7 +105056,7 @@ cNW
 cNW
 cNW
 cOe
-qXH
+fup
 csy
 cko
 cAf
@@ -105232,12 +105224,12 @@ aaa
 aaa
 aaa
 aaa
-tIk
-mCq
-mCq
-mCq
-mCq
-mCq
+wKe
+ndq
+ndq
+ndq
+ndq
+ndq
 asB
 atE
 auI
@@ -105489,18 +105481,18 @@ aaa
 aaa
 aaa
 aaa
-tIk
-mCq
-mCq
-mCq
-mCq
-mCq
+wKe
+ndq
+ndq
+ndq
+ndq
+ndq
 asB
 asB
 asB
 avL
 awR
-hRT
+hiV
 azu
 aAz
 asB
@@ -105574,7 +105566,7 @@ cgp
 chv
 ciJ
 cbf
-lLI
+diq
 clr
 bnt
 cOe
@@ -105746,12 +105738,12 @@ aaa
 aaa
 aaa
 aaa
-fzd
-wXP
-mCq
-nXa
-mCq
-nyH
+nsA
+lGV
+ndq
+pou
+ndq
+srG
 asB
 atG
 auL
@@ -106003,12 +105995,12 @@ aaa
 aaa
 aaa
 aaa
-fzd
-fzd
-fzd
-fzd
-fzd
-fzd
+nsA
+nsA
+nsA
+nsA
+nsA
+nsA
 asB
 atF
 auK
@@ -106092,7 +106084,7 @@ cNW
 clt
 cQw
 cNW
-abG
+mJo
 cNW
 cNW
 aaf
@@ -106294,9 +106286,9 @@ aXB
 aZh
 baB
 aCR
-riB
+kYk
 bdx
-dfI
+vHT
 bgc
 bgc
 biX
@@ -106348,7 +106340,7 @@ aaa
 cOT
 clt
 cQw
-aaO
+oEZ
 cOe
 cOe
 cNW
@@ -106605,18 +106597,18 @@ aaa
 cOT
 clt
 cQw
-aaQ
+ttL
 cOe
 cOe
 cNW
 aaa
-jzi
-jzi
-jzi
-jzi
-jzi
-jzi
-jzi
+fIs
+fIs
+fIs
+fIs
+fIs
+fIs
+fIs
 aaS
 aaS
 aba
@@ -106866,7 +106858,7 @@ bNB
 cOe
 cOe
 cNW
-lCL
+ktS
 aaS
 aaa
 aaf
@@ -107119,7 +107111,7 @@ cNW
 cNW
 clt
 cQw
-aaY
+cCt
 cOe
 cOe
 cNW
@@ -107368,7 +107360,7 @@ cbZ
 bSl
 cmo
 cNW
-vOq
+lZl
 cNW
 chC
 ciL
@@ -108668,17 +108660,17 @@ cpi
 cpi
 cpi
 cqJ
-ggg
+vZA
 crk
 crk
 crk
 crk
 crk
-pFt
+pTB
 cqJ
-ggg
+vZA
 crk
-pFt
+pTB
 cpi
 cpi
 ctB
@@ -108934,7 +108926,7 @@ crF
 aaa
 aaa
 aaa
-hik
+vPs
 aaa
 aaa
 aaa
@@ -109673,7 +109665,7 @@ cNW
 cNW
 cNW
 cNW
-vFt
+kAJ
 clt
 cac
 cbh
@@ -109939,7 +109931,7 @@ cbf
 cbf
 ceT
 cNW
-kCW
+dBm
 chH
 cNW
 aaf


### PR DESCRIPTION
## About The Pull Request

Caps office once again has a full carpet, as well as an arcade.
Caps toilet has had a surprise visit from the clown
Box'es gulag shuttle door is now glass and should not be locked.

## Why It's Good For The Game

OCD captains no longer have to deal with their carpet being miss planed
Clown did a honk
Gulag shuttle being locked away is kinda bad
## Changelog
:cl:
fix: Box station captain office issues
maping: Gulag on box can now be accessed
/:cl:
