### PR TITLE
hand teles uses a (slightly) less atrocious sprite for the beam

### DIFF
--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -142,7 +142,7 @@
 	return ..()
 
 /obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 20)
-	var/datum/beam/B = user.Beam(target, beam_icon_state = "rped_upgrade", maxdistance = 50)
+	var/datum/beam/B = user.Beam(target, icon_state = "rped_upgrade", maxdistance = 50)
 	if(is_parent_of_portal(target) && (!delay || do_after(user, delay, target = target)))
 		qdel(target)
 		to_chat(user, "<span class='notice'>You dispel [target] with \the [src]!</span>")

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -141,7 +141,7 @@
 		return TRUE
 	return ..()
 
-/obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 20)
+/obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 30)
 	var/datum/beam/B = user.Beam(target, icon_state = "rped_upgrade", maxdistance = 50)
 	if(is_parent_of_portal(target) && (!delay || do_after(user, delay, target = target)))
 		qdel(target)

--- a/code/game/objects/items/teleportation.dm
+++ b/code/game/objects/items/teleportation.dm
@@ -141,8 +141,8 @@
 		return TRUE
 	return ..()
 
-/obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 30)
-	var/datum/beam/B = user.Beam(target)
+/obj/item/hand_tele/proc/try_dispel_portal(atom/target, mob/user, delay = 20)
+	var/datum/beam/B = user.Beam(target, beam_icon_state = "rped_upgrade", maxdistance = 50)
 	if(is_parent_of_portal(target) && (!delay || do_after(user, delay, target = target)))
 		qdel(target)
 		to_chat(user, "<span class='notice'>You dispel [target] with \the [src]!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

[s]nerfed it too hard (still think it's powerful) and people complained[/s] fine

and the default beam is fucking atrocious

oh and the beam is longer for Those Who Care.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: hand teles use a less atrocious beam
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
