### PR TITLE
arrow craft nitpicking (alt title: "why are subtypes like this")

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -278,7 +278,7 @@
 
 /datum/crafting_recipe/arrow
 	name = "Arrow"
-	result = /obj/item/ammo_casing/caseless/arrow
+	result = /obj/item/ammo_casing/caseless/arrow/wood
 	time = 30
 	reqs = list(/obj/item/stack/sheet/mineral/wood = 1,
 				 /obj/item/stack/sheet/silk = 1,
@@ -293,17 +293,17 @@
 	always_availible = FALSE
 	reqs = list(/obj/item/stack/sheet/bone = 1,
 				 /obj/item/stack/sheet/sinew = 1,
-				 /obj/item/ammo_casing/caseless/arrow/ashen = 1)
+				 /obj/item/ammo_casing/caseless/arrow/ash = 1)
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 
 /datum/crafting_recipe/ashen_arrow
 	name = "Fire Hardened Arrow"
-	result = /obj/item/ammo_casing/caseless/arrow/ashen
+	result = /obj/item/ammo_casing/caseless/arrow/ash
 	tools = list(TOOL_WELDER)
 	time = 30
 	always_availible = FALSE
-	reqs = list(/obj/item/ammo_casing/caseless/arrow = 1)
+	reqs = list(/obj/item/ammo_casing/caseless/arrow/wood = 1)
 	category = CAT_WEAPONRY
 	subcategory = CAT_AMMO
 

--- a/code/modules/cargo/exports/weapons.dm
+++ b/code/modules/cargo/exports/weapons.dm
@@ -211,7 +211,7 @@
 /datum/export/weapon/arrows
 	cost = 150
 	unit_name = "arrow"
-	export_types = list(/obj/item/ammo_casing/caseless/arrow, /obj/item/ammo_casing/caseless/arrow/bone, /obj/item/ammo_casing/caseless/arrow/ashen)
+	export_types = list(/obj/item/ammo_casing/caseless/arrow, /obj/item/ammo_casing/caseless/arrow/bone, /obj/item/ammo_casing/caseless/arrow/ash)
 
 /datum/export/weapon/bow_teaching
 	cost = 500

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -15,7 +15,7 @@
 	name = "ashen arrow"
 	desc = "An arrow made of wood, hardened by fire."
 	icon_state = "ashenarrow"
-	projectile_type = /obj/item/projectile/bullet/reusable/arrow/ashen
+	projectile_type = /obj/item/projectile/bullet/reusable/arrow/ash
 
 /obj/item/ammo_casing/caseless/arrow/bone
 	name = "bone arrow"

--- a/code/modules/projectiles/ammunition/caseless/arrow.dm
+++ b/code/modules/projectiles/ammunition/caseless/arrow.dm
@@ -1,13 +1,17 @@
 /obj/item/ammo_casing/caseless/arrow
-	name = "wooden arrow"
-	desc = "An arrow made of wood, typically fired from a bow."
+	name = "arrow of questionable material"
+	desc = "You shouldn't be seeing this arrow."
 	projectile_type = /obj/item/projectile/bullet/reusable/arrow
 	caliber = "arrow"
 	icon_state = "arrow"
 	throwforce = 3 //good luck hitting someone with the pointy end of the arrow
 	throw_speed = 3
 
-/obj/item/ammo_casing/caseless/arrow/ashen
+/obj/item/ammo_casing/caseless/arrow/wood
+	name = "wooden arrow"
+	desc = "An arrow made of wood, typically fired from a bow."
+
+/obj/item/ammo_casing/caseless/arrow/ash
 	name = "ashen arrow"
 	desc = "An arrow made of wood, hardened by fire."
 	icon_state = "ashenarrow"

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -3,13 +3,13 @@
 	desc = "Woosh!"
 	damage = 15
 	icon_state = "arrow"
-	ammo_type = /obj/item/ammo_casing/caseless/arrow
+	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
 
 /obj/item/projectile/bullet/reusable/arrow/ashen
 	name = "ashen arrow"
 	desc = "Fire harderned arrow."
 	damage = 25
-	ammo_type = /obj/item/ammo_casing/caseless/arrow/ashen
+	ammo_type = /obj/item/ammo_casing/caseless/arrow/ash
 
 /obj/item/projectile/bullet/reusable/arrow/bone //AP for ashwalkers
 	name = "bone arrow"

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -5,7 +5,7 @@
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
 
-/obj/item/projectile/bullet/reusable/arrow/ashen
+/obj/item/projectile/bullet/reusable/arrow/ash
 	name = "ashen arrow"
 	desc = "Fire harderned arrow."
 	damage = 25


### PR DESCRIPTION
## About The Pull Request
moves the wooden arrow to a subtype of arrow, so as to prevent fire-hardening a fire-hardened arrow repeatedly
## Why It's Good For The Game
i really like not crafting a single arrow despite doing the same job multiple times
## Changelog
:cl:
tweak: Arrow crafting has been finagled with, preventing fire-hardened arrows from being fire-hardened repeatedly. Or something.
/:cl: