### PR TITLE
Addendum to PR #10812. REGEN STAMINA WHATEVER FUCK COMBAT REWORK IS CONFUSING

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -189,7 +189,7 @@
 
 
 	L.Knockdown(stunpwr, override_stamdmg = 0)
-	L.apply_damage(stunpwr*0.55, STAMINA, user.zone_selected)
+	L.apply_damage(stunpwr*0.5, STAMINA, user.zone_selected)
 	L.apply_effect(EFFECT_STUTTER, stunforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)


### PR DESCRIPTION
## About The Pull Request

Stamina regeneration should assist against stunbatons in the same way that it does against disablers.

## Why It's Good For The Game

This is necessary for the adjustment of stunbatons critting in 4 hits instead of 5, and the PR was merged before this adjustment was made.

## Changelog
Not necessary