### PR TITLE
Makes two new legion drops

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -411,6 +411,6 @@
 			belt = /obj/item/storage/belt/fannypack/yellow
 			id_job = "Assisant"
 			id = /obj/item/card/id
-			l_pocket = /obj/item/paper/fluff/bee_objectives
+			l_pocket = /obj/item/reagent_containers/food/drinks/soda_cans/buzz_fuzz
 			mask = /obj/item/clothing/mask/rat/bee
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -269,7 +269,7 @@
 	H.dna.add_mutation(DWARFISM)
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 66, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist", "Lavaknight")) = 4)) //CIT CHANGE: Lavaknights
+	var/type = pickweight(list("Miner" = 45, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist", "Lavaknight")) = 4, "Assistant" = 20, "Beelegionin" = 1))
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -377,4 +377,40 @@
 			suit_store = /obj/item/tank/internals/oxygen
 			id = /obj/item/card/id/knight //END OF CIT CHANGE
 			id_job = "Knight"
+		if("Assistant")
+			uniform = /obj/item/clothing/under/color/grey
+			belt = /obj/item/tank/internals/emergency_oxygen
+			mask = /obj/item/clothing/mask/gas
+			ears = /obj/item/radio/headset
+			if(prob(95))
+				head = /obj/item/clothing/head/hardhat/red
+			if(prob(95))
+				gloves = /obj/item/clothing/gloves/color/fyellow
+			else
+				gloves = /obj/item/clothing/gloves/color/yellow
+			if(prob(90))
+				back = /obj/item/twohanded/spear
+			else
+				back = /obj/item/storage/backpack
+				backpack_contents = list(/obj/item/stack/cable_coil = 12, /obj/item/assembly/flash = 1, /obj/item/storage/fancy/donut_box = 1, /obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 1, /obj/item/lighter = 1)
+			if(prob(90))
+				r_pocket = /obj/item/kitchen/knife
+			if(prob(60))
+				l_pocket = /obj/item/soap/homemade
+			if(prob(99))
+				id = /obj/item/card/id/knight
+				id_job = "Assisant"
+			else
+				id = /obj/item/card/id/silver/reaper //Same as aaisant but looks cool and has a fancy name
+		if("Beelegionin")
+			uniform = /obj/item/clothing/under/color/yellow
+			suit = /obj/item/clothing/suit/hooded/bee_costume
+			shoes = /obj/item/clothing/shoes/sneakers/yellow
+			gloves = /obj/item/clothing/gloves/color/yellow
+			ears = /obj/item/radio/headset
+			belt = /obj/item/storage/belt/fannypack/yellow
+			id_job = "Assisant"
+			id = /obj/item/card/id
+			l_pocket = /obj/item/paper/fluff/bee_objectives
+			mask = /obj/item/clothing/mask/rat/bee
 	. = ..()

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -269,7 +269,7 @@
 	H.dna.add_mutation(DWARFISM)
 
 /obj/effect/mob_spawn/human/corpse/damaged/legioninfested/Initialize()
-	var/type = pickweight(list("Miner" = 45, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist", "Lavaknight")) = 4, "Assistant" = 20, "Beelegionin" = 1))
+	var/type = pickweight(list("Miner" = 45, "Ashwalker" = 10, "Golem" = 10,"Clown" = 10, pick(list("Shadow", "YeOlde","Operative", "Cultist", "Lavaknight")) = 4, "Assistant" = 20, "Beelegion" = 1))
 	switch(type)
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
@@ -368,41 +368,39 @@
 			l_pocket = /obj/item/melee/cultblade/dagger
 			glasses =  /obj/item/clothing/glasses/hud/health/night/cultblind
 			backpack_contents = list(/obj/item/reagent_containers/glass/beaker/unholywater = 1, /obj/item/cult_shift = 1, /obj/item/flashlight/flare/culttorch = 1, /obj/item/stack/sheet/runed_metal = 15)
-		if("Lavaknight") //START OF CIT CHANGE
+		if("Lavaknight")
 			uniform = /obj/item/clothing/under/assistantformal
 			mask = /obj/item/clothing/mask/breath
 			shoes = /obj/item/clothing/shoes/sneakers/black
 			r_pocket = /obj/item/melee/transforming/energy/sword/cx/broken
 			suit = /obj/item/clothing/suit/space/hardsuit/lavaknight
 			suit_store = /obj/item/tank/internals/oxygen
-			id = /obj/item/card/id/knight //END OF CIT CHANGE
+			id = /obj/item/card/id/knight
 			id_job = "Knight"
 		if("Assistant")
 			uniform = /obj/item/clothing/under/color/grey
 			belt = /obj/item/tank/internals/emergency_oxygen
 			mask = /obj/item/clothing/mask/gas
 			ears = /obj/item/radio/headset
+			gloves = /obj/item/clothing/gloves/color/fyellow
+			id = /obj/item/card/id/silver/reaper //looks cool and has a fancy name but only a 1% chance
+			back = /obj/item/storage/backpack
+			backpack_contents = list(/obj/item/stack/cable_coil = 12, /obj/item/assembly/flash = 1, /obj/item/storage/fancy/donut_box = 1, /obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 1, /obj/item/lighter = 1)
+			if(prob(99))
+				id = /obj/item/card/id
+				id_job = "Assisant"
 			if(prob(95))
 				head = /obj/item/clothing/head/hardhat/red
-			if(prob(95))
-				gloves = /obj/item/clothing/gloves/color/fyellow
-			else
+			if(prob(5))
 				gloves = /obj/item/clothing/gloves/color/yellow
-			if(prob(90))
+			if(prob(10))
 				back = /obj/item/twohanded/spear
-			else
-				back = /obj/item/storage/backpack
-				backpack_contents = list(/obj/item/stack/cable_coil = 12, /obj/item/assembly/flash = 1, /obj/item/storage/fancy/donut_box = 1, /obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 1, /obj/item/lighter = 1)
+				backpack_contents = null
 			if(prob(90))
 				r_pocket = /obj/item/kitchen/knife
 			if(prob(60))
 				l_pocket = /obj/item/soap/homemade
-			if(prob(99))
-				id = /obj/item/card/id/knight
-				id_job = "Assisant"
-			else
-				id = /obj/item/card/id/silver/reaper //Same as aaisant but looks cool and has a fancy name
-		if("Beelegionin")
+		if("Beelegion")
 			uniform = /obj/item/clothing/under/color/yellow
 			suit = /obj/item/clothing/suit/hooded/bee_costume
 			shoes = /obj/item/clothing/shoes/sneakers/yellow


### PR DESCRIPTION

## About The Pull Request

legion now has infected the gray tide a bit and can spit out at a 20% rate a grayshirt. Grayshirt as the typical grayshirt gear, spear, random shit they pick up, and a few pwer gamer gear like hardhat and flash sometimes

legion A bee activest but without the traitor gear, this one is more a joke on bee-legion and less about someone dieing on lavaland with that gear. Buzz Buzz! - 1% drop
Miner drops have been reduced 21%
## Why It's Good For The Game

Adds brand new loot drops that are not to op or powergaming is always nice and it makes a bit more logic now that you would see the graytide on lava land with puplic mining being a thing now

## Changelog
:cl:
add: Two new legion drop. Assistant and Bee-Activist
/:cl:
