### PR TITLE
fermenting barrels now no longer get hit when taking liquids out 

### DIFF
--- a/code/modules/hydroponics/fermenting_barrel.dm
+++ b/code/modules/hydroponics/fermenting_barrel.dm
@@ -49,6 +49,10 @@
 		to_chat(user, "<span class='notice'>You place [I] into [src] to start the fermentation process.</span>")
 		addtimer(CALLBACK(src, .proc/makeWine, fruit), rand(80, 120) * speed_multiplier)
 		return TRUE
+	var/obj/item/W = I
+	if(W)
+		if(W.is_refillable())
+			return FALSE //so we can refill them via their afterattack.
 	else
 		return ..()
 


### PR DESCRIPTION
## About The Pull Request

ports TGs ``You no longer hit fermenting barrels when transferring reagents #50098`` PR that makes us no longer hit the barrel with the beaker as you take it out

## Why It's Good For The Game

Fixes an annoying action of hitting the barrel to get /some/ of the lots of the drink.

## Changelog
:cl: 	wesoda25
code: You no longer hit fermenting barrels when taking reagents from them
/:cl:
Link to their pr - 
https://github.com/tgstation/tgstation/pull/50098