### PR TITLE
Fixes bartender drink slide spill A

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -156,8 +156,6 @@
 		reagents.clear_reagents()
 		if(QDELETED(src))
 			return
-	if (!bartender_check(target)) // Needs to check for Bartender Slide before spilling.
-		reagents.clear_reagents() // Clear reagents of thrown container.
 
 //melts plastic beakers
 /obj/item/reagent_containers/microwave_act(obj/machinery/microwave/M)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -153,9 +153,9 @@
 		log_reagent("SPLASH - [src] object SplashReagents() onto [target] at [T] ([AREACOORD(T)])[throwerstring] - [reagents.log_list()]")
 		visible_message("<span class='notice'>[src] spills its contents all over [target].</span>")
 		reagents.reaction(target, TOUCH)
+		reagents.clear_reagents()
 		if(QDELETED(src))
 			return
-
 	if (!bartender_check(target)) // Needs to check for Bartender Slide before spilling.
 		reagents.clear_reagents() // Clear reagents of thrown container.
 

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -156,7 +156,8 @@
 		if(QDELETED(src))
 			return
 
-	reagents.clear_reagents()
+	if (!bartender_check(target)) // Needs to check for Bartender Slide before spilling.
+		reagents.clear_reagents() // Clear reagents of thrown container.
 
 //melts plastic beakers
 /obj/item/reagent_containers/microwave_act(obj/machinery/microwave/M)


### PR DESCRIPTION
Forces drink throw call to check for bartender throwing before spilling contents. Feels like a lazy fix, but it works. Refer to #11362 for different method.

Resolves #11342 