### PR TITLE
Rebinds combat mode examine to shift + space + click but only if you use shift hotkey for sprint

### DIFF
--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -82,11 +82,11 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
+	if(modifiers["shift"] && ((client && client.show_popup_menus) || modifiers["middle"])) //CIT CHANGE - makes shift-click examine use right click instead of left click in combat mode
+		ShiftClickOn(A)
+		return
 	if(modifiers["middle"])
 		MiddleClickOn(A)
-		return
-	if(modifiers["shift"] && (client && client.show_popup_menus || modifiers["right"])) //CIT CHANGE - makes shift-click examine use right click instead of left click in combat mode
-		ShiftClickOn(A)
 		return
 	if(modifiers["alt"]) // alt and alt-gr (rightalt)
 		AltClickOn(A)

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -82,7 +82,7 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
-	if(modifiers["shift"] && ((client && client.show_popup_menus) || modifiers["middle"])) //CIT CHANGE - makes shift-click examine use right click instead of left click in combat mode
+	if(modifiers["shift"] && ((client?.show_popup_menus) || (!client?.prefs.sprint_spacebar && clientkeys_held["Space"]))) //CIT CHANGE - makes shift-click examine use space instead of left click in combat mode
 		ShiftClickOn(A)
 		return
 	if(modifiers["middle"])

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -82,7 +82,7 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
-	if(modifiers["shift"] && ((client?.show_popup_menus) || (!client?.prefs.sprint_spacebar && clientkeys_held["Space"]))) //CIT CHANGE - makes shift-click examine use space instead of left click in combat mode
+	if(modifiers["shift"] && ((client?.show_popup_menus) || (!client?.prefs.sprint_spacebar && client.keys_held["Space"]))) //CIT CHANGE - makes shift-click examine use space instead of left click in combat mode
 		ShiftClickOn(A)
 		return
 	if(modifiers["middle"])

--- a/code/_onclick/click.dm
+++ b/code/_onclick/click.dm
@@ -82,7 +82,7 @@
 	if(modifiers["shift"] && modifiers["ctrl"])
 		CtrlShiftClickOn(A)
 		return
-	if(modifiers["shift"] && ((client?.show_popup_menus) || (!client?.prefs.sprint_spacebar && client.keys_held["Space"]))) //CIT CHANGE - makes shift-click examine use space instead of left click in combat mode
+	if(modifiers["shift"] && ((client?.show_popup_menus) || (client?.prefs.sprint_spacebar? modifiers["right"] : client.keys_held["Space"]))) //CIT CHANGE - makes shift-click examine use space instead of left click in combat mode
 		ShiftClickOn(A)
 		return
 	if(modifiers["middle"])


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Impossible to right click with shift control scheme in combat without this. The collision would prevent right click hits. 
Space is significantly as of now less important in combat.

This only takes effect if you do not have sprint hotkey set to space.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Combat mode examine rebound to shift + spacebar + click for people using shift hotkey for sprint.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
