### PR TITLE
Blood Drunk Miner now uses a PKA

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -73,7 +73,7 @@ Difficulty: Medium
 	target.stun_absorption -= "miner"
 
 /obj/item/projectile/kinetic/miner
-	damage = 50
+	damage = 40
 	speed = 0.9
 	icon_state = "ka_tracer"
 	range = MINER_DASH_RANGE

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/blood_drunk_miner.dm
@@ -39,8 +39,8 @@ Difficulty: Medium
 	ranged = 1
 	ranged_cooldown_time = 16
 	pixel_x = -16
-	crusher_loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator, /obj/item/crusher_trophy/miner_eye)
-	loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator)
+	crusher_loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator/premiumka, /obj/item/crusher_trophy/miner_eye)
+	loot = list(/obj/item/melee/transforming/cleaving_saw, /obj/item/gun/energy/kinetic_accelerator/premiumka)
 	wander = FALSE
 	del_on_death = TRUE
 	blood_volume = BLOOD_VOLUME_NORMAL
@@ -73,7 +73,7 @@ Difficulty: Medium
 	target.stun_absorption -= "miner"
 
 /obj/item/projectile/kinetic/miner
-	damage = 20
+	damage = 50
 	speed = 0.9
 	icon_state = "ka_tracer"
 	range = MINER_DASH_RANGE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Replaces the BDM normal KA with a PKA and damage accordingly  

## Why It's Good For The Game
Makes the BDM harder to fight as well as more rewording other then a rather lame large knife.

## Changelog
:cl:
balance: BDM now uses a PKA rather then a normal KA
/:cl:
