### PR TITLE
Fixes people in soft critical moving far slower than they should be 

### DIFF
--- a/code/modules/mob/living/carbon/carbon_movement.dm
+++ b/code/modules/mob/living/carbon/carbon_movement.dm
@@ -9,8 +9,6 @@
 			. += 6 - 3*get_num_arms() //crawling is harder with fewer arms
 		if(legcuffed)
 			. += legcuffed.slowdown
-	if(stat == SOFT_CRIT)
-		. += SOFTCRIT_ADD_SLOWDOWN
 
 /mob/living/carbon/slip(knockdown_amount, obj/O, lube)
 	if(movement_type & FLYING && !(lube & FLYING_DOESNT_HELP))


### PR DESCRIPTION
This is already a thing done in updatehealth() using movespeed modifiers, this is being duplicated if it's also added in movement_delay()

furthermore soft crit having a slowdown of +6 and compounding onto the slowdown from health is another thing but I'm not touching it here because frankly it worked before.