### PR TITLE
Remove Meteor Timer

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -20,13 +20,6 @@
 	var/wave_name = "normal"
 	var/direction
 
-/datum/round_event/meteor_wave/setup()
-	announceWhen = 1
-	startWhen = rand(60, 90) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
-	if(GLOB.singularity_counter)
-		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
-	endWhen = startWhen + 60
-
 /datum/round_event/meteor_wave/New()
 	..()
 	if(!wave_type)
@@ -74,7 +67,7 @@
 			directionstring = " towards starboard"
 		if(WEST)
 			directionstring = " towards port"
-	return "Meteors have been detected on a collision course with the station[directionstring]. Estimated time until impact: [round((startWhen * SSevents.wait) / 10, 0.1)] seconds.[GLOB.singularity_counter && syndiealert ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely." : ""]"
+	return "Meteors have been detected on a collision course with the station,[directionstring]. [GLOB.singularity_counter && syndiealert ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely." : ""]"
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))


### PR DESCRIPTION
Alternative to https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10930

## About The Pull Request
This remove the meteor timer, simple as that

## Why It's Good For The Game
Before I say why it is good, let's go back to the history of the timer :

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9081 added the timer with a 5-10 minutes delay, with the OP saying that it could be shorter to 2-5 if 5-10 was too long. It was merged the day after the PR was made, so I don't think there wasn't any test-merge.

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9790 reduced the timer to 3-5, because 5-10 was too long and they trusted the OP with this time. It was merged 2 days after it was made, so it is safe to say that there wasn't a test-merge

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10023 reduced it to 60-90 seconds, for no told reason, it was also argued that Engineering could print them. It was also told in the Discord somewhere that Meteors Sats are supposed to be set before the meteors, so being able to cover the entire station once announced removed that. Was merged 5 days after the original post.

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10728 made the meteor waves directional, which *did* ease the burden a little bit.

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10729 made the time report accurate.

https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10852 removed the printable sats.


So, due to the fact that the main arguments for the meteor timer being so low was :
- Engineering could print them.
- They were meant to be set before the meteors.

Since they are meant to be set before the meteors, and Engineering having lost the printable shields, I believe there isn't *any* reason for the timer, with only a **minute** warning, to be fulfilling its original goal, AKA to put up some sats in panic in key areas. So I don't think there isn't any real difference between keeping that 1 minute timer and not having a timer at all.

### _**I would still like for this to be test-merged, unlike literally all the other timer PRs.**_

## Changelog
:cl:
del: Removed the meteor timer
/:cl: