### PR TITLE
Projectiles now always hit chest if targeting chest, snipers now have 100% targeting zone accuracy

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -90,6 +90,10 @@
 	var/decayedRange			//stores original range
 	var/reflect_range_decrease = 5			//amount of original range that falls off when reflecting, so it doesn't go forever
 	var/is_reflectable = FALSE // Can it be reflected or not?
+	
+	/// factor to multiply by for zone accuracy percent.
+	var/zone_accuracy_factor = 1
+	
 		//Effects
 	var/stun = 0
 	var/knockdown = 0
@@ -253,7 +257,8 @@
 			return TRUE
 
 	var/distance = get_dist(T, starting) // Get the distance between the turf shot from and the mob we hit and use that for the calculations.
-	def_zone = ran_zone(def_zone, max(100-(7*distance), 5)) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
+	if(check_zone(def_zone) != BODY_ZONE_CHEST)
+		def_zone = ran_zone(def_zone, max(100-(7*distance), 5) * zone_accuracy_factor) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
 
 	if(isturf(A) && hitsound_wall)
 		var/volume = CLAMP(vol_by_damage() + 20, 0, 100)

--- a/code/modules/projectiles/projectile/bullets/sniper.dm
+++ b/code/modules/projectiles/projectile/bullets/sniper.dm
@@ -7,6 +7,7 @@
 	knockdown = 100
 	dismemberment = 50
 	armour_penetration = 50
+	zone_accuracy_factor = 100		//guarunteed 100%
 	var/breakthings = TRUE
 
 /obj/item/projectile/bullet/p50/on_hit(atom/target, blocked = 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

This was brought to my attention when we did testing in game and some secoff shot me 13 times from 10 tiles away

And all 13 of hits shots hit my limbs, instead of chest.

I like RNG being a thing sometimes but this is just shitty, if you're missing your shots ~43% of the time and making it go to a random limb with those chances at just 7 tiles of travel (note: this doesn't mean 7 tiles away, if you are both running from each other this will be way higher!!) (during the average sprint speed 7 dist chase it'll travel around 14 tiles before hitting that means it's almost guarunteed to miss 88% of the time) there's something wrong with the design of how this works.

ran_zone is its own heap of mess, why the fuck are random misses going to limbs 88% of the time how does this make sense. if I wasn't so busy with rp server/hardsync/being lazy mostly I'd code a new zone accuracy helper for when you ABSOLUTELY WANT RNG that isn't such bullshit but hey, I don't want to make sweeping changes in the middle of the night and I don't want to make sniping people's legs off with disablers ridiculously easy, so here we are :D 

Might be worth looking into to make shots targeting limbs have a good chance of being redirected to chest if missing too in the future probably not by me though

I made snipers 100% accuracy though because it's a sniper, its entire point is being a sniper, why is it a sniper if you are being actively punished for using it as a sniper instead of a two handed one shot kill pistol :)

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Projectiles now always hit chest if targeting chest, snipers have 100% targeting zone accuracy. All other cases are unchanged.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
