### PR TITLE
granting golems GPSes that are off by default

### DIFF
--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -18,6 +18,9 @@
 /obj/item/mining_scanner,
 /obj/item/flashlight/lantern,
 /obj/item/card/id/mining,
+/obj/item/gps/mining{
+	tracking = 0
+	},
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "d" = (
@@ -31,6 +34,9 @@
 /obj/item/mining_scanner,
 /obj/item/flashlight/lantern,
 /obj/item/card/id/mining,
+/obj/item/gps/mining{
+	tracking = 0
+	},
 /turf/open/floor/plating,
 /area/ruin/powered/golem_ship)
 "e" = (
@@ -150,6 +156,7 @@
 "x" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
+/obj/item/gps/mining,
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "z" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_golem_ship.dmm
@@ -156,7 +156,9 @@
 "x" = (
 /obj/structure/table/wood,
 /obj/machinery/reagentgrinder,
-/obj/item/gps/mining,
+/obj/item/gps/mining{
+	tracking = 0
+	},
 /turf/open/floor/mineral/titanium/purple,
 /area/ruin/powered/golem_ship)
 "z" = (


### PR DESCRIPTION
## About The Pull Request
title
## Why It's Good For The Game
allows free golems to find their way, makes it easier for them (or miners) to find their way back and/or to them. they all start off so you don't have grugshits rushing their lathes
## Changelog
:cl:
add: The ships often crashed by Free Golems on Lavaland now have GPSes. They're off, by default, but an awakening Golem could easily turn one on.
/:cl: