### PR TITLE
Makes Bluespace and Urianium reagents be able to be turned into sheets

### DIFF
--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -75,6 +75,39 @@
 	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/stack/sheet/mineral/gold(location)
 
+/datum/chemical_reaction/silversolidification
+	name = "Solid Silver"
+	id = "solidsilver"
+	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/silver = 20, /datum/reagent/iron = 1)
+	mob_react = FALSE
+
+/datum/chemical_reaction/silversolidification/on_reaction(datum/reagents/holder, multiplier)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= multiplier, i++)
+		new /obj/item/stack/sheet/mineral/silver(location)
+
+/datum/chemical_reaction/uraniumsolidification
+	name = "Solid Uranium"
+	id = "soliduranium"
+	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/uranium = 20, /datum/reagent/iron = 1)
+	mob_react = FALSE
+
+/datum/chemical_reaction/uraniumsolidification/on_reaction(datum/reagents/holder, multiplier)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= multiplier, i++)
+		new /obj/item/stack/sheet/mineral/uranium(location)
+
+/datum/chemical_reaction/bluespacecrystalifaction
+	name = "Crystal Bluespace"
+	id = "crystalbluespace"
+	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/bluespace = 20, /datum/reagent/iron = 1)
+	mob_react = FALSE
+
+/datum/chemical_reaction/bluespacecrystalifaction/on_reaction(datum/reagents/holder, multiplier)
+	var/location = get_turf(holder.my_atom)
+	for(var/i = 1, i <= multiplier, i++)
+		new /obj/item/stack/sheet/bluespace_crystal(location)
+
 /datum/chemical_reaction/capsaicincondensation
 	name = "Capsaicincondensation"
 	id = /datum/reagent/consumable/condensedcapsaicin

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -89,7 +89,7 @@
 /datum/chemical_reaction/uraniumsolidification
 	name = "Solid Uranium"
 	id = "soliduranium"
-	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/uranium = 20, /datum/reagent/iron = 1)
+	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/uranium = 20, /datum/reagent/bromine = 1)
 	mob_react = FALSE
 
 /datum/chemical_reaction/uraniumsolidification/on_reaction(datum/reagents/holder, multiplier)

--- a/code/modules/reagents/chemistry/recipes/others.dm
+++ b/code/modules/reagents/chemistry/recipes/others.dm
@@ -75,17 +75,6 @@
 	for(var/i = 1, i <= multiplier, i++)
 		new /obj/item/stack/sheet/mineral/gold(location)
 
-/datum/chemical_reaction/silversolidification
-	name = "Solid Silver"
-	id = "solidsilver"
-	required_reagents = list(/datum/reagent/consumable/frostoil = 5, /datum/reagent/silver = 20, /datum/reagent/iron = 1)
-	mob_react = FALSE
-
-/datum/chemical_reaction/silversolidification/on_reaction(datum/reagents/holder, multiplier)
-	var/location = get_turf(holder.my_atom)
-	for(var/i = 1, i <= multiplier, i++)
-		new /obj/item/stack/sheet/mineral/silver(location)
-
 /datum/chemical_reaction/uraniumsolidification
 	name = "Solid Uranium"
 	id = "soliduranium"


### PR DESCRIPTION
## About The Pull Request

Copy pasts gold soidifaction but changes it to  bluespace and urianium.

## Why It's Good For The Game

Makes it easyer for sci/chemies to go back and froth bettewn states of matter with time and effort
## Changelog
:cl:
add: Soidifaction of  and uranium can be done as well as making new bluespace shards
/:cl:
