### PR TITLE
Nerfs HoS taser and warden stun pump action blaster

### DIFF
--- a/code/modules/projectiles/projectile/energy/stun.dm
+++ b/code/modules/projectiles/projectile/energy/stun.dm
@@ -48,3 +48,4 @@
 	knockdown = 100
 	knockdown_stamoverride = 30
 	knockdown_stam_max = null
+	tase_duration = 10

--- a/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
+++ b/modular_citadel/code/modules/projectiles/guns/pumpenergy.dm
@@ -185,10 +185,12 @@
 	name = "electron blast"
 	icon_state = "stunjectile"
 	color = null
-	nodamage = 1
+	nodamage = TRUE
 	knockdown = 100
 	stamina = 5
 	stutter = 5
 	jitter = 20
+	strong_tase = FALSE
+	tase_duration = 0
 	hitsound = 'sound/weapons/taserhit.ogg'
 	range = 7


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

### DO NOT MERGE WITHOUT #11351 .

## About The Pull Request

HoS taser tase duration reduced to 1 second down from 5. Still has knockdown
Warden shotgun has the tase effect removed entirely.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

These two things are too strong.
I left it in on HoS taser because it's a unique thing that has needed flair for a while now.
Also @BlackMajor can you tell me why we don't want ion hos gun instead because this taser stuff is starting to be a bad meme.

And warden's shotgun outright has no reason to be "taser but better and hits everyone in the hall". You already get a combat shotgun, having the only other ranged disarm security gets roundstart is good damn enough.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: HoS taser now only applies tased effect for 1 second and warden's pump action stun blaster no longer applies it at all.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
