### PR TITLE
Raises blob point cap by 150 (aka they can store 250 now)

### DIFF
--- a/code/modules/antagonists/blob/blob/overmind.dm
+++ b/code/modules/antagonists/blob/blob/overmind.dm
@@ -24,7 +24,7 @@ GLOBAL_LIST_EMPTY(blob_nodes)
 	hud_type = /datum/hud/blob_overmind
 	var/obj/structure/blob/core/blob_core = null // The blob overmind's core
 	var/blob_points = 0
-	var/max_blob_points = 100
+	var/max_blob_points = 250
 	var/last_attack = 0
 	var/datum/reagent/blob/blob_reagent_datum = new/datum/reagent/blob()
 	var/list/blob_mobs = list()


### PR DESCRIPTION
## About The Pull Request

Blobs can now store more then 3 points but less then 251 points

## Why It's Good For The Game

Blobs tend to have a few powers that cost a lot meaning they have to save up a lot of points, then spending that points all in one place, making it harder for a blob to react to things.
If a blob is doing really good then they should not be punished for being in a good spot or having good team mates.

## Changelog
:cl:
balance: Blobs now can store 250 points.
/:cl: