### PR TITLE
Fixes bartender drink slide spill B

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -139,6 +139,7 @@
 		visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
 		transform = initial(transform)
 		addtimer(CALLBACK(src, .proc/ForceResetRotation), 1)
+		return FALSE
 
 	else
 		if(isturf(target) && reagents.reagent_list.len && thrownby)


### PR DESCRIPTION
Forces spill/splash proc out of loop before it can splash_reagents. Refer to #11361 for different method.

Resolves #11342 