### PR TITLE
Fixes no-grav lavaland labor/mining shuttle areas.

### DIFF
--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -674,6 +674,7 @@
 /area/mine/production)
 "mp" = (
 /obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
 	dwidth = 2;
 	height = 5;
@@ -1897,6 +1898,7 @@
 /area/mine/laborcamp)
 "Hk" = (
 /obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
 	dwidth = 3;
 	height = 7;
@@ -2286,6 +2288,7 @@
 /area/mine/living_quarters)
 "Lb" = (
 /obj/docking_port/stationary{
+	area_type = /area/lavaland/surface/outdoors;
 	dir = 8;
 	dwidth = 3;
 	height = 10;


### PR DESCRIPTION
## About The Pull Request
A little fix to stop the docking areas from being spess. A little mistake someone did a while ago.

## Why It's Good For The Game
This will close #10890.

## Changelog
:cl:
fix: Fixed no-grav lavaland labor/mining shuttle areas.
/:cl:
