### PR TITLE
Makes cargo passive point generation 125 a minute and not 2 or so every tick.

### DIFF
--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -113,7 +113,7 @@ SUBSYSTEM_DEF(shuttle)
 				qdel(T, force=TRUE)
 	CheckAutoEvac()
 
-	if(!(times_fired % (600/wait)))
+	if(!(times_fired % CEILING(600/wait, 1)))
 		points += passive_supply_points_per_minute
 
 	var/esETA = emergency?.getModeStr()

--- a/code/controllers/subsystem/shuttle.dm
+++ b/code/controllers/subsystem/shuttle.dm
@@ -113,11 +113,8 @@ SUBSYSTEM_DEF(shuttle)
 				qdel(T, force=TRUE)
 	CheckAutoEvac()
 
-	//Cargo stuff start
-	var/fire_time_diff = max(0, world.time - last_fire)		//Don't want this to be below 0, seriously.
-	var/point_gain = (fire_time_diff / 600) * passive_supply_points_per_minute
-	points += point_gain
-	//Cargo stuff end
+	if(!(times_fired % (600/wait)))
+		points += passive_supply_points_per_minute
 
 	var/esETA = emergency?.getModeStr()
 	emergency_shuttle_stat_text = "[esETA? "[esETA] [emergency.getTimerStr()]" : ""]"


### PR DESCRIPTION
## About The Pull Request 
Played CT again after a good while just to discover the passive point generation was going into decimals.

## Why It's Good For The Game
Cargo tweaks are a little wack.

## Changelog
:cl:
fix: Fixed cargo passive point generation to not go into decimals.
/:cl:

Edit: Sorry for shaming your contributions for a moment here, Trilby.