### PR TITLE
Stunbaton disarm mode also works on disarm intent now

### DIFF
--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -25,7 +25,7 @@
 
 /obj/item/melee/baton/examine(mob/user)
 	. = ..()
-	. += "<span class='notice'>Right click attack while in combat mode to disarm instead of stun.</span>"
+	. += "<span class='notice'>Right click attack while in combat mode or attack while in disarm intent to disarm instead of stun.</span>"
 
 /obj/item/melee/baton/get_cell()
 	. = cell
@@ -149,6 +149,8 @@
 
 //return TRUE to interrupt attack chain.
 /obj/item/melee/baton/proc/common_baton_melee(mob/M, mob/living/user, disarming = FALSE)
+	if(user.a_intent == INTENT_DISARM)
+		disarming = TRUE			//override if they're in disarm intent.
 	if(iscyborg(M) || !isliving(M))		//can't baton cyborgs
 		return FALSE
 	if(status && HAS_TRAIT(user, TRAIT_CLUMSY) && prob(50))
@@ -161,7 +163,7 @@
 		if(check_martial_counter(L, user))
 			return TRUE
 	if(status)
-		if(baton_stun(M, user, disarming || (user.a_intent == INTENT_DISARM)))
+		if(baton_stun(M, user, disarming))
 			user.do_attack_animation(M)
 			user.adjustStaminaLossBuffered(getweight())		//CIT CHANGE - makes stunbatonning others cost stamina
 	else if(user.a_intent != INTENT_HARM)			//they'll try to bash in the last proc.

--- a/code/game/objects/items/stunbaton.dm
+++ b/code/game/objects/items/stunbaton.dm
@@ -161,7 +161,7 @@
 		if(check_martial_counter(L, user))
 			return TRUE
 	if(status)
-		if(baton_stun(M, user, disarming))
+		if(baton_stun(M, user, disarming || (user.a_intent == INTENT_DISARM)))
 			user.do_attack_animation(M)
 			user.adjustStaminaLossBuffered(getweight())		//CIT CHANGE - makes stunbatonning others cost stamina
 	else if(user.a_intent != INTENT_HARM)			//they'll try to bash in the last proc.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

People complained right click is ass and they have no muscle memory for it.
Also added an examine "tip" for this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Batons now also trigger disarm behavior in disarm intent and not just on right click.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
