### PR TITLE
Made supermatter power increase with raw damage

### DIFF
--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -345,9 +345,9 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		// Pass all the gas related code an empty gas container
 		removed = new()
+	damage_archived = min(damage_archived + (DAMAGE_HARDCAP * explosion_point),damage)
 	matter_power += damage - damage_archived
-	damage = min(damage_archived + (DAMAGE_HARDCAP * explosion_point),damage) // hardcap any direct damage taken before doing atmos damage
-	damage_archived = damage
+	damage = damage_archived
 	if(!removed || !removed.total_moles() || isspaceturf(T)) //we're in space or there is no gas to process
 		if(takes_damage)
 			damage += max((power / 1000) * DAMAGE_INCREASE_MULTIPLIER, 0.1) // always does at least some damage

--- a/code/modules/power/supermatter/supermatter.dm
+++ b/code/modules/power/supermatter/supermatter.dm
@@ -345,7 +345,7 @@ GLOBAL_DATUM(main_supermatter_engine, /obj/machinery/power/supermatter_crystal)
 	else
 		// Pass all the gas related code an empty gas container
 		removed = new()
-
+	matter_power += damage - damage_archived
 	damage = min(damage_archived + (DAMAGE_HARDCAP * explosion_point),damage) // hardcap any direct damage taken before doing atmos damage
 	damage_archived = damage
 	if(!removed || !removed.total_moles() || isspaceturf(T)) //we're in space or there is no gas to process


### PR DESCRIPTION
## About The Pull Request

Shooting the supermatter will still hardcap the damage, but will incorporate the damage as power, which should result in an absolutely massive spike with enough bullets. 

## Why It's Good For The Game

Well, maybe shooting the supermatter should do *something*. Turns out when people read "hardcaps damage on supermatter getting shot" they don't think "basically removed shooting the supermatter as a viable way to cause damage to it", whoops. 

What I didn't convey last time is that I think shooting the supermatter was one of the worst cases of degenerate edge-cases in this entire game, a clear example of stuff falling through the cracks and leading to gameplay that's simply not good in any respect. The optimal way to destroy the supermatter should be to know how it works, sabotage it in ways that are difficult to notice, and pump gases into it that make it delaminate quickly so they have to scramble to fix it. The actual optimal way was to go in and shoot it. With a gun. That's not good, and I would argue that it's actually quite terrible, and the hardcap was meant to remove that from the game, but it wasn't conveyed well enough.

This reneges on it a bit: 

## Changelog
:cl:
balance: Shooting the supermatter now adds to the supermatter's power. CO2 setups beware!
/:cl:
