### PR TITLE
hey someone gave me this idea for stunbatons (and I sort of expanded it) and it's worth a test

### DIFF
--- a/code/game/objects/items/balls.dm
+++ b/code/game/objects/items/balls.dm
@@ -20,7 +20,7 @@
 	throw_range = 14
 	w_class = WEIGHT_CLASS_SMALL
 
-/obj/item/toy/tennis/pre_altattackby(atom/A, mob/living/user, params)	//checks if it can do right click memes
+/obj/item/toy/tennis/alt_pre_attack(atom/A, mob/living/user, params)	//checks if it can do right click memes
 	altafterattack(A, user, TRUE, params)
 	return TRUE
 

--- a/code/game/objects/items/melee/energy.dm
+++ b/code/game/objects/items/melee/energy.dm
@@ -259,7 +259,7 @@
 	light_color = "#37FFF7"
 	actions_types = list()
 
-/obj/item/melee/transforming/energy/sword/cx/pre_altattackby(atom/A, mob/living/user, params)	//checks if it can do right click memes
+/obj/item/melee/transforming/energy/sword/cx/alt_pre_attack(atom/A, mob/living/user, params)	//checks if it can do right click memes
 	altafterattack(A, user, TRUE, params)
 	return TRUE
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -15,12 +15,16 @@
 	attack_verb = list("beaten")
 	armor = list("melee" = 0, "bullet" = 0, "laser" = 0, "energy" = 0, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 80, "acid" = 80)
 
-	var/stunforce = 70
+	var/stamforce = 25
 	var/status = FALSE
 	var/obj/item/stock_parts/cell/cell
 	var/hitcost = 1000
 	var/throw_hit_chance = 35
 	var/preload_cell_type //if not empty the baton starts with this type of cell
+
+/obj/item/melee/baton/examine(mob/user)
+	. = ..()
+	. += "<span class='notice'>Right click attack while in combat mode to disarm instead of stun.</span>"
 
 /obj/item/melee/baton/get_cell()
 	. = cell
