### PR TITLE
removes bluespace dick compression 

### DIFF
--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -89,25 +89,6 @@
 		else
 			to_chat(user, "<span class='notice'>Anomalous error. Summon a coder.</span>")
 
-	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_GROIN)
-		var/mob/living/carbon/human/H = target
-		var/obj/item/organ/genital/penis/P = H.getorganslot(ORGAN_SLOT_PENIS)
-		if(!P)
-			return
-		playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1)
-		H.visible_message("<span class='warning'>[user] is preparing to shrink [H]\'s [P.name] with their bluespace compression kit!</span>")
-		if(do_mob(user, H, 40) && charges > 0 && P.length > 0)
-			H.visible_message("<span class='warning'>[user] has shrunk [H]\'s [P.name]!</span>")
-			playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 50, 1)
-			sparks()
-			flash_lighting_fx(3, 3, LIGHT_COLOR_CYAN)
-			charges -= 1
-			var/p_name = P.name
-			P.modify_size(-5)
-			if(QDELETED(P))
-				H.visible_message("<span class='warning'>[H]\'s [p_name] vanishes!</span>")
-
-
 /obj/item/compressionkit/attackby(obj/item/I, mob/user, params)
 	..()
 	if(istype(I, /obj/item/stack/ore/bluespace_crystal))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

valid complaints about prefbreaking and i'm not keen to add yet more memey erp preferences.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
remove: bluespace compression kits can no longer shrink dicks due to prefbreaking issues.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
