### PR TITLE
Removes bone armor and dagger from crafting menu

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_primal.dm
+++ b/code/datums/components/crafting/recipes/recipes_primal.dm
@@ -1,10 +1,3 @@
-/datum/crafting_recipe/bonearmor
-	name = "Bone Armor"
-	result = /obj/item/clothing/suit/armor/bone
-	time = 30
-	reqs = list(/obj/item/stack/sheet/bone = 6)
-	category = CAT_PRIMAL
-
 /datum/crafting_recipe/bonetalisman
 	name = "Bone Talisman"
 	result = /obj/item/clothing/accessory/talisman
@@ -27,13 +20,6 @@
 	time = 20
 	reqs = list(/obj/item/stack/sheet/bone = 2,
 				 /obj/item/stack/sheet/sinew = 1)
-	category = CAT_PRIMAL
-
-/datum/crafting_recipe/skullhelm
-	name = "Skull Helmet"
-	result = /obj/item/clothing/head/helmet/skull
-	time = 30
-	reqs = list(/obj/item/stack/sheet/bone = 4)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/goliathcloak
@@ -60,13 +46,6 @@
 	time = 30
 	reqs = list(/obj/item/stack/sheet/bone = 3,
 				/obj/item/stack/sheet/sinew = 2)
-	category = CAT_PRIMAL
-
-/datum/crafting_recipe/bonedagger
-	name = "Bone Dagger"
-	result = /obj/item/kitchen/knife/combat/bone
-	time = 20
-	reqs = list(/obj/item/stack/sheet/bone = 2)
 	category = CAT_PRIMAL
 
 /datum/crafting_recipe/bonespear

--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -698,6 +698,16 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	/*
  * Bones
  */
+
+GLOBAL_LIST_INIT(bone_recipes, list(
+	new /datum/stack_recipe("Bone Dagger", /obj/item/kitchen/knife/combat/bone, 2, time = 20), \
+	new /datum/stack_recipe("Skull Helmet", /obj/item/clothing/head/helmet/skull, 4, time = 30), \
+	new /datum/stack_recipe("Bone Armor", /obj/item/clothing/suit/armor/bone, 6, time = 30)))
+
+/obj/item/stack/sheet/bone/Initialize(mapload, new_amount, merge = TRUE)
+	recipes = GLOB.bone_recipes
+	. = ..()
+
 /obj/item/stack/sheet/bone
 	name = "bones"
 	icon = 'icons/obj/mining.dmi'
@@ -713,6 +723,10 @@ GLOBAL_LIST_INIT(bronze_recipes, list ( \
 	throw_range = 3
 	grind_results = list(/datum/reagent/carbon = 10)
 	merge_type = /obj/item/stack/sheet/bone
+
+	/*
+ * Plastic
+ */
 
 GLOBAL_LIST_INIT(plastic_recipes, list(
 	new /datum/stack_recipe("see-through plastic flaps", /obj/structure/plasticflaps, 5, one_per_turf = TRUE, on_floor = TRUE, time = 40), \


### PR DESCRIPTION
## About The Pull Request

You now can just craft the bone armor and dagger from bones itself rather then the list

## Why It's Good For The Game

Its just made of bones thus should not clog up crafting menu.
Making them made out of the bone crafting menu lets people not have to go through tabs and such to fine a dagger, same timers same amount of bones. Legit nothing really changed

## Changelog
:cl:
tweak: Bone armor/Dagger are now crafting from bones rather then crafting menu
/:cl:
