### PR TITLE
nerfs hand teleporters to have a dispel delay

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -141,11 +141,15 @@
 		return FALSE
 	return ..()
 
-/obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user)
-	if(is_parent_of_portal(target))
+/obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 30)
+	if(delay)
+		var/datum/beam/B = user.Beam(target)
+	if(is_parent_of_portal(target) && (!delay || do_after(user, delay, target = target)))
 		qdel(target)
 		to_chat(user, "<span class='notice'>You dispel [target] with \the [src]!</span>")
+		qdel(B)
 		return TRUE
+	qdel(B)
 	return FALSE
 
 /obj/item/hand_tele/afterattack(atom/target, mob/user)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -142,8 +142,7 @@
 	return ..()
 
 /obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 30)
-	if(delay)
-		var/datum/beam/B = user.Beam(target)
+	var/datum/beam/B = user.Beam(target)
 	if(is_parent_of_portal(target) && (!delay || do_after(user, delay, target = target)))
 		qdel(target)
 		to_chat(user, "<span class='notice'>You dispel [target] with \the [src]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

too spammable, this was my buff a few years ago anyways 

delay is 30 deciseconds

## Changelog
:cl:
balance: hand teleporters now require 30 deciseconds of still movement by the user to dispel portals. there's a beam effect too.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
