### PR TITLE
Maybe adds in Mentor-Help hot key to f9

### DIFF
--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -56,7 +56,7 @@
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
 			winset(src, null, "command=.screenshot [!keys_held["shift"] ? "auto" : ""]")
 			return
-		if("F3")
+		if("F13")
 			if(keys_held["Ctrl"] && keys_held["Shift"]) //So we cant spam
 				winset(src, null, "command=.options")
 			else

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -56,7 +56,7 @@
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
 			winset(src, null, "command=.screenshot [!keys_held["shift"] ? "auto" : ""]")
 			return
-		if("F13")
+		if("F9")
 			if(keys_held["Ctrl"] && keys_held["Shift"]) //So we cant spam
 				winset(src, null, "command=.options")
 			else

--- a/code/modules/keybindings/bindings_client.dm
+++ b/code/modules/keybindings/bindings_client.dm
@@ -56,6 +56,12 @@
 		if("F2") // Screenshot. Hold shift to choose a name and location to save in
 			winset(src, null, "command=.screenshot [!keys_held["shift"] ? "auto" : ""]")
 			return
+		if("F3")
+			if(keys_held["Ctrl"] && keys_held["Shift"]) //So we cant spam
+				winset(src, null, "command=.options")
+			else
+				get_mentorhelp()
+			return
 		if("F12") // Toggles minimal HUD
 			mob.button_pressed_F12()
 			return


### PR DESCRIPTION
## About The Pull Request

Gives f9 maybe the hotkey to mhelp

## Why It's Good For The Game

Makes it so people can just hit a hot key to ask a question rather then changing tabs and click a botton

## Changelog
:cl: 
add: F9 now can maybe be used to quickly make a Mentor Help
/:cl:
