### PR TITLE
purifying longswords - alt title "there's no way this should have worked"

### DIFF
--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -188,9 +188,8 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 					SS.release_shades(user)
 					qdel(SS)
 				new /obj/item/nullrod/claymore(get_turf(A))
-				user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
-				qdel(A)
-			new /obj/item/claymore/purified(get_turf(A))
+			else
+				new /obj/item/claymore/purified(get_turf(A))
 			user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
 			qdel(A)
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -173,22 +173,24 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 			var/unholy2clean = A.reagents.get_reagent_amount(/datum/reagent/fuel/unholywater)
 			A.reagents.del_reagent(/datum/reagent/fuel/unholywater)
 			A.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
-	if(istype(A, /obj/item/twohanded/required/cult_bastard) && !iscultist(user))
-		var/obj/item/twohanded/required/cult_bastard/sword = A
+	if(istype(A, /obj/item/twohanded/required/cult_bastard) || istype(A, /obj/item/melee/cultblade) && !iscultist(user))
+		var/isbastardsword = FALSE
+		var/obj/item/sword = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [sword].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
 		if(do_after(user, 40, target = sword))
 			playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
-			for(var/obj/item/soulstone/SS in sword.contents)
-				SS.usability = TRUE
-				for(var/mob/living/simple_animal/shade/EX in SS)
-					SSticker.mode.remove_cultist(EX.mind, 1, 0)
-					EX.icon_state = "ghost1"
-					EX.name = "Purified [EX.name]"
-				SS.release_shades(user)
-				qdel(SS)
+			if(isbastardsword)
+				for(var/obj/item/soulstone/SS in sword.contents)
+					SS.usability = TRUE
+					for(var/mob/living/simple_animal/shade/EX in SS)
+						SSticker.mode.remove_cultist(EX.mind, 1, 0)
+						EX.icon_state = "ghost1"
+						EX.name = "Purified [EX.name]"
+					SS.release_shades(user)
+					qdel(SS)
 			new /obj/item/nullrod/claymore(get_turf(sword))
-			user.visible_message("<span class='notice'>[user] has purified the [sword]!</span>")
+			user.visible_message("<span class='notice'>[user] has purified [sword]!</span>")
 			qdel(sword)
 
 	else if(istype(A, /obj/item/soulstone) && !iscultist(user))

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -190,7 +190,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 				new /obj/item/nullrod/claymore(get_turf(A))
 				user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
 				qdel(A)
-			new /obj/item/claymore(get_turf(A))
+			new /obj/item/claymore/purified(get_turf(A))
 			user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
 			qdel(A)
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -174,7 +174,7 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 			A.reagents.del_reagent(/datum/reagent/fuel/unholywater)
 			A.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
 	if(istype(A, /obj/item/twohanded/required/cult_bastard) || istype(A, /obj/item/melee/cultblade) && !iscultist(user))
-		to_chat(user, "<span class='notice'>You begin to exorcise [sword].</span>")
+		to_chat(user, "<span class='notice'>You begin to exorcise [A].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
 		if(do_after(user, 40, target = A))
 			playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
@@ -187,9 +187,9 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 						EX.name = "Purified [EX.name]"
 					SS.release_shades(user)
 					qdel(SS)
-			new /obj/item/nullrod/claymore(get_turf(sword))
-			user.visible_message("<span class='notice'>[user] has purified [sword]!</span>")
-			qdel(sword)
+			new /obj/item/nullrod/claymore(get_turf(A))
+			user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
+			qdel(A)
 
 	else if(istype(A, /obj/item/soulstone) && !iscultist(user))
 		var/obj/item/soulstone/SS = A

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -187,7 +187,10 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 						EX.name = "Purified [EX.name]"
 					SS.release_shades(user)
 					qdel(SS)
-			new /obj/item/nullrod/claymore(get_turf(A))
+				new /obj/item/nullrod/claymore(get_turf(A))
+				user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
+				qdel(A)
+			new /obj/item/claymore(get_turf(A))
 			user.visible_message("<span class='notice'>[user] has purified [A]!</span>")
 			qdel(A)
 

--- a/code/game/objects/items/storage/book.dm
+++ b/code/game/objects/items/storage/book.dm
@@ -174,14 +174,12 @@ GLOBAL_LIST_INIT(bibleitemstates, list("bible", "koran", "scrapbook", "bible",  
 			A.reagents.del_reagent(/datum/reagent/fuel/unholywater)
 			A.reagents.add_reagent(/datum/reagent/water/holywater,unholy2clean)
 	if(istype(A, /obj/item/twohanded/required/cult_bastard) || istype(A, /obj/item/melee/cultblade) && !iscultist(user))
-		var/isbastardsword = FALSE
-		var/obj/item/sword = A
 		to_chat(user, "<span class='notice'>You begin to exorcise [sword].</span>")
 		playsound(src,'sound/hallucinations/veryfar_noise.ogg',40,1)
-		if(do_after(user, 40, target = sword))
+		if(do_after(user, 40, target = A))
 			playsound(src,'sound/effects/pray_chaplain.ogg',60,1)
-			if(isbastardsword)
-				for(var/obj/item/soulstone/SS in sword.contents)
+			if(istype(A, /obj/item/twohanded/required/cult_bastard))
+				for(var/obj/item/soulstone/SS in A.contents)
 					SS.usability = TRUE
 					for(var/mob/living/simple_animal/shade/EX in SS)
 						SSticker.mode.remove_cultist(EX.mind, 1, 0)

--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -79,6 +79,11 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	user.visible_message("<span class='suicide'>[user] is falling on [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return(BRUTELOSS)
 
+/obj/item/claymore/purified
+	name = "purified longsword"
+	desc = "A hastily-purified longsword. While not as holy as it could be, it's still a formidable weapon against those who would rather see you dead."
+	force = 25
+
 /obj/item/claymore/highlander //ALL COMMENTS MADE REGARDING THIS SWORD MUST BE MADE IN ALL CAPS
 	desc = "<b><i>THERE CAN BE ONLY ONE, AND IT WILL BE YOU!!!</i></b>\nActivate it in your hand to point to the nearest victim."
 	flags_1 = CONDUCT_1


### PR DESCRIPTION
## About The Pull Request
allows purifying eldritch longswords like you could bloody bastard swords
(it makes a purified longsword which has 25 force and other claymore stats)
## Why It's Good For The Game
allows the new strat of dabbing on cultists by purifying their swords and then using those to beat the shit out of them
## Changelog
:cl:
balance: You can now purify eldritch longswords with a bible. This creates purified longswords, which do not have anti-magic properties, but are still good for swinging at cultists.
/:cl: