### PR TITLE
Shuttle timer display seconds fix

### DIFF
--- a/code/modules/shuttle/shuttle.dm
+++ b/code/modules/shuttle/shuttle.dm
@@ -660,7 +660,7 @@
 	if(timeleft > 1 HOURS)
 		return "--:--"
 	else if(timeleft > 0)
-		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, " ")]"
+		return "[add_leading(num2text((timeleft / 60) % 60), 2, "0")]:[add_leading(num2text(timeleft % 60), 2, "0")]"
 	else
 		return "00:00"
 


### PR DESCRIPTION
## About The Pull Request 
Basically #49366 by Timerpoes.

## Why It's Good For The Game
This will close #10895.

## Changelog
:cl: Timberpoes
fix: Shuttle countdowns once again read like "01:05" instead of "01: 5".
/:cl:
