### PR TITLE
Nerfs crafted switchblades

### DIFF
--- a/code/game/objects/items/weaponry.dm
+++ b/code/game/objects/items/weaponry.dm
@@ -346,8 +346,8 @@ for further reading, please see: https://github.com/tgstation/tgstation/pull/301
 	desc = "A concealable spring-loaded knife."
 	force = 2
 	throwforce = 3
-	extended_force = 15
-	extended_throwforce = 18
+	extended_force = 10
+	extended_throwforce = 10
 	extended_icon_state = "switchblade_ext_ms"
 	retracted_icon_state = "switchblade_ms"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

damage 15 --> 10
throwforce 18 --> 10
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

We're adding too many reliable improvised weapons. That, plus I realized giving people 15 damage tiny items as weapons when historically only stuff like nullrod and welders worked that way (welders don't bleed and have fuel, unless you have experimental welder or a super large capacity one) isn't the best idea. 
These were added for gangs. Stop powercreeping the shit out of nonantag improvised weapons.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Crafted switchblades are no longer 15 force.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
