### PR TITLE
Cogchamp mixing sound made less annoyingly long.

### DIFF
--- a/code/modules/food_and_drinks/recipes/drinks_recipes.dm
+++ b/code/modules/food_and_drinks/recipes/drinks_recipes.dm
@@ -591,7 +591,7 @@
 	results = list(/datum/reagent/consumable/ethanol/cogchamp = 3)
 	required_reagents = list(/datum/reagent/consumable/ethanol/cognac = 1, /datum/reagent/fuel = 1, /datum/reagent/consumable/ethanol/screwdrivercocktail = 1)
 	mix_message = "You hear faint sounds of gears turning as it mixes."
-	mix_sound = 'sound/effects/clockcult_gateway_closing.ogg'
+	mix_sound = 'sound/machines/clockcult/steam_whoosh.ogg'
 
 /datum/chemical_reaction/quadruplesec
 	name = "Quadruple Sec"


### PR DESCRIPTION
## About The Pull Request
Replacing it with `sound/machines/clockcult/steam_whoosh.ogg`
Out of plenty clockcult-ish shound, did you really have to pick a gateway sound loop one?

## Why It's Good For The Game
Sanity.

## Changelog
:cl:
sounddel: Made the cogchamp mixing sound less annoying.
/:cl: