### PR TITLE
Comment out meteors

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
+++ b/code/game/gamemodes/dynamic/dynamic_rulesets_events.dm
@@ -148,7 +148,7 @@
 //                METEORS                   //
 //                                          //
 //////////////////////////////////////////////
-
+/*
 /datum/dynamic_ruleset/event/meteor_wave
 	name = "Meteor Wave"
 	config_tag = "meteor_wave"
@@ -176,7 +176,7 @@
 		cost = 15
 		typepath = /datum/round_event/meteor_wave
 	return ..()
-
+*/
 //////////////////////////////////////////////
 //                                          //
 //               ANOMALIES                  //

--- a/code/modules/events/major_dust.dm
+++ b/code/modules/events/major_dust.dm
@@ -1,3 +1,4 @@
+/*
 /datum/round_event_control/meteor_wave/major_dust
 	name = "Major Space Dust"
 	typepath = /datum/round_event/meteor_wave/major_dust
@@ -21,3 +22,4 @@
 		priority_announce(pick(reason), "Collision Alert")
 	else
 		print_command_report("[pick(reason)]", "Collision Alert")
+*/

--- a/code/modules/events/meateor_wave.dm
+++ b/code/modules/events/meateor_wave.dm
@@ -1,3 +1,4 @@
+/*
 /datum/round_event_control/meteor_wave/meaty
 	name = "Meteor Wave: Meaty"
 	typepath = /datum/round_event/meteor_wave/meaty
@@ -9,3 +10,4 @@
 
 /datum/round_event/meteor_wave/meaty/announce(fake)
 	priority_announce("Meaty ores have been detected on collision course with the station.", "Oh crap, get the mop.", "meteors")
+*/

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -2,7 +2,7 @@
 
 #define SINGULO_BEACON_DISTURBANCE 0.2 //singularity beacon also improve the odds of meteor waves and speed them up a little.
 #define SINGULO_BEACON_MAX_DISTURBANCE 0.6 //maximum cap due to how meteor waves can be potentially round ending.
-
+/*
 /datum/round_event_control/meteor_wave
 	name = "Meteor Wave: Normal"
 	typepath = /datum/round_event/meteor_wave
@@ -19,13 +19,6 @@
 	var/list/wave_type
 	var/wave_name = "normal"
 	var/direction
-
-/datum/round_event/meteor_wave/setup()
-	announceWhen = 1
-	startWhen = rand(60, 90) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
-	if(GLOB.singularity_counter)
-		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
-	endWhen = startWhen + 60
 
 /datum/round_event/meteor_wave/New()
 	..()
@@ -74,7 +67,7 @@
 			directionstring = " towards starboard"
 		if(WEST)
 			directionstring = " towards port"
-	return "Meteors have been detected on a collision course with the station[directionstring]. Estimated time until impact: [round((startWhen * SSevents.wait) / 10, 0.1)] seconds.[GLOB.singularity_counter && syndiealert ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely." : ""]"
+	return "Meteors have been detected on a collision course with the station,[directionstring]. [GLOB.singularity_counter && syndiealert ? " Warning: Anomalous gravity pulse detected, Syndicate technology interference likely." : ""]"
 
 /datum/round_event/meteor_wave/tick()
 	if(ISMULTIPLE(activeFor, 3))
@@ -101,6 +94,6 @@
 
 /datum/round_event/meteor_wave/catastrophic
 	wave_name = "catastrophic"
-
+*/
 #undef SINGULO_BEACON_DISTURBANCE
 #undef SINGULO_BEACON_MAX_DISTURBANCE

--- a/code/modules/flufftext/Hallucination.dm
+++ b/code/modules/flufftext/Hallucination.dm
@@ -873,7 +873,7 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 	set waitfor = FALSE
 	..()
 	if(!message)
-		message = pick("ratvar","shuttle dock","blob alert","malf ai","meteors","supermatter")
+		message = pick("ratvar","shuttle dock","blob alert","malf ai",/*"meteors"*/,"supermatter")
 	feedback_details += "Type: [message]"
 	switch(message)
 		if("blob alert")
@@ -893,10 +893,10 @@ GLOBAL_LIST_INIT(hallucination_list, list(
 			to_chat(target, "<h1 class='alert'>Anomaly Alert</h1>")
 			to_chat(target, "<br><br><span class='alert'>Hostile runtimes detected in all station systems, please deactivate your AI to prevent possible damage to its morality core.</span><br><br>")
 			SEND_SOUND(target, get_announcer_sound("aimalf"))
-		if("meteors") //Meteors inbound!
+		/*if("meteors") //Meteors inbound!
 			to_chat(target, "<h1 class='alert'>Meteor Alert</h1>")
 			to_chat(target, "<br><br><span class='alert'>[generateMeteorString(rand(60, 90),FALSE,pick(GLOB.cardinals))]</span><br><br>")
-			SEND_SOUND(target, get_announcer_sound("meteors"))
+			SEND_SOUND(target, get_announcer_sound("meteors"))*/
 		if("supermatter")
 			SEND_SOUND(target, 'sound/magic/charge.ogg')
 			to_chat(target, "<span class='boldannounce'>You feel reality distort for a moment...</span>")


### PR DESCRIPTION
Alternative to https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10927

## About The Pull Request
This comment out the meteor events entirely

## Why It's Good For The Game
People generally agree that nothing is lost if we get rid of the meteors. Engineers don't want to repair the stations and command generally call the shuttle as soon as they are announced or they hit.

## Changelog
:cl:
del: Removed meteor events
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
