### PR TITLE
Nerfs ninja stungloves to match new batons

### DIFF
--- a/code/modules/ninja/suit/gloves.dm
+++ b/code/modules/ninja/suit/gloves.dm
@@ -37,8 +37,7 @@
 	var/mindrain = 200
 	var/maxdrain = 400
 
-	var/stunforce = 140 //Same as stunbaton, adjustable.
-
+	var/stunforce = 100
 
 /obj/item/clothing/gloves/space_ninja/Touch(atom/A,proximity)
 	if(!candrain || draining)

--- a/code/modules/ninja/suit/ninjaDrainAct.dm
+++ b/code/modules/ninja/suit/ninjaDrainAct.dm
@@ -264,7 +264,6 @@ They *could* go in their appropriate files, but this is supposed to be modular
 		electrocute_act(15, H)
 
 		DefaultCombatKnockdown(G.stunforce)
-		adjustStaminaLoss(G.stunforce*0.1, affected_zone = (istype(H) ? H.zone_selected : BODY_ZONE_CHEST))
 		apply_effect(EFFECT_STUTTER, G.stunforce)
 		SEND_SIGNAL(src, COMSIG_LIVING_MINOR_SHOCK)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Nerfs ninja stungloves from 49 stamina/hit to 25 stamina hit
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

This is already ridiculously, ridiculously powerful due to stamina + disarm at the same time, batons were nerfed to shit, this was only good because it lets ninjas counter security's baton spam.

Now that batons are nerfed there's no reason for this to exist
If anyone says you need this to kidnap: No you do not need a stun of that strength to kidnap, and like I said, in an 1v1 situation this will still dome just about anyone including security due to disarm + stamina + knockdown every hit vs security having to choose between knockdown + stamina OR disarm vs both.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Ninja stungloves nerfed 49 stamina to 25 (so they're basically just better than stunbatons).
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
