### PR TITLE
Makes ninja and wizards no longer spawn with suit sensors 

### DIFF
--- a/code/modules/clothing/outfits/standard.dm
+++ b/code/modules/clothing/outfits/standard.dm
@@ -272,7 +272,7 @@
 /datum/outfit/wizard
 	name = "Blue Wizard"
 
-	uniform = /obj/item/clothing/under/color/lightpurple
+	uniform = /obj/item/clothing/under/color/lightpurple/trackless
 	suit = /obj/item/clothing/suit/wizrobe
 	shoes = /obj/item/clothing/shoes/sandal/magic
 	ears = /obj/item/radio/headset

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -41,6 +41,10 @@
 	item_color = "black"
 	resistance_flags = NONE
 
+/obj/item/clothing/under/color/black/trackless
+	desc = "A black jumpsuit that has its sensors removed."
+	has_sensor = NO_SENSORS
+
 /obj/item/clothing/under/skirt/color/black
 	name = "black jumpskirt"
 	icon_state = "black_skirt"
@@ -189,7 +193,6 @@
 	item_state = "b_suit"
 	item_color = "teal_skirt"
 
-
 /obj/item/clothing/under/color/lightpurple
 	name = "purple jumpsuit"
 	icon_state = "lightpurple"
@@ -197,11 +200,7 @@
 	item_color = "lightpurple"
 
 /obj/item/clothing/under/color/lightpurple/trackless
-	name = "purple jumpsuit"
 	desc = "A magically colored jumpsuit. No sensors are attached!"
-	icon_state = "lightpurple"
-	item_state = "p_suit"
-	item_color = "lightpurple"
 	has_sensor = NO_SENSORS
 
 /obj/item/clothing/under/skirt/color/lightpurple

--- a/code/modules/clothing/under/color.dm
+++ b/code/modules/clothing/under/color.dm
@@ -196,6 +196,14 @@
 	item_state = "p_suit"
 	item_color = "lightpurple"
 
+/obj/item/clothing/under/color/lightpurple/trackless
+	name = "purple jumpsuit"
+	desc = "A magically colored jumpsuit. No sensors are attached!"
+	icon_state = "lightpurple"
+	item_state = "p_suit"
+	item_color = "lightpurple"
+	has_sensor = NO_SENSORS
+
 /obj/item/clothing/under/skirt/color/lightpurple
 	name = "lightpurple jumpskirt"
 	icon_state = "lightpurple_skirt"

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -1,6 +1,6 @@
 /datum/outfit/ninja
 	name = "Space Ninja"
-	uniform = /obj/item/clothing/under/syndicate
+	uniform = /obj/item/clothing/under/color/black/trackless
 	suit = /obj/item/clothing/suit/space/space_ninja
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/space_ninja

--- a/code/modules/ninja/outfit.dm
+++ b/code/modules/ninja/outfit.dm
@@ -1,6 +1,6 @@
 /datum/outfit/ninja
 	name = "Space Ninja"
-	uniform = /obj/item/clothing/under/color/black
+	uniform = /obj/item/clothing/under/syndicate
 	suit = /obj/item/clothing/suit/space/space_ninja
 	glasses = /obj/item/clothing/glasses/night
 	mask = /obj/item/clothing/mask/gas/space_ninja


### PR DESCRIPTION
## About The Pull Request

Ninja now spawns with a tactical turtleneck so that they are not spawning with max suits to be pin pointed

## Why It's Good For The Game

Stops ninjas for being known as soon as they spawn by a medical officer going `Huh whos this new unknown guy in space` and then sec getting pin pointers to track them down to their location

## Changelog
:cl:
balance: The suit full of spiders also known as a ninja now is a tactical turtleneck
balance: The Wiznerds now dont have suits set to max
/:cl:
