### PR TITLE
fixes mining vendors failing and eating your points iff you have exactly enough points

### DIFF
--- a/code/modules/mining/machine_vending.dm
+++ b/code/modules/mining/machine_vending.dm
@@ -122,13 +122,10 @@
 				to_chat(usr, "<span class='warning'>Error: Insufficient credits for [prize.equipment_name] on [I]!</span>")
 				flick(icon_deny, src)
 			else
-				if (I.mining_points -= prize.cost)
-					to_chat(usr, "<span class='notice'>[src] clanks to life briefly before vending [prize.equipment_name]!</span>")
-					new prize.equipment_path(src.loc)
-					SSblackbox.record_feedback("nested tally", "mining_equipment_bought", 1, list("[type]", "[prize.equipment_path]"))
-				else
-					to_chat(usr, "<span class='warning'>Error: Transaction failure, please try again later!</span>")
-					flick(icon_deny, src)
+				I.mining_points -= prize.cost
+				to_chat(usr, "<span class='notice'>[src] clanks to life briefly before vending [prize.equipment_name]!</span>")
+				new prize.equipment_path(src.loc)
+				SSblackbox.record_feedback("nested tally", "mining_equipment_bought", 1, list("[type]", "[prize.equipment_path]"))
 		else
 			to_chat(usr, "<span class='warning'>Error: An ID with a registered account is required!</span>")
 			flick(icon_deny, src)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

No, that iff is not a typo. It happens if and only if you have precisely enough points. Otherwise it stops you. If your points are equal to the cost, it would just eat it and fail, because whoever wrote the code had no idea what "if" actually does, I guess. The entire purpose of the "if" statement here was to make it fail if you have exactly enough points, that's all it did. Good lord.

## Why It's Good For The Game

Can you look me in the eyes and tell me this behavior is anything but bad?

## Changelog
:cl:
fix: Mining vendors no longer fail and eat your points iff you have precisely enough points to pay for an item
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
