### PR TITLE
Pixel shifting for ERP

### DIFF
--- a/code/modules/keybindings/bindings_mob.dm
+++ b/code/modules/keybindings/bindings_mob.dm
@@ -61,16 +61,28 @@
 	if(client.keys_held["Ctrl"])
 		switch(SSinput.movement_keys[_key])
 			if(NORTH)
-				northface()
+				if(client.keys_held["Shift"])
+					northshift()
+				else
+					northface()
 				return
 			if(SOUTH)
-				southface()
+				if(client.keys_held["Shift"])
+					southshift()
+				else
+					southface()
 				return
 			if(WEST)
-				westface()
+				if(client.keys_held["Shift"])
+					westshift()
+				else
+					westface()
 				return
 			if(EAST)
-				eastface()
+				if(client.keys_held["Shift"])
+					eastshift()
+				else
+					eastface()
 				return
 	return ..()
 

--- a/code/modules/mob/living/living_movement.dm
+++ b/code/modules/mob/living/living_movement.dm
@@ -1,6 +1,10 @@
 /mob/living/Moved()
 	. = ..()
 	update_turf_movespeed(loc)
+	if(is_shifted)
+		is_shifted = FALSE
+		pixel_x = get_standard_pixel_x_offset(lying)
+		pixel_y = get_standard_pixel_y_offset(lying)
 
 /mob/living/CanPass(atom/movable/mover, turf/target)
 	if((mover.pass_flags & PASSMOB))

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -712,6 +712,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		return FALSE
 	if(pixel_x <= 16)
 		pixel_x++
+		is_shifted = TRUE
 
 /mob/verb/westshift()
 	set hidden = TRUE
@@ -719,6 +720,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		return FALSE
 	if(pixel_x >= -16)
 		pixel_x--
+		is_shifted = TRUE
 
 /mob/verb/northshift()
 	set hidden = TRUE
@@ -726,6 +728,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		return FALSE
 	if(pixel_y <= 16)
 		pixel_y++
+		is_shifted = TRUE
 
 /mob/verb/southshift()
 	set hidden = TRUE
@@ -733,6 +736,7 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 		return FALSE
 	if(pixel_y >= -16)
 		pixel_y--
+		is_shifted = TRUE
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
 	return FALSE

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -724,14 +724,14 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	set hidden = TRUE
 	if(!canface())
 		return FALSE
-	if(pixel_y >= 16)
+	if(pixel_y <= 16)
 		pixel_y++
 
 /mob/verb/southshift()
 	set hidden = TRUE
 	if(!canface())
 		return FALSE
-	if(pixel_y <= -16)
+	if(pixel_y >= -16)
 		pixel_y--
 
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -706,6 +706,34 @@ GLOBAL_VAR_INIT(exploit_warn_spam_prevention, 0)
 	client.last_turn = world.time + MOB_FACE_DIRECTION_DELAY
 	return TRUE
 
+/mob/verb/eastshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x <= 16)
+		pixel_x++
+
+/mob/verb/westshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_x >= -16)
+		pixel_x--
+
+/mob/verb/northshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y >= 16)
+		pixel_y++
+
+/mob/verb/southshift()
+	set hidden = TRUE
+	if(!canface())
+		return FALSE
+	if(pixel_y <= -16)
+		pixel_y--
+
 /mob/proc/IsAdvancedToolUser()//This might need a rename but it should replace the can this mob use things check
 	return FALSE
 

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -38,7 +38,7 @@
 	var/resting = 0			//Carbon
 	var/lying = 0
 	var/lying_prev = 0
-	var/is_shifted = 0
+	var/is_shifted = FALSE
 
 	//MOVEMENT SPEED
 	var/list/movespeed_modification				//Lazy list, see mob_movespeed.dm

--- a/code/modules/mob/mob_defines.dm
+++ b/code/modules/mob/mob_defines.dm
@@ -38,6 +38,7 @@
 	var/resting = 0			//Carbon
 	var/lying = 0
 	var/lying_prev = 0
+	var/is_shifted = 0
 
 	//MOVEMENT SPEED
 	var/list/movespeed_modification				//Lazy list, see mob_movespeed.dm


### PR DESCRIPTION
This code is completely 100% untested.

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

What this does is make it so that if you are holding ctrl+shift and then do a direction it causes you to pixel shift

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

well you see I was doing a threesome ERP and I was on top of someone with someone else and we couldn't position ourselves correctly so I open this PR so that no one else has to deal with the limitations of tile based movement when trying to ERP.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Use Ctrl-Shift-direction key to shift your characters position. Use for ERP.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
