### PR TITLE
Crates are now fire proof and lava proof

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates.dm
+++ b/code/game/objects/structures/crates_lockers/crates.dm
@@ -16,6 +16,7 @@
 	material_drop = /obj/item/stack/sheet/plasteel
 	material_drop_amount = 5
 	var/obj/item/paper/fluff/jobs/cargo/manifest/manifest
+	resistance_flags = LAVA_PROOF | FIRE_PROOF
 
 /obj/structure/closet/crate/New()
 	..()


### PR DESCRIPTION
## About The Pull Request

Crates can no longer be on fire as they are made of plasteel

## Why It's Good For The Game

Stops the 1 tile of fire/lava way to cheese open crates from cargo as well as consistency 

## Changelog
:cl:
balance: Crates can no longer be set on fire or burned in lava
/:cl:
