### PR TITLE
Adds a blacklist to contractor dropoff areas

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1167,7 +1167,7 @@ GLOBAL_LIST_EMPTY(possible_sabotages)
 														/area/solar/,
 														/area/ruin/,	//thank you station space ruins
 														/area/science/test_area/,
-														/area/shuttle))
+														/area/shuttle/))
 
 /datum/objective/contract/proc/generate_dropoff()	// Generate a random valid area on the station that the dropoff will happen.
 	var/found = FALSE

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1163,12 +1163,16 @@ GLOBAL_LIST_EMPTY(possible_sabotages)
 	var/payout = 0
 	var/payout_bonus = 0
 	var/area/dropoff = null
+	var/static/list/blacklisted_areas = typecacheof(list(/area/ai_monitored/turret_protected,
+														/area/solar/,
+														/area/ruin/,	//thank you station space ruins
+														/area/science/test_area/))
 
 /datum/objective/contract/proc/generate_dropoff()	// Generate a random valid area on the station that the dropoff will happen.
 	var/found = FALSE
 	while(!found)
 		var/area/dropoff_area = pick(GLOB.sortedAreas)
-		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !istype(dropoff_area, /area/shuttle/))
+		if(dropoff_area && is_station_level(dropoff_area.z) && !dropoff_area.outdoors && !is_type_in_typecache(dropoff_area, blacklisted_areas))
 			dropoff = dropoff_area
 			found = TRUE
 

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -1166,7 +1166,8 @@ GLOBAL_LIST_EMPTY(possible_sabotages)
 	var/static/list/blacklisted_areas = typecacheof(list(/area/ai_monitored/turret_protected,
 														/area/solar/,
 														/area/ruin/,	//thank you station space ruins
-														/area/science/test_area/))
+														/area/science/test_area/,
+														/area/shuttle))
 
 /datum/objective/contract/proc/generate_dropoff()	// Generate a random valid area on the station that the dropoff will happen.
 	var/found = FALSE


### PR DESCRIPTION
## About The Pull Request

you can no longer receive the following areas as dropoff locations:
-AI sat and upload
-bomb test range 
-station space ruins (AGAIN)
-solars

## Why It's Good For The Game

yeah uh turns out expecting contractors to have to suit up their targets is bad?? maybe??

## Changelog
:cl:Kraso
tweak: Blacklists turret protected areas, the toxins test range, asteroid ruins, and solars from being valid dropoff locations for contracts.
/:cl:
