### PR TITLE
Makes nymphomania no longer cause inviolable arousal

### DIFF
--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -92,7 +92,6 @@
 	name = "Nymphomania"
 	desc = "You're always feeling a bit in heat. Also, you get aroused faster than usual."
 	value = 0
-	mob_trait = TRAIT_PERMABONER
 	gain_text = "<span class='notice'>You are feeling extra wild.</span>"
 	lose_text = "<span class='notice'>You don't feel that burning sensation anymore.</span>"
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Nymphomania does nothing mechanically now.

## Why It's Good For The Game

The old thing was waaaay worse than just having it do nothing.

Why not remove it? People use it as a kind of weird "likes ERP" indicator. I think it's probably better to keep it but have it do nothing, at least so that people don't get mad.

## Changelog
:cl:
del: Nymphomania no longer has an effect.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
