### PR TITLE
Removes soporific sniper rifle rounds from gang uplinks

### DIFF
--- a/code/game/gamemodes/gangs/gang_items.dm
+++ b/code/game/gamemodes/gangs/gang_items.dm
@@ -220,11 +220,11 @@ datum/gang_item/clothing/shades //Addition: Why not have cool shades on a gang m
 	cost = 15
 	item_path = /obj/item/ammo_box/magazine/sniper_rounds
 
-/datum/gang_item/weapon/ammo/sleeper_ammo
+/*/datum/gang_item/weapon/ammo/sleeper_ammo	//no. absolutely no.
 	name = "Illicit Soporific Cartridges"
 	id = "sniper_ammo"
-	cost = 15
-	item_path = /obj/item/ammo_box/magazine/sniper_rounds/soporific
+	cost = 15	//who the fuck thought a ONE-HIT K.O. for 15 gbp IN AN ENVIRONMENT WHERE WE'RE GETTING RID OF HARDSTUNS is a GOOD IDEA
+	item_path = /obj/item/ammo_box/magazine/sniper_rounds/soporific*/
 
 /datum/gang_item/weapon/machinegun
 	name = "Mounted Machine Gun"


### PR DESCRIPTION
## About The Pull Request

as seen in the title

## Why It's Good For The Game

one-and-dones are bad for the game, okay?

## Changelog
:cl:Kraseo
balance: Gangs no longer get soporific rounds for their sniper rifles.
/:cl:
