### PR TITLE
Makes monkey probability of gorillize from radiation exponential.

### DIFF
--- a/code/__DEFINES/radiation.dm
+++ b/code/__DEFINES/radiation.dm
@@ -23,6 +23,10 @@ Ask ninjanomnom if they're around
 
 #define RAD_MOB_MUTATE 1250							// How much stored radiation to check for mutation
 
+#define RAD_MONKEY_GORILLIZE 1650					// How much stored radiation to check for Harambe time.
+#define RAD_MOB_GORILLIZE_FACTOR 100
+#define RAD_MONKEY_GORILLIZE_EXPONENT 0.5
+
 #define RAD_MOB_VOMIT 2000							// The amount of radiation to check for vomitting
 #define RAD_MOB_VOMIT_PROB 1						// Chance per tick of vomitting
 

--- a/code/modules/mob/living/carbon/monkey/life.dm
+++ b/code/modules/mob/living/carbon/monkey/life.dm
@@ -30,9 +30,10 @@
 
 /mob/living/carbon/monkey/handle_mutations_and_radiation()
 	if(radiation)
-		if(radiation > RAD_MOB_MUTATE && prob((radiation - RAD_MOB_MUTATE) / 25))
-			gorillize() 
-			return
+		if(radiation > RAD_MONKEY_GORILLIZE)
+			if(prob((((radiation - RAD_MONKEY_GORILLIZE + RAD_MOB_GORILLIZE_FACTOR)/RAD_MOB_GORILLIZE_FACTOR)^RAD_MONKEY_GORILLIZE_EXPONENT) - 1))
+				gorillize()
+				return
 		if(radiation > RAD_MOB_KNOCKDOWN && prob(RAD_MOB_KNOCKDOWN_PROB))
 			if(!recoveringstam)
 				emote("collapse")


### PR DESCRIPTION
## About The Pull Request
I'm no mathematician, but over 9 out of 10 monkeys on the station turn into gorillas when rad storms strike, also thanks to a too linear probability growth.

Whatever, changed the expression to `(((a+b)/b)^c) -1` from `a/b`

Also some tweaks on the values, feel free to improve them later.

## Why It's Good For The Game
A less instant harambe party, expect monkeys to still inevitably gorillize after a while, at least until the whole feature is turned into something less reliant on probabilities.

## Changelog
:cl:
tweak: Chances are monkeys won't end up gorillizing as quickly after being exposed to a rad storm for a minute or so.
/:cl:
