### PR TITLE
AIs now understand dwarf

### DIFF
--- a/code/modules/language/language_holder.dm
+++ b/code/modules/language/language_holder.dm
@@ -138,7 +138,7 @@
 
 /datum/language_holder/synthetic
 	languages = list(/datum/language/common)
-	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic, /datum/language/slime)
+	shadow_languages = list(/datum/language/common, /datum/language/machine, /datum/language/draconic, /datum/language/slime, /datum/language/dwarf)
 
 /datum/language_holder/empty
 	languages = list()


### PR DESCRIPTION

## About The Pull Request

AI and borgs now understand can speak in dwarf
closes #11161 
## Why It's Good For The Game

AI and borgs can now be commanded in dwarf, talk to dwarfs in dwarf if ERP in dwarf

## Changelog
:cl:
fix: AIs now understand the old ways of drunken dwarfs
/:cl:

