### PR TITLE
Bluespace Compression Kit no longer prefbreaks, yikes

### DIFF
--- a/code/game/objects/items/devices/compressionkit.dm
+++ b/code/game/objects/items/devices/compressionkit.dm
@@ -89,25 +89,6 @@
 		else
 			to_chat(user, "<span class='notice'>Anomalous error. Summon a coder.</span>")
 
-	else if(ishuman(target) && user.zone_selected == BODY_ZONE_PRECISE_GROIN)
-		var/mob/living/carbon/human/H = target
-		var/obj/item/organ/genital/penis/P = H.getorganslot(ORGAN_SLOT_PENIS)
-		if(!P)
-			return
-		playsound(get_turf(src), 'sound/weapons/flash.ogg', 50, 1)
-		H.visible_message("<span class='warning'>[user] is preparing to shrink [H]\'s [P.name] with their bluespace compression kit!</span>")
-		if(do_mob(user, H, 40) && charges > 0 && P.length > 0)
-			H.visible_message("<span class='warning'>[user] has shrunk [H]\'s [P.name]!</span>")
-			playsound(get_turf(src), 'sound/weapons/emitter2.ogg', 50, 1)
-			sparks()
-			flash_lighting_fx(3, 3, LIGHT_COLOR_CYAN)
-			charges -= 1
-			var/p_name = P.name
-			P.modify_size(-5)
-			if(QDELETED(P))
-				H.visible_message("<span class='warning'>[H]\'s [p_name] vanishes!</span>")
-
-
 /obj/item/compressionkit/attackby(obj/item/I, mob/user, params)
 	..()
 	if(istype(I, /obj/item/stack/ore/bluespace_crystal))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

I thought 'hey what if this was flagged for the toggle' and then I realized that what the fuck would that even matter when this is literally a function meant for grief via prefbreaking. That's the core of the intent behind this. It'd better to just axe it. If anyone cared for it to have a toggle added, you're welcome to open an alternative PR.

## Why It's Good For The Game

Nobody would be able to use this function of the BSCK without administrative punishment in the first place and it encourages bad shit. A toggle doesn't do much for it given it's an antag item, and the hypnoflash was blockaded for much the same reasons. 

## Changelog
:cl:
del: BSCK no longer has prefbreaking functionality
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
