### PR TITLE
Flat guns can no longer be suppressed 

### DIFF
--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -79,6 +79,7 @@
 /obj/item/gun/ballistic/automatic/pistol/stickman
 	name = "flat gun"
 	desc = "A 2 dimensional gun.. what?"
+	can_suppress = FALSE
 	icon_state = "flatgun"
 
 /obj/item/gun/ballistic/automatic/pistol/stickman/pickup(mob/living/user)


### PR DESCRIPTION
## About The Pull Request

the 10mm flat guns can no longer be suppressed, they have no sprites for it

## Why It's Good For The Game

They should not be suppressed as they dont have sprites

## Changelog
:cl:
fix: Flat guns can no longer be suppressed
/:cl:
