### PR TITLE
nuclear fixes the blindness issue by making eye_blind() max() rather than add

### DIFF
--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -19,14 +19,10 @@
 /mob/proc/set_dizziness(amount)
 	dizziness = max(amount, 0)
 
-///Blind a mobs eyes by amount
-/mob/proc/blind_eyes(amount)
-	blindness(amount)
-
 /**
   * Sets a mob's blindness to an amount if it was not above it already, similar to how status effects work 
   */
-/mob/proc/blindness(amount)
+/mob/proc/blind_eyes(amount)
 	var/old_blind = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
 	eye_blind = max(eye_blind, amount)
 	var/new_blind = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -27,10 +27,10 @@
   * Sets a mob's blindness to an amount if it was not above it already, similar to how status effects work 
   */
 /mob/proc/blindness(amount)
-	var/old = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
+	var/old_blind = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
 	eye_blind = max(eye_blind, amount)
-	var/new = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
-	if(old != new)
+	var/new_blind = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
+	if(old_blind != new_blind)
 		update_blindness()
 
 /**

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -21,7 +21,17 @@
 
 ///Blind a mobs eyes by amount
 /mob/proc/blind_eyes(amount)
-	adjust_blindness(amount)
+	blindness(amount)
+
+/**
+  * Sets a mob's blindness to an amount if it was not above it already, similar to how status effects work 
+  */
+/mob/proc/blindness(amount)
+	var/old = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
+	eye_blind = max(eye_blind, amount)
+	var/new = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
+	if(old != new)
+		update_blindness()
 
 /**
   * Adjust a mobs blindness by an amount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

similar to how status effects work, there's no reason this proc should be stacking infinitely anyways, i wish all of this were status effects tbh
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

blindness is bad and this'll only keep happening, yeah i know maybe update stat shouldn't be called multiple times a tick but until someone goes and fixes the entire codebase to not require so many calls it's safer than sorry.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
experimental: eye_blind now is like Stun() and similar basic status effect procs, and only max()es the blindness duration to the amount rather than adding
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
