### PR TITLE
Something about box engine.

### DIFF
--- a/code/datums/ruins/station.dm
+++ b/code/datums/ruins/station.dm
@@ -37,22 +37,22 @@
 
 /datum/map_template/ruin/station/box/engine/teg
 	id = "engine_teg"
-	suffix = "Box/Engine/engine_tesla.dmm"
+	suffix = "Box/Engine/engine_teg.dmm"
 	name = "Box TEG"
 
 /datum/map_template/ruin/station/box/engine/empty
 	id = "engine_empty"
-	suffix = "Box/Engine/engine_tesla.dmm"
+	suffix = "Box/Engine/empty.dmm"
 	name = "Box Empty"
 
 /datum/map_template/ruin/station/box/engine/am
 	id = "engine_am"
-	suffix = "Box/Engine/engine_tesla.dmm"
+	suffix = "Box/Engine/engine_am.dmm"
 	name = "Box Antimatter"
 
 /datum/map_template/ruin/station/box/engine/budget
 	id = "engine_budget"
-	suffix = "Box/Engine/engine_tesla.dmm"
+	suffix = "Box/Engine/budget.dmm"
 	name = "Box P.A.C.M.A.N"
 
 // Lavaland


### PR DESCRIPTION
## About The Pull Request 
The tes-lag-a-lot is supposed to be disabled by configs thanks to the many absurd async explosion calls when released. But copypasta proved stronger.

## Why It's Good For The Game
Fixing asinine path copypasta by r4d6.

## Changelog
Nobody else noticed this. They are in for a surprise, implying this is why the tesla engine is being so frequent... Like, really, it's a 4/11 chance but I have seen nothing but tesla for more than a couple rounds now.