### PR TITLE
Changes to organ decay rate (tip it's not 15 minutes 0-100 damage and this was lying to you)

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -138,8 +138,8 @@
 
 ////organ defines
 #define STANDARD_ORGAN_THRESHOLD 	100
-#define STANDARD_ORGAN_HEALING 		0.001
-#define STANDARD_ORGAN_DECAY		0.00222		//designed to fail organs when left to decay for ~15 minutes
+#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / 1 SECOND))
+#define STANDARD_ORGAN_DECAY		(1/(15 MINUTES / 1 SECOND))		//designed to fail organs when left to decay for ~15 minutes. 1 SECOND is SSmobs tickrate.
 
 #define G_MALE 1
 #define G_FEMALE 2

--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -138,8 +138,8 @@
 
 ////organ defines
 #define STANDARD_ORGAN_THRESHOLD 	100
-#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / 1 SECOND))
-#define STANDARD_ORGAN_DECAY		(1/(15 MINUTES / 1 SECOND))		//designed to fail organs when left to decay for ~15 minutes. 1 SECOND is SSmobs tickrate.
+#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / 1 SECONDS))
+#define STANDARD_ORGAN_DECAY		(1/(15 MINUTES / 1 SECONDS))		//designed to fail organs when left to decay for ~15 minutes. 1 SECOND is SSmobs tickrate.
 
 #define G_MALE 1
 #define G_FEMALE 2

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -10,7 +10,7 @@
 	organ_flags = ORGAN_VITAL
 	attack_verb = list("attacked", "slapped", "whacked")
 	///The brain's organ variables are significantly more different than the other organs, with half the decay rate for balance reasons, and twice the maxHealth
-	decay_factor = STANDARD_ORGAN_DECAY	/ 4		//30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
+	decay_factor = STANDARD_ORGAN_DECAY	/ 2		//30 minutes of decaying to result in a fully damaged brain, since a fast decay rate would be unfun gameplay-wise
 	healing_factor = STANDARD_ORGAN_HEALING / 2
 
 	maxHealth	= BRAIN_DAMAGE_DEATH

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -6,7 +6,7 @@
 	slot = ORGAN_SLOT_HEART
 
 	healing_factor = STANDARD_ORGAN_HEALING
-	decay_factor = 2.5 * STANDARD_ORGAN_DECAY		//designed to fail about 5 minutes after death
+	decay_factor = 2 * STANDARD_ORGAN_DECAY
 
 	low_threshold_passed = "<span class='info'>Prickles of pain appear then die out from within your chest...</span>"
 	high_threshold_passed = "<span class='warning'>Something inside your chest hurts, and the pain isn't subsiding. You notice yourself breathing far faster than before.</span>"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

NErfs organ decay from 15 minutes to 7.5 minutes for full 100 damage (note that it fails before full). The define was lying, mob tick is 10 ds not 20 ds.

Buffs organ healing from more than 30 minutes from dead to full (that said you won't have dead organs so..) to the same speed as decay. Synthtissue is a mess right now, medical code is a mess, I don't trust a fermichem (sorry I love you fermis) to be a crucial point of balance at this point in time.

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

As said above. There's still plenty of ways to permanently kill someone and I'd rather off the cloning meta sooner rather than later.

Also brains stay at 30 minutes to fully decay. HEART, however, will be made to decay in 7.5 minutes. This will be the defib cap.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Organ healing rate doubled. Organ decay rate halved to match its define (15 minutes for full decay, so at around 8-10 minutes it'll be really fucked).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
