### PR TITLE
Massive metal tower shields now are not transparent

### DIFF
--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -236,3 +236,4 @@
 	throwforce = 15 //Massive pice of metal
 	w_class = WEIGHT_CLASS_HUGE
 	item_flags = SLOWS_WHILE_IN_HAND
+	transparent = FALSE


### PR DESCRIPTION
## About The Pull Request

A rather unintented nerf to gangs shields, making them not longer block laser fire

## Why It's Good For The Game

Makes the gang shields no longer worthless against laser based weapons, as its not transparent
Also consistency 
## Changelog
:cl:
tweak: Gang tower shield is no longer transparent
/:cl: