### PR TITLE
Allows warden to buy a dual tube shotgun for 12 tc if they can get it

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -231,3 +231,10 @@
 	cost = 2
 	item = /obj/item/clothing/shoes/magboots/crushing
 	restricted_roles = list("Chief Engineer", "Station Engineer", "Atmospheric Technician")
+
+/datum/uplink_item/role_restricted/dual_shotgun
+	name = "Cycler Shotgun"
+	desc = "An advanced shotgun with two separate magazine tubes, allowing you to quickly toggle between ammo types."
+	cost = 12
+	item = /obj/item/gun/ballistic/shotgun/automatic/dual_tube
+	restricted_roles = list("Warden")


### PR DESCRIPTION
## About The Pull Request

If a warden gets their hand on some TC and a uplink they can buy the Dual Tube shotgun for 12 tc

## Why It's Good For The Game

Sec and warden never really had anything for them in the uplink well every other department has something, this allows the warden to be a bit more corrupt and lead to RP

## Changelog
:cl:
add: Warden (traitors) can now buy a 12 tc dual tube shotgun
/:cl: