### PR TITLE
cosmic winter coat now glows like the bed sheet and can hold normal winter coat gear

### DIFF
--- a/code/modules/clothing/suits/miscellaneous.dm
+++ b/code/modules/clothing/suits/miscellaneous.dm
@@ -703,8 +703,9 @@
 	name = "cosmic winter coat"
 	icon_state = "coatcosmic"
 	item_state = "coatcosmic"
-	allowed = list(/obj/item/flashlight)
 	hoodtype = /obj/item/clothing/head/hooded/winterhood/cosmic
+	light_power = 1.8
+	light_range = 1.2
 
 /obj/item/clothing/head/hooded/winterhood/cosmic
 	icon_state = "winterhood_cosmic"


### PR DESCRIPTION
## About The Pull Request

The cosmic winter coat now shines a little less but simular to the bed sheet its crafted from.
The cosmic winter coat can now hold lights and cigs as well as air tanks just as a normal coat allows

## Why It's Good For The Game

The craft only winter coat, is now not a downgrade of both the bedsheet it takes and the coat it takes to make. This also allows its users to not have to only hold a flashlight in on the coat, but air and lights as well

## Changelog
:cl:
tweak: Cosmic winter coat now glows like the bedsheet, and holds normal winter coat gear
/:cl:
