### PR TITLE
Makes the default sprint config options match live's actual config

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -254,13 +254,13 @@
 	config_entry_value = 1
 
 /datum/config_entry/number/movedelay/sprint_buffer_max
-	config_entry_value = 42
+	config_entry_value = 24
 
 /datum/config_entry/number/movedelay/sprint_stamina_cost
-	config_entry_value = 0.7
+	config_entry_value = 1.4
 
 /datum/config_entry/number/movedelay/sprint_buffer_regen_per_ds
-	config_entry_value = 0.3
+	config_entry_value = 0.4
 
 /////////////////////////////////////////////////Outdated move delay
 /datum/config_entry/number/outdated_movedelay


### PR DESCRIPTION
Title. This PR does exactly as it says on the tin, makes the codebase's default sprint config vars match live's actual config. This will help a lot for devs looking to test balance stuff locally or with testers in an environment that matches live as closely as possible. `SPRINT_BUFFER_MAX`, `SPRINT_STAMINA_COST`, and `SPRINT_BUFFER_REGEN_PER_DS` were all changed. With the previous values, we found that sprinting was way, *way* too cheap of an action, especially during combat, since you could just hold shift to make yourself become untargettable with no actual cost. So we went ahead and trialled a doubling of the stamina cost and a halving of the sprint buffer on live, and it turned out to do a pretty good job at greatly reducing the power of sprinting without resorting to either just removing sprinting or reducing standard movement speed. To any downstreams that reduced movement speed to nerf sprinting: we strongly encourage you to try out these new values and see how they work in your environment!

## Changelog
:cl: Bhijn
config: The default values for sprinting now match the live server's actual config.
/:cl:
