### PR TITLE
The lavaland elite tumor shard revival now fetches the mob's ghost.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/elites/elite.dm
@@ -325,6 +325,7 @@ obj/structure/elite_tumor/proc/onEliteWon()
 			return
 		E.faction = list("neutral")
 		E.revive(full_heal = TRUE, admin_revive = TRUE)
+		E.grab_ghost()
 		user.visible_message("<span class='notice'>[user] stabs [E] with [src], reviving it.</span>")
 		E.playsound_local(get_turf(E), 'sound/effects/magic.ogg', 40, 0)
 		to_chat(E, "<span class='userdanger'>You have been revived by [user].  While you can't speak to them, you owe [user] a great debt.  Assist [user.p_them()] in achieving [user.p_their()] goals, regardless of risk.</span")


### PR DESCRIPTION
## About The Pull Request
The tumor shard now grabs the ghost and shoves it back into the lavaland mob.

## Why It's Good For The Game
This will close #11097.

## Changelog
An oversight, nothing worth of a changelog.