### PR TITLE
New Old Ninja Steal Goals

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -205,13 +205,18 @@
 	difficulty = 10
 
 /datum/objective_item/special/boh
-	name = "a bag of holding."
+	name = "a type of bag of holding."
 	targetitem = /obj/item/storage/backpack/holding
 	difficulty = 10
 
-/datum/objective_item/special/hypercell
-	name = "a hyper-capacity power cell."
-	targetitem = /obj/item/stock_parts/cell/hyper
+/datum/objective_item/special/adv_surgical_drapes
+	name = "a set of smart surgical drapes."
+	targetitem = /obj/item/surgical_drapes/advanced
+	difficulty = 10 //would be 15 but cmo rarely have it on themselfs and leave it in their lockers...
+
+/datum/objective_item/special/bluespace
+	name = "a bluespace power cell."
+	targetitem = /obj/item/stock_parts/cell/bluespace
 	difficulty = 5
 
 /datum/objective_item/special/laserpointer


### PR DESCRIPTION
## About The Pull Request

Changes the hyper cell to a blue space sell
CMO drapes are now a ninja steal goal
Clarifies any type of BoH will work

## Why It's Good For The Game

Helps ninja's get a better understand of their goal
Better tech and the best cell is what they want anyways
CMO drapes is a 1 in a round deal, and has rather good tech meaning It should prob be a steal goal for at lest 1 type of antag kinda like the CMO hypo
BoH sub types are the same as main one meaning they /should/ all work for the goal. Just less confusion
## Changelog
:cl:
add: Ninjas may be asked to steal the CMO's smart drapes
tweak: Hyper Cell steal goal is upgraded to a bluespace cell, as well as the BoH goal now wants a type of BoH rather then the normal default one.
/:cl:
