### PR TITLE
Hypereutactic blade properly slows you down again, adds set_slowdown() and hooks vv_edit_var for it

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -862,7 +862,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
   */
 /obj/item/proc/set_slowdown(new_slowdown)
 	slowdown = new_slowdown
-	if(CHECK_BITFIELD(flags, IN_INVENTORY))
+	if(CHECK_BITFIELD(item_flags, IN_INVENTORY))
 		var/mob/living/L = loc
 		if(istype(L))
 			L.update_equipment_speed_mods()

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -856,3 +856,18 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 
 /obj/item/proc/unembedded()
 	return
+
+/**
+  * Sets our slowdown and updates equipment slowdown of any mob we're equipped on.
+  */
+/obj/item/proc/set_slowdown(new_slowdown)
+	slowdown = new_slowdown
+	if(CHECK_BITFIELD(flags, IN_INVENTORY))
+		var/mob/living/L = loc
+		if(istype(L))
+			L.update_equipment_speed_mods()
+
+/obj/item/vv_edit_var(var_name, var_value)
+	. = ..()
+	if(var_name == NAMEOF(src, slowdown))
+		set_slowdown(var_value)			//don't care if it's a duplicate edit as slowdown'll be set, do it anyways to force normal behavior.

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -58,7 +58,7 @@
 	var/obj/item/twohanded/offhand/O = user.get_inactive_held_item()
 	if(O && istype(O))
 		O.unwield()
-	slowdown -= slowdown_wielded
+	set_slowdown(slowdown - slowdown_wielded)
 
 /obj/item/twohanded/proc/wield(mob/living/carbon/user)
 	if(wielded)
@@ -88,7 +88,7 @@
 	O.desc = "Your second grip on [src]."
 	O.wielded = TRUE
 	user.put_in_inactive_hand(O)
-	slowdown += slowdown_wielded
+	set_slowdown(slowdown + slowdown_wielded)
 
 /obj/item/twohanded/dropped(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix since slowdown isn't polled manually on every move and is a modifier now.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: slowdown on items should now be set by set_slowdown().
fix: hypereutactic blades properly slow down their wielders when being used and vv-editing an item's slowdown will once again properly update someone's slowdown to take the new value into account.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
