### PR TITLE
An old oversight with disease/var/viable_mobtypes. 

### DIFF
--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -21,7 +21,7 @@
 		return FALSE
 
 
-	if(!D.infectable_mobtypes[type])
+	if(!D.viable_mobtypes[type])
 		return FALSE
 
 	return TRUE

--- a/code/datums/diseases/_MobProcs.dm
+++ b/code/datums/diseases/_MobProcs.dm
@@ -21,7 +21,7 @@
 		return FALSE
 
 
-	if(!(type in D.viable_mobtypes))
+	if(!D.infectable_mobtypes[type])
 		return FALSE
 
 	return TRUE

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -18,7 +18,6 @@
 	var/stage_prob = 4
 
 	//Other
-	var/list/viable_mobtypes = list() //typepaths of viable mobs
 	var/mob/living/carbon/affected_mob = null
 	var/list/cures = list() //list of cures if the disease has the CURABLE flag, these are reagent ids
 	var/infectivity = 65
@@ -30,9 +29,16 @@
 	var/list/required_organs = list()
 	var/needs_all_cures = TRUE
 	var/list/strain_data = list() //dna_spread special bullshit
+	var/list/viable_mobtypes //typecache of viable mobs passed down the below variable.
+	var/list/infectable_mobtypes = list()
 	var/infectable_biotypes = MOB_ORGANIC //if the disease can spread on organics, synthetics, or undead
 	var/process_dead = FALSE //if this ticks while the host is dead
 	var/copy_type = null //if this is null, copies will use the type of the instance being copied
+
+/datum/disease/New()
+	..()
+	if(viable_mobtypes)
+		infectable_mobtypes = typecacheof(viable_mobtypes)
 
 /datum/disease/Destroy()
 	. = ..()

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -18,6 +18,7 @@
 	var/stage_prob = 4
 
 	//Other
+	var/list/viable_mobtypes = list() //typecache of viable mobs
 	var/mob/living/carbon/affected_mob = null
 	var/list/cures = list() //list of cures if the disease has the CURABLE flag, these are reagent ids
 	var/infectivity = 65
@@ -29,16 +30,14 @@
 	var/list/required_organs = list()
 	var/needs_all_cures = TRUE
 	var/list/strain_data = list() //dna_spread special bullshit
-	var/list/viable_mobtypes //typecache of viable mobs passed down the below variable.
-	var/list/infectable_mobtypes = list()
 	var/infectable_biotypes = MOB_ORGANIC //if the disease can spread on organics, synthetics, or undead
 	var/process_dead = FALSE //if this ticks while the host is dead
 	var/copy_type = null //if this is null, copies will use the type of the instance being copied
 
-/datum/disease/New()
+/datum/disease/New(make_typecache = TRUE)
 	..()
-	if(viable_mobtypes)
-		infectable_mobtypes = typecacheof(viable_mobtypes)
+	if(make_typecache && length(viable_mobtypes))
+		viable_mobtypes = typecacheof(viable_mobtypes)
 
 /datum/disease/Destroy()
 	. = ..()

--- a/code/datums/diseases/_disease.dm
+++ b/code/datums/diseases/_disease.dm
@@ -35,7 +35,6 @@
 	var/copy_type = null //if this is null, copies will use the type of the instance being copied
 
 /datum/disease/New(make_typecache = TRUE)
-	..()
 	if(make_typecache && length(viable_mobtypes))
 		viable_mobtypes = typecacheof(viable_mobtypes)
 

--- a/code/datums/diseases/advance/advance.dm
+++ b/code/datums/diseases/advance/advance.dm
@@ -80,7 +80,8 @@
 
  */
 
-/datum/disease/advance/New()
+/datum/disease/advance/New(make_typecache = TRUE)
+	..()
 	Refresh()
 
 /datum/disease/advance/Destroy()

--- a/code/datums/diseases/advance/presets.dm
+++ b/code/datums/diseases/advance/presets.dm
@@ -2,7 +2,7 @@
 /datum/disease/advance/cold
 	copy_type = /datum/disease/advance
 
-/datum/disease/advance/cold/New()
+/datum/disease/advance/cold/New(make_typecache = TRUE)
 	name = "Cold"
 	symptoms = list(new/datum/symptom/sneeze)
 	..()
@@ -11,7 +11,7 @@
 /datum/disease/advance/flu
 	copy_type = /datum/disease/advance
 
-/datum/disease/advance/flu/New()
+/datum/disease/advance/flu/New(make_typecache = TRUE)
 	name = "Flu"
 	symptoms = list(new/datum/symptom/cough)
 	..()
@@ -21,7 +21,7 @@
 	name = "Experimental Disease"
 	copy_type = /datum/disease/advance
 
-/datum/disease/advance/random/New(max_symptoms, max_level = 8)
+/datum/disease/advance/random/New(make_typecache = TRUE, max_symptoms, max_level = 8)
 	if(!max_symptoms)
 		max_symptoms = rand(1, VIRUS_SYMPTOM_LIMIT)
 	var/list/datum/symptom/possible_symptoms = list()
@@ -37,6 +37,6 @@
 		if(chosen_symptom)
 			var/datum/symptom/S = new chosen_symptom
 			symptoms += S
-	Refresh()
 
 	name = "Sample #[rand(1,10000)]"
+	..()

--- a/code/datums/diseases/retrovirus.dm
+++ b/code/datums/diseases/retrovirus.dm
@@ -13,7 +13,7 @@
 	stage_prob = 2
 	var/restcure = 0
 
-/datum/disease/dna_retrovirus/New()
+/datum/disease/dna_retrovirus/New(make_typecache = TRUE)
 	..()
 	agent = "Virus class [pick("A","B","C","D","E","F")][pick("A","B","C","D","E","F")]-[rand(50,300)]"
 	if(prob(40))

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -248,7 +248,7 @@
 
 			else if(href_list["vir"])
 				var/type = href_list["vir"]
-				var/datum/disease/Dis = new type(0)
+				var/datum/disease/Dis = new type(FALSE)
 				var/AfS = ""
 				for(var/mob/M in Dis.viable_mobtypes)
 					AfS += " [initial(M.name)];"

--- a/code/game/machinery/computer/medical.dm
+++ b/code/game/machinery/computer/medical.dm
@@ -145,7 +145,7 @@
 				if(5)
 					dat += "<CENTER><B>Virus Database</B></CENTER>"
 					for(var/Dt in typesof(/datum/disease/))
-						var/datum/disease/Dis = new Dt(0)
+						var/datum/disease/Dis = new Dt(FALSE)
 						if(istype(Dis, /datum/disease/advance))
 							continue // TODO (tm): Add advance diseases to the virus database which no one uses.
 						if(!Dis.desc)

--- a/code/modules/events/disease_outbreak.dm
+++ b/code/modules/events/disease_outbreak.dm
@@ -63,7 +63,7 @@
 			else
 				D = new virus_type()
 		else
-			D = new /datum/disease/advance/random(max_severity, max_severity)
+			D = new /datum/disease/advance/random(TRUE, max_severity, max_severity)
 		D.carrier = TRUE
 		H.ForceContractDisease(D, FALSE, TRUE)
 

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -280,7 +280,7 @@
 		if(miasma_partialpressure > MINIMUM_MOLES_DELTA_TO_MOVE)
 
 			if(prob(0.05 * miasma_partialpressure))
-				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(2,3)
+				var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(TRUE, 2,3)
 				miasma_disease.name = "Unknown"
 				ForceContractDisease(miasma_disease, TRUE, TRUE)
 

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -350,7 +350,7 @@
 
 				//Miasma sickness
 				if(prob(0.05 * miasma_pp))
-					var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(2,3)
+					var/datum/disease/advance/miasma_disease = new /datum/disease/advance/random(TRUE, 2,3)
 					miasma_disease.name = "Unknown"
 					miasma_disease.try_infect(owner)
 


### PR DESCRIPTION
## About The Pull Request
There are currently zero reasons only precise specific types can be infected and not their subtypes. Also typecaches are cheaper than both `istype` procs and `in` operations.

## Why It's Good For The Game
This will close #11292.

## Changelog
None.