### PR TITLE
Separates gulag and public mining, removes sec vendor from gulag

### DIFF
--- a/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
+++ b/_maps/RandomRuins/StationRuins/Lavaland/Mining_Station/Mining_Station_Public_01.dmm
@@ -64,6 +64,9 @@
 /turf/open/floor/plating,
 /area/mine/living_quarters)
 "aN" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
 "aW" = (
@@ -82,24 +85,10 @@
 "bg" = (
 /turf/closed/wall,
 /area/mine/eva)
-"bH" = (
-/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
-	dir = 4;
-	piping_layer = 3
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/mine/living_quarters)
-"bI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
-	},
-/turf/open/floor/plasteel,
+"bn" = (
+/obj/structure/cable,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/living_quarters)
 "bX" = (
 /obj/machinery/door/window/southleft,
@@ -174,13 +163,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"di" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "dk" = (
 /obj/structure/table,
 /obj/item/stack/packageWrap,
@@ -192,12 +174,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
-"dC" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "dL" = (
 /obj/machinery/atmospherics/components/binary/pump/on,
 /obj/structure/cable{
@@ -220,6 +196,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"dU" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/sign/warning/electricshock{
+	pixel_y = -32
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "dZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -301,12 +286,33 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"fx" = (
+/obj/machinery/light/small{
+	dir = 8
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
+"fA" = (
+/obj/machinery/power/terminal{
+	dir = 4
+	},
+/obj/machinery/power/port_gen/pacman{
+	anchored = 1
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "fN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 5
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -349,9 +355,18 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"gn" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "gs" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "gP" = (
@@ -376,6 +391,15 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
+"hb" = (
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/machinery/power/smes{
+	charge = 5e+006
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "hf" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
@@ -384,14 +408,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"hv" = (
-/obj/machinery/camera{
-	c_tag = "Crew Area Hallway West";
-	dir = 1;
-	network = list("mine")
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -415,25 +431,21 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "hP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/lattice/catwalk,
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 4;
+	piping_layer = 3
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
 "hQ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/components/unary/outlet_injector/atmos/atmos_waste{
+	dir = 1;
+	piping_layer = 3
 	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
+/obj/structure/lattice/catwalk,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/mine/laborcamp/security)
 "ia" = (
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
@@ -582,6 +594,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"kP" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp)
 "kR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -629,6 +649,9 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
@@ -715,6 +738,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "mN" = (
@@ -733,13 +759,11 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"nv" = (
+"nx" = (
 /obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "0-2"
-	},
+/obj/structure/cable,
 /turf/open/floor/plating,
-/area/mine/living_quarters)
+/area/mine/laborcamp/security)
 "ny" = (
 /obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/tile/red{
@@ -772,11 +796,17 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
 	},
-/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -790,6 +820,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"nL" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "nN" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -805,6 +843,19 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"nX" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "oo" = (
 /obj/machinery/conveyor{
 	id = "mining_internal"
@@ -827,6 +878,9 @@
 "ow" = (
 /obj/machinery/door/airlock/medical/glass{
 	name = "Infirmary"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
@@ -886,6 +940,22 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"pu" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
+/area/mine/living_quarters)
 "pK" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -946,6 +1016,15 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/plating,
+/area/mine/living_quarters)
+"qx" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/structure/sign/poster/official/random{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "qH" = (
 /obj/structure/extinguisher_cabinet{
@@ -1071,6 +1150,12 @@
 "si" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "sj" = (
@@ -1151,14 +1236,24 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"td" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mine/laborcamp)
 "tk" = (
 /obj/machinery/atmospherics/pipe/manifold4w/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/supply/hidden{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
@@ -1183,16 +1278,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"uh" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "uG" = (
 /obj/structure/table,
 /obj/item/clothing/glasses/meson,
@@ -1258,6 +1343,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
+"vA" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "vE" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -1285,6 +1377,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"vM" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/mine/living_quarters)
 "wd" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -1356,6 +1458,9 @@
 /area/mine/production)
 "xd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "xh" = (
@@ -1399,6 +1504,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "yt" = (
@@ -1416,6 +1524,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/mine/production)
+"yQ" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "yR" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
@@ -1435,12 +1550,26 @@
 	},
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"zk" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable,
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "zo" = (
 /obj/structure/table,
 /turf/open/floor/carpet,
 /area/mine/living_quarters)
 "zx" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plating,
 /area/mine/laborcamp)
 "zy" = (
@@ -1502,13 +1631,9 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Ah" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -1602,6 +1727,16 @@
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
 /area/mine/living_quarters)
+"BD" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Mining Station Maintenance";
+	req_access_txt = "48"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp/security)
 "BO" = (
 /obj/machinery/door/airlock{
 	name = "Labor Camp Storage"
@@ -1638,6 +1773,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"Cl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp)
 "Cm" = (
 /obj/machinery/vending/snack,
 /obj/effect/turf_decal/tile/bar,
@@ -1646,6 +1787,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
+"Cw" = (
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating,
+/area/mine/laborcamp)
 "Cy" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 4
@@ -1748,18 +1896,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"Em" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/brown{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "Ev" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -1792,7 +1928,9 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
-/obj/machinery/vending/security,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "EH" = (
@@ -1804,6 +1942,9 @@
 "Fx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
@@ -1825,28 +1966,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ge" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "Gt" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -1891,6 +2016,9 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "Hh" = (
@@ -1964,11 +2092,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"HR" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable,
-/turf/open/floor/plating,
-/area/mine/living_quarters)
 "HS" = (
 /obj/machinery/conveyor{
 	dir = 10;
@@ -2038,6 +2161,9 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "II" = (
@@ -2053,6 +2179,9 @@
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/recharger,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "IS" = (
@@ -2072,19 +2201,6 @@
 	dir = 6
 	},
 /turf/open/floor/carpet,
-/area/mine/living_quarters)
-"Jc" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
 /area/mine/living_quarters)
 "Jl" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -2267,12 +2383,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
-"KR" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "KS" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2347,10 +2457,11 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "LG" = (
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/living_quarters)
 "LL" = (
 /obj/effect/turf_decal/tile/red{
@@ -2392,6 +2503,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/production)
+"Mh" = (
+/obj/structure/table,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel/white,
+/area/mine/laborcamp)
 "Mj" = (
 /obj/structure/sink{
 	dir = 4;
@@ -2491,12 +2609,6 @@
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating,
-/area/mine/living_quarters)
-"ML" = (
-/obj/structure/chair{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "MM" = (
 /obj/machinery/light{
@@ -2702,16 +2814,16 @@
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
 "Qr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/door/airlock/security/glass{
-	name = "Labor Camp Monitoring";
-	req_access_txt = "2"
+/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel,
+/obj/effect/spawner/structure/window/reinforced,
+/turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "Qx" = (
 /obj/structure/chair{
@@ -2738,6 +2850,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/eva)
+"QL" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/mine/laborcamp/security)
 "Rf" = (
 /obj/machinery/mineral/unloading_machine{
 	dir = 1;
@@ -2754,6 +2872,9 @@
 	name = "Labor Camp Monitoring";
 	req_access_txt = "2";
 	security_level = 6
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
@@ -2837,6 +2958,12 @@
 /area/mine/living_quarters)
 "Sp" = (
 /obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
 /turf/open/floor/plating,
 /area/mine/laborcamp/security)
 "Sq" = (
@@ -2904,7 +3031,7 @@
 	dir = 8
 	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -2950,6 +3077,9 @@
 /mob/living/simple_animal/bot/secbot/beepsky{
 	desc = "Powered by the tears and sweat of laborers.";
 	name = "Prison Ofitser"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -3099,19 +3229,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel/dark,
 /area/mine/maintenance)
-"WX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "WY" = (
 /obj/machinery/door/airlock{
 	id_tag = "miningdorm1";
@@ -3170,12 +3287,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/living_quarters)
-"XR" = (
-/obj/structure/sign/poster/official/random{
-	pixel_y = 32
-	},
-/turf/open/floor/plasteel,
-/area/mine/living_quarters)
 "XU" = (
 /obj/machinery/power/smes{
 	charge = 5e+006
@@ -3210,9 +3321,6 @@
 	c_tag = "Labor Camp Security Office";
 	dir = 1;
 	network = list("labor")
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
@@ -3290,13 +3398,6 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /turf/open/floor/plasteel,
-/area/mine/living_quarters)
-"Zu" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/lattice/catwalk,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/mine/living_quarters)
 "Zw" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
@@ -4329,9 +4430,9 @@ cd
 cd
 HO
 cd
-zI
-zI
-VT
+RF
+RF
+RF
 VT
 VT
 VT
@@ -4386,9 +4487,9 @@ HU
 cd
 Jr
 cd
-my
-wV
-VT
+fA
+fx
+RF
 VT
 uJ
 VT
@@ -4443,13 +4544,13 @@ at
 cd
 Op
 cd
-wV
-wV
-wV
+hb
+dU
+RF
 VT
 VT
 VT
-Lm
+VT
 Lm
 wz
 wz
@@ -4486,8 +4587,8 @@ JY
 JY
 JY
 zx
-zx
-zx
+kP
+td
 cd
 cd
 cd
@@ -4501,15 +4602,15 @@ NH
 NH
 Ya
 Mn
-Mn
+BD
 Mn
 Dv
 Mn
-nv
-Ge
-HR
-VN
-Lm
+wV
+VT
+VT
+VT
+wz
 Lm
 Lm
 Lm
@@ -4542,9 +4643,9 @@ JY
 JY
 JY
 JY
-zx
+Cw
 wB
-wB
+Mh
 cd
 AH
 NH
@@ -4562,11 +4663,11 @@ EB
 MM
 LC
 Mn
-xH
-dC
-hf
-VN
-bH
+wV
+wV
+VT
+VT
+Lm
 Lm
 Lm
 Lm
@@ -4603,13 +4704,13 @@ cd
 eh
 aN
 ow
-NH
-NH
-NH
-NH
+Cl
+Cl
+Cl
+gn
 vo
 ly
-xd
+vA
 Hg
 gs
 gs
@@ -4619,11 +4720,11 @@ si
 fN
 TC
 Mn
-ML
-dC
-oy
-VN
-Zu
+wV
+my
+VT
+VT
+VT
 Lm
 Lm
 Lm
@@ -4664,7 +4765,7 @@ fs
 NH
 Wt
 xd
-xd
+vA
 Fx
 Yf
 uR
@@ -4676,13 +4777,13 @@ Hx
 mL
 Yg
 Mn
-XR
-dC
-Ag
-VN
-Jc
-HR
-VN
+zI
+VT
+VT
+VT
+VT
+wz
+Lm
 Lm
 Lm
 Lm
@@ -4732,14 +4833,14 @@ LL
 Hx
 xS
 Gt
-Sp
-FE
-Em
-cD
-Ag
-sm
-uh
-VN
+Dv
+my
+VT
+VT
+VT
+VT
+wz
+Lm
 Lm
 Lm
 Lm
@@ -4791,12 +4892,12 @@ nJ
 Ah
 Qr
 hQ
-bI
-hQ
-hQ
-WX
-hv
-VN
+VT
+VT
+VT
+Lm
+Lm
+Lm
 Lm
 Lm
 Lm
@@ -4846,13 +4947,13 @@ WL
 Hx
 IG
 UJ
-Sp
-Ag
-Ag
-di
-KR
+yQ
+my
+my
+VT
+Lm
 hP
-Ag
+Lm
 VN
 VN
 VN
@@ -4901,15 +5002,15 @@ Ya
 Mn
 kB
 Oh
-Hx
+QL
 sR
 Al
 Al
 Al
 Al
 LG
-hP
-Ag
+pu
+bn
 VN
 zy
 If
@@ -4955,7 +5056,7 @@ my
 my
 my
 zI
-Sp
+Dv
 ny
 ig
 IK
@@ -4964,9 +5065,9 @@ Al
 wC
 wC
 Al
-Ag
-hP
-Ag
+hf
+vM
+xH
 VN
 Ru
 Ag
@@ -5013,16 +5114,16 @@ my
 my
 zI
 Sp
-Sp
-Sp
-Sp
-Sp
+zk
+nL
+nX
+nx
 Al
 Uz
 Ue
 Al
-EH
-hP
+qx
+sm
 aW
 VN
 Dr


### PR DESCRIPTION
## About The Pull Request

Separates the public mining base from the gulag by @kevinz000's request, removes the Sec vendor from the gulag, and re-adds a SMES to the gulag to power the electrified windows.

## Why It's Good For The Game

This removes any reason for people to break into the gulag outside of conversion game modes through the removal of the Sec vendor, additionally the separation of gulag and public mining reduces the chance of Security having to get swarmed with their now worthless batons by gangsters or revolutionaries trying to rescue leaders who got gulag'd instead of executed.

## Changelog
:cl:
add: SMES and PACMAN attached to gulag Security to power electrified windows
remove: Removed Sec vendor from gulag Security
tweak: Separation of gulag and public mining
/:cl: