### PR TITLE
Missing contractor tablet icon state fix

### DIFF
--- a/code/modules/modular_computers/computers/item/tablet.dm
+++ b/code/modules/modular_computers/computers/item/tablet.dm
@@ -24,7 +24,7 @@
 /obj/item/modular_computer/tablet/syndicate_contract_uplink
 	name = "contractor tablet"
 	icon = 'icons/obj/contractor_tablet.dmi'
-	icon_state = "tablet-red"
+	icon_state = "tablet"
 	icon_state_unpowered = "tablet"
 	icon_state_powered = "tablet"
 	icon_state_menu = "assign"


### PR DESCRIPTION
## About The Pull Request 
Skyrat-SS13/Skyrat13#641 courtesy of Useroth.

## Why It's Good For The Game
Missing icon state fix

## Changelog
:cl: Useroth
fix: contractor tablets spawned with invalid icon_state
/:cl:
