### PR TITLE
Fixes storytellers sometimes dividing by zero

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic_storytellers.dm
+++ b/code/game/gamemodes/dynamic/dynamic_storytellers.dm
@@ -57,7 +57,8 @@ Property weights are:
 							mean += 2.5
 						if(CHAOS_MAX)
 							mean += 5
-			GLOB.dynamic_curve_centre += (mean/voters)
+			if(voters)
+				GLOB.dynamic_curve_centre += (mean/voters)
 		GLOB.dynamic_forced_threat_level = forced_threat_level
 
 /datum/dynamic_storyteller/proc/get_midround_cooldown()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Division by zero if nobody has a chaos pref. I didn't catch this locally cause I have a chaos pref locally, whoops.

## Why It's Good For The Game

Runtimes bad.

## Changelog
:cl:
fix: Runtime if nobody has a chaos pref set
/:cl:

