### PR TITLE
Blacklists two custom item flasks in "get drink" proc

### DIFF
--- a/code/__HELPERS/unsorted.dm
+++ b/code/__HELPERS/unsorted.dm
@@ -1426,7 +1426,9 @@ GLOBAL_DATUM_INIT(dview_mob, /mob/dview, new)
 
 /proc/get_random_drink()
 	var/list/blocked = list(/obj/item/reagent_containers/food/drinks/soda_cans,
-		/obj/item/reagent_containers/food/drinks/bottle
+		/obj/item/reagent_containers/food/drinks/bottle,
+		/obj/item/reagent_containers/food/drinks/flask/russian,
+		/obj/item/reagent_containers/food/drinks/flask/steel
 		)
 	return pick(subtypesof(/obj/item/reagent_containers/food/drinks) - blocked)
 


### PR DESCRIPTION

## About The Pull Request

removes The End flask and Russian Flask from get drink proc

## Why It's Good For The Game

They are custom items for people that had donated to the game 


## Changelog
:cl:
fix: No longer can you get the The End and Russian Flask without being the donator
/:cl:
