### PR TITLE
legion swarming now only applies to legions, not all of everything else that is a supertype and subtype of /hivelordbrood

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -229,7 +229,6 @@ Difficulty: Hard
 	attacktext = "pierces"
 	color = "#C80000"
 	density = FALSE
-	swarming = FALSE
 	faction = list("mining", "boss")
 	weather_immunities = list("lava","ash")
 

--- a/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/bubblegum.dm
@@ -229,6 +229,7 @@ Difficulty: Hard
 	attacktext = "pierces"
 	color = "#C80000"
 	density = FALSE
+	swarming = FALSE
 	faction = list("mining", "boss")
 	weather_immunities = list("lava","ash")
 

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -84,10 +84,12 @@
 	pass_flags = PASSTABLE | PASSMOB //they shouldn't get stuck behind hivelords.
 	density = FALSE
 	del_on_death = 1
+	var/swarming = TRUE
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/Initialize()
 	. = ..()
-	AddComponent(/datum/component/swarming) //oh god not the bees
+	if(swarming)
+		AddComponent(/datum/component/swarming) //oh god not the bees
 	addtimer(CALLBACK(src, .proc/death), 100)
 
 //Legion

--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -84,7 +84,7 @@
 	pass_flags = PASSTABLE | PASSMOB //they shouldn't get stuck behind hivelords.
 	density = FALSE
 	del_on_death = 1
-	var/swarming = TRUE
+	var/swarming = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/Initialize()
 	. = ..()
@@ -186,6 +186,7 @@
 	del_on_death = TRUE
 	stat_attack = UNCONSCIOUS
 	robust_searching = 1
+	swarming = TRUE
 	var/can_infest_dead = FALSE
 
 /mob/living/simple_animal/hostile/asteroid/hivelordbrood/legion/Life()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

mostly aimed at bubblegum
unnecessary change as part of the legion buff due to this being a subtype of legion heads, bubblegum fight did not need this, wasn't even aware this was a thing. not being able to shoot them is pretty bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: reverts bubblegum bloodling swarming.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
