### PR TITLE
Made power sink objective more feasible

### DIFF
--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -23,18 +23,18 @@
 	START_PROCESSING(SSprocessing, src)
 
 /datum/sabotage_objective/processing/proc/check_condition_processing()
-	return 100
+	return 1
 
 /datum/sabotage_objective/processing/process()
 	check_condition_processing()
-	if(won >= 100)
+	if(won >= 1)
 		STOP_PROCESSING(SSprocessing,src)
 
 /datum/sabotage_objective/processing/check_conditions()
 	return won
 
 /datum/sabotage_objective/processing/power_sink
-	name = "Drain at least 1 gigajoule of power using a power sink."
+	name = "Drain at least 100 megajoules of power using a power sink."
 	sabotage_type = "powersink"
 	special_equipment = list(/obj/item/sbeacondrop/powersink)
 	var/sink_found = FALSE
@@ -47,7 +47,7 @@
 		for(var/datum/powernet/PN in GLOB.powernets)
 			for(var/obj/item/powersink/sink in PN.nodes)
 				sink_found_this_time = TRUE
-				won = max(won,sink.power_drained/1e9)
+				won = max(won,sink.power_drained/1e8)
 		sink_found = sink_found_this_time
 		count = 0
 	return FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1 gigajoule was *way* too much. A gigajoule is of course 1000 megawatt-seconds (duh), which means it would take... y'know. 1000 seconds. at 1 MW. On a regular unoptimized power setup, you'll be getting 980 kW at most. A power sink is not gonna last 1000 seconds. Instead, it'll now take a mere 100 seconds, or a minute 40 seconds, a much more reasonable time. If engineering has set up a power-weighted supermatter or a mediocre TEG, it'll take 10 seconds instead.

## Why It's Good For The Game

If I'm keeping greentext then I'm making sure objectives can be greentexted.

## Changelog
:cl:
balance: Power sink objective is 10x as easy to get
fix: Processing objectives now properly stop once won
/:cl: