### PR TITLE
Changes the Stickmans projectile to be the correct caliber

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/stickman.dm
+++ b/code/modules/mob/living/simple_animal/hostile/stickman.dm
@@ -40,7 +40,7 @@
 	minimum_distance = 5
 	icon_state = "stickmanranged"
 	icon_living = "stickmanranged"
-	casingtype = /obj/item/ammo_casing/c45/nostamina
+	casingtype = /obj/item/ammo_casing/c10mm
 	projectilesound = 'sound/misc/bang.ogg'
 	loot = list(/obj/item/gun/ballistic/automatic/pistol/stickman)
 


### PR DESCRIPTION
## About The Pull Request 

Fun fact they shoot .45s that deal 30 damage but drop a 10mm gun that deals 30 damage. Novel!
Meaning this dosnt affect game wise anything and just is consistency pr

## Why It's Good For The Game

Consistency, and allows people to know what caliber they picked up without needing to check the mag that spawns full for some reason

## Changelog
:cl:
tweak: replaced stickmans .45 caliber with 10mm, for consistency. 
/:cl:
