### PR TITLE
Fixes nightmares deleting guns with flashlights

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -217,12 +217,12 @@
 		var/obj/item/gun/weapon = O
 		if(weapon.gun_light)
 			var/obj/item/flashlight/seclite/light = weapon.gun_light
-			light.on = FALSE
-			light.brightness_on = 0
-			light.flashlight_power = 0
-			light.update_brightness()
+			light.forceMove(get_turf(weapon))
+			light.burn()
+			weapon.gun_light = null
 			weapon.update_gunlight()
-			visible_message("<span class='danger'>[light] on [O] flickers out and dies!</span>")
+			QDEL_NULL(weapon.alight)
+			visible_message("<span class='danger'>[light] on [O] flickers out and disintegrates!</span>")
 	else
 		visible_message("<span class='danger'>[O] is disintegrated by [src]!</span>")
 		O.burn()

--- a/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/shadowpeople.dm
@@ -213,6 +213,16 @@
 		PDA.f_lum = 0
 		PDA.update_icon()
 		visible_message("<span class='danger'>The light in [PDA] shorts out!</span>")
+	else if(istype(O, /obj/item/gun))
+		var/obj/item/gun/weapon = O
+		if(weapon.gun_light)
+			var/obj/item/flashlight/seclite/light = weapon.gun_light
+			light.on = FALSE
+			light.brightness_on = 0
+			light.flashlight_power = 0
+			light.update_brightness()
+			weapon.update_gunlight()
+			visible_message("<span class='danger'>[light] on [O] flickers out and dies!</span>")
 	else
 		visible_message("<span class='danger'>[O] is disintegrated by [src]!</span>")
 		O.burn()


### PR DESCRIPTION
## About The Pull Request

previously if someone with a light eater clicked on you and you had a gun with a gunlight set to on it would completely evaporate the whole gun into the aether, this makes it so that it just ashes the flashlight instead

## Why It's Good For The Game

i died to a nightmare because it deleted my hos gun and i didn't like that

## Changelog
:cl:Kraso
fix: Nightmares no longer delete entire guns from existence for merely having a light on them.
/:cl:
