### PR TITLE
you can no longer stamcrit a goddamn xenomorph come on citadel why is this a thing 

### DIFF
--- a/code/modules/mob/living/carbon/alien/damage_procs.dm
+++ b/code/modules/mob/living/carbon/alien/damage_procs.dm
@@ -6,8 +6,8 @@
 	return FALSE
 
 //aliens are immune to stamina damage.
-/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_health = 1)
+/mob/living/carbon/alien/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	return
 
-/mob/living/carbon/alien/setStaminaLoss(amount, updating_health = 1)
+/mob/living/carbon/alien/setStaminaLoss(amount, updating_health = TRUE, forced = FALSE)
 	return

--- a/code/modules/mob/living/carbon/alien/damage_procs.dm
+++ b/code/modules/mob/living/carbon/alien/damage_procs.dm
@@ -5,11 +5,9 @@
 /mob/living/carbon/alien/adjustToxLoss(amount, updating_health = TRUE, forced = FALSE) //alien immune to tox damage
 	return FALSE
 
-/* CIT CHANGE - Pffffffffffffhahahahahhaha-- No.
 //aliens are immune to stamina damage.
 /mob/living/carbon/alien/adjustStaminaLoss(amount, updating_health = 1)
 	return
 
 /mob/living/carbon/alien/setStaminaLoss(amount, updating_health = 1)
 	return
-*/


### PR DESCRIPTION
this is just completely unnecessary now that i fixed the infinite hardstun bug

why was this a thing in the first place? it's a xenomorph, you lethal them and use face protection, not spam disablers/rubbers until they're ""stamcrit"" but not yet stamcrit what the fuck?