### PR TITLE
a mouth cover check for pies

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -53,7 +53,8 @@
 		H.adjust_blurriness(1)
 		H.visible_message("<span class='warning'>[H] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
 		playsound(H, "desceration", 50, TRUE)
-		reagents.trans_to(H,15) //Cream pie combat
+		if(H.is_mouth_covered())	
+			reagents.trans_to(H,15) //Cream pie combat
 		if(!H.creamed) // one layer at a time
 			H.add_overlay(creamoverlay)
 			H.creamed = TRUE

--- a/code/modules/food_and_drinks/food/snacks_pie.dm
+++ b/code/modules/food_and_drinks/food/snacks_pie.dm
@@ -53,7 +53,7 @@
 		H.adjust_blurriness(1)
 		H.visible_message("<span class='warning'>[H] is creamed by [src]!</span>", "<span class='userdanger'>You've been creamed by [src]!</span>")
 		playsound(H, "desceration", 50, TRUE)
-		if(H.is_mouth_covered())	
+		if(!H.is_mouth_covered())	
 			reagents.trans_to(H,15) //Cream pie combat
 		if(!H.creamed) // one layer at a time
 			H.add_overlay(creamoverlay)


### PR DESCRIPTION
## About The Pull Request
adds a "is this dude's mouth covered" for transferring pie reagents
## Why It's Good For The Game
chem combat is boring anyway
## Changelog
:cl:
balance: Pie reagent transfer now requires an uncovered mouth.
/:cl: