### PR TITLE
Fixing escaped characters in flavor texts.

### DIFF
--- a/code/__HELPERS/_cit_helpers.dm
+++ b/code/__HELPERS/_cit_helpers.dm
@@ -115,7 +115,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 
 	var/new_flavor = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", flavor_text, MAX_FAVOR_LEN, TRUE)
 	if(!isnull(new_flavor))
-		flavor_text = new_flavor
+		flavor_text = html_decode(new_flavor)
 		to_chat(src, "Your flavor text has been updated.")
 
 //Flavor Text
@@ -126,7 +126,7 @@ GLOBAL_VAR_INIT(miscreants_allowed, FALSE)
 
 	var/new_flavor = stripped_multiline_input(usr, "Set the temporary flavor text in your 'examine' verb. This should be used only for things pertaining to the current round!", "Short-Term Flavor Text", flavor_text_2, MAX_FAVOR_LEN, TRUE)
 	if(!isnull(new_flavor))
-		flavor_text_2 = new_flavor
+		flavor_text_2 = html_decode(new_flavor)
 		to_chat(src, "Your temporary flavor text has been updated.")
 
 /mob/proc/print_flavor_text(flavor,temp = FALSE)

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1474,8 +1474,8 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FAVOR_LEN, TRUE)
-					if(msg)
-						features["flavor_text"] = msg
+					if(!isnull(new_flavor))
+						features["flavor_text"] = html_decode(msg)
 
 				if("hair")
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1474,7 +1474,7 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 
 				if("flavor_text")
 					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FAVOR_LEN, TRUE)
-					if(!isnull(new_flavor))
+					if(!isnull(msg))
 						features["flavor_text"] = html_decode(msg)
 
 				if("hair")


### PR DESCRIPTION
## About The Pull Request 
Title. Misread `html_encode` for `html_decoded` on `stripped_multiline_input`.

## Why It's Good For The Game
Title. This will close #11228 because it only specified the issue on flavor texts.

## Changelog
I don't care.