### PR TITLE
Culls irrelevant targeting information on Drink Fling.

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -136,7 +136,7 @@
 		reagents.reaction(target, TOUCH)
 
 	else if(bartender_check(target) && thrown)
-		visible_message("<span class='notice'>[src] lands onto the [target.name] without spilling a single drop.</span>")
+		visible_message("<span class='notice'>[src] lands without spilling a single drop.</span>")
 		transform = initial(transform)
 		addtimer(CALLBACK(src, .proc/ForceResetRotation), 1)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes irrelevant targeting data from the Bartender drink slide proc.

## Why It's Good For The Game

Targeting data in Drink Flinging is pointless as, no matter what you're throwing the glass onto, it will specify the turf rather than the object (ex. Table) that it's being thrown onto. Noticed this while trying to fix #11342

The only way I can imagine fixing it is doing a refactor of how objects are thrown. Seeing as drink flinging doesn't necessarily have combat implications, having it slidd without the turf target seems permissible. Most other thrown objects don't specify their target turf, anyway. Typically the only projectiles that do are ones produced with weapons or upon striking (collision, damage) with the target.

That said, I can see why this would be undesirable, so feel free to close this. I don't necessarily need any feedback, just seeing "The glass of beer lands on the floor without spilling a single drop." was very immersion-breaking and in the meantime I'll try to brainstorm a better solution.

## Changelog
:cl:
tweak: Adjusted Bartender's Drink Flinging print message to not include name of target turf and save immersion.
/:cl: