### PR TITLE
Makes the autotransfer subsystem slightly more modulable.

### DIFF
--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -82,7 +82,9 @@
 	config_entry_value = 600
 	min_val = 0
 
-/datum/config_entry/number/vote_autotransfer_initial //length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
+/// Length of time before the first autotransfer vote is called (deciseconds, default 2 hours)
+/// Set to 0 to disable the subsystem altogether.
+/datum/config_entry/number/vote_autotransfer_initial
 	config_entry_value = 72000
 	min_val = 0
 
@@ -90,7 +92,7 @@
 	config_entry_value = 18000
 	min_val = 0
 
-/datum/config_entry/number/vote_autotransfer_maximum // maximum extensions until the round autoends
+/datum/config_entry/number/vote_autotransfer_maximum // maximum extensions until the round autoends, set to 0 to disable.
 	config_entry_value = 4
 	min_val = 0
 

--- a/code/controllers/configuration/entries/general.dm
+++ b/code/controllers/configuration/entries/general.dm
@@ -88,13 +88,17 @@
 	config_entry_value = 72000
 	min_val = 0
 
-/datum/config_entry/number/vote_autotransfer_interval //length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
+///length of time to wait before subsequent autotransfer votes (deciseconds, default 30 minutes)
+/datum/config_entry/number/vote_autotransfer_interval
 	config_entry_value = 18000
 	min_val = 0
 
-/datum/config_entry/number/vote_autotransfer_maximum // maximum extensions until the round autoends, set to 0 to disable.
+/// maximum extensions until the round autoends.
+/// Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
+/// Set to -1 to disable the maximum extensions cap.
+/datum/config_entry/number/vote_autotransfer_maximum
 	config_entry_value = 4
-	min_val = 0
+	min_val = -1
 
 /datum/config_entry/flag/default_no_vote	// vote does not default to nochange/norestart
 

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -20,7 +20,6 @@ SUBSYSTEM_DEF(autotransfer)
 	targettime = starttime + init_vote
 	voteinterval = CONFIG_GET(number/vote_autotransfer_interval)
 	maxvotes = CONFIG_GET(number/vote_autotransfer_maximum)
-	curvotes = 0
 	return ..()
 
 /datum/controller/subsystem/autotransfer/Recover()

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -7,18 +7,27 @@ SUBSYSTEM_DEF(autotransfer)
 	var/targettime
 	var/voteinterval
 	var/maxvotes
-	var/curvotes
+	var/curvotes = 0
 
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
+	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial)
+	if(init_vote == 0) //Autotransfer voting disabled.
+		can_fire = FALSE
+		return ..()
 	starttime = world.time
-	targettime = starttime + CONFIG_GET(number/vote_autotransfer_initial)
+	targettime = starttime + init_vote
 	voteinterval = CONFIG_GET(number/vote_autotransfer_interval)
 	maxvotes = CONFIG_GET(number/vote_autotransfer_maximum)
 	curvotes = 0
 	return ..()
 
+/datum/controller/subsystem/autotransfer/Recover()
+	starttime = SSautotransfer.starttime
+	voteinterval = SSautotransfer.voteinterval
+	curvotes = SSautotransfer.curvotes
+
 /datum/controller/subsystem/autotransfer/fire()
-	if(maxvotes > curvotes)
+	if(!maxvotes || maxvotes > curvotes)
 		if(world.time > targettime)
 			SSvote.initiate_vote("transfer","server")
 			targettime = targettime + voteinterval

--- a/code/controllers/subsystem/autotransfer.dm
+++ b/code/controllers/subsystem/autotransfer.dm
@@ -1,3 +1,5 @@
+#define NO_MAXVOTES_CAP -1
+
 SUBSYSTEM_DEF(autotransfer)
 	name = "Autotransfer Vote"
 	flags = SS_KEEP_TIMING | SS_BACKGROUND
@@ -11,7 +13,7 @@ SUBSYSTEM_DEF(autotransfer)
 
 /datum/controller/subsystem/autotransfer/Initialize(timeofday)
 	var/init_vote = CONFIG_GET(number/vote_autotransfer_initial)
-	if(init_vote == 0) //Autotransfer voting disabled.
+	if(!init_vote) //Autotransfer voting disabled.
 		can_fire = FALSE
 		return ..()
 	starttime = world.time
@@ -27,10 +29,13 @@ SUBSYSTEM_DEF(autotransfer)
 	curvotes = SSautotransfer.curvotes
 
 /datum/controller/subsystem/autotransfer/fire()
-	if(!maxvotes || maxvotes > curvotes)
-		if(world.time > targettime)
-			SSvote.initiate_vote("transfer","server")
-			targettime = targettime + voteinterval
-			curvotes += 1
+	if(world.time < targettime)
+		return
+	if(maxvotes == NO_MAXVOTES_CAP || maxvotes > curvotes)
+		SSvote.initiate_vote("transfer","server")
+		targettime = targettime + voteinterval
+		curvotes++
 	else
 		SSshuttle.autoEnd()
+
+#undef NO_MAXVOTES_CAP

--- a/code/datums/elements/ghost_role_eligibility.dm
+++ b/code/datums/elements/ghost_role_eligibility.dm
@@ -17,9 +17,10 @@
 			penalty += roundstart_quit_limit - world.time
 		if(penalty)
 			penalty += world.realtime
-			var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
-			if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
-				penalty = CANT_REENTER_ROUND
+			if(SSautotransfer.can_fire && SSautotransfer.max_votes)
+				var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
+				if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
+					penalty = CANT_REENTER_ROUND
 			if(!(M.ckey in timeouts))
 				timeouts += M.ckey
 				timeouts[M.ckey] = 0

--- a/code/datums/elements/ghost_role_eligibility.dm
+++ b/code/datums/elements/ghost_role_eligibility.dm
@@ -17,7 +17,7 @@
 			penalty += roundstart_quit_limit - world.time
 		if(penalty)
 			penalty += world.realtime
-			if(SSautotransfer.can_fire && SSautotransfer.max_votes)
+			if(SSautotransfer.can_fire && SSautotransfer.maxvotes)
 				var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
 				if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
 					penalty = CANT_REENTER_ROUND

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -292,9 +292,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/roundstart_quit_limit = CONFIG_GET(number/roundstart_suicide_time_limit) MINUTES
 	if(world.time < roundstart_quit_limit)
 		penalty += roundstart_quit_limit - world.time
-	var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
-	if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
-		penalty = CANT_REENTER_ROUND
+	if(SSautotransfer.can_fire && SSautotransfer.max_votes)
+		var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
+		if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
+			penalty = CANT_REENTER_ROUND
 
 	if(SEND_SIGNAL(src, COMSIG_MOB_GHOSTIZE, (stat == DEAD) ? TRUE : FALSE, FALSE, (stat == DEAD)? penalty : 0, (stat == DEAD)? TRUE : FALSE) & COMPONENT_BLOCK_GHOSTING)
 		return
@@ -327,9 +328,10 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/roundstart_quit_limit = CONFIG_GET(number/roundstart_suicide_time_limit) MINUTES
 	if(world.time < roundstart_quit_limit)
 		penalty += roundstart_quit_limit - world.time
-	var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
-	if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
-		penalty = CANT_REENTER_ROUND
+	if(SSautotransfer.can_fire && SSautotransfer.max_votes)
+		var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
+		if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
+			penalty = CANT_REENTER_ROUND
 
 	var/response = alert(src, "Are you -sure- you want to ghost?\n(You are alive. If you ghost whilst alive you won't be able to re-enter this round [penalty ? "or play ghost roles [penalty == CANT_REENTER_ROUND ? "until the round is over" : "for the next [DisplayTimeText(penalty)]"]" : ""]! You can't change your mind so choose wisely!!)","Are you sure you want to ghost?","Ghost","Stay in body")
 	if(response != "Ghost")

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -292,7 +292,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/roundstart_quit_limit = CONFIG_GET(number/roundstart_suicide_time_limit) MINUTES
 	if(world.time < roundstart_quit_limit)
 		penalty += roundstart_quit_limit - world.time
-	if(SSautotransfer.can_fire && SSautotransfer.max_votes)
+	if(SSautotransfer.can_fire && SSautotransfer.maxvotes)
 		var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
 		if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
 			penalty = CANT_REENTER_ROUND
@@ -328,7 +328,7 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	var/roundstart_quit_limit = CONFIG_GET(number/roundstart_suicide_time_limit) MINUTES
 	if(world.time < roundstart_quit_limit)
 		penalty += roundstart_quit_limit - world.time
-	if(SSautotransfer.can_fire && SSautotransfer.max_votes)
+	if(SSautotransfer.can_fire && SSautotransfer.maxvotes)
 		var/maximumRoundEnd = SSautotransfer.starttime + SSautotransfer.voteinterval * SSautotransfer.maxvotes
 		if(penalty - SSshuttle.realtimeofstart > maximumRoundEnd + SSshuttle.emergencyCallTime + SSshuttle.emergencyDockTime + SSshuttle.emergencyEscapeTime)
 			penalty = CANT_REENTER_ROUND

--- a/config/config.txt
+++ b/config/config.txt
@@ -191,7 +191,9 @@ VOTE_AUTOTRANSFER_INITIAL 72000
 ## autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
 VOTE_AUTOTRANSFER_INTERVAL 18000
 
-## autovote maximum votes until automatic transfer call, set to 0 to disable. (default 4)
+## autovote maximum votes until automatic transfer call. (default 4)
+## Set to 0 to force automatic crew transfer after the 'vote_autotransfer_initial' elapsed.
+## Set to -1 to disable the maximum votes cap.
 VOTE_AUTOTRANSFER_MAXIMUM 4
 
 ## prevents dead players from voting or starting votes

--- a/config/config.txt
+++ b/config/config.txt
@@ -185,12 +185,13 @@ VOTE_DELAY 6000
 VOTE_PERIOD 600
 
 ## autovote initial delay (deciseconds) before first automatic transfer vote call (default 120 minutes)
+## Set to 0 to disable the subsystem altogether.
 VOTE_AUTOTRANSFER_INITIAL 72000
 
 ## autovote delay (deciseconds) before sequential automatic transfer votes are called (default 30 minutes)
 VOTE_AUTOTRANSFER_INTERVAL 18000
 
-## autovote maximum votes until automatic transfer call (default 4)
+## autovote maximum votes until automatic transfer call, set to 0 to disable. (default 4)
 VOTE_AUTOTRANSFER_MAXIMUM 4
 
 ## prevents dead players from voting or starting votes


### PR DESCRIPTION
## About The Pull Request 
Useroth told me there is no good way to disable the autotransfer subsystem, and setting the `vote_autotransfer_initial` or `vote_autotransfer_maximum` configs to 0 causes the shuttle to be called before the players are even spawned on station.

## Why It's Good For The Game
Fixing the autotransfer subsystem lack of modulability.

## Changelog
:cl:
fix: The autotransfer subsystem is slightly more modulable now.
/:cl:

