### PR TITLE
adds sdql2 helpers for random turfs/turfs with offsets

### DIFF
--- a/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
+++ b/code/modules/admin/verbs/SDQL2/SDQL_2_wrappers.dm
@@ -220,4 +220,17 @@
 /proc/_instantiate_at(thing, location)
 	new thing(location)
 
+/// Locating turfs
+/proc/_turf_in_offset(s = usr, x = 0, y = 0, z = 0)
+	var/turf/T = get_turf(s)
+	return locate(clamp(T.x + x, 1, world.maxx), clamp(T.y + y, 1, world.maxy), clamp(T.z + z, 1, world.maxz))
 
+/proc/_random_turf_in_range(s = usr, r = 7)
+	return _turf_in_offset(s, rand(-r, r), rand(-r, r))
+
+/proc/_random_turf_in_view(s = usr, r = 7)
+	var/list/v = view(s, r)
+	. = list()
+	for(var/turf/T in v)
+		. += T
+	return pick(.)


### PR DESCRIPTION
sdql2 is extremely expensive in terms of proccalls in the expression, this is the only way to make it reasonable.