@@ -32,7 +36,7 @@
 	user.visible_message("<span class='suicide'>[user] is putting the live [name] in [user.p_their()] mouth! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (FIRELOSS)
 
-/obj/item/melee/baton/Initialize()
+/obj/item/melee/baton/Initialize(mapload)
 	. = ..()
 	if(preload_cell_type)
 		if(!ispath(preload_cell_type,/obj/item/stock_parts/cell))
@@ -134,44 +138,40 @@
 	add_fingerprint(user)
 
 /obj/item/melee/baton/attack(mob/M, mob/living/carbon/human/user)
+	var/interrupt = common_baton_melee(M, user, FALSE)
+	if(!interrupt)
+		..()
+
+/obj/item/melee/baton/alt_pre_attack(atom/A, mob/living/user, params)
+	. = common_baton_melee(M, user, TRUE)		//return true (attackchain interrupt) if this also returns true. no harm-disarming.
+
+//return TRUE to interrupt attack chain.
+/obj/item/melee/baton/proc/common_baton_melee(mob/M, mob/living/user, disarming = FALSE)
+	if(iscyborg(M) || !isliving(M))		//can't baton cyborgs
+		return FALSE
 	if(status && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
 		clowning_around(user)
-		return
-
-	if(user.getStaminaLoss() >= STAMINA_SOFTCRIT)//CIT CHANGE - makes it impossible to baton in stamina softcrit
-		to_chat(user, "<span class='danger'>You're too exhausted for that.</span>")//CIT CHANGE - ditto
-		return //CIT CHANGE - ditto
-
-	if(iscyborg(M))
-		..()
-		return
-
-
+	if(user.getStaminaLoss() >= STAMINA_SOFTCRIT)			//CIT CHANGE - makes it impossible to baton in stamina softcrit
+		to_chat(user, "<span class='danger'>You're too exhausted for that.</span>")
+		return TRUE
 	if(ishuman(M))
 		var/mob/living/carbon/human/L = M
 		if(check_martial_counter(L, user))
-			return
+			return TRUE
+	if(status)
+		if(baton_stun(M, user, disarming))
+			user.do_attack_animation(M)
+			user.adjustStaminaLossBuffered(getweight())		//CIT CHANGE - makes stunbatonning others cost stamina
+	else if(user.a_intent != INTENT_HARM)			//they'll try to bash in the last proc.
+		M.visible_message("<span class='warning'>[user] has prodded [M] with [src]. Luckily it was off.</span>", \
+						"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
+	return disarming || (user.a_intent != INTENT_HARM)
 
-	if(user.a_intent != INTENT_HARM)
-		if(status)
-			if(baton_stun(M, user))
-				user.do_attack_animation(M)
-				user.adjustStaminaLossBuffered(getweight())//CIT CHANGE - makes stunbatonning others cost stamina
-				return
-		else
-			M.visible_message("<span class='warning'>[user] has prodded [M] with [src]. Luckily it was off.</span>", \
-							"<span class='warning'>[user] has prodded you with [src]. Luckily it was off</span>")
-	else
-		if(status)
-			baton_stun(M, user)
-		..()
-
-
-/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user)
+/obj/item/melee/baton/proc/baton_stun(mob/living/L, mob/user, disarming = FALSE)
 	if(L.check_shields(src, 0, "[user]'s [name]", MELEE_ATTACK)) //No message; check_shields() handles that
 		playsound(L, 'sound/weapons/genhit.ogg', 50, 1)
 		return FALSE
-	var/stunpwr = stunforce
+	var/stunpwr = stamforce
 	var/obj/item/stock_parts/cell/our_cell = get_cell()
 	if(!our_cell)
 		switch_status(FALSE)
@@ -187,17 +187,19 @@
 			return FALSE
 		stunpwr *= round(stuncharge/hitcost, 0.1)
 
-
-	L.Knockdown(stunpwr, override_stamdmg = 0)
-	L.apply_damage(stunpwr*0.5, STAMINA, user.zone_selected)
-	L.apply_effect(EFFECT_STUTTER, stunforce)
+	if(!disarming)
+		L.Knockdown(100, override_stamdmg = 0)		//knockdown
+		L.adjustStaminaLoss(stunpwr)
+	else
+		L.drop_all_held_items()					//no knockdown/stamina damage, instead disarm.
+	L.apply_effect(EFFECT_STUTTER, stamforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)
 		L.lastattacker = user.real_name
 		L.lastattackerckey = user.ckey
-		L.visible_message("<span class='danger'>[user] has stunned [L] with [src]!</span>", \
-								"<span class='userdanger'>[user] has stunned you with [src]!</span>")
-		log_combat(user, L, "stunned")
+		L.visible_message("<span class='danger'>[user] has [disarming? "disarmed" : "stunned"] [L] with [src]!</span>", \
+								"<span class='userdanger'>[user] has [disarming? "disarmed" : "stunned"] you with [src]!</span>")
+		log_combat(user, L, disarming? "disarmed" : "stunned")
 
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -190,7 +190,7 @@
 
 	if(!disarming)
 		if(knockdown)
-			L.Knockdown(100, override_stamdmg = 0)		//knockdown
+			L.Knockdown(50, override_stamdmg = 0)		//knockdown
 		L.adjustStaminaLoss(stunpwr)
 	else
 		L.drop_all_held_items()					//no knockdown/stamina damage, instead disarm.

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -144,7 +144,8 @@
 		..()
 
 /obj/item/melee/baton/alt_pre_attack(atom/A, mob/living/user, params)
-	return common_baton_melee(A, user, TRUE)		//return true (attackchain interrupt) if this also returns true. no harm-disarming.
+	. = common_baton_melee(A, user, TRUE)		//return true (attackchain interrupt) if this also returns true. no harm-disarming.
+	user.changeNext_move(CLICK_CD_MELEE)
 
 //return TRUE to interrupt attack chain.
 /obj/item/melee/baton/proc/common_baton_melee(mob/M, mob/living/user, disarming = FALSE)
@@ -194,6 +195,7 @@
 		L.adjustStaminaLoss(stunpwr)
 	else
 		L.drop_all_held_items()					//no knockdown/stamina damage, instead disarm.
+	
 	L.apply_effect(EFFECT_STUTTER, stamforce)
 	SEND_SIGNAL(L, COMSIG_LIVING_MINOR_SHOCK)
 	if(user)

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -17,8 +17,9 @@
 
 	var/stamforce = 25
 	var/status = FALSE
+	var/knockdown = TRUE
 	var/obj/item/stock_parts/cell/cell
-	var/hitcost = 1000
+	var/hitcost = 750
 	var/throw_hit_chance = 35
 	var/preload_cell_type //if not empty the baton starts with this type of cell
 
@@ -52,7 +53,7 @@
 		baton_stun(hit_atom)
 
 /obj/item/melee/baton/loaded //this one starts with a cell pre-installed.
-	preload_cell_type = /obj/item/stock_parts/cell/high
+	preload_cell_type = /obj/item/stock_parts/cell/high/plus
 
 /obj/item/melee/baton/proc/deductcharge(chrgdeductamt, chargecheck = TRUE, explode = TRUE)
 	var/obj/item/stock_parts/cell/copper_top = get_cell()
@@ -143,7 +144,7 @@
 		..()
 
 /obj/item/melee/baton/alt_pre_attack(atom/A, mob/living/user, params)
-	. = common_baton_melee(M, user, TRUE)		//return true (attackchain interrupt) if this also returns true. no harm-disarming.
+	return common_baton_melee(A, user, TRUE)		//return true (attackchain interrupt) if this also returns true. no harm-disarming.
 
 //return TRUE to interrupt attack chain.
 /obj/item/melee/baton/proc/common_baton_melee(mob/M, mob/living/user, disarming = FALSE)
@@ -188,7 +189,8 @@
 		stunpwr *= round(stuncharge/hitcost, 0.1)
 
 	if(!disarming)
-		L.Knockdown(100, override_stamdmg = 0)		//knockdown
+		if(knockdown)
+			L.Knockdown(100, override_stamdmg = 0)		//knockdown
 		L.adjustStaminaLoss(stunpwr)
 	else
 		L.drop_all_held_items()					//no knockdown/stamina damage, instead disarm.
@@ -214,7 +216,7 @@
 	user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 						"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
 	SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
-	user.Knockdown(stunforce*3)
+	user.Knockdown(stamforce*6)
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 	deductcharge(hitcost)
 
@@ -276,8 +278,9 @@
 	w_class = WEIGHT_CLASS_BULKY
 	force = 3
 	throwforce = 5
-	stunforce = 60
-	hitcost = 2000
+	stamforce = 25
+	hitcost = 1000
+	knockdown = FALSE
 	throw_hit_chance = 10
 	slot_flags = ITEM_SLOT_BACK
 	var/obj/item/assembly/igniter/sparkler

--- a/code/game/objects/items/teleprod.dm
+++ b/code/game/objects/items/teleprod.dm
@@ -16,7 +16,7 @@
 	user.visible_message("<span class='danger'>[user] accidentally hits [user.p_them()]self with [src]!</span>", \
 						"<span class='userdanger'>You accidentally hit yourself with [src]!</span>")
 	SEND_SIGNAL(user, COMSIG_LIVING_MINOR_SHOCK)
-	user.Knockdown(stunforce*3)
+	user.Knockdown(stamforce * 6)
 	playsound(loc, 'sound/weapons/egloves.ogg', 50, 1, -1)
 	if(do_teleport(user, get_turf(user), 50, channel = TELEPORT_CHANNEL_BLUESPACE))
 		deductcharge(hitcost)

--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -289,7 +289,7 @@
 	var/light_brightness = 3
 	actions_types = list()
 
-/obj/item/toy/sword/cx/pre_altattackby(atom/A, mob/living/user, params)	//checks if it can do right click memes
+/obj/item/toy/sword/cx/alt_pre_attack(atom/A, mob/living/user, params)	//checks if it can do right click memes
 	altafterattack(A, user, TRUE, params)
 	return TRUE
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -510,7 +510,7 @@
 /obj/item/twohanded/dualsaber/hypereutactic/chaplain/IsReflect()
 	return FALSE
 
-/obj/item/twohanded/dualsaber/hypereutactic/pre_altattackby(atom/A, mob/living/user, params)	//checks if it can do right click memes
+/obj/item/twohanded/dualsaber/hypereutactic/alt_pre_attack(atom/A, mob/living/user, params)	//checks if it can do right click memes
 	altafterattack(A, user, TRUE, params)
 	return TRUE
 

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -528,8 +528,8 @@
 		if(B.cell)
 			if(B.cell.charge > 0 && B.status == 1)
 				flick("baton_active", src)
-				var/stunforce = B.stunforce
-				user.Knockdown(stunforce)
+				var/stunforce = B.stamforce
+				user.Knockdown(stunforce * 2)
 				user.stuttering = stunforce/20
 				B.deductcharge(B.hitcost)
 				user.visible_message("<span class='warning'>[user] shocks [user.p_them()]self while attempting to wash the active [B.name]!</span>", \

--- a/code/modules/reagents/reagent_containers/rags.dm
+++ b/code/modules/reagents/reagent_containers/rags.dm
@@ -52,7 +52,7 @@
 			SEND_SIGNAL(A, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_MEDIUM)
 	return
 
-/obj/item/reagent_containers/rag/pre_altattackby(mob/living/M, mob/living/user, params)
+/obj/item/reagent_containers/rag/alt_pre_attack(mob/living/M, mob/living/user, params)
 	if(istype(M) && user.a_intent == INTENT_HELP)
 		user.changeNext_move(CLICK_CD_MELEE)
 		if(M.on_fire)

--- a/modular_citadel/code/_onclick/item_attack.dm
+++ b/modular_citadel/code/_onclick/item_attack.dm
@@ -1,12 +1,12 @@
 /obj/item/proc/rightclick_melee_attack_chain(mob/user, atom/target, params)
-	if(!pre_altattackby(target, user, params)) //Hey, does this item have special behavior that should override all normal right-click functionality?
+	if(!alt_pre_attack(target, user, params)) //Hey, does this item have special behavior that should override all normal right-click functionality?
 		if(!target.altattackby(src, user, params)) //Does the target do anything special when we right-click on it?
 			melee_attack_chain(user, target, params) //Ugh. Lame! I'm filing a legal complaint about the discrimination against the right mouse button!
 		else
 			altafterattack(target, user, TRUE, params)
 	return
 
-/obj/item/proc/pre_altattackby(atom/A, mob/living/user, params)
+/obj/item/proc/alt_pre_attack(atom/A, mob/living/user, params)
 	return FALSE //return something other than false if you wanna override attacking completely
 
 /atom/proc/altattackby(obj/item/W, mob/user, params)


### PR DESCRIPTION
## About The Pull Request

Baton stamina damage reduced to 25 down from 35 when stunning and knocking down. 
**This means a 5 hit stamcrit, up from 3.** (100/25 round up by 1 for regen vs 100/35 round up) 
**Guns are being made unable to be used while in soft stamcrit in another PR. Same with cult stuns and whatever else gets brought up as Bhijn has said that they were infact unintentional.**
Batons by default now get a high capacity + cell and 750 hitcost.
For the sake of math, this is a total stamina damage of ~500 (up from 350 before this PR) with default cells. This also restores (see below) the 2:1 stunbaton:stunprod efficiency. Only stunprods lost knockdown soooo :^) don't know if that's going to turn out better or worse.
Batons are now able to force disarm again but only when used in right click, and **using it in right click does not knock down or do stamina damage.**
clowning around (clumsy hitting yourself) now hits a bit harder again. clown nerf clown nerf 🤡 

Stunprods are the same in everything including damage but 1000 hitcost instead of 750 without knockdown. Open to making it knockdown with less damage (but seriously how less can you get than 25 lmao)
Mathematically: stunprods now get from a 10k cell (because where are assistants getting anything else (^:) 250 stam damage total vs the old 150. Open to buffing this a bit too because shame on you tupin for nerfing the greytide.  😞 

Limb specific damage is gone. Requiring limb targeting is stupid.

## Why It's Good For The Game

Gives security their disarms back with some method of outplaying it (no stunning + disarming at the same time).
I can already see this being either too powerful due to sec players having twitch reflexes or the low delay meaning you can immediately knockdown afterwards/pick their weapon up, or too weak due to the other side having the same reflexes and killing you before you can knock them down again but it's worth a try.
I can also see complaints that the stunforce is a bit low (it is somewhat of a reduction, you can now only hard stamcrit 3 people or soft stamcrit 4) and it can be raised if this turns out to work like shit.

Raising capacity and balancing around 15k also reduces the balance issue of "40k bluespace cell". That said, it'll also make charged slime cores a slight bit weaker so.. oof, but the charge rate on those is pretty powerful so who knows how that'll play out.

Also y'all nerfed stunprods too hard, yikes. Maybe I'm nerfing it harder with no knockdown though, so give comments below.

## Changelog
:cl:
balance: Stunbatons changed yet again.
/:cl:
