### PR TITLE
Reblances flares, flashlights and eye-lights

### DIFF
--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -330,7 +330,7 @@
 	name = "torch"
 	desc = "A torch fashioned from some leaves and a log."
 	w_class = WEIGHT_CLASS_BULKY
-	brightness_on = 4
+	brightness_on = 6 //When on were like a lantern
 	light_color = "#FAA44B"
 	icon_state = "torch"
 	item_state = "torch"

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -170,7 +170,7 @@
 	flags_1 = CONDUCT_1
 	brightness_on = 2
 	light_color = "#FFDDCC"
-	flashlight_power = 0.3
+	flashlight_power = 0.5
 	var/holo_cooldown = 0
 
 /obj/item/flashlight/pen/afterattack(atom/target, mob/user, proximity_flag)
@@ -207,6 +207,7 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	force = 9 // Not as good as a stun baton.
 	brightness_on = 5 // A little better than the standard flashlight.
+	total_mass = 0.4
 	light_color = "#CDDDFF"
 	flashlight_power = 0.9
 	hitsound = 'sound/weapons/genhit1.ogg'
@@ -227,14 +228,11 @@
 	custom_materials = null
 	on = TRUE
 
-
 // green-shaded desk lamp
 /obj/item/flashlight/lamp/green
 	desc = "A classic green-shaded desk lamp."
 	icon_state = "lampgreen"
 	item_state = "lampgreen"
-
-
 
 /obj/item/flashlight/lamp/verb/toggle_light()
 	set name = "Toggle light"
@@ -258,12 +256,13 @@
 	desc = "A red Nanotrasen issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = WEIGHT_CLASS_SMALL
 	brightness_on = 7 // Pretty bright.
+	total_mass = 0.2
 	light_color = "#FA421A"
 	icon_state = "flare"
 	item_state = "flare"
 	actions_types = list()
 	var/fuel = 0
-	var/on_damage = 7
+	var/on_damage = 9
 	var/produce_heat = 1500
 	heat = 1000
 	light_color = LIGHT_COLOR_FLARE
@@ -338,7 +337,8 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	light_color = LIGHT_COLOR_ORANGE
-	on_damage = 10
+	total_mass = 0.5
+	on_damage = 12 //Its a log thats on fire
 	slot_flags = null
 
 /obj/item/flashlight/lantern
@@ -348,10 +348,9 @@
 	lefthand_file = 'icons/mob/inhands/equipment/mining_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/mining_righthand.dmi'
 	desc = "A mining lantern."
-	brightness_on = 6			// luminosity when on
+	brightness_on = 6	// luminosity when on
 	light_color = "#FFAA44"
-	flashlight_power = 0.75
-
+	flashlight_power = 0.9
 
 /obj/item/flashlight/slime
 	gender = PLURAL
@@ -371,7 +370,6 @@
 	var/emp_max_charges = 4
 	var/emp_cur_charges = 4
 	var/charge_tick = 0
-
 
 /obj/item/flashlight/emp/New()
 	..()
@@ -435,7 +433,7 @@
 	var/fuel = 0
 
 /obj/item/flashlight/glowstick/Initialize()
-	fuel = rand(1600, 2000)
+	fuel = rand(1000, 1500)
 	light_color = color
 	. = ..()
 
@@ -540,7 +538,7 @@
 /obj/item/flashlight/eyelight
 	name = "eyelight"
 	desc = "This shouldn't exist outside of someone's head, how are you seeing this?"
-	brightness_on = 15
+	brightness_on = 10
 	flags_1 = CONDUCT_1
 	item_flags = DROPDEL
 	actions_types = list()

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -207,7 +207,6 @@
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	force = 9 // Not as good as a stun baton.
 	brightness_on = 5 // A little better than the standard flashlight.
-	total_mass = 0.4
 	light_color = "#CDDDFF"
 	flashlight_power = 0.9
 	hitsound = 'sound/weapons/genhit1.ogg'

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -337,7 +337,7 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	light_color = LIGHT_COLOR_ORANGE
-	total_mass = 1.25
+	total_mass = TOTAL_MASS_NORMAL_ITEM
 	on_damage = 12 //Its a log thats on fire
 	slot_flags = null
 

--- a/code/game/objects/items/devices/flashlight.dm
+++ b/code/game/objects/items/devices/flashlight.dm
@@ -256,7 +256,7 @@
 	desc = "A red Nanotrasen issued flare. There are instructions on the side, it reads 'pull cord, make light'."
 	w_class = WEIGHT_CLASS_SMALL
 	brightness_on = 7 // Pretty bright.
-	total_mass = 0.2
+	total_mass = 0.8
 	light_color = "#FA421A"
 	icon_state = "flare"
 	item_state = "flare"
@@ -337,7 +337,7 @@
 	lefthand_file = 'icons/mob/inhands/items_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/items_righthand.dmi'
 	light_color = LIGHT_COLOR_ORANGE
-	total_mass = 0.5
+	total_mass = 1.25
 	on_damage = 12 //Its a log thats on fire
 	slot_flags = null
 
@@ -350,7 +350,7 @@
 	desc = "A mining lantern."
 	brightness_on = 6	// luminosity when on
 	light_color = "#FFAA44"
-	flashlight_power = 0.9
+	flashlight_power = 0.8
 
 /obj/item/flashlight/slime
 	gender = PLURAL


### PR DESCRIPTION
## About The Pull Request

Pen lights have a slightly better light so that they are not just `welp I can see around me just as well as before but now, people can see me from miles away` 
Seclights are now not as much stamina to use as a weapon. Still bad at being a weapon
Flares are also better stamina wise and now hurt a bit more.
Wooden torches now are not as bad as a weapon as they were, more damage less stamina to use and are a bit brighter then before
Eye lights are 30~% less bright when on.
Glow sticks dont last as long - I want to see were you get a glowstick that lasts for 40 mins and still is able to see by

## Why It's Good For The Game

All and all makes improvised `Oh got this is all I got left to fight with` weapon - Tourch/Seclight a it less shit to use well making things like pen lights useable.
Torches are a joke atm as they are so bad, for needing a bit of resources to make shockingly, Also I dont think it was intended to take as much stamina as a bulky item. 
Eye lights are a bit to powerful of a endless light that really is hard to turn off making the round start item a bit to good.
Glow sticks as a easy-to-spam light that does shockingly good work is also a bit powerful. 

## Changelog
:cl:
balance: torches take less staminda to use.
balance: Glowsticks dont last as long
balance: Penlights are better at being lights
balance: Torches are brighter then before - Indian Johns want to be on lava land rejoy!
balance: Eye lights have 30% less light coming out of them.
/:cl:

## Remember?
All the lighting changes that actively happen with station lights, well iirc none of those changes ever touched flash lights, torches and other things. 