### PR TITLE
Makes MKUltra's explosion no longer spread prefbreak gas

### DIFF
--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -303,7 +303,7 @@
 	HIonRelease 			= 0.1
 	RateUpLim 				= 1
 	FermiChem				= TRUE
-	FermiExplode 			= TRUE
+	FermiExplode 			= FALSE
 	PurityMin 				= 0.2
 
 /datum/chemical_reaction/fermi/enthrall/FermiFinish(datum/reagents/holder, var/atom/my_atom)
@@ -348,15 +348,6 @@
 	E.creatorName = B.data["real_name"]
 	E.data["creatorID"] = B.data["ckey"]
 	E.creatorID = B.data["ckey"]
-
-/datum/chemical_reaction/fermi/enthrall/FermiExplode(datum/reagents, var/atom/my_atom, volume, temp, pH)
-	var/turf/T = get_turf(my_atom)
-	var/datum/reagents/R = new/datum/reagents(1000)
-	var/datum/effect_system/smoke_spread/chem/s = new()
-	R.add_reagent(/datum/reagent/fermi/enthrallExplo, volume)
-	s.set_up(R, volume/2, T)
-	s.start()
-	my_atom.reagents.clear_reagents()
 
 /datum/chemical_reaction/fermi/hatmium // done
 	name = "Hat growth serum"

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -303,7 +303,7 @@
 	HIonRelease 			= 0.1
 	RateUpLim 				= 1
 	FermiChem				= TRUE
-	FermiExplode 			= FALSE
+	FermiExplode 			= TRUE
 	PurityMin 				= 0.2
 
 /datum/chemical_reaction/fermi/enthrall/FermiFinish(datum/reagents/holder, var/atom/my_atom)
@@ -348,6 +348,10 @@
 	E.creatorName = B.data["real_name"]
 	E.data["creatorID"] = B.data["ckey"]
 	E.creatorID = B.data["ckey"]
+
+/datum/chemical_reaction/fermi/enthrall/FermiExplode(datum/reagents/R0, var/atom/my_atom, volume, temp, pH)
+	R0.clear_reagents()
+	..()
 
 /datum/chemical_reaction/fermi/hatmium // done
 	name = "Hat growth serum"


### PR DESCRIPTION
## About The Pull Request

Makes MKUltra no longer make love gas when failed. 

## Why It's Good For The Game

This was banbait at best. A mechanic whose existence is ultimately "accidentally prefbreak everyone nearby" is... probably not for the best. I know I've set up prefs to better prevent this, but I can't expect everyone to always have those.

If anyone tries to tell me I'm hugboxing prefs (and yes, people do say this, every time, in memes or otherwise): maybe consider how this is an execrable position. Really think about it for a while.

## Changelog
:cl:
del: MKUltra no longer explodes into lovegas when it fermi explodes, instead causing a regular ol' fireball.
/:cl: