### PR TITLE
Bow corrections.

### DIFF
--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -10,7 +10,7 @@
 /obj/item/ammo_casing/caseless/arrow/ashen
 	name = "ashen arrow"
 	desc = "Fire harderned wooden arrow."
-	icon_state = "asharrow"
+	icon_state = "ashenarrow"
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow/ashen
 
 /obj/item/ammo_casing/caseless/arrow/bone

--- a/code/modules/projectiles/guns/ballistic/bow.dm
+++ b/code/modules/projectiles/guns/ballistic/bow.dm
@@ -22,11 +22,9 @@
 /obj/item/gun/ballistic/bow/chamber_round()
 	chambered = magazine.get_round(1)
 
-/obj/item/gun/ballistic/bow/afterattack()
-	. = ..()
-	if (chambered)
-		chambered = null
-		magazine.get_round(0)
+/obj/item/gun/ballistic/bow/process_chamber()
+	chambered = null
+	magazine.get_round(0)
 	update_icon()
 
 /obj/item/gun/ballistic/bow/attack_self(mob/living/user)
@@ -47,7 +45,7 @@
 		update_icon()
 
 /obj/item/gun/ballistic/bow/update_icon()
-	icon_state = "bow_[get_ammo() ? (chambered ? "firing" : "loaded") : "unloaded"]"
+	icon_state = "[initial(icon_state)]_[get_ammo() ? (chambered ? "firing" : "loaded") : "unloaded"]"
 
 /obj/item/gun/ballistic/bow/can_shoot()
 	return chambered


### PR DESCRIPTION
## About The Pull Request

Bows now respect their sprites.
Bows now will not dquel arrows that are not fired
Ashen Arrow has a definitive name now

## Why It's Good For The Game

Turns out the base now had a few corrections to be made
Ashen arrow as infact misspelled

## Changelog
:cl: Linzolle
fix: Bows now will not delete an arrow if it cant fire it.
fix: bows now like and respect sprite changes
/:cl:
