### PR TITLE
ghosts can not force re rendering of storage to a different size

### DIFF
--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -363,7 +363,7 @@
 					break
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
 
-/datum/component/storage/proc/show_to(mob/M, set_screen_size = FALSE)
+/datum/component/storage/proc/show_to(mob/M, set_screen_size = TRUE)
 	if(!M.client)
 		return FALSE
 	var/list/cview = getviewsize(M.client.view)

--- a/code/datums/components/storage/storage.dm
+++ b/code/datums/components/storage/storage.dm
@@ -41,6 +41,7 @@
 
 	var/obj/screen/storage/boxes					//storage display object
 	var/obj/screen/close/closer						//close button object
+	var/current_maxscreensize
 
 	var/allow_big_nesting = FALSE					//allow storage objects of the same or greater size.
 
@@ -362,11 +363,15 @@
 					break
 	closer.screen_loc = "[screen_start_x + cols]:[screen_pixel_x],[screen_start_y]:[screen_pixel_y]"
 
-/datum/component/storage/proc/show_to(mob/M)
+/datum/component/storage/proc/show_to(mob/M, set_screen_size = FALSE)
 	if(!M.client)
 		return FALSE
 	var/list/cview = getviewsize(M.client.view)
 	var/maxallowedscreensize = cview[1]-8
+	if(set_screen_size)
+		current_maxscreensize = maxallowedscreensize
+	else if(current_maxscreensize)
+		maxallowedscreensize = current_maxscreensize
 	if(M.active_storage != src && (M.stat == CONSCIOUS))
 		for(var/obj/item/I in accessible_items())
 			if(I.on_found(M))
@@ -547,14 +552,14 @@
 				return
 			A.add_fingerprint(M)
 
-/datum/component/storage/proc/user_show_to_mob(mob/M, force = FALSE)
+/datum/component/storage/proc/user_show_to_mob(mob/M, force = FALSE, ghost = FALSE)
 	var/atom/A = parent
 	if(!istype(M))
 		return FALSE
 	A.add_fingerprint(M)
 	if(!force && (check_locked(null, M) || !M.CanReach(parent, view_only = TRUE)))
 		return FALSE
-	show_to(M)
+	show_to(M, !ghost)
 
 /datum/component/storage/proc/mousedrop_receive(datum/source, atom/movable/O, mob/M)
 	if(isitem(O))
@@ -665,7 +670,7 @@
 	return can_be_inserted(I, silent, M)
 
 /datum/component/storage/proc/show_to_ghost(datum/source, mob/dead/observer/M)
-	return user_show_to_mob(M, TRUE)
+	return user_show_to_mob(M, TRUE, TRUE)
 
 /datum/component/storage/proc/signal_show_attempt(datum/source, mob/showto, force = FALSE)
 	return user_show_to_mob(showto, force)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ghosts clicking on storage re-renders it to their view preferences. This makes it locked to only non ghosts, ghosts can still view but can no longer force a re-render.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Unless someone wants to refactor storage viewing to be per mob (impossible as it uses screen locs unless you use holder objects or something) this is the most efficient way to fix ghosts impacting playing players, as if you view someone with an incompatible view range you will distort their screen from the re-render.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Storage now caches max screen size and only stores when being opened by a non ghost, meaning ghosts will no longer distort living player screens when viewing storage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
