### PR TITLE
Ash walker camp tweak because Ghommie asked me to.

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -197,11 +197,10 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
 "cp" = (
-/obj/structure/stone_tile,
-/obj/structure/stone_tile{
-	dir = 8
+/obj/structure/stone_tile/block{
+	dir = 1
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "cq" = (
 /obj/structure/cable{
@@ -261,13 +260,10 @@
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
 "dA" = (
-/obj/structure/stone_tile/block{
-	dir = 4
-	},
 /obj/structure/stone_tile/block/cracked{
-	dir = 8
+	dir = 1
 	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/turf/closed/indestructible/riveted/boss,
 /area/ruin/unpowered/ash_walkers)
 "dD" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -278,7 +274,7 @@
 "dF" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "dG" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -314,19 +310,19 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "eq" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "eP" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
 	},
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "eQ" = (
 /obj/structure/closet/crate/radiation,
 /obj/item/flashlight/lantern,
@@ -379,7 +375,7 @@
 /obj/structure/stone_tile/block,
 /obj/item/twohanded/bonespear,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "fC" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp/security)
@@ -389,7 +385,7 @@
 	},
 /obj/item/twohanded/bonespear,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "fQ" = (
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors/unexplored/danger)
@@ -487,7 +483,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "gy" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile{
@@ -526,12 +522,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"gF" = (
-/obj/structure/stone_tile/block{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "gG" = (
 /obj/structure/stone_tile{
 	dir = 1
@@ -571,7 +561,7 @@
 "hd" = (
 /obj/structure/mineral_door/sandstone,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "hg" = (
 /obj/structure/stone_tile/surrounding,
 /obj/structure/stone_tile/center/cracked,
@@ -589,7 +579,7 @@
 /obj/structure/stone_tile/center,
 /obj/item/hatchet,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "hs" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -608,7 +598,7 @@
 /obj/effect/mob_spawn/human/corpse/damaged,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "hG" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -660,7 +650,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "id" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -674,10 +664,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/lavaland/surface/outdoors)
-"io" = (
-/obj/structure/stone_tile/slab/cracked,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "iq" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -981,12 +967,6 @@
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kk" = (
-/obj/structure/stone_tile{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "kl" = (
 /obj/structure/fluff/drake_statue/falling,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1052,9 +1032,6 @@
 /obj/structure/stone_tile/center/cracked,
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
-"kI" = (
-/turf/closed/mineral/random/volcanic,
-/area/ruin/unpowered/ash_walkers)
 "kJ" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 4
@@ -1090,7 +1067,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "kR" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
@@ -1103,7 +1080,7 @@
 	dir = 8
 	},
 /turf/closed/indestructible/riveted/boss,
-/area/lavaland/surface/outdoors)
+/area/ruin/unpowered/ash_walkers)
 "le" = (
 /obj/structure/stone_tile,
 /obj/structure/stone_tile{
@@ -1722,7 +1699,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "nC" = (
 /obj/machinery/cryopod{
 	dir = 4
@@ -1732,9 +1709,6 @@
 "nE" = (
 /turf/closed/mineral/random/volcanic,
 /area/lavaland/surface/outdoors/explored)
-"nI" = (
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "nJ" = (
 /turf/closed/wall/mineral/wood,
 /area/ruin/unpowered/ash_walkers)
@@ -1770,14 +1744,14 @@
 "ot" = (
 /obj/structure/stone_tile/surrounding_tile,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "oB" = (
 /obj/item/stack/sheet/mineral/wood,
 /obj/structure/stone_tile{
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "oL" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -1809,7 +1783,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "pf" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -1836,7 +1810,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "pF" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 8
@@ -1849,13 +1823,13 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "pG" = (
 /obj/structure/stone_tile/surrounding_tile{
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "pH" = (
 /obj/structure/stone_tile/surrounding_tile/cracked{
 	dir = 1
@@ -1909,7 +1883,7 @@
 /obj/item/flashlight/lantern,
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "qN" = (
 /obj/structure/stone_tile/block,
 /obj/structure/stone_tile{
@@ -1919,11 +1893,11 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "qS" = (
 /obj/structure/stone_tile/slab,
 /turf/closed/indestructible/riveted/boss,
-/area/lavaland/surface/outdoors)
+/area/ruin/unpowered/ash_walkers)
 "rb" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -1948,7 +1922,7 @@
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/ore_box,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "rQ" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -1989,7 +1963,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "sl" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -1998,10 +1972,6 @@
 	dir = 8
 	},
 /turf/closed/indestructible/riveted/boss,
-/area/lavaland/surface/outdoors)
-"sq" = (
-/obj/structure/stone_tile,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "sx" = (
 /obj/item/stack/sheet/mineral/coal,
@@ -2019,7 +1989,7 @@
 /obj/item/stack/sheet/mineral/coal,
 /obj/item/stack/sheet/mineral/coal,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "sN" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/light/small{
@@ -2027,10 +1997,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"sR" = (
-/obj/structure/stone_tile/block/cracked,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "tp" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -2065,10 +2031,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"ub" = (
-/obj/structure/stone_tile/slab,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "ug" = (
 /obj/structure/table,
 /obj/item/storage/firstaid/regular,
@@ -2177,7 +2139,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "wm" = (
 /obj/item/seeds/glowshroom,
 /obj/item/seeds/glowshroom,
@@ -2234,20 +2196,13 @@
 /obj/item/pickaxe,
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "xs" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
 	},
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"xJ" = (
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/obj/structure/stone_tile/block,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "xR" = (
 /obj/machinery/mineral/processing_unit_console,
 /turf/closed/wall,
@@ -2258,7 +2213,7 @@
 	},
 /obj/item/pickaxe,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "yd" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable,
@@ -2282,11 +2237,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"yv" = (
-/obj/structure/stone_tile/block,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "yw" = (
 /obj/machinery/conveyor_switch/oneway{
 	id = "gulag"
@@ -2318,7 +2269,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "zx" = (
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
@@ -2348,15 +2299,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"Ad" = (
-/obj/structure/stone_tile{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"Ag" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "An" = (
 /obj/structure/stone_tile/slab,
 /obj/structure/table/wood,
@@ -2373,7 +2315,7 @@
 	},
 /obj/item/twohanded/bonespear,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "AP" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -2401,7 +2343,7 @@
 "AU" = (
 /obj/structure/stone_tile,
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "AX" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors/explored)
@@ -2418,12 +2360,6 @@
 	},
 /obj/item/flashlight/lantern,
 /turf/open/indestructible/boss,
-/area/ruin/unpowered/ash_walkers)
-"Bf" = (
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Bg" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2449,7 +2385,7 @@
 /obj/structure/stone_tile/slab,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Bs" = (
 /obj/structure/stone_tile/cracked{
 	dir = 8
@@ -2472,7 +2408,7 @@
 "BF" = (
 /obj/structure/flora/rock/jungle,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "BG" = (
 /obj/structure/stone_tile/block{
 	dir = 4
@@ -2494,7 +2430,7 @@
 	},
 /obj/structure/stone_tile/center/cracked,
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "BP" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -2520,7 +2456,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Cy" = (
 /obj/structure/chair/office{
 	dir = 1
@@ -2551,17 +2487,11 @@
 	},
 /turf/closed/indestructible/riveted/boss,
 /area/lavaland/surface/outdoors)
-"Ds" = (
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "Dx" = (
 /obj/structure/bonfire/dense,
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Dz" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 8
@@ -2578,7 +2508,7 @@
 	},
 /obj/item/book/granter/crafting_recipe/bone_bow,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Ef" = (
 /obj/structure/stone_tile/block/cracked,
 /turf/open/lava/smooth{
@@ -2590,7 +2520,7 @@
 	name = "old rusty grill"
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "ED" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -2608,15 +2538,6 @@
 /area/mine/laborcamp/security)
 "EQ" = (
 /obj/structure/stone_tile/surrounding/cracked,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"EV" = (
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "Fn" = (
@@ -2661,7 +2582,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "FC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -2688,7 +2609,7 @@
 "Gc" = (
 /obj/structure/flora/junglebush/b,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Gw" = (
 /obj/structure/stone_tile/block{
 	dir = 1
@@ -2701,7 +2622,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "GC" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/center,
@@ -2755,7 +2676,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Ik" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red,
@@ -2765,15 +2686,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"It" = (
-/obj/structure/stone_tile/block{
-	dir = 8
-	},
-/obj/structure/stone_tile/block/cracked{
-	dir = 4
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "IV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2820,17 +2732,6 @@
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
-"JR" = (
-/obj/structure/stone_tile/block,
-/obj/structure/stone_tile/block/cracked{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"JZ" = (
-/obj/structure/stone_tile/cracked,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "Ks" = (
 /obj/machinery/shower{
 	dir = 8
@@ -2857,7 +2758,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "KO" = (
 /obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/tile/red{
@@ -2885,7 +2786,7 @@
 	dir = 1
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Ld" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/loading_area{
@@ -2895,7 +2796,7 @@
 /area/mine/laborcamp)
 "LJ" = (
 /turf/open/water,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Mh" = (
 /obj/structure/stone_tile/cracked,
 /obj/structure/stone_tile/block{
@@ -2920,7 +2821,7 @@
 	},
 /obj/structure/stone_tile/cracked,
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "MX" = (
 /obj/structure/stone_tile/slab/cracked,
 /turf/open/indestructible/boss,
@@ -2931,13 +2832,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/mine/laborcamp)
-"NN" = (
-/obj/structure/stone_tile/block/cracked,
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "NS" = (
 /obj/machinery/computer/prisoner,
 /obj/effect/turf_decal/tile/red{
@@ -2977,17 +2871,10 @@
 /obj/structure/stone_tile/center,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "OK" = (
 /turf/closed/wall/r_wall,
 /area/mine/laborcamp)
-"OR" = (
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/obj/structure/stone_tile/block/cracked,
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "Pj" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /obj/structure/stone_tile/surrounding_tile/cracked{
@@ -2998,7 +2885,7 @@
 	},
 /obj/structure/stone_tile/center,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "PF" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -3102,7 +2989,7 @@
 "QM" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "QZ" = (
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 8
@@ -3146,7 +3033,7 @@
 	dir = 8
 	},
 /turf/closed/indestructible/riveted/boss,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Rs" = (
 /obj/machinery/light/small{
 	dir = 1
@@ -3182,12 +3069,9 @@
 "Sh" = (
 /obj/structure/stone_tile/block,
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Si" = (
 /turf/closed/indestructible/riveted/boss,
-/area/ruin/unpowered/ash_walkers)
-"Sr" = (
-/turf/closed/mineral/random/high_chance/volcanic,
 /area/ruin/unpowered/ash_walkers)
 "SG" = (
 /obj/structure/stone_tile/block{
@@ -3301,13 +3185,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/mine/laborcamp)
-"UG" = (
-/obj/structure/stone_tile/block,
-/obj/structure/stone_tile/block{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "UV" = (
 /obj/structure/stone_tile{
 	dir = 8
@@ -3315,7 +3192,7 @@
 /obj/structure/stone_tile/cracked,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Vb" = (
 /obj/structure/stone_tile/block/cracked{
 	dir = 4
@@ -3336,7 +3213,7 @@
 	dir = 1
 	},
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Vs" = (
 /obj/machinery/camera{
 	c_tag = "Labor Camp Central";
@@ -3360,16 +3237,7 @@
 	},
 /obj/structure/reagent_dispensers/watertank,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
-"VP" = (
-/obj/structure/stone_tile/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/cracked{
-	dir = 1
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "VV" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -3395,7 +3263,7 @@
 "Wj" = (
 /obj/structure/stone_tile/surrounding_tile/cracked,
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Wq" = (
 /obj/structure/chair{
 	dir = 1
@@ -3453,13 +3321,6 @@
 	},
 /turf/open/indestructible/boss,
 /area/ruin/unpowered/ash_walkers)
-"WU" = (
-/obj/structure/stone_tile,
-/obj/structure/stone_tile/cracked{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "Xe" = (
 /obj/structure/stone_tile/surrounding_tile,
 /obj/structure/stone_tile/center/cracked,
@@ -3470,7 +3331,7 @@
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Xf" = (
 /obj/structure/stone_tile/block{
 	dir = 8
@@ -3505,7 +3366,7 @@
 	dir = 8
 	},
 /turf/closed/mineral/volcanic/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "XG" = (
 /obj/effect/decal/cleanable/blood,
 /obj/structure/stone_tile/cracked{
@@ -3515,7 +3376,7 @@
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "XS" = (
 /obj/machinery/flasher{
 	id = "labor"
@@ -3527,7 +3388,7 @@
 	light_range = null
 	},
 /turf/open/water,
-/area/ruin/unpowered/ash_walkers)
+/area/lavaland/surface/outdoors)
 "Ym" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3554,15 +3415,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/mine/laborcamp/security)
-"YH" = (
-/obj/structure/stone_tile/block/cracked{
-	dir = 4
-	},
-/obj/structure/stone_tile/block{
-	dir = 8
-	},
-/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
-/area/ruin/unpowered/ash_walkers)
 "Zc" = (
 /obj/structure/stone_tile{
 	dir = 4
@@ -55272,16 +55124,16 @@ aa
 aa
 aa
 aa
-Si
-Si
-Si
-Si
-Si
-Si
-Si
-Ag
-Ag
-Ag
+aa
+aa
+aa
+aa
+aa
+aa
+aa
+Mx
+Mx
+Mx
 Mx
 Mx
 Mx
@@ -55529,19 +55381,19 @@ aa
 aa
 aa
 aa
-Si
-Sr
-Sr
-Sr
-JZ
-nI
-nI
-nI
-nI
-CG
-Ag
-Ag
-Ag
+aa
+ad
+ad
+ad
+iy
+ab
+ab
+ab
+ab
+jR
+Mx
+Mx
+Mx
 Mx
 aj
 aj
@@ -55786,19 +55638,19 @@ aa
 aa
 aa
 aa
-Si
-Sr
-nI
-nI
-nI
-nI
-pq
-nI
+aa
+ad
+ab
+ab
+ab
+ab
+kN
+ab
 LJ
-nI
-nI
-nI
-Ag
+ab
+ab
+ab
+Mx
 Mx
 aj
 aj
@@ -56043,19 +55895,19 @@ aa
 aa
 aa
 aa
-Si
-yv
-nI
-nI
-nI
-nI
+aa
+it
+ab
+ab
+ab
+ab
 BF
 LJ
 LJ
 LJ
-nI
-JZ
-nI
+ab
+iy
+ab
 Mx
 aj
 aj
@@ -56300,19 +56152,19 @@ aa
 aa
 aa
 aa
-Si
-yv
-nI
-nI
-Ad
-nI
+aa
+it
+ab
+ab
+jx
+ab
 LJ
 LJ
 LJ
 LJ
-kI
-nI
-JZ
+ai
+ab
+iy
 Mx
 aj
 aj
@@ -56557,19 +56409,19 @@ aa
 aa
 aa
 aa
-Si
-nI
-nI
+aa
+ab
+ab
 Ez
-nI
+ab
 LJ
 LJ
 Yg
 LJ
-kI
-kI
-nI
-nI
+ai
+ai
+ab
+ab
 Mx
 aj
 ab
@@ -56814,19 +56666,19 @@ aa
 aa
 aa
 aa
-Si
-nI
-nI
+aa
+ab
+ab
 sx
-nI
+ab
 LJ
 LJ
 LJ
 LJ
-kI
-kI
-Sr
-Ag
+ai
+ai
+ad
+Mx
 Mx
 Mx
 aj
@@ -57071,19 +56923,19 @@ aa
 aa
 aa
 aa
-Si
-nI
-nI
-nI
-Wh
-nI
+aa
+ab
+ab
+ab
+jQ
+ab
 LJ
 LJ
 Gc
-nI
-Sr
-nI
-Ag
+ab
+ad
+ab
+Mx
 Mx
 Mx
 aj
@@ -57328,19 +57180,19 @@ aa
 aa
 aa
 aa
-Si
-Sr
-nI
-nI
-nI
-Wh
-nI
-nI
-nI
-nI
-nI
-nI
-Ag
+aa
+ad
+ab
+ab
+ab
+jQ
+ab
+ab
+ab
+ab
+ab
+ab
+Mx
 Mx
 Mx
 aj
@@ -57585,19 +57437,19 @@ aa
 aa
 aa
 aa
-Si
-Ag
-Ag
-nI
-nI
-nI
-nI
-Ds
-nI
-Ds
-nI
-nI
-Ag
+aa
+Mx
+Mx
+ab
+ab
+ab
+ab
+jS
+ab
+jS
+ab
+ab
+Mx
 Mx
 Mx
 aj
@@ -57843,18 +57695,18 @@ Mh
 aa
 aa
 Rr
-Ag
+Mx
 xs
 eq
-nI
-nI
-nI
-nI
-nI
-nI
-nI
-nI
-Ag
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+ab
+Mx
 Mx
 aj
 aj
@@ -58102,16 +57954,16 @@ Si
 Si
 Si
 Si
-yv
-nI
-nI
-sq
-kk
+it
+ab
+ab
+jq
+ja
 Gx
-nI
-nI
-nI
-Si
+ab
+ab
+ab
+aa
 Mx
 aj
 aj
@@ -58359,16 +58211,16 @@ wm
 Vb
 Bs
 Si
-yv
-sq
-CG
+it
+jq
+jR
 AH
-Ds
-Ds
+jS
+jS
 KV
-nI
+ab
 DQ
-Si
+aa
 aa
 ab
 aj
@@ -58616,16 +58468,16 @@ zf
 Qk
 iG
 Si
-Wh
-EV
+jQ
+ll
 Xe
-ke
+iu
 Ch
-kk
-Ad
-Wh
-nI
-Ad
+ja
+jx
+jQ
+ab
+jx
 lp
 lz
 lp
@@ -58873,16 +58725,16 @@ qh
 pq
 Jq
 ke
-ub
-YH
-sR
+gP
+ma
+ix
 Dx
-Bf
+kM
 UV
-kk
-Ds
-nI
-yv
+ja
+jS
+ab
+it
 lu
 lq
 lD
@@ -59130,16 +58982,16 @@ ui
 Xw
 Rb
 Si
-sR
-Wh
+ix
+jQ
 gt
-gF
+jb
 pF
-sq
-Ad
-VP
-Ad
-pq
+jq
+jx
+ky
+jx
+kN
 lv
 lv
 lE
@@ -59387,16 +59239,16 @@ dM
 eQ
 Zc
 Si
-Wh
+jQ
 XG
-pq
-NN
-JZ
+kN
+mn
+iy
 oB
-EV
+ll
 nB
-nI
-Si
+ab
+aa
 aa
 aj
 aj
@@ -59644,16 +59496,16 @@ Si
 Si
 Si
 Si
-CG
-Wh
-CG
-JR
-Ad
+jR
+jQ
+jR
+ae
+jx
 Pj
 ia
 yf
-Ds
-Si
+jS
+aa
 aj
 aj
 ab
@@ -59899,18 +59751,18 @@ Dn
 Zs
 Zs
 xX
-gF
+jb
 Fz
 QM
-CG
-Wh
+jR
+jQ
 pc
-dA
-yv
+lg
+it
 qA
 vR
-WU
-Ag
+mD
+Mx
 aj
 aj
 aj
@@ -60159,15 +60011,15 @@ Si
 Si
 Br
 pD
-Wh
-Ad
-NN
-Wh
+jQ
+jx
+mn
+jQ
 hr
 zv
 BH
-sq
-Ag
+jq
+Mx
 ab
 aj
 aj
@@ -60405,7 +60257,7 @@ aj
 aa
 aa
 aa
-Gw
+cp
 Si
 KA
 KA
@@ -60416,15 +60268,15 @@ Si
 Si
 Si
 ft
-Ad
-pq
-NN
+jx
+kN
+mn
 VI
 Vj
 MS
 AU
-Ag
-Ag
+Mx
+Mx
 ab
 aj
 aj
@@ -60673,15 +60525,15 @@ ty
 Si
 Si
 qN
-nI
+ab
 hD
-UG
-Ag
-Ag
-Ag
-Ag
-Ag
-Ag
+gR
+Mx
+Mx
+Mx
+Mx
+Mx
+Mx
 Mx
 ab
 aj
@@ -60919,7 +60771,7 @@ aj
 aa
 aa
 aa
-uz
+dA
 Ou
 KA
 QC
@@ -60930,11 +60782,11 @@ vi
 Si
 BU
 kP
-cp
-CG
-xJ
-RF
-Ag
+iY
+jR
+lG
+js
+Mx
 xs
 xs
 xs
@@ -61176,7 +61028,7 @@ aj
 aa
 aa
 aa
-Gw
+cp
 An
 KA
 nt
@@ -61186,16 +61038,16 @@ rQ
 MX
 sa
 Bj
-ub
-It
-dA
+gP
+kj
+lg
 sk
 Si
 Si
 nJ
 Si
 Si
-Ag
+Mx
 Mx
 ab
 aj
@@ -61433,7 +61285,7 @@ aj
 aa
 aa
 aa
-Gw
+cp
 Uh
 KA
 jj
@@ -61444,15 +61296,15 @@ RX
 Si
 BU
 Oy
-cp
-pq
-UG
+iY
+kN
+gR
 nJ
 WN
 Yy
 Hq
 nJ
-Ag
+Mx
 Mx
 ab
 ab
@@ -61701,15 +61553,15 @@ se
 Si
 Si
 KJ
-CG
+jR
 fN
-ub
+gP
 RF
 eh
 EQ
 Tn
 nJ
-Ag
+Mx
 Mx
 aj
 aj
@@ -61947,7 +61799,7 @@ aj
 aa
 aa
 aa
-Gw
+cp
 Si
 KA
 KA
@@ -61957,10 +61809,10 @@ KA
 Si
 Si
 Si
-sR
-pq
-sq
-nI
+ix
+kN
+jq
+ab
 nJ
 JP
 Qd
@@ -62213,10 +62065,10 @@ Si
 Si
 Si
 Si
-io
+kR
 rO
 xr
-nI
+ab
 eo
 nJ
 nJ
@@ -62471,15 +62323,15 @@ BG
 SG
 Xo
 ot
-nI
-nI
-nI
+ab
+ab
+ab
 pG
-Ag
-Ag
+Mx
+Mx
 eP
-Ag
-Ag
+Mx
+Mx
 Wj
 Mx
 ab
@@ -62728,11 +62580,11 @@ aa
 aa
 Mx
 Mx
-nI
-nI
-nI
+ab
+ab
+ab
 HX
-Ag
+Mx
 Mx
 Mx
 Mx
@@ -62985,11 +62837,11 @@ aa
 aa
 Mx
 Mx
-Ag
-nI
-nI
-OR
-Ag
+Mx
+ab
+ab
+iC
+Mx
 Mx
 Mx
 ab
@@ -63242,11 +63094,11 @@ aa
 aa
 ad
 Mx
-Ag
-Ag
-nI
-gF
-Ag
+Mx
+Mx
+ab
+jb
+Mx
 Mx
 ab
 ab
@@ -63501,9 +63353,9 @@ ad
 ad
 Mx
 Mx
-Ag
+Mx
 hd
-Ag
+Mx
 Mx
 ab
 ab

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -59,6 +59,7 @@
 	new_spawn.real_name = random_unique_lizard_name(gender)
 	if(is_mining_level(z))
 		to_chat(new_spawn, "<b>Drag the corpses of men and beasts to your nest. It will absorb them to create more of your kind. Glory to the Necropolis!</b>")
+		to_chat(new_spawn, "<b>You can expand the weather proof area provided by your shelters by using the 'New Area' key near the bottom right of your HUD.</b>")
 	else
 		to_chat(new_spawn, "<span class='userdanger'>You have been born outside of your natural home! Whether you decide to return home, or make due with your new home is your own decision.</span>")
 


### PR DESCRIPTION
-Reduces the size of the ash storm proofing provided by the ash walker camp alcove to the huts instead.
-Adds a tip in the ash walker spawntext that informs them they have a "New Area" button they can use to expand their storm proofing anyway.

To my annoyance, however, ash walkers have to bisect their alcove to be able to make an area small enough to satisfy the create area button.

:cl:
tweak: Adjusted the ash walker camp's storm proofing.
add: Added a tip about creating areas to the ash walker spawn text.
/:cl: