### PR TITLE
absolutely ensures that screenshake can never, ever cause sleep() style latency in attacks

### DIFF
--- a/modular_citadel/code/game/objects/cit_screenshake.dm
+++ b/modular_citadel/code/game/objects/cit_screenshake.dm
@@ -1,6 +1,7 @@
 //we vlambeer now
 
 /obj/proc/shake_camera(mob/M, duration, strength=1)//byond's wonky with this shit
+	set waitfor = FALSE
 	if(!M || !M.client || duration <= 0)
 		return
 	var/client/C = M.client


### PR DESCRIPTION
not sure if animate sleep()s but i've been noticing that melee/ranged attacks sometime take their dear time to process, let's uh, make sure that won't happen.