### PR TITLE
Corrects bar stool name

### DIFF
--- a/code/game/objects/structures/beds_chairs/chair.dm
+++ b/code/game/objects/structures/beds_chairs/chair.dm
@@ -407,7 +407,7 @@
 	buildstackamount = 1
 
 /obj/structure/chair/stool/bar/alien
-	name = "bronze bar stool"
+	name = "alien bar stool"
 	desc = "A hard bar stool made of advanced alien alloy."
 	icon_state = "baralien"
 	icon = 'icons/obj/abductor.dmi'


### PR DESCRIPTION

## About The Pull Request

My bad forgot to change the name
## Why It's Good For The Game

wrong mat type

## Changelog
:cl:
spellcheck: Alien bar stool is no longer bronze
/:cl:
