### PR TITLE
Makes xenobiology powergamers slightly less horrible for the server by caching slime mutation lists

### DIFF
--- a/code/modules/mob/living/simple_animal/slime/slime.dm
+++ b/code/modules/mob/living/simple_animal/slime/slime.dm
@@ -70,7 +70,8 @@
 
 	var/colour = "grey"
 	var/coretype = /obj/item/slime_extract/grey
-	var/list/slime_mutation[4]
+	var/list/slime_mutation
+	var/static/list/color_mutation_cache = list()
 
 	var/static/list/slime_colours = list("rainbow", "grey", "purple", "metal", "orange",
 	"blue", "dark blue", "dark purple", "yellow", "silver", "pink", "red",
@@ -84,6 +85,7 @@
 
 
 /mob/living/simple_animal/slime/Initialize(mapload, new_colour="grey", new_is_adult=FALSE)
+	initialize_mutations()
 	var/datum/action/innate/slime/feed/F = new
 	F.Grant(src)
 
@@ -108,10 +110,16 @@
 		AC.Remove(src)
 	return ..()
 
+/mob/living/simple_animal/slime/proc/initialize_mutations()
+	var/list/cached = color_mutation_cache[colour]
+	if(!cached)
+		cached = color_mutation_cache[colour] = mutation_table(colour)
+	slime_mutation = cached
+
 /mob/living/simple_animal/slime/proc/set_colour(new_colour)
 	colour = new_colour
 	update_name()
-	slime_mutation = mutation_table(colour)
+	initialize_mutations()
 	var/sanitizedcolour = replacetext(colour, " ", "")
 	coretype = text2path("/obj/item/slime_extract/[sanitizedcolour]")
 	regenerate_icons()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

saves memory usage by not having every goddamn slime save their own list.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

download more ram
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
nah

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
