### PR TITLE
Meat wheat no longer has blood

### DIFF
--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -271,7 +271,7 @@
 /obj/item/reagent_containers/food/snacks/meat/slab/meatwheat
 	name = "meatwheat clump"
 	desc = "This doesn't look like meat, but your standards aren't <i>that</i> high to begin with."
-	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/blood = 5, /datum/reagent/consumable/cooking_oil = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 3, /datum/reagent/consumable/nutriment/vitamin = 2, /datum/reagent/consumable/cooking_oil = 1)
 	filling_color = rgb(150, 0, 0)
 	icon_state = "meatwheat_clump"
 	bitesize = 4


### PR DESCRIPTION
##  About The Pull Request

Meat wheat is no longer toxic to people, as it has no longer blood in it.

## Why It's Good For The Game

Man I dont want to kill the crew im cooking for, neather does like 30% of the cooks, Lets make it easyer to not kill crew with toxic food.

## Changelog
:cl:
tweak: Meat wheat no longer has blood
/:cl:
