### PR TITLE
Something about a PR, simple mathematical expressions and SSmobs wait value.

### DIFF
--- a/code/__DEFINES/DNA.dm
+++ b/code/__DEFINES/DNA.dm
@@ -138,8 +138,8 @@
 
 ////organ defines
 #define STANDARD_ORGAN_THRESHOLD 	100
-#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / 1 SECONDS))
-#define STANDARD_ORGAN_DECAY		(1/(15 MINUTES / 1 SECONDS))		//designed to fail organs when left to decay for ~15 minutes. 1 SECOND is SSmobs tickrate.
+#define STANDARD_ORGAN_HEALING 		(1/(15 MINUTES / (2 SECONDS)))
+#define STANDARD_ORGAN_DECAY		(1/(15 MINUTES / (2 SECONDS)))		//designed to fail organs when left to decay for ~15 minutes. 2 SECOND is SSmobs tickrate.
 
 #define G_MALE 1
 #define G_FEMALE 2


### PR DESCRIPTION
## About The Pull Request 
Adding a missing bracket which leads to the expression being `1/(15 * 10 * 60 / 1 * 10)` instead of `1/(15 * 10 * 60 / (1 * 10))`.
Also SSmobs.wait is 20 (standard controller subsystem value), not 10. Can't use SSmobs.wait in the define because the define is used in typepaths not constant variables

## Why It's Good For The Game
Sometimes we realize mistakes were made a bit too late.

## Changelog
None. PR was merged just a dozen minutes ago