### PR TITLE
Fixes the "blind while not unconscious bug", alternatively, "if in doubt, assume something is coded in the worst possible way and is held together by duct tape and prayers"

### DIFF
--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -21,7 +21,8 @@
 		if(IsUnconscious() || IsSleeping() || getOxyLoss() > 50 || (HAS_TRAIT(src, TRAIT_DEATHCOMA)) || health <= crit_threshold)
 			if(stat == CONSCIOUS)
 				stat = UNCONSCIOUS
-				blind_eyes(1)
+				if(!eye_blind)
+					blind_eyes(1)
 				update_mobility()
 		else
 			if(stat == UNCONSCIOUS)

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -813,7 +813,8 @@
 			return
 		if(IsUnconscious() || IsSleeping() || getOxyLoss() > 50 || (HAS_TRAIT(src, TRAIT_DEATHCOMA)) || (health <= HEALTH_THRESHOLD_FULLCRIT && !HAS_TRAIT(src, TRAIT_NOHARDCRIT)))
 			stat = UNCONSCIOUS
-			blind_eyes(1)
+			if(!eye_blind)
+				blind_eyes(1)
 			if(combatmode)
 				toggle_combat_mode(TRUE, TRUE)
 		else

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -490,7 +490,7 @@
 		GLOB.alive_mob_list += src
 		suiciding = 0
 		stat = UNCONSCIOUS //the mob starts unconscious,
-		if(!blind_eyes)
+		if(!eye_blind)
 			blind_eyes(1)
 		updatehealth() //then we check if the mob should wake up.
 		update_mobility()

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -490,7 +490,8 @@
 		GLOB.alive_mob_list += src
 		suiciding = 0
 		stat = UNCONSCIOUS //the mob starts unconscious,
-		blind_eyes(1)
+		if(!blind_eyes)
+			blind_eyes(1)
 		updatehealth() //then we check if the mob should wake up.
 		update_mobility()
 		update_sight()

--- a/code/modules/mob/living/silicon/robot/robot.dm
+++ b/code/modules/mob/living/silicon/robot/robot.dm
@@ -968,7 +968,8 @@
 		if(IsUnconscious() || IsStun() || IsParalyzed() || getOxyLoss() > maxHealth*0.5)
 			if(stat == CONSCIOUS)
 				stat = UNCONSCIOUS
-				blind_eyes(1)
+				if(!eye_blind)
+					blind_eyes(1)
 				update_mobility()
 				update_headlamp()
 		else


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

how do you think the game handles blindness while unconscious:
1. flag you as blind with traits to disable eyesight or atleast just set your blindness to 1 to make sure you're blind during unconsciousness
2. eye_blind += 1, if it updates your stat (consciousness) multiple times in a tick you are going to get more than 1 tick of blindness for that 1 tick, but you only heal 1 tick of blindness per tick.

(it's 2)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

bugfix

oh yeah and @ maintainer might be good to make blind_eyes() clamp instead of += but I'm not doing that here because I'm not sure what side effects it'd entail.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: unnecessary blindness post-unconsciouss has been fixed with a hack that's almost as garbage as the code that caused it in the first place.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
