### PR TITLE
Fixing sprint buffer cost and regen being rounded down.

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -234,6 +234,7 @@
 
 /datum/config_entry/number/movedelay	//Used for modifying movement speed for mobs.
 	abstract_type = /datum/config_entry/number/movedelay
+	integer = FALSE
 
 /datum/config_entry/number/movedelay/ValidateAndSet()
 	. = ..()


### PR DESCRIPTION
## About The Pull Request 
I wonder how much longer this issue would have gone unnoticed if I didn't tell head admins that the configs should be cleaned up a little a few days ago.

## Why It's Good For The Game
Sprint buffer regen is currently 0. This will close #11118.

## Changelog
:cl:
fix: Fixed sprint buffer cost and regen being rounded down.
/:cl:
