### PR TITLE
Kills screen-wide EMPs

### DIFF
--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -114,9 +114,12 @@
 
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
-	// 100 multiplier = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 multiplier = used to be 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades. Shouldn't be all that much higher now.
-	empulse(location, round(log(2.25, multiplier)), round(log(1.75, multiplier)), 1)
+	// 50 multiplier = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
+	// 100 multiplier = 5 heavy range & 10 light range.
+	// 200 multiplier = 7 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
+	// 300 multiplier = 8 heavy range & 17 light range. Still rather significant, considering that you can get dozens of bluespace beakers 30 minutes in with a competent crew.
+	// 900 multiplier = 12 heavy range & 30 light range. Still less than 300 before this commit.
+	empulse(location, round(multiplier ** (3/8)), round(multiplier ** (1/2)), 1)
 	holder.clear_reagents()
 
 

--- a/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
+++ b/code/modules/reagents/chemistry/recipes/pyrotechnics.dm
@@ -115,8 +115,8 @@
 /datum/chemical_reaction/emp_pulse/on_reaction(datum/reagents/holder, multiplier)
 	var/location = get_turf(holder.my_atom)
 	// 100 multiplier = 4 heavy range & 7 light range. A few tiles smaller than traitor EMP grandes.
-	// 200 multiplier = 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades.
-	empulse(location, round(multiplier / 12), round(multiplier / 7), 1)
+	// 200 multiplier = used to be 8 heavy range & 14 light range. 4 tiles larger than traitor EMP grenades. Shouldn't be all that much higher now.
+	empulse(location, round(log(2.25, multiplier)), round(log(1.75, multiplier)), 1)
 	holder.clear_reagents()
 
 


### PR DESCRIPTION

## About The Pull Request

This makes a small line change to make the EMP reaction's size be determined logarithmically, rather than linearly. That meaning, there's diminishing returns on EMPs. As a consequence, there's not TOO much reason to try to make a very big EMP, like with maxcaps before toxins became research... Though I'm sure some of you, who like to get the largest numbers on things possible, can still reach some ungodly numbers with payloads.

## Why It's Good For The Game

Because you won't be able to EMP the whole station with one grenade anymore. You should, of course, be welcome to reach for new heights, but you shouldn't be able to lolEMP the entire station. Even if it costs a fair deal of uranium, a good miner can get 15 sheets in no time, assuming the ORM is upgraded in a timely manner.

## Changelog
:cl:
balance: Made EMP reaction growth logarithmic.
/:cl: