### PR TITLE
tasers are now as fast as disablers and 7 --> 14 tile range  but do not have impact damage

### DIFF
--- a/code/datums/status_effects/debuffs.dm
+++ b/code/datums/status_effects/debuffs.dm
@@ -132,7 +132,7 @@
 	var/slowdown_priority = 50		//to make sure the stronger effect overrides
 	var/affect_crawl = FALSE
 	var/nextmove_modifier = 1
-	var/stamdmg_per_ds = 1		//a 20 duration would do 20 stamdmg, disablers do 24 or something
+	var/stamdmg_per_ds = 0		//a 20 duration would do 20 stamdmg, disablers do 24 or something
 	var/last_tick = 0			//fastprocess processing speed is a goddamn sham, don't trust it.
 
 /datum/status_effect/electrode/on_creation(mob/living/new_owner, set_duration)
@@ -167,6 +167,7 @@
 	slowdown_priority = 100
 	nextmove_modifier = 2
 	blocks_combatmode = TRUE
+	stamdmg_per_ds = 1
 
 /datum/status_effect/electrode/no_combat_mode/on_creation(mob/living/new_owner, set_duration)
 	. = ..()

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -10,6 +10,7 @@
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 7
+	speed = 0.6
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun
 	impact_type = /obj/effect/projectile/impact/stun

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -43,7 +43,6 @@
 	knockdown_stamoverride = 0
 	knockdown_stam_max = 0
 	strong_tase = FALSE
-	range = 12
 
 /obj/item/projectile/energy/electrode/security/hos
 	knockdown = 100

--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -9,7 +9,7 @@
 	stutter = 10
 	jitter = 20
 	hitsound = 'sound/weapons/taserhit.ogg'
-	range = 7
+	range = 14
 	speed = 0.6
 	tracer_type = /obj/effect/projectile/tracer/stun
 	muzzle_type = /obj/effect/projectile/muzzle/stun


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

changes projectile speed to match disablers + 14 tiles range vs 12 for hybrids and 7 for the other ones
Removes impact damage from taser
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

maybe i should have just killed it instead of making it a weird thing but uh ok

Tasers were meant to be an alternative fire mode to slowdown. Not a better or worse disabler.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: disabler taser alt fire shots are faster and have a 14 tile range now
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
