### PR TITLE
Something about tesla revolvers and tk.

### DIFF
--- a/code/modules/projectiles/projectile/energy/tesla.dm
+++ b/code/modules/projectiles/projectile/energy/tesla.dm
@@ -7,10 +7,11 @@
 	var/zap_range = 3
 	var/power = 10000
 
-/obj/item/projectile/energy/tesla/fire(setAngle)
-	if(firer)
-		chain = firer.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
-	..()
+/obj/item/projectile/energy/tesla/fire(setAngle, atom/direct_target)
+	var/atom/source = fired_from || firer
+	if(source)
+		chain = source.Beam(src, icon_state = "lightning[rand(1, 12)]", time = INFINITY, maxdistance = INFINITY)
+	return ..()
 
 /obj/item/projectile/energy/tesla/on_hit(atom/target)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
The lighting chain is connected to the firer instead of the fired weapon.

## Why It's Good For The Game
This will close #11099. Beams are drawn using the target and origin turfs through get_turf(), so there should be no issue if the firearm is held.

## Changelog
Uhh, nah.