### PR TITLE
Mining Shuttle Fix

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_singulo.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_singulo.dmm
@@ -735,7 +735,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "Si" = (
 /obj/structure/cable/yellow{

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_tesla.dmm
@@ -240,7 +240,7 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector{
 	dir = 1
 	},
-/turf/open/space/basic,
+/turf/open/floor/plating/airless,
 /area/engine/engineering)
 "nR" = (
 /obj/structure/cable{
@@ -902,14 +902,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/space/nearstation)
-"VR" = (
-/obj/structure/lattice/catwalk,
-/obj/machinery/camera/emp_proof{
-	c_tag = "Tesla Engine Northeast";
-	network = list("ss13","engine")
 	},
 /turf/open/space/basic,
 /area/space/nearstation)
@@ -1728,7 +1720,7 @@ dz
 dz
 FP
 FP
-VR
+FP
 dz
 dz
 Yl

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -81645,6 +81645,19 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plating,
 /area/crew_quarters/cryopod)
+"eQf" = (
+/obj/machinery/computer/shuttle/mining/common{
+	dir = 1
+	},
+/obj/structure/window/reinforced,
+/obj/structure/window/reinforced{
+	dir = 8
+	},
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/hallway/primary/port)
 "eZe" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -98511,7 +98524,7 @@ bgA
 biz
 bkb
 blZ
-bnM
+eQf
 bqf
 bqf
 bqf

--- a/code/modules/mining/mine_items.dm
+++ b/code/modules/mining/mine_items.dm
@@ -93,7 +93,7 @@
 	req_access = list()
 	circuit = /obj/item/circuitboard/computer/mining_shuttle/common
 	shuttleId = "mining_common"
-	possible_destinations = "whiteship_home;lavaland_common_away;landing_zone_dock;mining_public"
+	possible_destinations = "lavaland_common_away;commonmining_home"
 
 /**********************Mining car (Crate like thing, not the rail car)**************************/
 


### PR DESCRIPTION
## About The Pull Request
This remove an extra camera floating in space in the Tesla Engine

And also make the public mining shuttle correctly dock.
And give Meta a console for said shuttle.
The public shuttle can't dock at the same place as the white ship.

## Why It's Good For The Game
Fixes

## Changelog
:cl:
Fix mining shutte's dock
Remove an folating camera in tesla
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
