### PR TITLE
Adds diethylamine and saltpetre to the biogenerator

### DIFF
--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -664,7 +664,7 @@
 		adjustHealth(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 1))
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 2))
 		if(myseed)
-			myseed.adjust_yield(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 0.02))
+			myseed.adjust_yield(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 0.034))
 		adjustPests(-rand(1,2))
 
 	// Nutriment Compost, effectively

--- a/code/modules/hydroponics/hydroponics.dm
+++ b/code/modules/hydroponics/hydroponics.dm
@@ -664,7 +664,7 @@
 		adjustHealth(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 1))
 		adjustNutri(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 2))
 		if(myseed)
-			myseed.adjust_yield(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 0.034))
+			myseed.adjust_yield(round(S.get_reagent_amount(/datum/reagent/diethylamine) * 0.02))
 		adjustPests(-rand(1,2))
 
 	// Nutriment Compost, effectively

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -112,6 +112,11 @@
 	desc = "A small bottle of diethylamine."
 	list_reagents = list(/datum/reagent/diethylamine = 30)
 
+/obj/item/reagent_containers/glass/bottle/saltpetre
+	name = "saltpetre bottle"
+	desc = "A small bottle of saltpetre."
+	list_reagents = list(/datum/reagent/saltpetre = 30)
+
 /obj/item/reagent_containers/glass/bottle/facid
 	name = "Fluorosulfuric Acid Bottle"
 	desc = "A small bottle. Contains a small amount of fluorosulfuric acid."

--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -112,11 +112,6 @@
 	desc = "A small bottle of diethylamine."
 	list_reagents = list(/datum/reagent/diethylamine = 30)
 
-/obj/item/reagent_containers/glass/bottle/saltpetre
-	name = "saltpetre bottle"
-	desc = "A small bottle of saltpetre."
-	list_reagents = list(/datum/reagent/saltpetre = 30)
-
 /obj/item/reagent_containers/glass/bottle/facid
 	name = "Fluorosulfuric Acid Bottle"
 	desc = "A small bottle. Contains a small amount of fluorosulfuric acid."

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -123,12 +123,12 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/killer/pestkiller
 	category = list("initial","Botany Chemicals")
 
-/datum/design/diethylamine
-	name = "10u Diethylamine"
-	id = "diethylamine_biogen"
+/datum/design/ammonia
+	name = "10u Ammonia"
+	id = "ammonia_biogen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 50)
-	make_reagents = list(/datum/reagent/diethylamine = 10)
+	materials = list(MAT_BIOMASS = 25)
+	make_reagents = list(/datum/reagent/ammonia = 10)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/saltpetre

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -107,6 +107,22 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/rh
 	category = list("initial","Botany Chemicals")
 
+/datum/design/diethylamine
+	name = "Diethylamine"
+	id = "diethylamine_biogen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 75)
+	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
+	category = list("initial","Botany Chemicals")
+
+/datum/design/saltpetre
+	name = "Saltpetre"
+	id = "saltpetre_biogen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 125)
+	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
+	category = list("initial","Botany Chemicals")
+
 /datum/design/weed_killer
 	name = "Weed Killer"
 	id = "weed_killer"

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -3,7 +3,7 @@
 ///////////////////////////////////
 
 /datum/design/milk
-	name = "10 Milk"
+	name = "10u Milk"
 	id = "milk"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 20)
@@ -11,7 +11,7 @@
 	category = list("initial","Food")
 
 /datum/design/cream
-	name = "10 Cream"
+	name = "10u Cream"
 	id = "cream"
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 30)
@@ -124,19 +124,19 @@
 	category = list("initial","Botany Chemicals")
 
 /datum/design/diethylamine
-	name = "Diethylamine"
+	name = "10u Diethylamine"
 	id = "diethylamine_biogen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 150)
-	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
+	materials = list(MAT_BIOMASS = 50)
+	make_reagents = list(/datum/reagent/diethylamine = 10)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/saltpetre
-	name = "Saltpetre"
+	name = "10u Saltpetre"
 	id = "saltpetre_biogen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 225)
-	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
+	materials = list(MAT_BIOMASS = 75)
+	make_reagents = list(/datum/reagent/saltpetre = 10)
 	category = list("initial","Botany Chemicals")
 
 /datum/design/botany_bottle

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -107,22 +107,6 @@
 	build_path = /obj/item/reagent_containers/glass/bottle/nutrient/rh
 	category = list("initial","Botany Chemicals")
 
-/datum/design/diethylamine
-	name = "Diethylamine"
-	id = "diethylamine_biogen"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 75)
-	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
-	category = list("initial","Botany Chemicals")
-
-/datum/design/saltpetre
-	name = "Saltpetre"
-	id = "saltpetre_biogen"
-	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 125)
-	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
-	category = list("initial","Botany Chemicals")
-
 /datum/design/weed_killer
 	name = "Weed Killer"
 	id = "weed_killer"
@@ -137,6 +121,22 @@
 	build_type = BIOGENERATOR
 	materials = list(MAT_BIOMASS = 50)
 	build_path = /obj/item/reagent_containers/glass/bottle/killer/pestkiller
+	category = list("initial","Botany Chemicals")
+
+/datum/design/diethylamine
+	name = "Diethylamine"
+	id = "diethylamine_biogen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 75)
+	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
+	category = list("initial","Botany Chemicals")
+
+/datum/design/saltpetre
+	name = "Saltpetre"
+	id = "saltpetre_biogen"
+	build_type = BIOGENERATOR
+	materials = list(MAT_BIOMASS = 125)
+	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
 	category = list("initial","Botany Chemicals")
 
 /datum/design/botany_bottle

--- a/code/modules/research/designs/biogenerator_designs.dm
+++ b/code/modules/research/designs/biogenerator_designs.dm
@@ -127,7 +127,7 @@
 	name = "Diethylamine"
 	id = "diethylamine_biogen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 75)
+	materials = list(MAT_BIOMASS = 150)
 	build_path = /obj/item/reagent_containers/glass/bottle/diethylamine
 	category = list("initial","Botany Chemicals")
 
@@ -135,7 +135,7 @@
 	name = "Saltpetre"
 	id = "saltpetre_biogen"
 	build_type = BIOGENERATOR
-	materials = list(MAT_BIOMASS = 125)
+	materials = list(MAT_BIOMASS = 225)
 	build_path = /obj/item/reagent_containers/glass/bottle/saltpetre
 	category = list("initial","Botany Chemicals")
 


### PR DESCRIPTION
## About The Pull Request

- Ammonia can be printed from the biogenerator at 25 biomass for 10 units.
- Saltpetre can be printed from the biogenerator at 75 biomass for 10 units.

## Why It's Good For The Game

**Who does this benefit?** Botanists and public garden users who either cannot or do not want to construct chem dispensers in their department, but still want to participate in the stat manipulation part of the department to grow better produce for the kitchen. 

**Who does this not benefit?** Serial powergamers will still want to get their chem dispensers, as it can make unstable mutagen to fuel their projects, and with chem macros, can produce diethylamine and saltpetre in greater quantities faster.

**Why not just give them a chem dispenser?** If we're still making any attempt at roleplay standards, chemical synthesis _should_ be a skill reserved for chemists, not gardeners. I don't like the non-interactivity of chem dispensers, or the behavior they encourage: breaking into technical storage, stealing any public-access cell charger you can get your hands on, and generally availing yourself to uncontested access to one of the strongest machines on the station, all just for fertilizer.

With this PR, botanists can create these important chemicals by _working their department_. It will take a few harvests of the initial, low-yield and low-potency plants to get their hands on these bottles, but once they're established, they can focus more on experimenting and filling orders than trying to source an infinite supply of fertilizer chems.

They will **still** need to source mutagen, but I think that is a reasonable opportunity for coordination with chemistry that doesn't feel overbearing or annoying for either side.

## Changelog
:cl:
add: Ammonia and saltpetre can now be made at the biogenerator.
/:cl: