### PR TITLE
Fixes the panic bunker persistence.

### DIFF
--- a/code/controllers/subsystem/persistence.dm
+++ b/code/controllers/subsystem/persistence.dm
@@ -265,7 +265,8 @@ SUBSYSTEM_DEF(persistence)
 /datum/controller/subsystem/persistence/proc/LoadPanicBunker()
 	var/bunker_path = file("data/bunker_passthrough.json")
 	if(fexists(bunker_path))
-		GLOB.bunker_passthrough = json_decode(file2text(bunker_path))
+		var/list/json = json_decode(file2text(bunker_path))
+		GLOB.bunker_passthrough = json["data"]
 		for(var/ckey in GLOB.bunker_passthrough)
 			if(daysSince(GLOB.bunker_passthrough[ckey]) >= CONFIG_GET(number/max_bunker_days))
 				GLOB.bunker_passthrough -= ckey


### PR DESCRIPTION
## About The Pull Request
So far the bunker_passthrough list only wraps up more nested "data" lists with each passing round and runtimes with type mismatches everytime.

## Why It's Good For The Game
Fixing that.

## Changelog
None, but an admin has to reset GLOB.bunker_passthrough to an empty list to fix this server side.