### PR TITLE
Prevents certain unpurchasable discounts.

### DIFF
--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -157,6 +157,7 @@
 	category = "Role-Restricted"
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 	surplus = 0
+	cant_discount = TRUE
 
 /datum/uplink_item/badass
 	category = "(Pointless) Badassery"


### PR DESCRIPTION
## About The Pull Request 
Easiest way to ensure people can get all three discounts.

## Why It's Good For The Game
Fixing some RNG issue. I'll ponder about the idea of having role restricted discounts available for everyone some other time.

## Changelog
:cl:
fix: Stopped role restricted uplink items from being discounted despite not being purchasable most times.
/:cl:
