### PR TITLE
Buffs oats and makes meatwheat have rarity

### DIFF
--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -33,6 +33,7 @@
 	icon_state = "seed-oat"
 	species = "oat"
 	plantname = "Oat Stalks"
+	rarity = 10 //Not really new, just better
 	product = /obj/item/reagent_containers/food/snacks/grown/oat
 	mutatelist = list()
 
@@ -45,7 +46,7 @@
 	filling_color = "#556B2F"
 	bitesize_mod = 2
 	foodtype = GRAIN
-	grind_results = list(/datum/reagent/consumable/flour = 0)
+	grind_results = list(/datum/reagent/consumable/flour = 0.5) //So when it grinds it has 50% more wheat
 	tastes = list("oat" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/ale
 
@@ -81,6 +82,7 @@
 	species = "meatwheat"
 	plantname = "Meatwheat"
 	product = /obj/item/reagent_containers/food/snacks/grown/meatwheat
+	rarity = 40
 	mutatelist = list()
 
 /obj/item/reagent_containers/food/snacks/grown/meatwheat

--- a/code/modules/hydroponics/grown/cereals.dm
+++ b/code/modules/hydroponics/grown/cereals.dm
@@ -46,7 +46,7 @@
 	filling_color = "#556B2F"
 	bitesize_mod = 2
 	foodtype = GRAIN
-	grind_results = list(/datum/reagent/consumable/flour = 0.5) //So when it grinds it has 50% more wheat
+	grind_results = list(/datum/reagent/consumable/flour = 0.5) //So when it grinds it has 50% more flour
 	tastes = list("oat" = 1)
 	distill_reagent = /datum/reagent/consumable/ethanol/ale
 


### PR DESCRIPTION
## About The Pull Request

Meat wheat now has rarity  40
Oats now have rarity of 10
Oats now should have 50% more flour in them

## Why It's Good For The Game

Oats atm are just a useless deadend plant that can only be used in ale and have 0 uses outside that.
Meatwheat is legit blood and meat in a flour... That should be have some rarity

## Changelog
:cl:
tweak: Meatwheat and Oats now have rarity
balance: Oats now have at lest 50% more flour in them
/:cl: