### PR TITLE
Reduced tongue organ damage and tasting pH message spam.

### DIFF
--- a/code/modules/mob/living/taste.dm
+++ b/code/modules/mob/living/taste.dm
@@ -16,21 +16,22 @@
 
 // non destructively tastes a reagent container
 /mob/living/proc/taste(datum/reagents/from)
-	if(last_taste_time + 50 < world.time)
-		var/taste_sensitivity = get_taste_sensitivity()
-		var/text_output = from.generate_taste_message(taste_sensitivity)
-		// We dont want to spam the same message over and over again at the
-		// person. Give it a bit of a buffer.
-		if(hallucination > 50 && prob(25))
-			text_output = pick("spiders","dreams","nightmares","the future","the past","victory",\
-			"defeat","pain","bliss","revenge","poison","time","space","death","life","truth","lies","justice","memory",\
-			"regrets","your soul","suffering","music","noise","blood","hunger","the american way")
-		if(text_output != last_taste_text || last_taste_time + 100 < world.time)
-			to_chat(src, "<span class='notice'>You can taste [text_output].</span>")
-			// "something indescribable" -> too many tastes, not enough flavor.
-
-			last_taste_time = world.time
-			last_taste_text = text_output
+	if(last_taste_time + 50 > world.time)
+		return FALSE
+	var/taste_sensitivity = get_taste_sensitivity()
+	var/text_output = from.generate_taste_message(taste_sensitivity)
+	// We dont want to spam the same message over and over again at the
+	// person. Give it a bit of a buffer.
+	if(hallucination > 50 && prob(25))
+		text_output = pick("spiders","dreams","nightmares","the future","the past","victory",\
+		"defeat","pain","bliss","revenge","poison","time","space","death","life","truth","lies","justice","memory",\
+		"regrets","your soul","suffering","music","noise","blood","hunger","the american way")
+	if(text_output != last_taste_text || last_taste_time + 100 < world.time)
+		to_chat(src, "<span class='notice'>You can taste [text_output].</span>")
+		// "something indescribable" -> too many tastes, not enough flavor.
+		last_taste_time = world.time
+		last_taste_text = text_output
+	return TRUE
 
 //FermiChem - How to check pH of a beaker without a meter/pH paper.
 //Basically checks the pH of the holder and burns your poor tongue if it's too acidic!
@@ -41,22 +42,24 @@
 	if (!T)
 		return
 	.=..()
+	if(!.)
+		return
 	if ((from.pH > 12.5) || (from.pH < 1.5))
-		to_chat(src, "<span class='warning'>You taste chemical burns!</span>")
 		T.applyOrganDamage(5)
+		to_chat(src, "<span class='warning'>You taste chemical burns!</span>")
 	if(istype(T, /obj/item/organ/tongue/cybernetic))
 		to_chat(src, "<span class='notice'>Your tongue moves on it's own in response to the liquid.</span>")
 		say("The pH is appropriately [round(from.pH, 1)].")
 		return
 	if (!HAS_TRAIT(src, TRAIT_AGEUSIA)) //I'll let you get away with not having 1 damage.
 		switch(from.pH)
-			if(11.5 to INFINITY)
+			if(11.5 to 12.5)
 				to_chat(src, "<span class='warning'>You taste a strong alkaline flavour!</span>")
 			if(8.5 to 11.5)
 				to_chat(src, "<span class='notice'>You taste a sort of soapy tone in the mixture.</span>")
 			if(2.5 to 5.5)
 				to_chat(src, "<span class='notice'>You taste a sort of acid tone in the mixture.</span>")
-			if(-INFINITY to 2.5)
+			if(1.5 to 2.5)
 				to_chat(src, "<span class='warning'>You taste a strong acidic flavour!</span>")
 
 #undef DEFAULT_TASTE_SENSITIVITY

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -39,14 +39,7 @@
 	languages_possible = languages_possible_base
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args)
-
-/obj/item/organ/tongue/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	if(organ_flags & ORGAN_SYNTHETIC)
-		var/errormessage = list("Runtime in tongue.dm, line 39: Undefined operation \"zapzap ow my tongue\"", "afhsjifksahgjkaslfhashfjsak", "-1.#IND", "Graham's number", "inside you all along", "awaiting at least 1 approving review before merging this taste request")
-		owner.say("The pH is appropriately [pick(errormessage)].", forced = "EMPed synthetic tongue")
+	return
 
 /obj/item/organ/tongue/applyOrganDamage(d, maximum = maxHealth)
 	. = ..()
@@ -301,6 +294,13 @@
 	taste_sensitivity = 10
 	maxHealth = 60 //It's robotic!
 	organ_flags = ORGAN_SYNTHETIC
+
+/obj/item/organ/tongue/cybernetic/emp_act(severity)
+	. = ..()
+	if(. & EMP_PROTECT_SELF)
+		return
+	var/errormessage = list("Runtime in tongue.dm, line 39: Undefined operation \"zapzap ow my tongue\"", "afhsjifksahgjkaslfhashfjsak", "-1.#IND", "Graham's number", "inside you all along", "awaiting at least 1 approving review before merging this taste request")
+	owner.say("The pH is appropriately [pick(errormessage)].", forced = "EMPed synthetic tongue")
 
 /obj/item/organ/tongue/cybernetic/handle_speech(datum/source, list/speech_args)
 	speech_args[SPEECH_SPANS] |= SPAN_ROBOT

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -30,6 +30,12 @@
 
 /obj/item/organ/tongue/Initialize(mapload)
 	. = ..()
+	low_threshold_passed = "<span class='info'>Your [name] feels a little sore.</span>"
+	low_threshold_cleared = "<span class='info'>Your [name] soreness subsides.</span>"
+	high_threshold_passed = "<span class='warning'>Your [name] is really starting to hurt.</span>"
+	high_threshold_cleared = "<span class='info'>The pain of your [name] subsides a little.</span>"
+	now_failing = "<span class='warning'>Your [name] feels like it's about to fall out!.</span>"
+	now_fixed = "<span class='info'>The excruciating pain of your [name] subsides.</span>"
 	languages_possible = languages_possible_base
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args)
@@ -40,7 +46,7 @@
 		return
 	if(organ_flags & ORGAN_SYNTHETIC)
 		var/errormessage = list("Runtime in tongue.dm, line 39: Undefined operation \"zapzap ow my tongue\"", "afhsjifksahgjkaslfhashfjsak", "-1.#IND", "Graham's number", "inside you all along", "awaiting at least 1 approving review before merging this taste request")
-		owner.say("The pH is appropriately [pick(errormessage)].")
+		owner.say("The pH is appropriately [pick(errormessage)].", forced = "EMPed synthetic tongue")
 
 /obj/item/organ/tongue/applyOrganDamage(var/d, var/maximum = maxHealth)
 
@@ -58,11 +64,6 @@
 		to_chat(owner, "<span class='userdanger'>Your tongue is singed beyond recognition, and disintegrates!</span>")
 		SSblackbox.record_feedback("tally", "fermi_chem", 1, "Tongues lost to Fermi")
 		qdel(src)
-	else if ((damage / maxHealth) > 0.85)
-		to_chat(owner, "<span class='warning'>Your tongue feels like it's about to fall out!.</span>")
-	else if ((damage / maxHealth) > 0.5)
-		to_chat(owner, "<span class='notice'>Your tongue is really starting to hurt.</span>")
-
 
 /obj/item/organ/tongue/Insert(mob/living/carbon/M, special = 0, drop_if_replaced = TRUE)
 	..()

--- a/code/modules/surgery/organs/tongue.dm
+++ b/code/modules/surgery/organs/tongue.dm
@@ -31,11 +31,11 @@
 /obj/item/organ/tongue/Initialize(mapload)
 	. = ..()
 	low_threshold_passed = "<span class='info'>Your [name] feels a little sore.</span>"
-	low_threshold_cleared = "<span class='info'>Your [name] soreness subsides.</span>"
+	low_threshold_cleared = "<span class='info'>Your [name] soreness has subsided.</span>"
 	high_threshold_passed = "<span class='warning'>Your [name] is really starting to hurt.</span>"
-	high_threshold_cleared = "<span class='info'>The pain of your [name] subsides a little.</span>"
+	high_threshold_cleared = "<span class='info'>The pain of your [name] has subsided a little.</span>"
 	now_failing = "<span class='warning'>Your [name] feels like it's about to fall out!.</span>"
-	now_fixed = "<span class='info'>The excruciating pain of your [name] subsides.</span>"
+	now_fixed = "<span class='info'>The excruciating pain of your [name] has subsided.</span>"
 	languages_possible = languages_possible_base
 
 /obj/item/organ/tongue/proc/handle_speech(datum/source, list/speech_args)
@@ -48,19 +48,9 @@
 		var/errormessage = list("Runtime in tongue.dm, line 39: Undefined operation \"zapzap ow my tongue\"", "afhsjifksahgjkaslfhashfjsak", "-1.#IND", "Graham's number", "inside you all along", "awaiting at least 1 approving review before merging this taste request")
 		owner.say("The pH is appropriately [pick(errormessage)].", forced = "EMPed synthetic tongue")
 
-/obj/item/organ/tongue/applyOrganDamage(var/d, var/maximum = maxHealth)
-
-	if(!d) //Micro-optimization.
-		return
-	if(maximum < damage)
-		return
-	damage = CLAMP(damage + d, 0, maximum)
-	var/mess = check_damage_thresholds(owner)
-	prev_damage = damage
-	if(mess && owner)
-		to_chat(owner, mess)
-
-	if ((damage / maxHealth) > 1)
+/obj/item/organ/tongue/applyOrganDamage(d, maximum = maxHealth)
+	. = ..()
+	if (damage >= maxHealth)
 		to_chat(owner, "<span class='userdanger'>Your tongue is singed beyond recognition, and disintegrates!</span>")
 		SSblackbox.record_feedback("tally", "fermi_chem", 1, "Tongues lost to Fermi")
 		qdel(src)


### PR DESCRIPTION
## About The Pull Request
Title. Organ decay won't be so insufferable now. Idem for tasting acidic and basic reagents.
Also moving the (synthetic) tongue emp_act() effect to tongue/cybernetic for consistency since it's the only tongue that actually reports the pH of tasted food.

## Why It's Good For The Game
Removing some nuisances.

## Changelog
:cl:
fix: Reduced tongue organ damage and tasting pH message spam.
/:cl:
