### PR TITLE
Fixes a spurious dynamic runtime if nobody votes

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -41,7 +41,7 @@ GLOBAL_LIST_EMPTY(dynamic_forced_roundstart_ruleset)
 // Forced threat level, setting this to zero or higher forces the roundstart threat to the value.
 GLOBAL_VAR_INIT(dynamic_forced_threat_level, -1)
 
-GLOBAL_VAR_INIT(dynamic_storyteller_type, null)
+GLOBAL_VAR_INIT(dynamic_storyteller_type, /datum/dynamic_storyteller/classic)
 
 /datum/game_mode/dynamic
 	name = "dynamic mode"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. I initialized the GLOB storyteller (which... doesn't particularly have a good reason to exist anymore, but whatever) to "null" instead of a sane default value. As a staunch opponent of "null", I have no idea why I did this.

## Why It's Good For The Game

It made local testing slightly annoying. Fixing runtimes is good.

## Changelog
:cl:
fix: Dynamic now defaults to "classic" storyteller instead of just failing if the vote didn't choose a storyteller.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
