### PR TITLE
Fixing right click / verb set_APTFT

### DIFF
--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -50,7 +50,7 @@
 	var/N = input("Amount per transfer from this:","[src]") as null|anything in possible_transfer_amounts
 	if(N)
 		amount_per_transfer_from_this = N
-		to_chat(user, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
+		to_chat(usr, "<span class='notice'>[src]'s transfer amount is now [amount_per_transfer_from_this] units.</span>")
 
 /obj/item/reagent_containers/proc/add_initial_reagents()
 	if(list_reagents)

--- a/code/modules/reagents/reagent_containers.dm
+++ b/code/modules/reagents/reagent_containers.dm
@@ -43,7 +43,7 @@
 		set_APTFT()
 		return TRUE
 
-/obj/item/reagent_containers/proc/set_APTFT(mob/user) //set amount_per_transfer_from_this
+/obj/item/reagent_containers/proc/set_APTFT() //set amount_per_transfer_from_this
 	set name = "Set Transfer Amount"
 	set category = "Object"
 	set waitfor = FALSE


### PR DESCRIPTION
## About The Pull Request 
Someone told me using the verb (not through alt click) shows a list of mobs in the current area instead of possible transfer amounts for the input.

## Why It's Good For The Game
"The beaker's transfer amount is now Urist McChemistry units."

## Changelog
None.