### PR TITLE
Add dwarves as a round-start race

### DIFF
--- a/config/game_options.txt
+++ b/config/game_options.txt
@@ -426,6 +426,7 @@ ROUNDSTART_RACES lizard
 ROUNDSTART_RACES plasmaman
 #ROUNDSTART_RACES shadow
 ROUNDSTART_RACES felinid
+ROUNDSTART_RACES dwarf
 
 ## Races that are better than humans in some ways, but worse in others
 #ROUNDSTART_RACES jelly


### PR DESCRIPTION
### _**This need an headmin to change the config anyway!!**_

## About The Pull Request
This update the config in the repo and inform everyone if a headmin decide to add dwarves as a roundstart race

## Why It's Good For The Game
1. Dorf
2. Wouldn't it suck if we bugged a headmin to add them in, but everyone who made a fork or copied the repo need to change the config themselves?

This does not affect the game at all since the actual config that matter are only accessible/modifiable by headmins, so technically you could bug the headmins to change the config to add them in, but then you wouldn't get any trace that they are now available as a roundstart race.

## Changelog
:cl:
config: Made dwarves into a roundstart races
/:cl: