### PR TITLE
Buffs borg hypos - Anti-radiation addition 

### DIFF
--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -462,7 +462,7 @@
 	desc = "An upgrade to the Medical module's hypospray, containing \
 		stronger versions of existing chemicals."
 	additional_reagents = list(/datum/reagent/medicine/oxandrolone, /datum/reagent/medicine/sal_acid,
-								/datum/reagent/medicine/rezadone, /datum/reagent/medicine/pen_acid)
+								/datum/reagent/medicine/rezadone, /datum/reagent/medicine/pen_acid, /datum/reagent/medicine/prussian_blue)
 
 /obj/item/borg/upgrade/piercing_hypospray
 	name = "cyborg piercing hypospray"

--- a/code/modules/reagents/reagent_containers/borghydro.dm
+++ b/code/modules/reagents/reagent_containers/borghydro.dm
@@ -28,7 +28,7 @@ Borg Hypospray
 
 	var/list/datum/reagents/reagent_list = list()
 	var/list/reagent_ids = list(/datum/reagent/medicine/dexalin, /datum/reagent/medicine/kelotane, /datum/reagent/medicine/bicaridine, /datum/reagent/medicine/antitoxin,
-								/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/insulin)
+								/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/spaceacillin, /datum/reagent/medicine/salglu_solution, /datum/reagent/medicine/insulin, /datum/reagent/medicine/potass_iodide)
 	var/accepts_reagent_upgrades = TRUE //If upgrades can increase number of reagents dispensed.
 	var/list/modes = list() //Basically the inverse of reagent_ids. Instead of having numbers as "keys" and strings as values it has strings as keys and numbers as values.
 								//Used as list for input() in shakers.
@@ -164,7 +164,7 @@ Borg Hypospray
 	icon_state = "borghypo_s"
 	charge_cost = 20
 	recharge_time = 2
-	reagent_ids = list(/datum/reagent/medicine/syndicate_nanites, /datum/reagent/medicine/potass_iodide, /datum/reagent/medicine/morphine, /datum/reagent/medicine/insulin)
+	reagent_ids = list(/datum/reagent/medicine/syndicate_nanites, /datum/reagent/medicine/prussian_blue, /datum/reagent/medicine/morphine, /datum/reagent/medicine/insulin)
 	bypass_protection = 1
 	accepts_reagent_upgrades = FALSE
 
@@ -261,5 +261,5 @@ Borg Shaker
 /obj/item/reagent_containers/borghypo/epi
 	name = "Stabilizer injector"
 	desc = "An advanced chemical synthesizer and injection system, designed to stabilize patients."
-	reagent_ids = list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/insulin)
+	reagent_ids = list(/datum/reagent/medicine/epinephrine, /datum/reagent/medicine/insulin, /datum/reagent/medicine/potass_iodide)
 	accepts_reagent_upgrades = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Are you sick and tired of crew/nukies running around the SM giving it snuggles and not having any way to deal with it? Well look no more for that "Final Fix" also known as your personal little EMP bomb you keep on yourself and try out Potass Iodide, yes thats right radiation CAN be healed!
Whats that little Bolty? 3000 RADS?! That can not do, so if YOU are an AI having trubbles dealing with brain dead CEs CALL YOUR LOCAL ROBOTICS NOW!!! Upgraded Hypos now have Prussian Blue! Yes Prussian Blue! For the low low price of what ever it takes to get your robotic oils on that Robotics!

## Why It's Good For The Game

Borgs can better deal with radiation now and dont have to sit and 'cry'(We both know your laughting you ass off) as everyone dies

## Changelog
:cl:
add: Potass Iodide has been fitted into standered borgs as well as medical ones. Upgraded hypos now have Prussian Blue as well.
tweak: Syndi borgs Potass Iodide has been swapped for Prussian Blue
/:cl:
