### PR TITLE
Fixes energy lens not being in gun contents

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -150,7 +150,7 @@
 		if(istype(v, /obj/item/ammo_casing/energy))		//already set
 			ammo_type[v] = isnull(user_can_select)? TRUE : user_can_select
 		else
-			C = new v			//if you put non energycasing/type stuff in here you deserve the runtime
+			C = new v(src)			//if you put non energycasing/type stuff in here you deserve the runtime
 			ammo_type[i] = C
 			ammo_type[C] = isnull(user_can_select)? TRUE : user_can_select
 	set_firemode_index(initial(current_firemode_index))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title

## Why It's Good For The Game

Accidently removed making lens part of contents on the refactor PR.


## Changelog
:cl:
fix: Energy weapons now once again have their lens in contents.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
