### PR TITLE
Makes the valentines chocolates no longer rule 9 bait

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_other.dm
+++ b/code/modules/food_and_drinks/food/snacks_other.dm
@@ -549,7 +549,7 @@
 	name = "chocolate"
 	desc = "A tiny and sweet chocolate. Has a 'strawberry' filling!"
 	icon_state = "tiny_chocolate"
-	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/coco = 1, /datum/reagent/drug/aphrodisiac = 1)
+	list_reagents = list(/datum/reagent/consumable/nutriment = 1, /datum/reagent/consumable/sugar = 1, /datum/reagent/consumable/coco = 1)
 	filling_color = "#A0522D"
 	tastes = list("chocolate" = 1)
 	foodtype = JUNKFOOD | SUGAR


### PR DESCRIPTION

## About The Pull Request

less than a one line change to remove aphrodisiacs from a candy

## Why It's Good For The Game

Literally everyone spawning with **actual** roofied chocolates is pretty big Rule 9 bait.
 
## Changelog
:cl:
fix: valentines candy no longer prefbreaks
/:cl:

