### PR TITLE
One liner fixing dynamic voting resulting in the unstartable gamemode.

### DIFF
--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -370,7 +370,7 @@ SUBSYSTEM_DEF(vote)
 				var/list/runnable_storytellers = config.get_runnable_storytellers()
 				for(var/T in runnable_storytellers)
 					var/datum/dynamic_storyteller/S = T
-					runnable_storytellers[S] *= scores[initial(S.name)]
+					runnable_storytellers[S] *= stored_gamemode_votes[initial(S.name)]
 				var/datum/dynamic_storyteller/S = pickweightAllowZero(runnable_storytellers)
 				GLOB.dynamic_storyteller_type = S
 			if("map")


### PR DESCRIPTION
## About The Pull Request 
Because scores and choices are cut before we reach this part of the procedure, but `stored_gamemode_votes` is filled out on `announcement_results` just fine as I see on VV.

## Why It's Good For The Game
Fixing a bad meanie issue. Speed-testmerge please.

## Changelog
:cl:
fix: Fixed dynamic voting.
/:cl:
