### PR TITLE
Cyborging someone will now be able to force-remove gang lead status, much like how it can force-deantag headrevs and bloodsuckers

### DIFF
--- a/code/modules/mob/living/silicon/login.dm
+++ b/code/modules/mob/living/silicon/login.dm
@@ -7,4 +7,7 @@
 		var/datum/antagonist/bloodsucker/V = mind.has_antag_datum(/datum/antagonist/bloodsucker)
 		if(V)
 			mind.remove_antag_datum(V)
+		var/datum/antagonist/gang/G = mind.has_antag_datum(/datum/antagonist/gang)
+		if(G)
+			mind.remove_antag_datum(G)
 	..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Kinda sucks having to remove half the crew from the game in lowpop, even if the mode is supposed to end fast. It's nice to have a "technical" way of deconverting that isn't at all feasible in chaotic rounds/spammable, but something security can choose to do during downtime instead of killing all the gangheads and hiding their bodies.

## Changelog
:cl:
balance: Cyborgization will now de-gang people, even gangheads.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
