### PR TITLE
The Grey Tide can now be harnessed by assistants

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -778,11 +778,11 @@
 	throwforce = 20
 	throw_speed = 4
 	attack_verb = list("gored")
-	var/clonechance = 50
+	var/clonechance = 75
 	var/clonedamage = 12
 	var/clonespeed = 0
-	var/clone_replication_chance = 30
-	var/clone_lifespan = 100
+	var/clone_replication_chance = 40
+	var/clone_lifespan = 120
 
 /obj/item/twohanded/spear/grey_tide/afterattack(atom/movable/AM, mob/living/user, proximity)
 	. = ..()

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -262,7 +262,7 @@
 
 /datum/uplink_item/dangerous/lonerevolver
 	name = "Just The Revolver That You Really Shouldn't Be Seeing Here I Mean Dang"
-	desc = "This...shouldn't be here, really. The standard Syndicate revolver, not including the actual magazine."
+	desc = "This...shouldn't be here, really. The standard Syndicate revolver, not including the actual kit with the free speedloader."
 	item = /obj/item/gun/ballistic/revolver
 	include_modes = list()
 	cost = 20

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -259,3 +259,10 @@
 	item = /obj/item/gun/ballistic/automatic/toy/pistol/riot
 	cost = 3
 	surplus = 10
+
+/datum/uplink_item/dangerous/lonerevolver
+	name = "Just The Revolver That You Really Shouldn't Be Seeing Here I Mean Dang"
+	desc = "This...shouldn't be here, really. The standard Syndicate revolver, not including the actual magazine."
+	include_modes = list()
+	cost = 20
+	surplus = 0

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -263,6 +263,7 @@
 /datum/uplink_item/dangerous/lonerevolver
 	name = "Just The Revolver That You Really Shouldn't Be Seeing Here I Mean Dang"
 	desc = "This...shouldn't be here, really. The standard Syndicate revolver, not including the actual magazine."
+	item = /obj/item/gun/ballistic/revolver
 	include_modes = list()
 	cost = 20
 	surplus = 0

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -14,6 +14,13 @@
 	cost = 20
 	restricted_roles = list("Assistant")
 
+/datum/uplink_item/role_restricted/grey_tide
+	name = "The Grey Tide"
+	desc = "Recovered by - and stolen from - NanoTrasen after fending off a seemingly endless tide of assistants. Perhaps this was the key?"
+	item = /obj/item/twohanded/spear/grey_tide
+	cost = 12
+	restricted_roles = list("Assistant")
+
 /datum/uplink_item/role_restricted/pie_cannon
 	name = "Banana Cream Pie Cannon"
 	desc = "A special pie cannon for a special clown, this gadget can hold up to 20 pies and automatically fabricates one every two seconds!"


### PR DESCRIPTION
## About The Pull Request
The Grey Tide spear has received a buff. But why? Because it's buyable by Assistant traitors, now. 12 TC.

also revolvers are actually illegal again and shouldn't be buyable outside of the kit
## Why It's Good For The Game
spear
## Changelog
:cl:
add: A certain almost-magical spear was lost by NanoTrasen storage operatives, and is rumored to be in the hands of the Syndicate...
fix: Revolvers should be illegal again. If you have the option to buy the lone revolver, don't.
/:cl: