### PR TITLE
Tweaks for the transfer vote

### DIFF
--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -20,7 +20,7 @@ SUBSYSTEM_DEF(autotransfer)
 /datum/controller/subsystem/autotransfer/fire()
 	if(maxvotes > curvotes)
 		if(world.time > targettime)
-			SSvote.initiate_vote("transfer",null) //TODO figure out how to not use null as the user
+			SSvote.initiate_vote("transfer","server")
 			targettime = targettime + voteinterval
 			curvotes += 1
 	else

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -89,20 +89,6 @@ SUBSYSTEM_DEF(vote)
 					choices[GLOB.master_mode] += non_voters.len
 					if(choices[GLOB.master_mode] >= greatest_votes)
 						greatest_votes = choices[GLOB.master_mode]
-			else if(mode == "transfer") // austation begin -- Crew autotransfer vote
-				var/factor = 1
-				switch(world.time / (1 MINUTES))
-					if(0 to 60)
-						factor = 0.5
-					if(61 to 120)
-						factor = 0.8
-					if(121 to 240)
-						factor = 1
-					if(241 to 300)
-						factor = 1.2
-					else
-						factor = 1.4
-				choices["Initiate Crew Transfer"] += round(non_voters.len * factor) // austation end
 	//get all options with that many votes and return them in a list
 	. = list()
 	if(greatest_votes)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

1. Makes the autotransfer vote have a proper user ("server") like the rest of the server.
2. Doesn't make the autotransfer vote make no-votes count as not just votes to transfer, but *more votes than actually voting to transfer*.

## Why It's Good For The Game

Consistency and that second decision just seems super questionable to me.

## Changelog
:cl:
tweak: Autotransfer vote now requires actual transfer votes to transfer.
/:cl: