### PR TITLE
Changes up some lava land ruins spawns

### DIFF
--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -176,8 +176,8 @@
 	id = "fountain"
 	description = "The fountain has a warning on the side. DANGER: May have undeclared side effects that only become obvious when implemented."
 	suffix = "lavaland_surface_fountain_hall.dmm"
-	allow_duplicates = FALSE
 	cost = 5
+	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/survivalcapsule
 	name = "Survival Capsule Ruins"

--- a/code/datums/ruins/lavaland.dm
+++ b/code/datums/ruins/lavaland.dm
@@ -168,13 +168,15 @@
 	id = "alien-nest"
 	description = "Not even Necropolis is safe from alien infestation. The competition for hosts has locked the legion and aliens in an endless conflict that can only be resolved by a PKA."
 	suffix = "lavaland_surface_alien_nest.dmm"
-	cost = 20
+	cost = 10
+	allow_duplicates = FALSE
 
 /datum/map_template/ruin/lavaland/fountain
 	name = "Fountain Hall"
 	id = "fountain"
 	description = "The fountain has a warning on the side. DANGER: May have undeclared side effects that only become obvious when implemented."
 	suffix = "lavaland_surface_fountain_hall.dmm"
+	allow_duplicates = FALSE
 	cost = 5
 
 /datum/map_template/ruin/lavaland/survivalcapsule
@@ -198,7 +200,7 @@
 	description = "A place of vile worship, the scrawling of blood in the middle glowing eerily. A demonic laugh echoes throughout the caverns"
 	suffix = "lavaland_surface_cultaltar.dmm"
 	allow_duplicates = FALSE
-	cost = 10
+	cost = 5
 
 /datum/map_template/ruin/lavaland/hermit
 	name = "Makeshift Shelter"
@@ -244,6 +246,7 @@
 	description = "A strange tumor which houses a powerful beast..."
 	suffix = "lavaland_surface_elite_tumor.dmm"
 	cost = 5
+	placement_weight = 3
 	always_place = TRUE
 	allow_duplicates = TRUE
 


### PR DESCRIPTION

## About The Pull Request

Makes the game want to spawn in more tumors 
Makes the game not spawn in doups of Fountain Hall and Xeno Nest.
Lowers the costs of Xeno Nest and survival pods as those had 0 ghost roles in them

## Why It's Good For The Game

Only one tumor from what ive seen ever really spawns
Doups of xeno-nests and hall fountains are not fun to deal with and Xeno nests can lead to a lot "free" alien loot then wanted. Wall fountain hall can jump start cults just like the summan ruin but not as bad
## Changelog
:cl:
balance: Xeno and Fountain Hall will no longer spawn more then once
tweak: Makes the game want to spawn in more then one tumor maybe
/:cl:
