### PR TITLE
Doubled halved flavor text max length and removed crappy code.

### DIFF
--- a/code/__DEFINES/say.dm
+++ b/code/__DEFINES/say.dm
@@ -81,6 +81,7 @@
 
 //Don't set this very much higher then 1024 unless you like inviting people in to dos your server with message spam
 #define MAX_MESSAGE_LEN			2048		//Citadel edit: What's the WORST that could happen?
+#define MAX_FAVOR_LEN			4096		//double the maximum message length.
 #define MAX_NAME_LEN			42
 #define MAX_BROADCAST_LEN		512
 #define MAX_CHARTER_LEN			80

--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -113,7 +113,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 	set desc = "Sets an extended description of your character's features."
 	set category = "IC"
 
-	var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", flavor_text, MAX_FAVOR_LEN, TRUE)
+	var/new_flavor = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", flavor_text, MAX_FAVOR_LEN, TRUE)
 	if(!isnull(new_flavor))
 		flavor_text = new_flavor
 		to_chat(src, "Your flavor text has been updated.")

--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -108,26 +108,36 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 		message_admins("[key_name_admin(usr)] manually reloaded mentors")
 
 //Flavor Text
-/mob/living/carbon/human/verb/set_flavor()
+/mob/proc/set_flavor()
 	set name = "Set Flavor Text"
 	set desc = "Sets an extended description of your character's features."
 	set category = "IC"
 
-	var/new_flavor = input(src, "Enter your new flavor text:", "Flavor text", null) as message|null
+	var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", flavor_text, MAX_FAVOR_LEN, TRUE)
 	if(!isnull(new_flavor))
-		flavor_text = sanitize(new_flavor)
+		flavor_text = new_flavor
 		to_chat(src, "Your flavor text has been updated.")
 
 //Flavor Text
-/mob/living/carbon/human/verb/set_flavor_2()
+/mob/proc/set_flavor_2()
 	set name = "Set Temporary Flavor Text"
 	set desc = "Sets a description of your character's current appearance. Use this for emotions, poses etc."
 	set category = "IC"
 
-	var/new_flavor = input(src, "Enter your new temporary flavor text:", "Temporary flavor text", null) as message|null
+	var/new_flavor = stripped_multiline_input(usr, "Set the temporary flavor text in your 'examine' verb. This should be used only for things pertaining to the current round!", "Short-Term Flavor Text", flavor_text_2, MAX_FAVOR_LEN, TRUE)
 	if(!isnull(new_flavor))
-		flavor_text_2 = sanitize(new_flavor)
+		flavor_text_2 = new_flavor
 		to_chat(src, "Your temporary flavor text has been updated.")
+
+/mob/proc/print_flavor_text(flavor)
+	if(!flavor)
+		return
+	// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
+	var/msg = html_decode(replacetext(flavor, "\n", " "))
+	if(length_char(msg) <= 40)
+		return "<span class='notice'>[html_encode(msg)]</span>"
+	else
+		return "<span class='notice'>[html_encode(copytext_char(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
 
 //LOOC toggles
 /client/verb/listen_looc()

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1473,9 +1473,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", html_decode(features["flavor_text"]), MAX_MESSAGE_LEN, TRUE)
+					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FAVOR_LEN, TRUE)
 					if(msg)
-						msg = msg
 						features["flavor_text"] = msg
 
 				if("hair")

--- a/code/modules/mob/living/carbon/human/examine.dm
+++ b/code/modules/mob/living/carbon/human/examine.dm
@@ -394,10 +394,10 @@
 	if(invisible_man)
 		. += "...?"
 	else
-		var/flavor = print_flavor_text()
+		var/flavor = print_flavor_text(flavor_text)
 		if(flavor)
 			. += flavor
-		var/temp_flavor = print_flavor_text_2()
+		var/temp_flavor = print_flavor_text(flavor_text_2)
 		if(temp_flavor)
 			. += temp_flavor
 	SEND_SIGNAL(src, COMSIG_PARENT_EXAMINE, user, .)

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -9,6 +9,8 @@
 	verbs += /mob/living/proc/mob_sleep
 	verbs += /mob/living/proc/lay_down
 	verbs += /mob/living/carbon/human/proc/underwear_toggle //fwee
+	verbs += /mob/proc/set_flavor
+	verbs += /mob/proc/set_flavor_2
 
 	//initialize limbs first
 	create_bodyparts()

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -512,9 +512,6 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		usr << browse(text("<HTML><HEAD><TITLE>[]</TITLE></HEAD><BODY><TT>[]</TT></BODY></HTML>", name, replacetext(flavor_text_2, "\n", "<BR>")), text("window=[];size=500x200", name))
 		onclose(usr, "[name]")
 
-	if(href_list["flavor_change"])
-		update_flavor_text()
-
 	if(href_list["refresh"])
 		if(machine && in_range(src, usr))
 			show_inv(machine)

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -125,3 +125,6 @@
 	var/siliconaccesstoggle = FALSE
 
 	var/voluntary_ghosted = FALSE		//whether or not they voluntarily ghosted.
+
+	var/flavor_text = ""
+	var/flavor_text_2 = "" //version of the above that only lasts for the current round.

--- a/code/modules/mob/say_vr.dm
+++ b/code/modules/mob/say_vr.dm
@@ -1,52 +1,6 @@
 //////////////////////////////////////////////////////
 ////////////////////SUBTLE COMMAND////////////////////
 //////////////////////////////////////////////////////
-/mob
-	var/flavor_text = "" //tired of fucking double checking this
-	var/flavor_text_2 = ""
-
-/mob/proc/update_flavor_text()
-	set src in usr
-	if(usr != src)
-		to_chat(usr, "No.")
-	var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", html_decode(flavor_text), MAX_MESSAGE_LEN, TRUE)
-
-	if(msg)
-		flavor_text = html_encode(msg)
-
-/mob/proc/update_flavor_text_2()
-	set src in usr
-	if(usr != src)
-		to_chat(usr, "No.")
-	var/msg = stripped_multiline_input(usr, "Set the temporary flavor text in your 'examine' verb. This should be used only for things pertaining to the current round!", "Short-Term Flavor Text", html_decode(flavor_text_2), MAX_MESSAGE_LEN, TRUE)
-
-	if(msg)
-		flavor_text_2 = html_encode(msg)
-
-
-/mob/proc/warn_flavor_changed()
-	if(flavor_text && flavor_text != "") // don't spam people that don't use it!
-		to_chat(src, "<h2 class='alert'>OOC Warning:</h2>")
-		to_chat(src, "<span class='alert'>Your flavor text is likely out of date! <a href='?src=[REF(src)];flavor_change=1'>Change</a></span>")
-
-/mob/proc/print_flavor_text()
-	if(flavor_text && flavor_text != "")
-		// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
-		var/msg = html_decode(replacetext(flavor_text, "\n", " "))
-		if(length_char(msg) <= 40)
-			return "<span class='notice'>[html_encode(msg)]</span>"
-		else
-			return "<span class='notice'>[html_encode(copytext_char(msg, 1, 37))]... <a href='?src=[REF(src)];flavor_more=1'>More...</span></a>"
-
-/mob/proc/print_flavor_text_2()
-	if(flavor_text && flavor_text != "")
-		// We are decoding and then encoding to not only get correct amount of characters, but also to prevent partial escaping characters being shown.
-		var/msg = html_decode(replacetext(flavor_text_2, "\n", " "))
-		if(length_char(msg) <= 40)
-			return "<span class='notice'>[html_encode(msg)]</span>"
-		else
-			return "<span class='notice'>[html_encode(copytext_char(msg, 1, 37))]... <a href='?src=[REF(src)];flavor2_more=1'>More...</span></a>"
-
 
 /mob/proc/get_top_level_mob()
 	if(istype(src.loc,/mob)&&src.loc!=src)
@@ -59,9 +13,6 @@ proc/get_top_level_mob(var/mob/S)
 		var/mob/M=S.loc
 		return M.get_top_level_mob()
 	return S
-
-
-
 
 ///////////////// EMOTE CODE
 // Maybe making this as an emote is less messy?


### PR DESCRIPTION
## About The Pull Request
I thought the flavor text maximum length of 2^12 was an oversight since the message maximum length was already 2^11 instead of the normal 2^10. Bhjin said it's intended to be so.
Also minor clean up of flavor text code.

## Why It's Good For The Game
This will close #11054.

## Changelog
:cl:
fix: Doubled the halved flavor text maximum length.
/:cl: