### PR TITLE
Remember when Kev made IPCs hearts no longer emp? Me ether!

### DIFF
--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -222,9 +222,8 @@ obj/item/organ/heart/cybernetic/upgraded/on_life()
 
 /obj/item/organ/heart/ipc
 	name = "IPC heart"
-	desc = "An electronic pump that regulates hydraulic functions, they have an auto-restart after EMPs."
+	desc = "An electronic pump that regulates hydraulic functions, they have an not affected by EMPs."
 	icon_state = "heart-c"
-	organ_flags = ORGAN_SYNTHETIC
 
 /obj/item/organ/heart/freedom
 	name = "heart of freedom"

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -222,7 +222,7 @@ obj/item/organ/heart/cybernetic/upgraded/on_life()
 
 /obj/item/organ/heart/ipc
 	name = "IPC heart"
-	desc = "An electronic pump that regulates hydraulic functions, they have an not affected by EMPs."
+	desc = "An electronic pump that regulates hydraulic functions, the electronics have EMP shielding."
 	icon_state = "heart-c"
 
 /obj/item/organ/heart/freedom


### PR DESCRIPTION

## About The Pull Request

Corrects IPC hearts to be an organic thing, meaning it self heals and no longer get fucken murdered by emps

## Why It's Good For The Game

They are not meant to be heart attack proof nor have any affect on being EMPed 

## Changelog
:cl:
fix: IPC hearts are now made of robomeat and roboblood thats emp proof. Heals and is all and all just like an normal heart
/:cl: