### PR TITLE
/carbons now null out hand_bodyparts on Destroy()

### DIFF
--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -16,6 +16,7 @@
 	QDEL_LIST(stomach_contents)
 	QDEL_LIST(bodyparts)
 	QDEL_LIST(implants)
+	hand_bodyparts = null		//Just references out bodyparts, don't need to delete twice.
 	remove_from_all_data_huds()
 	QDEL_NULL(dna)
 	GLOB.carbon_list -= src


### PR DESCRIPTION
Don't think this'll break anything. It's just a reference to bodyparts which we del'd literally lines above lmao