### PR TITLE
Dwarven Update

### DIFF
--- a/code/__DEFINES/components.dm
+++ b/code/__DEFINES/components.dm
@@ -187,10 +187,10 @@
 	#define SPEECH_MESSAGE 1
 	// #define SPEECH_BUBBLE_TYPE 2
 	#define SPEECH_SPANS 3
-	/* #define SPEECH_SANITIZE 4
+//	#define SPEECH_SANITIZE 4
 	#define SPEECH_LANGUAGE 5
-	#define SPEECH_IGNORE_SPAM 6
-	#define SPEECH_FORCED 7 */
+//	#define SPEECH_IGNORE_SPAM 6
+//	#define SPEECH_FORCED 7
 
 // /mob/living signals
 #define COMSIG_LIVING_FULLY_HEAL "living_fully_healed"		//from base of /mob/living/fully_heal(): (admin_revive)

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -58,18 +58,16 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 		if(message[1] != "*")
 			message = " [message]" //Credits to goonstation for the strings list.
 			var/list/dwarf_words = strings("dwarf_replacement.json", "dwarf") //thanks to regex too.
-
 			for(var/key in dwarf_words) //Theres like 1459 words or something man.
 				var/value = dwarf_words[key] //Thus they will always be in character.
 				if(islist(value)) //Whether they like it or not.
 					value = pick(value) //This could be drastically reduced if needed though.
-
 				message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
 				message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
 				message = replacetextEx(message, " [key]", " [value]") //Also its scottish.
 
 	if(prob(3))
-		message += pick(" By Armok!")
+		message += " By Armok!"
 	speech_args[SPEECH_MESSAGE] = trim(message)
 
 //This mostly exists because my testdwarf's liver died while trying to also not die due to no alcohol.

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -54,21 +54,22 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 //Dwarf Speech handling - Basically a filter/forces them to say things. The IC helper
 /datum/species/dwarf/proc/handle_speech(datum/source, list/speech_args)
 	var/message = speech_args[SPEECH_MESSAGE]
-	if(message[1] != "*")
-		message = " [message]" //Credits to goonstation for the strings list.
-		var/list/dwarf_words = strings("dwarf_replacement.json", "dwarf") //thanks to regex too.
+	if(speech_args[SPEECH_LANGUAGE] != /datum/language/dwarf) // No accent if they speak their language
+		if(message[1] != "*")
+			message = " [message]" //Credits to goonstation for the strings list.
+			var/list/dwarf_words = strings("dwarf_replacement.json", "dwarf") //thanks to regex too.
 
-		for(var/key in dwarf_words) //Theres like 1459 words or something man.
-			var/value = dwarf_words[key] //Thus they will always be in character.
-			if(islist(value)) //Whether they like it or not.
-				value = pick(value) //This could be drastically reduced if needed though.
+			for(var/key in dwarf_words) //Theres like 1459 words or something man.
+				var/value = dwarf_words[key] //Thus they will always be in character.
+				if(islist(value)) //Whether they like it or not.
+					value = pick(value) //This could be drastically reduced if needed though.
 
-			message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
-			message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
-			message = replacetextEx(message, " [key]", " [value]") //Also its scottish.
+				message = replacetextEx(message, " [uppertext(key)]", " [uppertext(value)]")
+				message = replacetextEx(message, " [capitalize(key)]", " [capitalize(value)]")
+				message = replacetextEx(message, " [key]", " [value]") //Also its scottish.
 
-		if(prob(3))
-			message += pick(" By Armok!")
+	if(prob(3))
+		message += pick(" By Armok!")
 	speech_args[SPEECH_MESSAGE] = trim(message)
 
 //This mostly exists because my testdwarf's liver died while trying to also not die due to no alcohol.

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -725,11 +725,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	var/dorf_mode
 
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_metabolize(mob/living/M)
+	var/real_dorf = is_species(H, /datum/species/dwarf)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.dna.check_mutation(DWARFISM) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE || is_species(H, /datum/species/dwarf)))
+		if(H.dna.check_mutation(DWARFISM) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE || real_dorf)
 			to_chat(H, "<span class='notice'>Now THAT is MANLY!</span>")
-			if(is_species(H, /datum/species/dwarf))
+			if(real_dorf)
 				boozepwr = 100 // Don't want dwarves to die because of a low booze power
 			else
 				boozepwr = 5 //We've had worse in the mines

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -727,9 +727,12 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_metabolize(mob/living/M)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.dna.check_mutation(DWARFISM) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE))
+		if(H.dna.check_mutation(DWARFISM) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE || is_species(H, /datum/species/dwarf)))
 			to_chat(H, "<span class='notice'>Now THAT is MANLY!</span>")
-			boozepwr = 5 //We've had worse in the mines
+			if(is_species(H, /datum/species/dwarf))
+				boozepwr = 100 // Don't want dwarves to die because of a low booze power
+			else
+				boozepwr = 5 //We've had worse in the mines
 			dorf_mode = TRUE
 
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_life(mob/living/carbon/M)

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -725,10 +725,10 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	var/dorf_mode
 
 /datum/reagent/consumable/ethanol/manly_dorf/on_mob_metabolize(mob/living/M)
-	var/real_dorf = is_species(H, /datum/species/dwarf)
+	var/real_dorf = isdwarf(M) //_species(H, /datum/species/dwarf)
 	if(ishuman(M))
 		var/mob/living/carbon/human/H = M
-		if(H.dna.check_mutation(DWARFISM) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE || real_dorf)
+		if(H.dna.check_mutation(DWARFISM) || HAS_TRAIT(H, TRAIT_ALCOHOL_TOLERANCE) || real_dorf)
 			to_chat(H, "<span class='notice'>Now THAT is MANLY!</span>")
 			if(real_dorf)
 				boozepwr = 100 // Don't want dwarves to die because of a low booze power


### PR DESCRIPTION
## About The Pull Request
This make it so that dwarves get 100 booze-power from The Manly Dorf, even if they have the dwarfism mutation or the Alcohol Tolerance trait. Because it suck that this drink basically become as weak as water.

As an intended side-effect, dwarves now heal brute and burn damage when drinking The Manly Dorf, because it was asked and I liked the idea.

Third and final change for this Dwarven Update : Dwarves speaking in Dwarvish no longer have a bad Scottish accent. So a dwarf can now understand another dwarf.

## Why It's Good For The Game
Better Dwarves, who won't die.

## Changelog
:cl:
Dwarf : Dwarves with Alcohol Tolerance now take full effect from The Manly Dorf
Dwarf : Dwarves now speak normally, without accent when speaking in Dwarvish
Dwarf : Dwarves now heal when drinking The Manly Dorf
/:cl:
