### PR TITLE
Adds a verb for AIs to cryo

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1004,3 +1004,28 @@
 	. = ..()
 	if(.)
 		end_multicam()
+
+/mob/living/silicon/ai/verb/ai_cryo()
+	set name = "AI Cryogenic Stasis"
+	set desc = "Puts the current AI personality into cryogenic stasis, freeing the space for another."
+	set category = "AI Commands"
+
+	if(incapacitated())
+		return
+	switch(alert("Would you like to enter cryo? This will ghost you. Remember to AHELP before cryoing out of important roles, even with no admins online.",,"Yes.","No."))
+		if("Yes.")
+			src.ghostize(FALSE, penalize = TRUE)
+			var/announce_rank = "Artificial Intelligence,"
+			if(GLOB.announcement_systems.len) 
+				// Sends an announcement the AI has cryoed.
+				var/obj/machinery/announcement_system/announcer = pick(GLOB.announcement_systems)
+				announcer.announce("CRYOSTORAGE", src.real_name, announce_rank, list())
+			new /obj/structure/AIcore/latejoin_inactive(loc)
+			if(src.mind)
+				//Handle job slot/tater cleanup.
+				if(src.mind.assigned_role)
+					SSjob.FreeRole("AI")
+			src.mind.special_role = null
+			qdel(src)
+		else
+			return

--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -1023,7 +1023,7 @@
 			new /obj/structure/AIcore/latejoin_inactive(loc)
 			if(src.mind)
 				//Handle job slot/tater cleanup.
-				if(src.mind.assigned_role)
+				if(src.mind.assigned_role == "AI")
 					SSjob.FreeRole("AI")
 			src.mind.special_role = null
 			qdel(src)


### PR DESCRIPTION
## About The Pull Request
Allows AIs to cryo without unbolting and being dragged to cryostasis; or as Dapnee said they sometimes had to do; spawning in a cryo pod to stuff the AI in when they had to go.
## Why It's Good For The Game
Having an AI just log off in the middle of the round, often without ever cryoing the core is a real problem, as it's a rather essential role, this fixes that by allowing them to cryo in location under the guise of "storing the current personality."

I originally had planned to use the cryo sleepers' own function for this but according to kevinz it's hardcoded somewhat and wouldn't be easy to use for a function like this.

this is the first PR where I've actually written a body of code completely from scratch, reviews are appreciated because lord knows I fucked stuff up.
## Changelog
:cl:
add:AI ability to cryo.
/:cl:
Requested by Dap, big thanks to Kevinz for helping me when I was tearing my hair out trying to figure out how things worked.