### PR TITLE
Allows blobbernauts to drag objects (but not mobs) again.

### DIFF
--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -223,7 +223,7 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/start_pulling(atom/movable/AM, state, force = pull_force, supress_message = FALSE)
 	if(!independent && ismob(AM))
-		if(!suppress_message)
+		if(!supress_message)
 			to_chat(src, "<span class='warning'>You are unable to grasp people in this form.</span>")
 		return FALSE
 	return ..()

--- a/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
+++ b/code/modules/antagonists/blob/blob/blobs/blob_mobs.dm
@@ -218,10 +218,15 @@
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Initialize()
 	. = ..()
-	if(!independent) //no pulling people deep into the blob
-		verbs -= /mob/living/verb/pulled
-	else
+	if(independent)
 		pass_flags &= ~PASSBLOB
+
+/mob/living/simple_animal/hostile/blob/blobbernaut/start_pulling(atom/movable/AM, state, force = pull_force, supress_message = FALSE)
+	if(!independent && ismob(AM))
+		if(!suppress_message)
+			to_chat(src, "<span class='warning'>You are unable to grasp people in this form.</span>")
+		return FALSE
+	return ..()
 
 /mob/living/simple_animal/hostile/blob/blobbernaut/Life()
 	if(..())


### PR DESCRIPTION
## About The Pull Request
Re-enables tactical blebbernaut fuel tank bombing etcetera.

## Why It's Good For The Game
Still no pulling people deep into the blob but it gives blobbernauts a little more freedom of tactics.
(I need to port that PR nerfing the amount of stored dakka in mecha firearms later. And buff the structure damage the blob can make.)

## Changelog
:cl:
balance: Allowed blobbernauts to drag objects (but not mobs) again.
/:cl:
