### PR TITLE
[TESTMERGE ONLY] Patches out examiner integrated circuits' checking descriptions.

### DIFF
--- a/code/modules/integrated_electronics/subtypes/input.dm
+++ b/code/modules/integrated_electronics/subtypes/input.dm
@@ -349,10 +349,7 @@
 		set_pin_data(IC_OUTPUT, 2, H.desc)
 
 		if(istype(H, /mob/living))
-			var/mob/living/M = H
-			var/msg = M.examine()
-			if(msg)
-				set_pin_data(IC_OUTPUT, 2, msg)
+			set_pin_data(IC_OUTPUT, 2, "Living being checking has been removed until further notice. We are sorry for the inconvenience.")
 
 		set_pin_data(IC_OUTPUT, 3, H.x-T.x)
 		set_pin_data(IC_OUTPUT, 4, H.y-T.y)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Checking a description requires a mob. Circuits are not a mob. Circuit runtimes every time it tries to check a mob's description, without fail. Nice job testing the code y'all!

## Why It's Good For The Game

Every time anyone would use an examiner it would runtime every single circuits tick. Joy.

## Changelog
:cl:
fix: Dummied out mob/living descriptions for examiner circuits.
/:cl: