### PR TITLE
Removes more Trek armor.

### DIFF
--- a/code/modules/clothing/under/trek.dm
+++ b/code/modules/clothing/under/trek.dm
@@ -19,7 +19,6 @@
 	icon_state = "trek_engsec"
 	item_color = "trek_engsec"
 	item_state = "r_suit"
-	armor = list("melee" = 10, "bullet" = 0, "laser" = 0,"energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 0, "acid" = 0) //more sec than eng, but w/e.
 	strip_delay = 50
 
 /obj/item/clothing/under/trek/medsci


### PR DESCRIPTION
## About The Pull Request

Engis no longer get basicly free armor from star trek suits

## Why It's Good For The Game

1) Some of these spawn throughout box station
2) You get these as engi or sec and its free armor for half of the people that get it
3) No other trek suits really have armor like this

## Changelog
:cl:
balance: Engi/Sec Trek suit no longer has 10% melee protection
/:cl:
