### PR TITLE
Removes stun bullet .45/Kitchen Gun a lot more desirable for heavy duty cleaning!

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/syndicate.dm
+++ b/code/modules/mob/living/simple_animal/hostile/syndicate.dm
@@ -204,7 +204,7 @@
 	rapid = 2
 	icon_state = "syndicate_smg"
 	icon_living = "syndicate_smg"
-	casingtype = /obj/item/ammo_casing/c45/nostamina
+	casingtype = /obj/item/ammo_casing/c45
 	projectilesound = 'sound/weapons/gunshot_smg.ogg'
 
 /mob/living/simple_animal/hostile/syndicate/ranged/smg/pilot //caravan ambush ruin

--- a/code/modules/projectiles/ammunition/ballistic/smg.dm
+++ b/code/modules/projectiles/ammunition/ballistic/smg.dm
@@ -24,9 +24,6 @@
 	caliber = ".45"
 	projectile_type = /obj/item/projectile/bullet/c45
 
-/obj/item/ammo_casing/c45/nostamina
-	projectile_type = /obj/item/projectile/bullet/c45_nostamina
-
 /obj/item/ammo_casing/c45/kitchengun
 	desc = "A .45 bullet casing. It has a small sponge attached to it."
 	projectile_type = /obj/item/projectile/bullet/c45_cleaning

--- a/code/modules/projectiles/boxes_magazines/external/smg.dm
+++ b/code/modules/projectiles/boxes_magazines/external/smg.dm
@@ -60,7 +60,7 @@
 /obj/item/ammo_box/magazine/smgm45
 	name = "SMG magazine (.45)"
 	icon_state = "c20r45-24"
-	ammo_type = /obj/item/ammo_casing/c45/nostamina
+	ammo_type = /obj/item/ammo_casing/c45
 	caliber = ".45"
 	max_ammo = 24
 

--- a/code/modules/projectiles/projectile/bullets/smg.dm
+++ b/code/modules/projectiles/projectile/bullets/smg.dm
@@ -2,17 +2,11 @@
 
 /obj/item/projectile/bullet/c45
 	name = ".45 bullet"
-	damage = 20
-	stamina = 65
-
-/obj/item/projectile/bullet/c45_nostamina
-	name = ".45 bullet"
 	damage = 30
 
 /obj/item/projectile/bullet/c45_cleaning
 	name = ".45 bullet"
-	damage = 24
-	stamina = 10
+	damage = 40 //BANG BANG BANG
 
 /obj/item/projectile/bullet/c45_cleaning/on_hit(atom/target, blocked = FALSE)
 	. = ..()

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -159,7 +159,7 @@
 /datum/uplink_item/role_restricted/kitchen_gun
 	name = "Kitchen Gun (TM)"
 	desc = "A revolutionary .45 caliber cleaning solution! Say goodbye to daily stains and dirty surfaces with Kitchen Gun (TM)! \
-	Just five shots from Kitchen Gun (TM), and it'll sparkle like new! Includes two extra ammunition clips!"
+	Just three shots from Kitchen Gun (TM), and it'll sparkle like new! Includes two extra ammunition clips!"
 	cost = 10
 	surplus = 40
 	restricted_roles = list("Cook", "Janitor")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Essentially completely removes the stun bullet version of the .45, which could be printed from autolathes. These were not being used by the primary user of the .45, which is the c20-r, but could be abused by using them in the KITCHEN GUN (TM). You can however get the 30 damage version used in the c20-r still from the autolathe, since now the 30 damage version is the standard version.

Speaking of the KITCHEN GUN (TM), true to the original skit, it now takes three shots to kill someone unarmored with the gun while using cleaning bullets. Cleaning bullets are basically significantly better than standard .45.

## Why It's Good For The Game

**BANG BANG BANG.**

## Changelog
:cl:
balance: You can no longer acquire stun bullets in the .45 calibre. You can get the 30 damage version out of the autolathe instead.
balance: KITCHEN GUN (TM) is a lot stronger. Cleaning bullets are a whole 40 damage!
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
