### PR TITLE
Revenge Of Synthflesh : Electric Boogalo Part 2

### DIFF
--- a/code/modules/food_and_drinks/recipes/food_mixtures.dm
+++ b/code/modules/food_and_drinks/recipes/food_mixtures.dm
@@ -101,6 +101,10 @@
 	required_reagents = list(/datum/reagent/blood = 5, /datum/reagent/medicine/cryoxadone = 1)
 	mob_react = FALSE
 
+/datum/chemical_reaction/synthmeat/synthblood
+	id = "synthmeat_synthblood"
+	required_reagents = list(/datum/reagent/blood/synthetics = 5, /datum/reagent/medicine/cryoxadone = 1)
+
 /datum/chemical_reaction/synthmeat/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	for(var/i = 1, i <= multiplier, i++)

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -68,6 +68,12 @@
 	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
 
+/datum/chemical_reaction/synthflesh2
+	name = "Synthflesh"
+	id = /datum/reagent/medicine/synthflesh
+	results = list(/datum/reagent/medicine/synthflesh = 3)
+	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
+
 /datum/chemical_reaction/synthtissue
 	name = "Synthtissue"
 	id = /datum/reagent/synthtissue

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -70,7 +70,7 @@
 
 /datum/chemical_reaction/synthflesh2
 	name = "Synthflesh"
-	id = /datum/reagent/medicine/synthflesh
+	id = "synthflesh_2"
 	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
 

--- a/code/modules/reagents/chemistry/recipes/medicine.dm
+++ b/code/modules/reagents/chemistry/recipes/medicine.dm
@@ -68,10 +68,8 @@
 	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
 
-/datum/chemical_reaction/synthflesh2
-	name = "Synthflesh"
+/datum/chemical_reaction/synthflesh/synthblood
 	id = "synthflesh_2"
-	results = list(/datum/reagent/medicine/synthflesh = 3)
 	required_reagents = list(/datum/reagent/blood/synthetics = 1, /datum/reagent/carbon = 1, /datum/reagent/medicine/styptic_powder = 1)
 
 /datum/chemical_reaction/synthtissue

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -752,3 +752,4 @@
 	results = list(/datum/reagent/blood/synthetics = 3)
 	required_reagents = list(/datum/reagent/medicine/salglu_solution = 1, /datum/reagent/iron = 1, /datum/reagent/stable_plasma = 1)
 	mix_message = "The mixture congeals and gives off a faint copper scent."
+	required_temp = 350

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -743,3 +743,12 @@
 	id = "blue_glitter_white"
 	results = list(/datum/reagent/glitter/blue  = 2)
 	required_reagents = list(/datum/reagent/glitter/white = 1, /datum/reagent/colorful_reagent/crayonpowder/blue = 1)
+
+//////////////////////////////////// Synthblood ///////////////////////////////////////////
+
+/datum/chemical_reaction/synth_blood
+	name = "Synthetic Blood"
+	id = /datum/reagent/blood/synthetics
+	results = list(/datum/reagent/blood/synthetics = 3)
+	required_reagents = list(/datum/reagent/medicine/salglu_solution = 1, /datum/reagent/iron = 1, /datum/reagent/stable_plasma = 1)
+	mix_message = "The mixture congeals and gives off a faint copper scent."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
Synth-flesh can be created with synthetic blood.
Synthetic Blood is now mixable in chemistry

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->
Recently the ability to mass produce synth-flesh was nerfed due to the removal of mutagen's blood duplication. As one of those people who liked carrying 10 100u beakers of synth-flesh them as medical this hurt my gamer heart so I made this PR so I can mass produce synth-flesh again with slightly more effort involved.

Also it bothered me synthetic blood doesn't work in synthetic flesh since it made no sense

Do take this PR with a grain of salt as it is my first and is clearly a salt pr because no easy synth-flesh makes me mad.

## Changelog
:cl:
add: You can now make synth-flesh with synthetic blood.
add: You can now make synthetic blood via mixing saline glucose, iron, stable plasma and heating it to 350 temp.
add: You can mix synthetic blood and cryoxadone to create synth-meat in addition to normal blood.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
