### PR TITLE
Something about pAIs and silicon access priviledges.

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -54,3 +54,9 @@
 
 //Checks to determine borg availability depending on the server's config. These are defines in the interest of reducing copypasta
 #define BORG_SEC_AVAILABLE (!CONFIG_GET(flag/disable_secborg) && GLOB.security_level >= CONFIG_GET(number/minimum_secborg_alert))
+
+//silicon_priviledges flags
+#define PRIVILEDGES_SILICON	(1<<0)
+#define PRIVILEDGES_PAI		(1<<1)
+#define PRIVILEDGES_BOT		(1<<2)
+#define PRIVILEDGES_DRONE	(1<<3)

--- a/code/game/machinery/bloodbankgen.dm
+++ b/code/game/machinery/bloodbankgen.dm
@@ -274,20 +274,20 @@
 
 	return TRUE
 
-/obj/machinery/bloodbankgen/proc/detachinput()
+/obj/machinery/bloodbankgen/proc/detachinput(mob/user)
 	if(bag)
 		bag.forceMove(drop_location())
-		if(usr && Adjacent(usr) && !issiliconoradminghost(usr))
-			usr.put_in_hands(bag)
+		if(user && Adjacent(usr) && user.can_hold_items())
+			user.put_in_hands(bag)
 		bag = null
 		draining = null
 		update_icon()
 
-/obj/machinery/bloodbankgen/proc/detachoutput()
+/obj/machinery/bloodbankgen/proc/detachoutput(mob/user)
 	if(outbag)
 		outbag.forceMove(drop_location())
-		if(usr && Adjacent(usr) && !issiliconoradminghost(usr))
-			usr.put_in_hands(outbag)
+		if(user && Adjacent(user) && user.can_hold_items())
+			user.put_in_hands(outbag)
 		outbag = null
 		filling = null
 		update_icon()
@@ -325,12 +325,12 @@
 		activateinput()
 
 	else if(href_list["detachinput"])
-		detachinput()
+		detachinput(usr)
 
 	else if(href_list["activateoutput"])
 		activateoutput()
 
 	else if(href_list["detachoutput"])
-		detachoutput()
+		detachoutput(usr)
 
 	updateUsrDialog()

--- a/code/game/machinery/computer/camera_advanced.dm
+++ b/code/game/machinery/computer/camera_advanced.dm
@@ -72,7 +72,7 @@
 	playsound(src, 'sound/machines/terminal_off.ogg', 25, 0)
 
 /obj/machinery/computer/camera_advanced/check_eye(mob/user)
-	if( (stat & (NOPOWER|BROKEN)) || (!Adjacent(user) && !user.has_unlimited_silicon_privilege) || user.eye_blind || user.incapacitated() )
+	if( (stat & (NOPOWER|BROKEN)) || (!Adjacent(user) && hasSiliconAccessInArea(user)) || user.eye_blind || user.incapacitated() )
 		user.unset_machine()
 
 /obj/machinery/computer/camera_advanced/Destroy()

--- a/code/game/machinery/cryopod.dm
+++ b/code/game/machinery/cryopod.dm
@@ -116,7 +116,7 @@
 		playsound(src, 'sound/machines/terminal_prompt_confirm.ogg', 50, 0)
 
 		I.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(I)
 		frozen_items -= I
 		updateUsrDialog()

--- a/code/game/machinery/iv_drip.dm
+++ b/code/game/machinery/iv_drip.dm
@@ -184,7 +184,7 @@
 	if(usr.incapacitated())
 		return
 	if(beaker)
-		if(usr && Adjacent(usr) && !issiliconoradminghost(usr))
+		if(usr && Adjacent(usr) && usr.can_hold_items())
 			if(!usr.put_in_hands(beaker))
 				beaker.forceMove(drop_location())
 		beaker = null

--- a/code/game/objects/items/RCD.dm
+++ b/code/game/objects/items/RCD.dm
@@ -196,7 +196,7 @@ RLD
 
 /obj/item/construction/rcd/verb/change_airlock_access(mob/user)
 
-	if (!ishuman(user) && !user.has_unlimited_silicon_privilege)
+	if (!ishuman(user) && !user.silicon_privileges)
 		return
 
 	var/t1 = ""

--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -714,7 +714,7 @@ GLOBAL_PROTECT(admin_verbs_hideable)
 
 	AI_Interact = !AI_Interact
 	if(mob && IsAdminGhost(mob))
-		mob.has_unlimited_silicon_privilege = AI_Interact
+		mob.silicon_privileges = AI_Interact ? ALL : NONE
 
 	log_admin("[key_name(usr)] has [AI_Interact ? "activated" : "deactivated"] Admin AI Interact")
 	message_admins("[key_name_admin(usr)] has [AI_Interact ? "activated" : "deactivated"] their AI interaction")

--- a/code/modules/antagonists/bloodsucker/powers/bs_feed.dm
+++ b/code/modules/antagonists/bloodsucker/powers/bs_feed.dm
@@ -170,7 +170,7 @@
 		// Warn Feeder about Witnesses...
 		var/was_unnoticed = TRUE
 		for(var/mob/living/M in viewers(notice_range, owner))
-			if(M != owner && M != target && iscarbon(M) && M.mind && !M.has_unlimited_silicon_privilege && !M.eye_blind && !M.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER))
+			if(M != owner && M != target && iscarbon(M) && M.mind && !M.silicon_privileges && !M.eye_blind && !M.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER))
 				was_unnoticed = FALSE
 				break
 		if(was_unnoticed)

--- a/code/modules/antagonists/bloodsucker/powers/bs_gohome.dm
+++ b/code/modules/antagonists/bloodsucker/powers/bs_gohome.dm
@@ -28,9 +28,9 @@
 			to_chat(owner, "<span class='warning'>Your coffin has been destroyed!</span>")
 		return FALSE
 	return TRUE
-	
+
 /datum/action/bloodsucker/gohome/proc/flicker_lights(var/flicker_range, var/beat_volume)
-	for(var/obj/machinery/light/L in view(flicker_range, get_turf(owner)))	
+	for(var/obj/machinery/light/L in view(flicker_range, get_turf(owner)))
 	playsound(get_turf(owner), 'sound/effects/singlebeat.ogg', beat_volume, 1)
 
 
@@ -45,7 +45,7 @@
 	flicker_lights(4, 40)
 	sleep(50)
 	flicker_lights(4, 60)
-	for(var/obj/machinery/light/L in view(6, get_turf(owner)))		
+	for(var/obj/machinery/light/L in view(6, get_turf(owner)))
 		L.flicker(5)
 	playsound(get_turf(owner), 'sound/effects/singlebeat.ogg', 60, 1)
 	// ( STEP TWO: Lights OFF? )
@@ -56,7 +56,7 @@
 	if(!owner)
 		return
 	// SEEN?: (effects ONLY if there are witnesses! Otherwise you just POOF)
-	
+
 	var/am_seen = FALSE		// Do Effects (seen by anyone)
 	var/drop_item = FALSE	// Drop Stuff (seen by non-vamp)
 	if(isturf(owner.loc)) // Only check if I'm not in a Locker or something.
@@ -65,7 +65,7 @@
 		if(T && T.lighting_object && T.get_lumcount()>= 0.1)
 			// B) Check for Viewers
 			for(var/mob/living/M in viewers(get_turf(owner)))
-				if(M != owner && isliving(M) && M.mind && !M.has_unlimited_silicon_privilege && !M.eye_blind) // M.client <--- add this in after testing!
+				if(M != owner && isliving(M) && M.mind && !M.silicon_privileges && !M.eye_blind) // M.client <--- add this in after testing!
 					am_seen = TRUE
 					if (!M.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER))
 						drop_item = TRUE
@@ -95,12 +95,12 @@
 		puff.effect_type = /obj/effect/particle_effect/smoke/vampsmoke
 		puff.set_up(3, 0, get_turf(owner))
 		puff.start()
-	
+
 	//STEP FIVE: Create animal at prev location
 	var/mob/living/simple_animal/SA = pick(/mob/living/simple_animal/mouse,/mob/living/simple_animal/mouse,/mob/living/simple_animal/mouse, /mob/living/simple_animal/hostile/retaliate/bat) //prob(300) /mob/living/simple_animal/mouse,
 	new SA (owner.loc)
 	// TELEPORT: Move to Coffin & Close it!
-	do_teleport(owner, bloodsuckerdatum.coffin, no_effects = TRUE, forced = TRUE, channel = TELEPORT_CHANNEL_QUANTUM) 
+	do_teleport(owner, bloodsuckerdatum.coffin, no_effects = TRUE, forced = TRUE, channel = TELEPORT_CHANNEL_QUANTUM)
 	user.resting = TRUE
 	user.Stun(30,1)
 	// CLOSE LID: If fail, force me in.
@@ -112,4 +112,4 @@
 		bloodsuckerdatum.coffin.update_icon()
 		// Lock Coffin
 		bloodsuckerdatum.coffin.LockMe(owner)
-	
+

--- a/code/modules/cargo/expressconsole.dm
+++ b/code/modules/cargo/expressconsole.dm
@@ -97,7 +97,7 @@
 	var/canBeacon = beacon && (isturf(beacon.loc) || ismob(beacon.loc))//is the beacon in a valid location?
 	var/list/data = list()
 	data["locked"] = locked//swipe an ID to unlock
-	data["siliconUser"] = user.has_unlimited_silicon_privilege
+	data["siliconUser"] = hasSiliconAccessInArea(user)
 	data["beaconzone"] = beacon ? get_area(beacon) : ""//where is the beacon located? outputs in the tgui
 	data["usingBeacon"] = usingBeacon //is the mode set to deliver to the beacon or the cargobay?
 	data["canBeacon"] = !usingBeacon || canBeacon //is the mode set to beacon delivery, and is the beacon in a valid location?

--- a/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/icecream_vat.dm
@@ -319,7 +319,7 @@
 /obj/machinery/icecream_vat/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
 	if(beaker)
 		beaker.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(beaker)
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/mob/dead/observer/login.dm
+++ b/code/modules/mob/dead/observer/login.dm
@@ -6,7 +6,7 @@
 	var/preferred_form = null
 
 	if(IsAdminGhost(src))
-		has_unlimited_silicon_privilege = 1
+		silicon_privileges = ALL
 
 	if(client.prefs.unlock_content)
 		preferred_form = client.prefs.ghost_form

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -987,3 +987,6 @@
 			return TRUE
 	if(isclothing(wear_mask) && (wear_mask.clothing_flags & SCAN_REAGENTS))
 		return TRUE
+
+/mob/living/carbon/can_hold_items()
+	return TRUE

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -823,9 +823,6 @@
 		. += dna.species.check_weakness(weapon, attacker)
 
 /mob/living/carbon/human/is_literate()
-	return 1
-
-/mob/living/carbon/human/can_hold_items()
 	return TRUE
 
 /mob/living/carbon/human/update_gravity(has_gravity,override = 0)

--- a/code/modules/mob/living/silicon/pai/pai.dm
+++ b/code/modules/mob/living/silicon/pai/pai.dm
@@ -11,6 +11,7 @@
 	health = 500
 	maxHealth = 500
 	layer = BELOW_MOB_LAYER
+	silicon_privileges = PRIVILEDGES_PAI
 	var/datum/element/mob_holder/current_mob_holder //because only a few of their chassis can be actually held.
 
 	var/network = "ss13"

--- a/code/modules/mob/living/silicon/silicon.dm
+++ b/code/modules/mob/living/silicon/silicon.dm
@@ -1,6 +1,6 @@
 /mob/living/silicon
 	gender = NEUTER
-	has_unlimited_silicon_privilege = 1
+	silicon_privileges = PRIVILEDGES_SILICON
 	verb_say = "states"
 	verb_ask = "queries"
 	verb_exclaim = "declares"

--- a/code/modules/mob/living/simple_animal/bot/bot.dm
+++ b/code/modules/mob/living/simple_animal/bot/bot.dm
@@ -15,7 +15,7 @@
 	maxbodytemp = INFINITY
 	minbodytemp = 0
 	blood_volume = 0
-	has_unlimited_silicon_privilege = 1
+	silicon_privileges = PRIVILEDGES_BOT
 	sentience_type = SENTIENCE_ARTIFICIAL
 	status_flags = NONE //no default canpush
 	verb_say = "states"

--- a/code/modules/mob/living/simple_animal/bot/mulebot.dm
+++ b/code/modules/mob/living/simple_animal/bot/mulebot.dm
@@ -180,7 +180,7 @@
 	var/list/data = list()
 	data["on"] = on
 	data["locked"] = locked
-	data["siliconUser"] = user.has_unlimited_silicon_privilege
+	data["siliconUser"] = hasSiliconAccessInArea(usr)
 	data["mode"] = mode ? mode_name[mode] : "Ready"
 	data["modeStatus"] = ""
 	switch(mode)
@@ -205,11 +205,12 @@
 	return data
 
 /mob/living/simple_animal/bot/mulebot/ui_act(action, params)
-	if(..() || (locked && !usr.has_unlimited_silicon_privilege))
+	var/silicon_access = hasSiliconAccessInArea(usr)
+	if(..() || (locked && silicon_access))
 		return
 	switch(action)
 		if("lock")
-			if(usr.has_unlimited_silicon_privilege)
+			if(silicon_access)
 				locked = !locked
 				. = TRUE
 		if("power")
@@ -766,4 +767,3 @@
 
 /obj/machinery/bot_core/mulebot
 	req_access = list(ACCESS_CARGO)
-	

--- a/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
+++ b/code/modules/mob/living/simple_animal/friendly/drone/_drone.dm
@@ -41,7 +41,7 @@
 	bubble_icon = "machine"
 	initial_language_holder = /datum/language_holder/drone
 	mob_size = MOB_SIZE_SMALL
-	has_unlimited_silicon_privilege = 1
+	silicon_privileges = PRIVILEDGES_DRONE
 	damage_coeff = list(BRUTE = 1, BURN = 1, TOX = 0, CLONE = 0, STAMINA = 0, OXY = 0)
 	hud_possible = list(DIAG_STAT_HUD, DIAG_HUD, ANTAG_HUD)
 	unique_name = TRUE

--- a/code/modules/mob/living/simple_animal/hostile/statue.dm
+++ b/code/modules/mob/living/simple_animal/hostile/statue.dm
@@ -126,7 +126,7 @@
 	// This loop will, at most, loop twice.
 	for(var/atom/check in check_list)
 		for(var/mob/living/M in viewers(world.view + 1, check) - src)
-			if(M.client && CanAttack(M) && !M.has_unlimited_silicon_privilege)
+			if(M.client && CanAttack(M) && !M.silicon_privileges)
 				if(!M.eye_blind)
 					return M
 		for(var/obj/mecha/M in view(world.view + 1, check)) //assuming if you can see them they can see you

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -95,7 +95,7 @@
 	var/digitalinvis = 0 //Are they ivisible to the AI?
 	var/image/digitaldisguise = null  //what does the AI see instead of them?
 
-	var/has_unlimited_silicon_privilege = 0 // Can they interact with station electronics
+	var/silicon_privileges = NONE // Can they interact with station electronics
 
 	var/obj/control_object //Used by admins to possess objects. All mobs should have this var
 	var/atom/movable/remote_control //Calls relaymove() to whatever it is

--- a/code/modules/mob/mob_helpers.dm
+++ b/code/modules/mob/mob_helpers.dm
@@ -406,8 +406,8 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 		return
 	return TRUE
 
-/atom/proc/hasSiliconAccessInArea(mob/user)
-	return user && (issilicon(user) || (user.siliconaccesstoggle && (get_area(src) in user.siliconaccessareas)))
+/atom/proc/hasSiliconAccessInArea(mob/user, flags = PRIVILEDGES_SILICON)
+	return user.silicon_privileges & (flags) || (user.siliconaccesstoggle && (get_area(src) in user.siliconaccessareas))
 
 /mob/proc/toggleSiliconAccessArea(area/area)
 	if (area in siliconaccessareas)
@@ -555,4 +555,4 @@ It's fairly easy to fix if dealing with single letters but not so much with comp
 
 //Can the mob see reagents inside of containers?
 /mob/proc/can_see_reagents()
-	return stat == DEAD || has_unlimited_silicon_privilege //Dead guys and silicons can always see reagents
+	return stat == DEAD || silicon_privileges //Dead guys and silicons can always see reagents

--- a/code/modules/oracle_ui/hookup_procs.dm
+++ b/code/modules/oracle_ui/hookup_procs.dm
@@ -5,7 +5,7 @@
 	return "Default Implementation"
 
 /datum/proc/oui_canuse(mob/user)
-	if(isobserver(user) && !user.has_unlimited_silicon_privilege)
+	if(isobserver(user) && !user.silicon_privileges)
 		return FALSE
 	return oui_canview(user)
 
@@ -35,7 +35,7 @@
 	return ..()
 
 /obj/machinery/oui_canview(mob/user)
-	if(user.has_unlimited_silicon_privilege || hasSiliconAccessInArea(user))
+	if(hasSiliconAccessInArea(user, ALL))
 		return TRUE
 	if(!can_interact(user))
 		return FALSE

--- a/code/modules/power/apc.dm
+++ b/code/modules/power/apc.dm
@@ -846,7 +846,7 @@
 		return
 
 /obj/machinery/power/apc/oui_canview(mob/user)
-	if(user.has_unlimited_silicon_privilege || area.hasSiliconAccessInArea(user))
+	if(area.hasSiliconAccessInArea(user)) //some APCs are mapped outside their assigned area, so this is required.
 		return TRUE
 	return ..()
 
@@ -864,7 +864,7 @@
 	if (H && !H.stealthmode && H.toggled)
 		abilitiesavail = TRUE
 	var/list/data = list(
-		"locked" = locked && !(integration_cog && is_servant_of_ratvar(user)) && !area.hasSiliconAccessInArea(user),
+		"locked" = locked && !(integration_cog && is_servant_of_ratvar(user)) && !area.hasSiliconAccessInArea(user, PRIVILEDGES_SILICON|PRIVILEDGES_DRONE),
 		"lock_nightshift" = nightshift_requires_auth,
 		"failTime" = failure_timer,
 		"isOperating" = operating,
@@ -874,7 +874,7 @@
 		"chargingStatus" = charging,
 		"totalLoad" = DisplayPower(lastused_total),
 		"coverLocked" = coverlocked,
-		"siliconUser" = user.has_unlimited_silicon_privilege || user.using_power_flow_console() || area.hasSiliconAccessInArea(user),
+		"siliconUser" = user.using_power_flow_console() || area.hasSiliconAccessInArea(user),
 		"malfStatus" = get_malf_status(user),
 		"emergencyLights" = !emergency_lights,
 		"nightshiftLights" = nightshift_lights,
@@ -951,7 +951,7 @@
 		return TRUE
 	if (user == hijacker || (area.hasSiliconAccessInArea(user) && !aidisabled))
 		return TRUE
-	if(user.has_unlimited_silicon_privilege)
+	if(user.silicon_privileges & PRIVILEDGES_SILICON)
 		var/mob/living/silicon/ai/AI = user
 		var/mob/living/silicon/robot/robot = user
 		if (src.aidisabled || malfhack && istype(malfai) && ((istype(AI) && (malfai!=AI && malfai != AI.parent)) || (istype(robot) && (robot in malfai.connected_robots))))
@@ -985,7 +985,7 @@
 	if (action == "hijack" && can_use(usr, 1)) //don't need auth for hijack button
 		hijack(usr)
 		return
-	var/authorized = (!locked || usr.has_unlimited_silicon_privilege || area.hasSiliconAccessInArea(usr) || (integration_cog && (is_servant_of_ratvar(usr))))
+	var/authorized = (!locked || area.hasSiliconAccessInArea(usr, PRIVILEDGES_SILICON|PRIVILEDGES_DRONE) || (integration_cog && (is_servant_of_ratvar(usr))))
 	if((action == "toggle_nightshift") && (!nightshift_requires_auth || authorized))
 		toggle_nightshift_lights()
 		return TRUE
@@ -993,7 +993,7 @@
 		return
 	switch(action)
 		if("lock")
-			if(usr.has_unlimited_silicon_privilege || area.hasSiliconAccessInArea(usr))
+			if(area.hasSiliconAccessInArea(usr))
 				if((obj_flags & EMAGGED) || (stat & (BROKEN|MAINT)))
 					to_chat(usr, "The APC does not respond to the command.")
 				else
@@ -1027,7 +1027,7 @@
 				update()
 			return TRUE
 		if("overload")
-			if(usr.has_unlimited_silicon_privilege || area.hasSiliconAccessInArea(usr))
+			if(area.hasSiliconAccessInArea(usr))
 				overload_lighting()
 			return TRUE
 		if("hack")

--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -408,7 +408,7 @@
 	if(beaker)
 		var/obj/item/reagent_containers/B = beaker
 		B.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(B)
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_heater.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_heater.dm
@@ -38,7 +38,7 @@
 /obj/machinery/chem_heater/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
 	if(beaker)
 		beaker.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(beaker)
 	if(new_beaker)
 		beaker = new_beaker

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -129,7 +129,7 @@
 	if(beaker)
 		var/obj/item/reagent_containers/B = beaker
 		B.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(B)
 	if(new_beaker)
 		beaker = new_beaker
@@ -139,7 +139,7 @@
 	if(bottle)
 		var/obj/item/storage/pill_bottle/B = bottle
 		B.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(B)
 		else
 			adjust_item_drop_location(B)

--- a/code/modules/reagents/chemistry/machinery/pandemic.dm
+++ b/code/modules/reagents/chemistry/machinery/pandemic.dm
@@ -192,7 +192,7 @@
 			update_icon()
 			var/turf/source_turf = get_turf(src)
 			log_virus("A culture bottle was printed for the virus [A.admin_details()] at [loc_name(source_turf)] by [key_name(usr)]")
-			
+
 			. = TRUE
 		if("create_vaccine_bottle")
 			wait = TRUE
@@ -202,9 +202,9 @@
 			var/obj/item/reagent_containers/glass/bottle/B = new(drop_location())
 			B.name = "[D.name] vaccine bottle"
 			B.reagents.add_reagent(/datum/reagent/vaccine, 15, list(id))
-			
+
 			update_icon()
-			
+
 			. = TRUE
 
 /obj/machinery/computer/pandemic/attackby(obj/item/I, mob/user, params)
@@ -229,7 +229,7 @@
 
 /obj/machinery/computer/pandemic/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
 	if(beaker)
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			if(!user.put_in_hands(beaker))
 				beaker.forceMove(drop_location())
 	if(new_beaker)

--- a/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
+++ b/code/modules/reagents/chemistry/machinery/reagentgrinder.dm
@@ -75,7 +75,7 @@
 /obj/machinery/reagentgrinder/proc/replace_beaker(mob/living/user, obj/item/reagent_containers/new_beaker)
 	if(beaker)
 		beaker.forceMove(drop_location())
-		if(user && Adjacent(user) && !issiliconoradminghost(user))
+		if(user && Adjacent(user) && user.can_hold_items())
 			user.put_in_hands(beaker)
 	if(new_beaker)
 		beaker = new_beaker


### PR DESCRIPTION
## About The Pull Request
Ever since the hijack implant was merged, I noticed how the `has_unlimited_silicon_priviledges` variable fell misused in favor of a hardcoded silicon typecheck which enabled those pesky pAIs to be even dorkier...
Of course I waited until the issue report was made to make a fix.

## Why It's Good For The Game
Fixing stuff. This will close #11137.

## Changelog
:cl:
fix: pAIs are yet again unable to perform certain silicon interactions with machineries yet again.
/:cl:
