### PR TITLE
Cham projector no longer lets you become literally unclickable

### DIFF
--- a/code/game/objects/items/devices/chameleonproj.dm
+++ b/code/game/objects/items/devices/chameleonproj.dm
@@ -49,6 +49,10 @@
 		return
 	if(istype(target, /obj/structure/falsewall))
 		return
+	if(target.alpha != 255)
+		return
+	if(target.invisibility != 0)
+		return
 	if(iseffect(target))
 		if(!(istype(target, /obj/effect/decal))) //be a footprint
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Yikes. Also it would seem that some decals ARE working with the cham projector when they shouldn't be I'll try and work out why later aaaah

Port of tgstation/tgstation#46827

## Why It's Good For The Game

Being unclickable bad.

## Changelog
:cl:
fix: Literally unclickability with a cham projector
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
