### PR TITLE
Clarifies comments and locks defusal kits behind an emag

### DIFF
--- a/code/modules/cargo/packs.dm
+++ b/code/modules/cargo/packs.dm
@@ -2,7 +2,7 @@
 	var/name = "Crate"
 	var/group = ""
 	var/hidden = FALSE //Aka emag only
-	var/contraband = FALSE //Hacking the console with a multitool
+	var/contraband = FALSE //Requires a hacked console UNLESS DropPodOnly = TRUE, in which case it requires an emag
 	var/cost = 700 // Minimum cost, or infinite points are possible.
 	var/access = FALSE //What access does the Crate itself need?
 	var/access_any = FALSE //Do we care about access?

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -113,8 +113,7 @@
 	desc = "Contains set of tools to defuse a nuke."
 	cost = 7500 //Useful for traitors/nukies that fucked up
 	dangerous = TRUE
-	contraband = TRUE
-	DropPodOnly = TRUE
+	hidden = TRUE
 	contains = list(/obj/item/nuke_core_container/nt,
 					/obj/item/screwdriver/nuke/nt,
 					/obj/item/paper/guides/nt/nuke_instructions)

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -84,7 +84,7 @@
 
 /datum/supply_pack/science/glasswork
 	name = "Glass Blower Kit Crate"
-	desc = "Learn and make glassworks of usefull things for a profit! Contains glassworking tools and blowing rods. Glass not included."
+	desc = "Learn and make glassworks of useful things for a profit! Contains glassworking tools and blowing rods. Glass not included."
 	cost = 1000
 	contains = list(/obj/item/glasswork/glasskit,
 					/obj/item/glasswork/glasskit,
@@ -111,8 +111,9 @@
 /datum/supply_pack/science/nuke_b_gone
 	name = "Nuke Defusal Kit"
 	desc = "Contains set of tools to defuse a nuke."
-	cost = 7500 //Usefull for traitors/nukies that fucked up
+	cost = 7500 //Useful for traitors/nukies that fucked up
 	dangerous = TRUE
+	contraband = TRUE
 	DropPodOnly = TRUE
 	contains = list(/obj/item/nuke_core_container/nt,
 					/obj/item/screwdriver/nuke/nt,
@@ -194,7 +195,7 @@
 /datum/supply_pack/science/supermater
 	name = "Supermatter Extraction Tools Crate"
 	desc = "Contains a set of tools to extract a sliver of supermatter. Consult your CE today!"
-	cost = 7500 //Usefull for traitors that fucked up
+	cost = 7500 //Useful for traitors that fucked up
 	hidden = TRUE
 	contains = list(/obj/item/nuke_core_container/supermatter,
 					/obj/item/scalpel/supermatter,


### PR DESCRIPTION
## About The Pull Request

Clarifies comments regarding the contraband tag in Cargo pack code and makes the nuclear defusal kit require an emag to be purchased.

## Why It's Good For The Game

Who legitimately thought spammable defusal kits were a good idea?
Also, the comments included when this was added explicitly state this was intended for antags to purchase if they lose their own kit somehow...

## Changelog
:cl:
add: Better clarified the comment explaining the contraband tag.
tweak: Cargo nuclear defusal kits now require an emag'd drop pod console to be purchased.
spellcheck: fixed a few typos
/:cl: