### PR TITLE
Fixes an issue with the nearsighted prescription glasses taking over worn eyewear

### DIFF
--- a/code/datums/traits/negative.dm
+++ b/code/datums/traits/negative.dm
@@ -144,9 +144,8 @@ GLOBAL_LIST_EMPTY(family_heirlooms)
 /datum/quirk/nearsighted/on_spawn()
 	var/mob/living/carbon/human/H = quirk_holder
 	var/obj/item/clothing/glasses/regular/glasses = new(get_turf(H))
-	H.put_in_hands(glasses)
-	H.equip_to_slot(glasses, SLOT_GLASSES)
-	H.regenerate_icons() //this is to remove the inhand icon, which persists even if it's not in their hands
+	if(!H.equip_to_slot_if_possible(glasses, SLOT_GLASSES))
+		H.put_in_hands(glasses)
 
 /datum/quirk/nyctophobia
 	name = "Nyctophobia"


### PR DESCRIPTION
## About The Pull Request
`equip_to_slot` is an UNSAFE proc. Damnit errorage.

## Why It's Good For The Game
Fixing a years old issue.

## Changelog
:cl:
fix: Fixed an issue with the nearsighted prescription glasses taking over worn eyewear.
/:cl:
