### PR TITLE
renames the lawyer cartridge to something more accurate to its function

### DIFF
--- a/code/game/objects/items/devices/PDA/cart.dm
+++ b/code/game/objects/items/devices/PDA/cart.dm
@@ -100,7 +100,8 @@
 	bot_access_flags = CLEAN_BOT
 
 /obj/item/cartridge/lawyer
-	name = "\improper P.R.O.V.E. cartridge"
+	name = "\improper S.P.A.M. cartridge"
+	desc = "Introducing the Station Public Announcement Messenger cartridge, featuring the unique ability to broadcast-mark messages, designed for lawyers across Nanotrasen to advertise their useful and important services."
 	icon_state = "cart-law"
 	access = CART_SECURITY
 	spam_enabled = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Introducing the Station Public Announcement Messenger cartridge, featuring the unique ability to broadcast-mark messages, designed for lawyers across Nanotrasen to advertise their useful and important services.

## Why It's Good For The Game

P.R.O.V.E. me wrong (haha get it)

## Changelog
:cl:
tweak: The lawyer's PDA cartridge has been rebranded to something more accurate to its true nature.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
