### PR TITLE
Corrects Peach Cake Slice to have an icon

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_cake.dm
+++ b/code/modules/food_and_drinks/food/snacks_cake.dm
@@ -389,7 +389,7 @@ obj/item/reagent_containers/food/snacks/store/cake/pound_cake
 /obj/item/reagent_containers/food/snacks/cakeslice/peach_slice
 	name = "peach cake slice"
 	desc = "A slice of peach cake."
-	icon_state = "peach_slice"
+	icon_state = "peachcake_slice"
 	filling_color = "#00FFFF"
 	tastes = list("cake" = 1, "sugar" = 1, "peachjuice" = 10)
 	foodtype = GRAIN | SUGAR | DAIRY


### PR DESCRIPTION

## About The Pull Request

Corrects icon_state so that peach cake slices can be seen

## Why It's Good For The Game

Unless its a mime, we dont eat invisible food

## Changelog
:cl:
fix: Peach cake slices are no long made by mimes
/:cl:
