### PR TITLE
Moves the hypospray mode change to CTRL click

### DIFF
--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -423,7 +423,7 @@
 		else
 			unload_hypo(vial,user)
 
-/obj/item/hypospray/mkii/AltClick(mob/living/user)
+/obj/item/hypospray/mkii/CtrlClick(mob/living/user)
 	. = ..()
 	if(user.canUseTopic(src, FALSE))
 		switch(mode)
@@ -437,7 +437,7 @@
 
 /obj/item/hypospray/mkii/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'><b>Alt-Click</b> it to toggle its mode from spraying to injecting and vice versa.</span>"
+	. += "<span class='notice'><b>Ctrl-Click</b> it to toggle its mode from spraying to injecting and vice versa.</span>"
 
 #undef HYPO_SPRAY
 #undef HYPO_INJECT

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -425,7 +425,7 @@
 
 /obj/item/hypospray/mkii/CtrlClick(mob/living/user)
 	. = ..()
-	if(user.canUseTopic(src, FALSE))
+	if(user.canUseTopic(src, FALSE) && user.get_active_held_item(src))
 		switch(mode)
 			if(HYPO_SPRAY)
 				mode = HYPO_INJECT


### PR DESCRIPTION
Apparently alt click was already reserved and i failed to notice this.

## Changelog
:cl:
tweak: Hyposprays now switch modes on CTRL click, instead of alt, as it was already reserved for dispension amount.
/:cl:
