### PR TITLE
Gives traitors with power-draining sabotage objective a free powersink

### DIFF
--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -19,7 +19,6 @@
 	var/won = FALSE
 
 /datum/sabotage_objective/processing/New()
-	special_equipment += /obj/item/sbeacondrop/powersink
 	..()
 	START_PROCESSING(SSprocessing, src)
 
@@ -37,7 +36,7 @@
 /datum/sabotage_objective/processing/power_sink
 	name = "Drain at least 1 gigajoule of power using a power sink."
 	sabotage_type = "powersink"
-	special_equipment = list(/obj/item/powersink)
+	special_equipment = list(/obj/item/sbeacondrop/powersink)
 	var/sink_found = FALSE
 	var/count = 0
 

--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -19,6 +19,7 @@
 	var/won = FALSE
 
 /datum/sabotage_objective/processing/New()
+	special_equipment += /obj/item/sbeacondrop/powersink
 	..()
 	START_PROCESSING(SSprocessing, src)
 


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

having to deliberately buy a 14 tc item severely limits traitors who want to be stealthy

## Changelog
:cl:Kraseo
balance: If you have the powersink objective, you will now receive a free beacon.
/:cl: