### PR TITLE
gives CMO special surgery drapes that can initiate techweb surgeries without operating console

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -179,17 +179,23 @@
 		/obj/item/pinpointer/crew
 		))
 
-
 /obj/item/storage/belt/medical/surgery_belt_adv
 	name = "surgical supply belt"
 	desc = "A specialized belt designed for holding surgical equipment. It seems to have specific pockets for each and every surgical tool you can think of."
 	content_overlays = FALSE
+	var/advanced_drapes = FALSE
 
 /obj/item/storage/belt/medical/surgery_belt_adv/PopulateContents()
 	new /obj/item/scalpel/advanced(src)
 	new /obj/item/retractor/advanced(src)
 	new /obj/item/surgicaldrill/advanced(src)
-	new /obj/item/surgical_drapes(src)
+	if(advanced_drapes)
+		new /obj/item/surgical_drapes/advanced(src)
+	else
+		new /obj/item/surgical_drapes(src)
+
+/obj/item/storage/belt/medical/surgery_belt_adv/cmo
+	advanced_drapes = TRUE
 
 /obj/item/storage/belt/security
 	name = "security belt"

--- a/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
+++ b/code/game/objects/structures/crates_lockers/closets/secure/medical.dm
@@ -76,7 +76,7 @@
 	new /obj/item/door_remote/chief_medical_officer(src)
 	new /obj/item/clothing/neck/petcollar(src)
 	new /obj/item/pet_carrier(src)
-	new /obj/item/storage/belt/medical/surgery_belt_adv(src)
+	new /obj/item/storage/belt/medical/surgery_belt_adv/cmo(src)
 	new /obj/item/wallframe/defib_mount(src)
 	new /obj/item/circuitboard/machine/techfab/department/medical(src)
 	new /obj/item/storage/photo_album/CMO(src)

--- a/code/modules/surgery/advanced/bioware/bioware_surgery.dm
+++ b/code/modules/surgery/advanced/bioware/bioware_surgery.dm
@@ -2,7 +2,7 @@
 	name = "enhancement surgery"
 	var/bioware_target = BIOWARE_GENERIC
 
-/datum/surgery/advanced/bioware/can_start(mob/user, mob/living/carbon/human/target)
+/datum/surgery/advanced/bioware/can_start(mob/user, mob/living/carbon/human/target, obj/item/tool)
 	if(!..())
 		return FALSE
 	if(!istype(target))

--- a/code/modules/surgery/advanced/brainwashing.dm
+++ b/code/modules/surgery/advanced/brainwashing.dm
@@ -16,7 +16,7 @@
 	target_mobtypes = list(/mob/living/carbon/human)
 	possible_locs = list(BODY_ZONE_HEAD)
 
-/datum/surgery/advanced/brainwashing/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/advanced/brainwashing/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(!..())
 		return FALSE
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/advanced/lobotomy.dm
+++ b/code/modules/surgery/advanced/lobotomy.dm
@@ -12,7 +12,7 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-/datum/surgery/advanced/lobotomy/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/advanced/lobotomy/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(!..())
 		return FALSE
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)

--- a/code/modules/surgery/advanced/necrotic_revival.dm
+++ b/code/modules/surgery/advanced/necrotic_revival.dm
@@ -8,7 +8,7 @@
 				/datum/surgery_step/bionecrosis,
 				/datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_HEAD)
-/datum/surgery/advanced/necrotic_revival/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/advanced/necrotic_revival/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	. = ..()
 	var/obj/item/organ/zombie_infection/ZI = target.getorganslot(ORGAN_SLOT_ZOMBIE)
 	if(ZI)

--- a/code/modules/surgery/advanced/pacification.dm
+++ b/code/modules/surgery/advanced/pacification.dm
@@ -11,7 +11,7 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-/datum/surgery/advanced/pacify/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/advanced/pacify/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	. = ..()
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(!B)

--- a/code/modules/surgery/advanced/revival.dm
+++ b/code/modules/surgery/advanced/revival.dm
@@ -12,7 +12,7 @@
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_HEAD)
 	requires_bodypart_type = 0
-/datum/surgery/advanced/revival/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/advanced/revival/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(!..())
 		return FALSE
 	if(target.stat != DEAD)

--- a/code/modules/surgery/advanced/viral_bonding.dm
+++ b/code/modules/surgery/advanced/viral_bonding.dm
@@ -10,7 +10,7 @@
 
 	target_mobtypes = list(/mob/living/carbon/human, /mob/living/carbon/monkey)
 	possible_locs = list(BODY_ZONE_CHEST)
-/datum/surgery/advanced/viral_bonding/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/advanced/viral_bonding/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(!..())
 		return FALSE
 	if(!LAZYLEN(target.diseases))

--- a/code/modules/surgery/brain_surgery.dm
+++ b/code/modules/surgery/brain_surgery.dm
@@ -15,7 +15,7 @@
 	name = "fix brain"
 	implements = list(TOOL_HEMOSTAT = 85, TOOL_SCREWDRIVER = 35, /obj/item/pen = 15) //don't worry, pouring some alcohol on their open brain will get that chance to 100
 	time = 120 //long and complicated
-/datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/brain_surgery/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/brain/B = target.getorganslot(ORGAN_SLOT_BRAIN)
 	if(!B)
 		return FALSE

--- a/code/modules/surgery/core_removal.dm
+++ b/code/modules/surgery/core_removal.dm
@@ -6,7 +6,7 @@
 	lying_required = FALSE
 	ignore_clothes = TRUE
 
-/datum/surgery/core_removal/can_start(mob/user, mob/living/target)
+/datum/surgery/core_removal/can_start(mob/user, mob/living/target, obj/item/tool)
 	if(target.stat == DEAD)
 		return 1
 	return 0

--- a/code/modules/surgery/coronary_bypass.dm
+++ b/code/modules/surgery/coronary_bypass.dm
@@ -4,7 +4,7 @@
 				 /datum/surgery_step/incise_heart, /datum/surgery_step/coronary_bypass, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 
-/datum/surgery/coronary_bypass/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/coronary_bypass/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/heart/H = target.getorganslot(ORGAN_SLOT_HEART)
 	if(H)
 		if(H.damage > 60 && !H.operated)

--- a/code/modules/surgery/experimental_dissection.dm
+++ b/code/modules/surgery/experimental_dissection.dm
@@ -15,7 +15,7 @@
 	requires_tech = FALSE
 	var/value_multiplier = 1
 
-/datum/surgery/advanced/experimental_dissection/can_start(mob/user, mob/living/target)
+/datum/surgery/advanced/experimental_dissection/can_start(mob/user, mob/living/target, obj/item/tool)
 	. = ..()
 	if(HAS_TRAIT_FROM(target, TRAIT_DISSECTED,"[name]"))
 		return FALSE

--- a/code/modules/surgery/eye_surgery.dm
+++ b/code/modules/surgery/eye_surgery.dm
@@ -9,7 +9,7 @@
 	name = "fix eyes"
 	implements = list(TOOL_HEMOSTAT = 100, TOOL_SCREWDRIVER = 45, /obj/item/pen = 25)
 	time = 64
-/datum/surgery/eye_surgery/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/eye_surgery/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/eyes/E = target.getorganslot(ORGAN_SLOT_EYES)
 	if(!E)
 		to_chat(user, "It's hard to do surgery on someone's eyes when [target.p_they()] [target.p_do()]n't have any.")

--- a/code/modules/surgery/helpers.dm
+++ b/code/modules/surgery/helpers.dm
@@ -34,7 +34,7 @@
 				continue
 			if(S.lying_required && !(M.lying))
 				continue
-			if(!S.can_start(user, M))
+			if(!S.can_start(user, M, I))
 				continue
 			for(var/path in S.target_mobtypes)
 				if(istype(M, path))
@@ -64,7 +64,7 @@
 				return
 			if(S.lying_required && !(M.lying))
 				return
-			if(!S.can_start(user, M))
+			if(!S.can_start(user, M, I))
 				return
 
 			if(S.ignore_clothes || get_location_accessible(M, selected_zone))

--- a/code/modules/surgery/lipoplasty.dm
+++ b/code/modules/surgery/lipoplasty.dm
@@ -2,7 +2,7 @@
 	name = "Lipoplasty"
 	steps = list(/datum/surgery_step/incise, /datum/surgery_step/clamp_bleeders, /datum/surgery_step/cut_fat, /datum/surgery_step/remove_fat, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
-/datum/surgery/lipoplasty/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/lipoplasty/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(HAS_TRAIT(target, TRAIT_FAT))
 		return 1
 	return 0

--- a/code/modules/surgery/lobectomy.dm
+++ b/code/modules/surgery/lobectomy.dm
@@ -4,7 +4,7 @@
 				 /datum/surgery_step/lobectomy, /datum/surgery_step/close)
 	possible_locs = list(BODY_ZONE_CHEST)
 
-/datum/surgery/lobectomy/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/lobectomy/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	var/obj/item/organ/lungs/L = target.getorganslot(ORGAN_SLOT_LUNGS)
 	if(L)
 		if(L.damage > 60 && !L.operated)

--- a/code/modules/surgery/prosthetic_replacement.dm
+++ b/code/modules/surgery/prosthetic_replacement.dm
@@ -5,7 +5,7 @@
 	possible_locs = list(BODY_ZONE_R_ARM, BODY_ZONE_L_ARM, BODY_ZONE_L_LEG, BODY_ZONE_R_LEG, BODY_ZONE_HEAD)
 	requires_bodypart = FALSE //need a missing limb
 	requires_bodypart_type = 0
-/datum/surgery/prosthetic_replacement/can_start(mob/user, mob/living/carbon/target)
+/datum/surgery/prosthetic_replacement/can_start(mob/user, mob/living/carbon/target, obj/item/tool)
 	if(!iscarbon(target))
 		return 0
 	var/mob/living/carbon/C = target

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -55,27 +55,26 @@
 	if(requires_tech)
 		. = FALSE
 
+	var/list/advanced_surgeries = list()
 	if(iscyborg(user))
 		var/mob/living/silicon/robot/R = user
 		var/obj/item/surgical_processor/SP = locate() in R.module.modules
 		if(SP)
-			if (replaced_by in SP.advanced_surgeries)
-				return .
-			if(type in SP.advanced_surgeries)
-				return TRUE
-
+			advanced_surgeries |= SP.advanced_surgeries
 
 	var/turf/T = get_turf(patient)
 	var/obj/structure/table/optable/table = locate(/obj/structure/table/optable, T)
-	if(table)
-		if(!table.computer)
-			return .
-		if(table.computer.stat & (NOPOWER|BROKEN))
-			return .
-		if(replaced_by in table.computer.advanced_surgeries)
-			return FALSE
-		if(type in table.computer.advanced_surgeries)
-			return TRUE
+	if(table?.computer && !CHECK_BITFIELD(table.computer.stat, NOPOWER|BROKEN))
+		advanced_surgeries |= table.computer.advanced_surgeries
+
+	if(istype(tool, /obj/item/surgical_drapes/advanced))
+		var/obj/item/surgical_drapes/advanced/A = tool
+		advanced_surgeries |= A.get_advanced_surgeries()
+
+	if(replaced_by in advanced_surgeries)
+		return FALSE
+	if(type in advanced_surgeries)
+		return TRUE
 
 /datum/surgery/proc/next_step(mob/user, intent)
 	if(step_in_progress)

--- a/code/modules/surgery/surgery.dm
+++ b/code/modules/surgery/surgery.dm
@@ -37,7 +37,7 @@
 	return ..()
 
 
-/datum/surgery/proc/can_start(mob/user, mob/living/patient) //FALSE to not show in list
+/datum/surgery/proc/can_start(mob/user, mob/living/patient, obj/item/tool) //FALSE to not show in list
 	. = TRUE
 	if(replaced_by == /datum/surgery)
 		return FALSE

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -287,6 +287,26 @@
 	if(!attempt_initiate_surgery(src, M, user))
 		..()
 
+/obj/item/surgical_drapes/advanced
+	name = "smart surgical drapes"
+	desc = "A quite quirky set of drapes with wireless synchronization to the station's research networks, with an integrated display allowing users to execute advanced surgeries without the aid of an operating computer."
+	var/datum/techweb/linked_techweb
+
+/obj/item/surgical_drapes/advanced/Initialize(mapload)
+	. = ..()
+	linked_techweb = SSresearch.science_tech
+
+/obj/item/surgical_drapes/advanced/proc/get_advanced_surgeries()
+	. = list()
+	if(!linked_techweb)
+		return
+	for(var/subtype in subtypesof(/datum/design/surgery))
+		var/datum/design/surgery/prototype = subtype
+		var/id = initial(prototype.id)
+		if(id in linked_techweb.researched_designs)
+			prototype = SSresearch.techweb_design_by_id(id)
+			. |= prototype.surgery
+
 /obj/item/organ_storage //allows medical cyborgs to manipulate organs without hands
 	name = "organ storage bag"
 	desc = "A container for holding body parts."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

cool interesting "unique" head of staff item because you powercreepers gave medical compact defibs and cmo needed stuff anyways, that at the same time isn't horribly abusable for combat.

## Changelog
:cl:
add: cmo now gets advanced surgery drapes that techweb-sync for advanced surgeries without an operating console.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
