### PR TITLE
make the CMO hypokit not literally worse than normal ones

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -525,14 +525,6 @@
 	desc = "A kit containing a Deluxe hypospray and Vials."
 	icon_state = "tactical-mini"
 
-/obj/item/storage/hypospraykit/cmo/ComponentInitialize()
-	. = ..()
-	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
-	STR.max_items = 6
-	STR.can_hold = typecacheof(list(
-	/obj/item/hypospray/mkii,
-	/obj/item/reagent_containers/glass/bottle/vial))
-
 /obj/item/storage/hypospraykit/cmo/PopulateContents()
 	if(empty)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
there is absolutely no reason for the CMO's kit to hold less items
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Every round as CMO I find myself going to the nanomed and getting a hypo kit, dumping it out, and putting my deluxe stuff inside the normal kit because it's bigger. Why?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: cmo hypokit now holds the same amount of items as normal kits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
