### PR TITLE
Lavaland's Herald speech fix.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/herald.dm
@@ -62,8 +62,9 @@
 	
 /mob/living/simple_animal/hostile/asteroid/elite/herald/say(message, bubble_type, var/list/spans = list(), sanitize = TRUE, datum/language/language = null, ignore_spam = FALSE, forced = null)
 	. = ..()
-	playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
-	
+	if(.)
+		playsound(get_turf(src), 'sound/magic/clockwork/invoke_general.ogg', 20, TRUE)
+
 /datum/action/innate/elite_attack/herald_trishot
 	name = "Triple Shot"
 	button_icon_state = "herald_trishot"


### PR DESCRIPTION
## About The Pull Request
Stopping the "war horn" sound from playing if the mob is not actually speaking (deadchat, emoting etc.)

## Why It's Good For The Game
This will close #10574.

## Changelog
:cl:
fix: The Lavaland's Herald speech sound should only play if they are actually speaking.
/:cl:

