### PR TITLE
Nerfing cargo passive points generation

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/points = 5000					//number of trade-points we have
 	var/centcom_message = ""			//Remarks from CentCom on how well you checked the last order.
 	var/list/discoveredPlants = list()	//Typepaths for unusual plants we've already sent CentCom, associated with their potencies
-	var/passive_supply_points_per_minute = 500
+	var/passive_supply_points_per_minute = 200
 
 	var/list/supply_packs = list()
 	var/list/shoppinglist = list()

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -38,7 +38,7 @@ SUBSYSTEM_DEF(shuttle)
 	var/points = 5000					//number of trade-points we have
 	var/centcom_message = ""			//Remarks from CentCom on how well you checked the last order.
 	var/list/discoveredPlants = list()	//Typepaths for unusual plants we've already sent CentCom, associated with their potencies
-	var/passive_supply_points_per_minute = 200
+	var/passive_supply_points_per_minute = 125
 
 	var/list/supply_packs = list()
 	var/list/shoppinglist = list()


### PR DESCRIPTION
## About The Pull Request
40k free space bucks at the 80 minutes mark is a pretty amount for a feature that is meant to provide some bare minimum of funds over time to cover the improbable lack of cargo personnel and volunteers.

## Why It's Good For The Game
Cargo already has plenty of ways to make lotsa money. This feature is a bit of a power creep.

## Changelog
:cl:
fix: Nerfed cargo passive points generation from 500 to 125 creds per minute.
/:cl: