### PR TITLE
Fixed antag quirk blacklisting

### DIFF
--- a/code/modules/antagonists/_common/antag_datum.dm
+++ b/code/modules/antagonists/_common/antag_datum.dm
@@ -120,15 +120,16 @@ GLOBAL_LIST_EMPTY(antagonists)
 	SEND_SIGNAL(owner.current, COMSIG_CLEAR_MOOD_EVENT, "antag_moodlet")
 
 /datum/antagonist/proc/remove_blacklisted_quirks()
-	var/mob/living/L = owner
+	var/mob/living/L = owner.current
 	if(istype(L))
-		var/list/cut = list()
-		cut = SSquirks.filter_quirks(L.roundstart_quirks,blacklisted_quirks)
-		for(var/q in cut)
+		var/list/my_quirks = L.client?.prefs.all_quirks.Copy()
+		SSquirks.filter_quirks(my_quirks,blacklisted_quirks)
+		for(var/q in L.roundstart_quirks)
 			var/datum/quirk/Q = q
-			if(Q.antag_removal_text)
-				to_chat(L, "<span class='boldannounce'>[Q.antag_removal_text]</span>")
-			L.remove_quirk(Q.type)
+			if(!(SSquirks.quirk_name_by_path(Q.type) in my_quirks))
+				if(initial(Q.antag_removal_text))
+					to_chat(L, "<span class='boldannounce'>[initial(Q.antag_removal_text)]</span>")
+				L.remove_quirk(Q.type)
 
 //Returns the team antagonist belongs to if any.
 /datum/antagonist/proc/get_team()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

consistency? why? no, we must have a different return type or argument type for every single quirk proc. wee

## Why It's Good For The Game

it's not but it's best that this works

## Changelog
:cl:
fix: antag quirk blacklisting works now
/:cl: