### PR TITLE
Removes the hypospray verb for toggling spray/inject mode and makes it into an Alt click proc.

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -423,18 +423,19 @@
 		else
 			unload_hypo(vial,user)
 
-/obj/item/hypospray/mkii/verb/modes()
-	set name = "Toggle Application Mode"
-	set category = "Object"
-	set src in usr
-	var/mob/M = usr
-	switch(mode)
-		if(HYPO_SPRAY)
-			mode = HYPO_INJECT
-			to_chat(M, "[src] is now set to inject contents on application.")
-		if(HYPO_INJECT)
-			mode = HYPO_SPRAY
-			to_chat(M, "[src] is now set to spray contents on application.")
+/obj/item/hypospray/mkii/AltClick(mob/living/user)
+	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+		switch(mode)
+			if(HYPO_SPRAY)
+				mode = HYPO_INJECT
+				to_chat(user, "[src] is now set to inject contents on application.")
+			if(HYPO_INJECT)
+				mode = HYPO_SPRAY
+				to_chat(user, "[src] is now set to spray contents on application.")
+
+/obj/item/hypospray/mkii/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>You can click on it while holding <b>Alt</b> to toggle its mode from spraying to injecting.</span>"
 
 #undef HYPO_SPRAY
 #undef HYPO_INJECT

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -424,7 +424,7 @@
 			unload_hypo(vial,user)
 
 /obj/item/hypospray/mkii/AltClick(mob/living/user)
-	if(user.canUseTopic(src, BE_CLOSE, FALSE,))
+	if(user.canUseTopic(src, FALSE))
 		switch(mode)
 			if(HYPO_SPRAY)
 				mode = HYPO_INJECT
@@ -432,10 +432,11 @@
 			if(HYPO_INJECT)
 				mode = HYPO_SPRAY
 				to_chat(user, "[src] is now set to spray contents on application.")
+		return TRUE
 
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>You can click on it while holding <b>Alt</b> to toggle its mode from spraying to injecting.</span>"
+	. += "<span class='notice'><b>Alt-Click</b> it to toggle its mode from spraying to injecting and vice versa.</span>"
 
 #undef HYPO_SPRAY
 #undef HYPO_INJECT

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -424,6 +424,7 @@
 			unload_hypo(vial,user)
 
 /obj/item/hypospray/mkii/AltClick(mob/living/user)
+	..()
 	if(user.canUseTopic(src, FALSE))
 		switch(mode)
 			if(HYPO_SPRAY)

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -424,7 +424,7 @@
 			unload_hypo(vial,user)
 
 /obj/item/hypospray/mkii/AltClick(mob/living/user)
-	..()
+	. = ..()
 	if(user.canUseTopic(src, FALSE))
 		switch(mode)
 			if(HYPO_SPRAY)


### PR DESCRIPTION
Its really hard to use especially in emergencies, and makes the hypospray feel cumbsy for changing from modes
## Changelog
:cl:
tweak: The MK2 hypospray now
/:cl:
Also adds a neat little examine text so you actually know its a feature.