### PR TITLE
Put the meteor timer to 3-5 minutes

### DIFF
--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -22,7 +22,7 @@
 
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
-	startWhen = rand(60, 90) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	startWhen = rand(120, 360) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
 	if(GLOB.singularity_counter)
 		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -22,7 +22,7 @@
 
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
-	startWhen = rand(120, 360) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	startWhen = rand(180, 360) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
 	if(GLOB.singularity_counter)
 		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60

--- a/code/modules/events/meteor_wave.dm
+++ b/code/modules/events/meteor_wave.dm
@@ -22,7 +22,7 @@
 
 /datum/round_event/meteor_wave/setup()
 	announceWhen = 1
-	startWhen = rand(180, 360) //Yeah for SOME REASON this is measured in seconds and not deciseconds???
+	startWhen = rand(90, 180) // Apparently it is by 2 seconds, so 90 is actually 180 seconds, and 180 is 360 seconds. So this is 3-6 minutes
 	if(GLOB.singularity_counter)
 		startWhen *= 1 - min(GLOB.singularity_counter * SINGULO_BEACON_DISTURBANCE, SINGULO_BEACON_MAX_DISTURBANCE)
 	endWhen = startWhen + 60


### PR DESCRIPTION
Alternative to https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10927

## About The Pull Request
This change the timer from 60-90 seconds to 180-360 seconds, effectively reverting https://github.com/Citadel-Station-13/Citadel-Station-13/pull/10023 and redoing https://github.com/Citadel-Station-13/Citadel-Station-13/pull/9790

## Why It's Good For The Game
There is two way to fix the current meteor problem, either remove the timer entirely, or put it back to 3-5 minutes.

## Changelog
:cl:
tweak: Meteor Timer back to 3-5 minutes
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
