### PR TITLE
Bullets no longer do equal blood volume deletion to unmitigated damage; replicates #9682

### DIFF
--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -185,10 +185,6 @@
 				else
 					new /obj/effect/temp_visual/dir_setting/bloodsplatter(target_loca, splatter_dir, bloodtype_to_color())
 
-			if(iscarbon(L) && !HAS_TRAIT(L, TRAIT_NOMARROW))
-				var/mob/living/carbon/C = L
-				C.bleed(damage)
-			else
 				L.add_splatter_floor(target_loca)
 		else if(impact_effect_type && !hitscan)
 			new impact_effect_type(target_loca, hitx, hity)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

[Accompanying video for this pr](https://www.youtube.com/watch?v=tCtYuARcQPg)

This is clearly an incredibly half-arsed mechanic which might have been implemented with the intent of making blood loss a problem that requires management and consideration, but what it ends up doing is causing any damage you otherwise potentially would take from bullets (and plasma cutter beams I believe since it's based on brute damage taken) results in equal amounts of blood loss in bleed. Since the danger zone for blood loss is about 300 or less, you probably end up dipping into that zone regardless of what bullet hit you or where. Fairly quickly too. It is a one for one bleed rate to the damage you would otherwise take given how much you take and even if it DIDN'T, it would still be an immense amount of damage given how much damage is actually dealt with brute ballistics. You could mitigate the bullets damage to 1 and it would still bleed you out.

Since no alternatives have been accepted and I have absolutely no interest in providing one and am more concerned for the current, prevailing damage this change is causing to the game's balance, I'd just cut losses. Maybe down the line someone can make a bleed rate from bullets that actually matters, or possibly even pinch goon's bullet embedding.

There was a similar problem with a chem introduced on /tg/station that caused uncapped massively increasing bleed rates being used in shotgun darts to kill people in under 30 seconds. This proc basically does that but slower and puncturing thick material AND on all bullets. It's a death sentence to everyone and anyone who is hit by a bullet and isn't gaming blood replication, and makes any non-brute projectiles look like a bad joke. We have a gun that does this already. It's the CX Shredder, and that's part of the guns gimmick. Since every ballistic gun, even a stechkin, does this natively, the point of the Shredder is...not really any point besides maybe accidental dismemberment.

How this has survived as it has for so long is beyond me, but I'm going to just kill it with this PR without mercy. Hopefully I didn't miss anything and everything is fucked as a result of my lack of foresight. 
![13359033171319](https://user-images.githubusercontent.com/40847847/74406924-f7e74580-4e84-11ea-95b2-b20c3022df86.png)

## Why It's Good For The Game

Melonseed guns can kill you through Deathsquad armor.

## Changelog
:cl:
del: Bullets causing bleed rates equal to unmitigated damage through all forms of defense.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
