### PR TITLE
Nuke ops deployable turrets!

### DIFF
--- a/code/game/machinery/porta_turret/portable_turret.dm
+++ b/code/game/machinery/porta_turret/portable_turret.dm
@@ -692,7 +692,6 @@
 	lethal_projectile_sound = 'sound/weapons/laser.ogg'
 	desc = "An energy blaster auto-turret."
 
-
 /obj/machinery/porta_turret/syndicate/energy/heavy
 	icon_state = "standard_stun"
 	base_icon_state = "standard"
@@ -708,7 +707,6 @@
 	max_integrity = 260
 	integrity_failure = 20
 	armor = list("melee" = 50, "bullet" = 30, "laser" = 30, "energy" = 30, "bomb" = 50, "bio" = 0, "rad" = 0, "fire" = 90, "acid" = 90)
-
 
 /obj/machinery/porta_turret/syndicate/setup()
 	return
@@ -739,6 +737,32 @@
 		addtimer(CALLBACK(src, .proc/shootAt, target), 10)
 		addtimer(CALLBACK(src, .proc/shootAt, target), 15)
 		return TRUE
+
+/obj/machinery/porta_turret/syndicate/turret_c10mm
+	density = FALSE
+	integrity_failure = 20
+	max_integrity = 80
+	shot_delay = 2
+	scan_range = 10 //So it can shoot people in full screen mode
+	stun_projectile = /obj/item/projectile/bullet/c10mm
+	lethal_projectile = /obj/item/projectile/bullet/c10mm
+
+/obj/machinery/porta_turret/syndicate/turret_c10mm/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
+
+/obj/machinery/porta_turret/syndicate/turret_45
+	density = FALSE
+	integrity_failure = 20
+	max_integrity = 80
+	shot_delay = 2
+	scan_range = 10 //So it can shoot people in full screen mode
+	stun_projectile = /obj/item/projectile/bullet/c45
+	lethal_projectile = /obj/item/projectile/bullet/c45_nostamina
+
+obj/machinery/porta_turret/syndicate/turret_45/ComponentInitialize()
+	. = ..()
+	AddComponent(/datum/component/empprotection, EMP_PROTECT_WIRES)
 
 /obj/machinery/porta_turret/ai
 	faction = list("silicon")

--- a/code/game/machinery/syndicatebeacon.dm
+++ b/code/game/machinery/syndicatebeacon.dm
@@ -162,4 +162,13 @@ GLOBAL_VAR_INIT(singularity_counter, 0)
 	desc = "A label on it reads: <i>Warning: Activating this device will send a silly explosive to your location</i>."
 	droptype = /obj/machinery/syndicatebomb/badmin/clown
 
+/obj/item/sbeacondrop/turret_10mm
+	desc = "A label on it reads: <i>Warning: Activating this device will send a active 10mm turret</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/turret_c10mm
+
+/obj/item/sbeacondrop/turret_45
+	desc = "A label on it reads: <i>Warning: Activating this device will send a active .45 turret</i>."
+	droptype = /obj/machinery/porta_turret/syndicate/turret_45
+
+
 #undef METEOR_DISASTER_MODIFIER

--- a/code/modules/uplink/uplink_items/uplink_support.dm
+++ b/code/modules/uplink/uplink_items/uplink_support.dm
@@ -25,6 +25,22 @@
 	include_modes = list(/datum/game_mode/nuclear)
 	restricted = TRUE
 
+/datum/uplink_item/support/turret_10mm
+	name = "Deployable Turret (10mm)"
+	desc = "Place down a weak Turret on demand, useful for protecting the bomb or suppressive fire."
+	item = /obj/item/sbeacondrop/turret_10mm
+	cost = 20
+	include_modes = list(/datum/game_mode/nuclear)
+	restricted = TRUE
+
+/datum/uplink_item/support/turret_45
+	name = "Deployable Turret (.45)"
+	desc = "Place down a weak turret on demand, useful for protecting the bomb or suppressive fire."
+	cost = 20
+	item = /obj/item/sbeacondrop/turret_45
+	include_modes = list(/datum/game_mode/nuclear)
+	restricted = TRUE
+
 /datum/uplink_item/support/reinforcement/assault_borg
 	name = "Syndicate Assault Cyborg"
 	desc = "A cyborg designed and programmed for systematic extermination of non-Syndicate personnel. \


### PR DESCRIPTION
## About The Pull Request
Two new nuke ops only deployables!
a 10mm turret for 20 tc
a .45 turret for only 20 tc
Weaker then the agv turret and are rather slow to fire, but can make someone think twice before rushing at your entrenched area
.45 is set to none-lethal will use the stam draining rounds rather then the lethal caliber, useful if you ever can set it to non-lethal...
## Why It's Good For The Game
This should help Nukies deal with people rushing at them to steal the bomb and or defuse it once they leave, this also has the added affect of making small little get away moves like deploying a gun in the halls well running to give suppressive fire well you or a team mate heals/flees.

## Changelog
:cl:
add: Two new deployable turrets, one being .45 lethal and the other being 10mm for nuke ops.
/:cl: