### PR TITLE
Supermatter sabotage no longer shows up with no supermatter

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1096,7 +1096,7 @@ GLOBAL_LIST_EMPTY(possible_sabotages)
 	var/approved_targets = list()
 	check_sabotages:
 		for(var/datum/sabotage_objective/possible_sabotage in GLOB.possible_sabotages)
-			if(!is_unique_objective(possible_sabotage.sabotage_type) || possible_sabotage.check_conditions())
+			if(!is_unique_objective(possible_sabotage.sabotage_type) || possible_sabotage.check_conditions() || !possible_sabotage.can_run())
 				continue
 			for(var/datum/mind/M in owners)
 				if(M.current.mind.assigned_role in possible_sabotage.excludefromjob)

--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -12,6 +12,9 @@
 /datum/sabotage_objective/proc/check_conditions()
 	return TRUE
 
+/datum/sabotage_objective/proc/can_run()
+	return TRUE
+
 /datum/sabotage_objective/processing
 	var/won = FALSE
 
@@ -78,6 +81,9 @@
 	for(var/obj/machinery/power/supermatter_crystal/S in supermatters) // you can win this with a wishgranter... lol.
 		won = max(1-((S.get_integrity()-50)/50),won)
 	return FALSE
+
+/datum/sabotage_objective/processing/supermatter/can_run()
+	return (locate(/obj/machinery/power/supermatter_crystal) in GLOB.machines)
 
 /datum/sabotage_objective/station_integrity
 	name = "Make sure the station is at less than 80% integrity by the end. Smash walls, windows etc. to reach this goal."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title

## Why It's Good For The Game

Super onerous objective, if there was no supermatter on station.

## Changelog
:cl:
tweak: Supermatter sabotage objective no longer shows up with no supermatter
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
