### PR TITLE
Buffs the Pirate Ship to be bomb resistant

### DIFF
--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "aj" = (
-/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate,
 /area/shuttle/pirate)
 "ak" = (
 /obj/machinery/airalarm/all_access{
@@ -419,6 +419,7 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aK" = (
@@ -466,18 +467,16 @@
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 1;
 	faction = list("pirate");
-	icon_state = "standard_lethal";
-	mode = 1
+	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate,
 /area/shuttle/pirate)
 "aR" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	faction = list("pirate");
-	icon_state = "standard_lethal";
-	mode = 1
+	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitaniumpirate,
+/turf/closed/wall/mineral/plastitanium/pirate,
 /area/shuttle/pirate)
 "aS" = (
 /obj/effect/turf_decal/stripes/line,
@@ -486,7 +485,7 @@
 /area/shuttle/pirate)
 "aU" = (
 /obj/structure/sign/departments/engineering,
-/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal,
+/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate,
 /area/shuttle/pirate)
 "aV" = (
 /obj/effect/mob_spawn/human/pirate{
@@ -867,37 +866,36 @@
 	dir = 1
 	},
 /obj/docking_port/mobile/pirate{
-	callTime = 100;
-	dheight = 0;
-	dir = 1;
 	dwidth = 11;
 	height = 16;
-	id = "pirateship";
 	launch_status = 0;
 	movement_force = list("KNOCKDOWN" = 0, "THROW" = 0);
 	name = "Pirate Ship";
 	port_direction = 2;
-	preferred_direction = 1;
 	width = 17
 	},
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 11;
 	height = 16;
 	id = "pirateship_home";
 	name = "Deep Space";
 	width = 17
 	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
+/area/shuttle/pirate)
+"db" = (
+/obj/structure/shuttle/engine/heater,
+/obj/effect/spawner/structure/window/plastitanium/pirate,
+/turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "df" = (
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 4;
 	faction = list("pirate");
-	icon_state = "standard_lethal";
-	mode = 1
+	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitaniumpirate,
+/turf/closed/wall/mineral/plastitanium/pirate,
 /area/shuttle/pirate)
 "dy" = (
 /obj/structure/chair/wood/normal,
@@ -948,8 +946,7 @@
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "ep" = (
-/obj/structure/window/plastitaniumpirate{
-//obj/structure/window/reinforced{
+/obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
@@ -979,8 +976,7 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "ex" = (
-/obj/structure/window/plastitaniumpirate
-//obj/structure/window/reinforced,
+/obj/structure/window/reinforced,
 /obj/structure/frame/machine,
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
@@ -990,19 +986,17 @@
 	id = "piratebridge"
 	},
 /obj/structure/grille,
-/obj/structure/window/plastitaniumpirate,
+/obj/structure/window/plastitanium/pirate,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "ez" = (
-/obj/structure/window/plastitaniumpirate
-//obj/structure/window/reinforced,
+/obj/structure/window/reinforced,
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "eA" = (
-/obj/structure/window/plastitaniumpirate
-//obj/structure/window/reinforced{
+/obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
@@ -1020,7 +1014,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "fW" = (
-/turf/closed/wall/mineral/plastitaniumpirate,
+/turf/closed/wall/mineral/plastitanium/pirate,
 /area/shuttle/pirate)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1091,10 +1085,9 @@
 /obj/machinery/porta_turret/syndicate/energy{
 	dir = 8;
 	faction = list("pirate");
-	icon_state = "standard_lethal";
-	mode = 1
+	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitaniumpirate,
+/turf/closed/wall/mineral/plastitanium/pirate,
 /area/shuttle/pirate)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -1330,7 +1323,7 @@ aU
 be
 aD
 aG
-ep
+db
 aH
 "}
 (9,1,1) = {"
@@ -1348,7 +1341,7 @@ mU
 aL
 bP
 bX
-ep
+db
 aK
 "}
 (10,1,1) = {"
@@ -1366,7 +1359,7 @@ aj
 bO
 bQ
 bk
-ep
+db
 er
 "}
 (11,1,1) = {"

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "aj" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate/nodiagonal,
 /area/shuttle/pirate)
 "ak" = (
 /obj/machinery/airalarm/all_access{
@@ -464,19 +464,19 @@
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "aQ" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate/energy/pirate{
 	dir = 1;
 	faction = list("pirate");
 	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate/nodiagonal,
 /area/shuttle/pirate)
 "aR" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate/energy/pirate{
 	faction = list("pirate");
 	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitanium/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate,
 /area/shuttle/pirate)
 "aS" = (
 /obj/effect/turf_decal/stripes/line,
@@ -485,7 +485,7 @@
 /area/shuttle/pirate)
 "aU" = (
 /obj/structure/sign/departments/engineering,
-/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate/nodiagonal,
 /area/shuttle/pirate)
 "aV" = (
 /obj/effect/mob_spawn/human/pirate{
@@ -890,12 +890,12 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "df" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate/energy/pirate{
 	dir = 4;
 	faction = list("pirate");
 	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitanium/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate,
 /area/shuttle/pirate)
 "dy" = (
 /obj/structure/chair/wood/normal,
@@ -1014,7 +1014,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "fW" = (
-/turf/closed/wall/mineral/plastitanium/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate,
 /area/shuttle/pirate)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1082,12 +1082,12 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/shuttle/pirate)
 "wR" = (
-/obj/machinery/porta_turret/syndicate/energy{
+/obj/machinery/porta_turret/syndicate/energy/pirate{
 	dir = 8;
 	faction = list("pirate");
 	icon_state = "standard_lethal"
 	},
-/turf/closed/wall/mineral/plastitanium/pirate,
+/turf/closed/wall/r_wall/syndicate/pirate,
 /area/shuttle/pirate)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{

--- a/_maps/shuttles/pirate_default.dmm
+++ b/_maps/shuttles/pirate_default.dmm
@@ -89,7 +89,7 @@
 /turf/open/floor/pod/dark,
 /area/shuttle/pirate)
 "aj" = (
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal,
 /area/shuttle/pirate)
 "ak" = (
 /obj/machinery/airalarm/all_access{
@@ -469,7 +469,7 @@
 	icon_state = "standard_lethal";
 	mode = 1
 	},
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal,
 /area/shuttle/pirate)
 "aR" = (
 /obj/machinery/porta_turret/syndicate/energy{
@@ -477,7 +477,7 @@
 	icon_state = "standard_lethal";
 	mode = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitaniumpirate,
 /area/shuttle/pirate)
 "aS" = (
 /obj/effect/turf_decal/stripes/line,
@@ -486,7 +486,7 @@
 /area/shuttle/pirate)
 "aU" = (
 /obj/structure/sign/departments/engineering,
-/turf/closed/wall/mineral/plastitanium/nodiagonal,
+/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal,
 /area/shuttle/pirate)
 "aV" = (
 /obj/effect/mob_spawn/human/pirate{
@@ -897,7 +897,7 @@
 	icon_state = "standard_lethal";
 	mode = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitaniumpirate,
 /area/shuttle/pirate)
 "dy" = (
 /obj/structure/chair/wood/normal,
@@ -948,7 +948,8 @@
 /turf/open/floor/pod/light,
 /area/shuttle/pirate)
 "ep" = (
-/obj/structure/window/reinforced{
+/obj/structure/window/plastitaniumpirate{
+//obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
@@ -978,7 +979,8 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "ex" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plastitaniumpirate
+//obj/structure/window/reinforced,
 /obj/structure/frame/machine,
 /obj/item/wrench,
 /turf/open/floor/plating/airless,
@@ -988,17 +990,19 @@
 	id = "piratebridge"
 	},
 /obj/structure/grille,
-/obj/structure/window/plastitanium,
+/obj/structure/window/plastitaniumpirate,
 /turf/open/floor/plating,
 /area/shuttle/pirate)
 "ez" = (
-/obj/structure/window/reinforced,
+/obj/structure/window/plastitaniumpirate
+//obj/structure/window/reinforced,
 /obj/structure/frame/machine,
 /obj/item/stack/cable_coil/cut/red,
 /turf/open/floor/plating/airless,
 /area/shuttle/pirate)
 "eA" = (
-/obj/structure/window/reinforced{
+/obj/structure/window/plastitaniumpirate
+//obj/structure/window/reinforced{
 	dir = 1;
 	pixel_y = 1
 	},
@@ -1016,7 +1020,7 @@
 /turf/open/floor/plasteel,
 /area/shuttle/pirate)
 "fW" = (
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitaniumpirate,
 /area/shuttle/pirate)
 "fY" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -1090,7 +1094,7 @@
 	icon_state = "standard_lethal";
 	mode = 1
 	},
-/turf/closed/wall/mineral/plastitanium,
+/turf/closed/wall/mineral/plastitaniumpirate,
 /area/shuttle/pirate)
 "yi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -348,6 +348,22 @@
 		spark_system.start()	//creates some sparks because they look cool
 		qdel(cover)	//deletes the cover - no need on keeping it there!
 
+//turret healing
+/obj/machinery/porta_turret/attackby(obj/item/I, mob/living/user, params)
+	if(istype(I, /obj/item/weldingtool) && user.a_intent == INTENT_HELP)
+		if(obj_integrity < max_integrity)
+			if(!I.tool_start_check(user, amount=0))
+				return
+			user.visible_message("[user] is welding the turret.", \
+							"<span class='notice'>You begin repairing the turret...</span>", \
+							"<span class='italics'>You hear welding.</span>")
+			if(I.use_tool(src, user, 40, volume=50))
+				obj_integrity = max_integrity
+				user.visible_message("[user.name] has repaired [src].", \
+									"<span class='notice'>You finish repairing the turret.</span>")
+		else
+			to_chat(user, "<span class='notice'>The turret doesn't need repairing.</span>")
+		return
 
 
 /obj/machinery/porta_turret/process()
@@ -670,7 +686,11 @@
 	nonlethal_projectile_sound = 'sound/weapons/taser2.ogg'
 	lethal_projectile = /obj/item/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
-	desc = "An energy blaster auto-turret."
+	desc = "An energy blaster auto-turret. Use a welder to fix."
+	explosion_block = 50
+	max_integrity = 350
+	integrity_failure = 20
+
 
 /obj/machinery/porta_turret/syndicate/energy/heavy
 	icon_state = "standard_stun"

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -27,7 +27,7 @@
 
 	max_integrity = 160		//the turret's health
 	integrity_failure = 80
-	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
 	var/locked = TRUE			//if the turret's behaviour control access is locked
 	var/controllock = FALSE		//if the turret responds to control panels
@@ -349,7 +349,13 @@
 		qdel(cover)	//deletes the cover - no need on keeping it there!
 
 //turret healing
+/obj/machinery/porta_turret/examine(mob/user)
+	. = ..()
+	if(obj_integrity < max_integrity)
+		. += "<span class='notice'>Use a welder to fix it.</span>"
+
 /obj/machinery/porta_turret/welder_act(mob/living/user, obj/item/I)
+	. = TRUE
 	if(obj_integrity < max_integrity)
 		if(!I.tool_start_check(user, amount=0))
 			return
@@ -360,10 +366,8 @@
 			obj_integrity = max_integrity
 			user.visible_message("[user.name] has repaired [src].", \
 								"<span class='notice'>You finish repairing the turret.</span>")
-			return TRUE
 	else
 		to_chat(user, "<span class='notice'>The turret doesn't need repairing.</span>")
-	return
 
 
 /obj/machinery/porta_turret/process()
@@ -686,7 +690,7 @@
 	nonlethal_projectile_sound = 'sound/weapons/taser2.ogg'
 	lethal_projectile = /obj/item/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
-	desc = "An energy blaster auto-turret. Use a welder to fix."
+	desc = "An energy blaster auto-turret."
 
 
 /obj/machinery/porta_turret/syndicate/energy/heavy
@@ -703,6 +707,7 @@
 /obj/machinery/porta_turret/syndicate/energy/pirate
 	max_integrity = 260
 	integrity_failure = 20
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
 
 /obj/machinery/porta_turret/syndicate/setup()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -27,7 +27,7 @@
 
 	max_integrity = 160		//the turret's health
 	integrity_failure = 80
-	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 30, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
+	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
 
 	var/locked = TRUE			//if the turret's behaviour control access is locked
 	var/controllock = FALSE		//if the turret responds to control panels
@@ -687,9 +687,6 @@
 	lethal_projectile = /obj/item/projectile/beam/laser
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	desc = "An energy blaster auto-turret. Use a welder to fix."
-	explosion_block = 50
-	max_integrity = 260
-	integrity_failure = 20
 
 
 /obj/machinery/porta_turret/syndicate/energy/heavy
@@ -702,6 +699,10 @@
 	lethal_projectile = /obj/item/projectile/beam/laser/heavylaser
 	lethal_projectile_sound = 'sound/weapons/lasercannonfire.ogg'
 	desc = "An energy blaster auto-turret."
+
+/obj/machinery/porta_turret/syndicate/energy/pirate
+	max_integrity = 260
+	integrity_failure = 20
 
 
 /obj/machinery/porta_turret/syndicate/setup()

--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -349,21 +349,21 @@
 		qdel(cover)	//deletes the cover - no need on keeping it there!
 
 //turret healing
-/obj/machinery/porta_turret/attackby(obj/item/I, mob/living/user, params)
-	if(istype(I, /obj/item/weldingtool) && user.a_intent == INTENT_HELP)
-		if(obj_integrity < max_integrity)
-			if(!I.tool_start_check(user, amount=0))
-				return
-			user.visible_message("[user] is welding the turret.", \
-							"<span class='notice'>You begin repairing the turret...</span>", \
-							"<span class='italics'>You hear welding.</span>")
-			if(I.use_tool(src, user, 40, volume=50))
-				obj_integrity = max_integrity
-				user.visible_message("[user.name] has repaired [src].", \
-									"<span class='notice'>You finish repairing the turret.</span>")
-		else
-			to_chat(user, "<span class='notice'>The turret doesn't need repairing.</span>")
-		return
+/obj/machinery/porta_turret/welder_act(mob/living/user, obj/item/I)
+	if(obj_integrity < max_integrity)
+		if(!I.tool_start_check(user, amount=0))
+			return
+		user.visible_message("[user] is welding the turret.", \
+						"<span class='notice'>You begin repairing the turret...</span>", \
+						"<span class='italics'>You hear welding.</span>")
+		if(I.use_tool(src, user, 40, volume=50))
+			obj_integrity = max_integrity
+			user.visible_message("[user.name] has repaired [src].", \
+								"<span class='notice'>You finish repairing the turret.</span>")
+			return TRUE
+	else
+		to_chat(user, "<span class='notice'>The turret doesn't need repairing.</span>")
+	return
 
 
 /obj/machinery/porta_turret/process()
@@ -688,7 +688,7 @@
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	desc = "An energy blaster auto-turret. Use a welder to fix."
 	explosion_block = 50
-	max_integrity = 350
+	max_integrity = 260
 	integrity_failure = 20
 
 

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -166,6 +166,7 @@ again.
 //plastitanium pirate window
 
 /obj/effect/spawner/structure/window/plastitanium/pirate
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitanium/pirate)
 
 //ice window
 

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -166,8 +166,6 @@ again.
 //plastitanium pirate window
 
 /obj/effect/spawner/structure/window/plastitanium/pirate
-	explosion_block = 50
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitanium/pirate)
 
 //ice window
 

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -163,6 +163,13 @@ again.
 	icon_state = "plastitaniumwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitanium)
 
+//plastitaniumpirate window
+
+/obj/effect/spawner/structure/window/plastitaniumpirate
+	name = "plastitanium window spawner"
+	icon_state = "plastitaniumwindow_spawner"
+	explosion_block = 50
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitaniumpirate)
 
 //ice window
 

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -163,13 +163,11 @@ again.
 	icon_state = "plastitaniumwindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitanium)
 
-//plastitaniumpirate window
+//plastitanium pirate window
 
-/obj/effect/spawner/structure/window/plastitaniumpirate
-	name = "plastitanium window spawner"
-	icon_state = "plastitaniumwindow_spawner"
+/obj/effect/spawner/structure/window/plastitanium/pirate
 	explosion_block = 50
-	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitaniumpirate)
+	spawn_list = list(/obj/structure/grille, /obj/structure/window/plastitanium/pirate)
 
 //ice window
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -596,27 +596,11 @@
 	anchored = FALSE
 
 //pirate ship windows
-/obj/structure/window/plastitaniumpirate
-	name = "plastitanium window"
+/obj/structure/window/plastitanium/pirate
 	desc = "Yarr this window be explosion proof!"
-	icon = 'icons/obj/smooth_structures/plastitanium_window.dmi'
-	icon_state = "plastitanium_window"
-	dir = FULLTILE_WINDOW_DIR
-	max_integrity = 100
-	wtype = "shuttle"
-	fulltile = TRUE
-	flags_1 = PREVENT_CLICK_UNDER_1
-	reinf = TRUE
-	heat_resistance = 1600
-	armor = list("melee" = 50, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 100)
-	smooth = SMOOTH_TRUE
-	canSmoothWith = null
 	explosion_block = 50
-	level = 3
-	glass_type = /obj/item/stack/sheet/plastitaniumglass
-	glass_amount = 2
 
-/obj/structure/window/plastitaniumpirate/unanchored
+/obj/structure/window/plastitanium/pirate/unanchored
 	anchored = FALSE
 
 /obj/structure/window/reinforced/clockwork

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -595,6 +595,30 @@
 /obj/structure/window/plastitanium/unanchored
 	anchored = FALSE
 
+//pirate ship windows
+/obj/structure/window/plastitaniumpirate
+	name = "plastitanium window"
+	desc = "Yarr this window be explosion proof!"
+	icon = 'icons/obj/smooth_structures/plastitanium_window.dmi'
+	icon_state = "plastitanium_window"
+	dir = FULLTILE_WINDOW_DIR
+	max_integrity = 100
+	wtype = "shuttle"
+	fulltile = TRUE
+	flags_1 = PREVENT_CLICK_UNDER_1
+	reinf = TRUE
+	heat_resistance = 1600
+	armor = list("melee" = 50, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 100, "rad" = 100, "fire" = 80, "acid" = 100)
+	smooth = SMOOTH_TRUE
+	canSmoothWith = null
+	explosion_block = 50
+	level = 3
+	glass_type = /obj/item/stack/sheet/plastitaniumglass
+	glass_amount = 2
+
+/obj/structure/window/plastitaniumpirate/unanchored
+	anchored = FALSE
+
 /obj/structure/window/reinforced/clockwork
 	name = "brass window"
 	desc = "A paper-thin pane of translucent yet reinforced brass."

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -598,7 +598,7 @@
 //pirate ship windows
 /obj/structure/window/plastitanium/pirate
 	desc = "Yarr this window be explosion proof!"
-	explosion_block = 50
+	explosion_block = 30
 
 /obj/structure/window/plastitanium/pirate/unanchored
 	anchored = FALSE

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -303,19 +303,3 @@
 /turf/closed/wall/mineral/plastitanium/copyTurf(turf/T)
 	. = ..()
 	T.transform = transform
-
-/////////////////////Pirate Plastitanium walls/////////////////////
-
-/turf/closed/wall/mineral/plastitanium/pirate
-	desc = "Yarr just try to blow this to smithereens!"
-	explosion_block = 50
-	canSmoothWith = list(/turf/closed/wall/mineral/plastitanium/pirate, /obj/machinery/door/airlock/shuttle, /obj/machinery/door/airlock, /obj/structure/window/plastitanium/pirate, /obj/structure/shuttle/engine, /obj/structure/falsewall/plastitanium)
-
-/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate/
-	explosion_block = 50
-
-/turf/closed/wall/mineral/plastitanium/nosmooth/pirate/
-	explosion_block = 50
-
-/turf/closed/wall/mineral/plastitanium/overspace/pirate/
-	explosion_block = 50

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -306,61 +306,16 @@
 
 /////////////////////Pirate Plastitanium walls/////////////////////
 
-/turf/closed/wall/mineral/plastitaniumpirate
-	name = "wall"
+/turf/closed/wall/mineral/plastitanium/pirate
 	desc = "Yarr just try to blow this to smithereens!"
-	icon = 'icons/turf/walls/plastitanium_wall.dmi'
-	icon_state = "map-shuttle"
 	explosion_block = 50
-	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
-	smooth = SMOOTH_MORE|SMOOTH_DIAGONAL
-	canSmoothWith = list(/turf/closed/wall/mineral/plastitaniumpirate, /obj/machinery/door/airlock/shuttle, /obj/machinery/door/airlock, /obj/structure/window/plastitaniumpirate, /obj/structure/shuttle/engine, /obj/structure/falsewall/plastitanium)
+	canSmoothWith = list(/turf/closed/wall/mineral/plastitanium/pirate, /obj/machinery/door/airlock/shuttle, /obj/machinery/door/airlock, /obj/structure/window/plastitanium/pirate, /obj/structure/shuttle/engine, /obj/structure/falsewall/plastitanium)
 
-/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal
-	smooth = SMOOTH_MORE
-	icon_state = "map-shuttle_nd"
+/turf/closed/wall/mineral/plastitanium/nodiagonal/pirate/
 	explosion_block = 50
 
-/turf/closed/wall/mineral/plastitaniumpirate/nosmooth
-	icon = 'icons/turf/shuttle.dmi'
-	icon_state = "wall"
-	smooth = SMOOTH_FALSE
+/turf/closed/wall/mineral/plastitanium/nosmooth/pirate/
 	explosion_block = 50
 
-/turf/closed/wall/mineral/plastitaniumpirate/overspace
-	icon_state = "map-overspace"
-	fixed_underlay = list("space"=1)
+/turf/closed/wall/mineral/plastitanium/overspace/pirate/
 	explosion_block = 50
-
-/turf/closed/wall/mineral/plastitaniumpirate/explosive/ex_act(severity)
-	var/datum/explosion/acted_explosion = null
-	for(var/datum/explosion/E in GLOB.explosions)
-		if(E.explosion_id == explosion_id)
-			acted_explosion = E
-			break
-	if(acted_explosion && istype(acted_explosion.explosion_source, /obj/item/bombcore))
-		var/obj/item/bombcore/large/bombcore = new(get_turf(src))
-		bombcore.detonate()
-	..()
-
-//have to copypaste this code
-/turf/closed/wall/mineral/plastitaniumpirate/interior/copyTurf(turf/T)
-	if(T.type != type)
-		T.ChangeTurf(type)
-		if(underlays.len)
-			T.underlays = underlays
-	if(T.icon_state != icon_state)
-		T.icon_state = icon_state
-	if(T.icon != icon)
-		T.icon = icon
-	if(color)
-		T.atom_colours = atom_colours.Copy()
-		T.update_atom_colour()
-	if(T.dir != dir)
-		T.setDir(dir)
-	T.transform = transform
-	return T
-
-/turf/closed/wall/mineral/plastitaniumpirate/copyTurf(turf/T)
-	. = ..()
-	T.transform = transform

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -303,3 +303,64 @@
 /turf/closed/wall/mineral/plastitanium/copyTurf(turf/T)
 	. = ..()
 	T.transform = transform
+
+/////////////////////Pirate Plastitanium walls/////////////////////
+
+/turf/closed/wall/mineral/plastitaniumpirate
+	name = "wall"
+	desc = "Yarr just try to blow this to smithereens!"
+	icon = 'icons/turf/walls/plastitanium_wall.dmi'
+	icon_state = "map-shuttle"
+	explosion_block = 50
+	sheet_type = /obj/item/stack/sheet/mineral/plastitanium
+	smooth = SMOOTH_MORE|SMOOTH_DIAGONAL
+	canSmoothWith = list(/turf/closed/wall/mineral/plastitaniumpirate, /obj/machinery/door/airlock/shuttle, /obj/machinery/door/airlock, /obj/structure/window/plastitaniumpirate, /obj/structure/shuttle/engine, /obj/structure/falsewall/plastitanium)
+
+/turf/closed/wall/mineral/plastitaniumpirate/nodiagonal
+	smooth = SMOOTH_MORE
+	icon_state = "map-shuttle_nd"
+	explosion_block = 50
+
+/turf/closed/wall/mineral/plastitaniumpirate/nosmooth
+	icon = 'icons/turf/shuttle.dmi'
+	icon_state = "wall"
+	smooth = SMOOTH_FALSE
+	explosion_block = 50
+
+/turf/closed/wall/mineral/plastitaniumpirate/overspace
+	icon_state = "map-overspace"
+	fixed_underlay = list("space"=1)
+	explosion_block = 50
+
+/turf/closed/wall/mineral/plastitaniumpirate/explosive/ex_act(severity)
+	var/datum/explosion/acted_explosion = null
+	for(var/datum/explosion/E in GLOB.explosions)
+		if(E.explosion_id == explosion_id)
+			acted_explosion = E
+			break
+	if(acted_explosion && istype(acted_explosion.explosion_source, /obj/item/bombcore))
+		var/obj/item/bombcore/large/bombcore = new(get_turf(src))
+		bombcore.detonate()
+	..()
+
+//have to copypaste this code
+/turf/closed/wall/mineral/plastitaniumpirate/interior/copyTurf(turf/T)
+	if(T.type != type)
+		T.ChangeTurf(type)
+		if(underlays.len)
+			T.underlays = underlays
+	if(T.icon_state != icon_state)
+		T.icon_state = icon_state
+	if(T.icon != icon)
+		T.icon = icon
+	if(color)
+		T.atom_colours = atom_colours.Copy()
+		T.update_atom_colour()
+	if(T.dir != dir)
+		T.setDir(dir)
+	T.transform = transform
+	return T
+
+/turf/closed/wall/mineral/plastitaniumpirate/copyTurf(turf/T)
+	. = ..()
+	T.transform = transform

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -276,3 +276,4 @@
 
 /turf/closed/wall/r_wall/syndicate/pirate/overspace
 	icon_state = "map-overspace"
+	fixed_underlay = list("space"=1)

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -258,3 +258,25 @@
 /turf/closed/wall/r_wall/syndicate/overspace
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
+
+/////////////////////Pirate Ship walls/////////////////////
+
+/turf/closed/wall/r_wall/syndicate/pirate
+	desc = "Yarr just try to blow this to smithereens!"
+	explosion_block = 30
+	canSmoothWith = list(/turf/closed/wall/r_wall/syndicate/pirate, /obj/machinery/door/airlock/shuttle, /obj/machinery/door/airlock, /obj/structure/window/plastitanium/pirate, /obj/structure/shuttle/engine, /obj/structure/falsewall/plastitanium)
+
+/turf/closed/wall/r_wall/syndicate/pirate/nodiagonal/
+	smooth = SMOOTH_MORE
+	icon_state = "map-shuttle_nd"
+	explosion_block = 30
+
+/turf/closed/wall/r_wall/syndicate/pirate/nosmooth/
+	icon = 'icons/turf/shuttle.dmi'
+	icon_state = "wall"
+	explosion_block = 30
+
+/turf/closed/wall/r_wall/syndicate/pirate/overspace/
+	icon_state = "map-overspace"
+	fixed_underlay = list("space"=1)
+	explosion_block = 30

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -266,17 +266,17 @@
 	explosion_block = 30
 	canSmoothWith = list(/turf/closed/wall/r_wall/syndicate/pirate, /obj/machinery/door/airlock/shuttle, /obj/machinery/door/airlock, /obj/structure/window/plastitanium/pirate, /obj/structure/shuttle/engine, /obj/structure/falsewall/plastitanium)
 
-/turf/closed/wall/r_wall/syndicate/pirate/nodiagonal/
+/turf/closed/wall/r_wall/syndicate/pirate/nodiagonal
 	smooth = SMOOTH_MORE
 	icon_state = "map-shuttle_nd"
 	explosion_block = 30
 
-/turf/closed/wall/r_wall/syndicate/pirate/nosmooth/
+/turf/closed/wall/r_wall/syndicate/pirate/nosmooth
 	icon = 'icons/turf/shuttle.dmi'
 	icon_state = "wall"
 	explosion_block = 30
 
-/turf/closed/wall/r_wall/syndicate/pirate/overspace/
+/turf/closed/wall/r_wall/syndicate/pirate/overspace
 	icon_state = "map-overspace"
 	fixed_underlay = list("space"=1)
 	explosion_block = 30

--- a/code/game/turfs/simulated/wall/reinf_walls.dm
+++ b/code/game/turfs/simulated/wall/reinf_walls.dm
@@ -269,14 +269,10 @@
 /turf/closed/wall/r_wall/syndicate/pirate/nodiagonal
 	smooth = SMOOTH_MORE
 	icon_state = "map-shuttle_nd"
-	explosion_block = 30
 
 /turf/closed/wall/r_wall/syndicate/pirate/nosmooth
 	icon = 'icons/turf/shuttle.dmi'
 	icon_state = "wall"
-	explosion_block = 30
 
 /turf/closed/wall/r_wall/syndicate/pirate/overspace
 	icon_state = "map-overspace"
-	fixed_underlay = list("space"=1)
-	explosion_block = 30

--- a/code/modules/events/pirates.dm
+++ b/code/modules/events/pirates.dm
@@ -177,6 +177,7 @@
 	shuttleId = "pirateship"
 	icon_screen = "syndishuttle"
 	icon_keyboard = "syndie_key"
+	resistance_flags = INDESTRUCTIBLE
 	light_color = LIGHT_COLOR_RED
 	possible_destinations = "pirateship_away;pirateship_home;pirateship_custom"
 
@@ -184,6 +185,7 @@
 	name = "pirate shuttle navigation computer"
 	desc = "Used to designate a precise transit location for the pirate shuttle."
 	shuttleId = "pirateship"
+	resistance_flags = INDESTRUCTIBLE
 	lock_override = CAMERA_LOCK_STATION
 	shuttlePortId = "pirateship_custom"
 	x_offset = 9
@@ -226,6 +228,7 @@
 	desc = "This sophisticated machine scans the nearby space for items of value."
 	icon = 'icons/obj/machines/research.dmi'
 	icon_state = "tdoppler"
+	resistance_flags = INDESTRUCTIBLE
 	density = TRUE
 	var/cooldown = 300
 	var/next_use = 0
@@ -259,6 +262,7 @@
 	name = "cargo hold pad"
 	icon = 'icons/obj/telescience.dmi'
 	icon_state = "lpad-idle-o"
+	resistance_flags = INDESTRUCTIBLE
 	var/idle_state = "lpad-idle-o"
 	var/warmup_state = "lpad-idle"
 	var/sending_state = "lpad-beam"
@@ -272,6 +276,7 @@
 
 /obj/machinery/computer/piratepad_control
 	name = "cargo hold control terminal"
+	resistance_flags = INDESTRUCTIBLE
 	var/status_report = "Idle"
 	var/obj/machinery/piratepad/pad
 	var/warmup_time = 100


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title, also makes a few computers/machines indestructible and buffs turret health.  It also allows turrets to be repairable now.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Bomber man bad.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Added repairable turrets
add: Adds Tiny Fans to the pirate ship
tweak: changes some reinforced windows to plastinanium pirate windows
tweak: made the pirate shuttle + turrets bomb resistant
tweak: made most pirate machines + consoles indestructible
tweak: increased pirate turret health
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
