### PR TITLE
Correct Template Headers to use the correct wiki - Yay

### DIFF
--- a/html/templates/header.html
+++ b/html/templates/header.html
@@ -25,7 +25,7 @@
 		<td valign='top'>
 			<div align='center'><font size='3'><b>Traditional Games Space Station 13</b></font></div>
 			
-			<p><div align='center'><font size='3'><a href="https://citadel-station.net/forum/index.php">Forum</a> | <a href="https://katlin.dog/citadel-wiki">Wiki</a> | <a href="https://github.com/Citadel-Station-13/Citadel-Station-13">Source</a></font></div></p>
+			<p><div align='center'><font size='3'><a href="https://citadel-station.net/forum/index.php">Forum</a> | <a href="https://citadel-station.net/wiki/index.php?title=Main_Page">Wiki</a> | <a href="https://github.com/Citadel-Station-13/Citadel-Station-13">Source</a></font></div></p>
 			</td>
 	</tr>
 </table>


### PR DESCRIPTION
## About The Pull Request

Template Headers now use Cit wiki page rather then the old wiki page

## Why It's Good For The Game

Links to the correct pages rather then confusing people

## Changelog
:cl: YakumoChen
server: Templates Headers will now correctly use the Citadel Official Wiki Link
/:cl:
