### PR TITLE
Makes harm intent clicking closets attack them rather than place an item inside

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -359,7 +359,7 @@
 								"<span class='italics'>You hear [welder ? "welding" : "rustling of screws and metal"].</span>")
 				deconstruct(TRUE)
 				return
-		if(user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
+		if(user.a_intent != INTENT_HARM && user.transferItemToLoc(W, drop_location())) // so we put in unlit welder too
 			return TRUE
 	else if(istype(W, /obj/item/electronics/airlock))
 		handle_lock_addition(user, W)


### PR DESCRIPTION
Does exactly what it says on the tin. Consistency with tables, racks, and closed closets.

## Changelog
:cl: Bhijn
tweak: Clicking an open closet with harm intent no longer attempts to place your currently held item inside, but rather attacks it.
/:cl:
