### PR TITLE
Removes the roundstart syringe guns on each map, replacing them with medidart guns.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -718,8 +718,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -1167,8 +1166,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -4085,8 +4083,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera{
 	c_tag = "Brig Infirmary";
-	dir = 4;
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -4658,8 +4655,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Central";
-	dir = 8;
-	network = list("ss13")
+	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 8
@@ -4683,8 +4679,7 @@
 /area/security/brig)
 "aiK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -5087,8 +5082,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -6516,8 +6510,7 @@
 /area/security/brig)
 "amU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/structure/chair/office/dark{
 	dir = 8
@@ -6673,7 +6666,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/security{
 	name = "Evidence Storage";
-	req_access = null;
 	req_access_txt = "3"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -6743,8 +6735,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -6830,8 +6821,7 @@
 	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/blue,
@@ -7552,7 +7542,6 @@
 	normaldoorcontrol = 1;
 	pixel_x = -24;
 	pixel_y = -40;
-	req_access = null;
 	req_access_txt = "2"
 	},
 /obj/machinery/button/door{
@@ -7561,7 +7550,6 @@
 	normaldoorcontrol = 1;
 	pixel_x = -24;
 	pixel_y = -24;
-	req_access = null;
 	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/showroomfloor,
@@ -8324,9 +8312,7 @@
 "ary" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/warden";
-	dir = 2;
 	name = "Brig Control APC";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/machinery/button/door{
@@ -8334,7 +8320,6 @@
 	name = "Cell Shutters";
 	pixel_x = 6;
 	pixel_y = -40;
-	req_access = null;
 	req_access_txt = "2"
 	},
 /obj/machinery/button/door{
@@ -8392,8 +8377,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -8512,8 +8496,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -8580,8 +8563,7 @@
 /area/hallway/primary/fore)
 "asb" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Brig Evidence Storage";
@@ -8735,8 +8717,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -8754,7 +8735,6 @@
 	name = "Brig Control Shutters";
 	pixel_x = 6;
 	pixel_y = -40;
-	req_access = null;
 	req_access_txt = "2"
 	},
 /obj/machinery/button/door{
@@ -8805,8 +8785,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -33788,9 +33767,9 @@
 "bCG" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/gun/syringe,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCH" = (
@@ -35592,6 +35571,7 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/neck/stethoscope,
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bGT" = (
@@ -54412,8 +54392,7 @@
 /area/security/prison)
 "eXz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -54973,8 +54952,7 @@
 "gDP" = (
 /obj/machinery/firealarm{
 	dir = 8;
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -56598,8 +56576,7 @@
 /obj/machinery/door/airlock/security/glass{
 	id_tag = "innerbrig";
 	name = "Brig Infirmary";
-	req_access_txt = "2";
-	req_one_access_txt = "0"
+	req_access_txt = "2"
 	},
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
@@ -56720,8 +56697,7 @@
 	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/yellow,
@@ -57070,7 +57046,6 @@
 "nEj" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plating,
@@ -57287,8 +57262,7 @@
 	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /obj/structure/bed,
 /obj/item/bedsheet/green,
@@ -58087,8 +58061,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
-	dir = 1;
-	pixel_x = 0
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -60615,7 +60588,6 @@
 "xWq" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -99195,7 +99195,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/light/small,
 /obj/structure/bedsheetbin,
-/obj/item/gun/syringe,
+/obj/item/gun/syringe/dart,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -90569,7 +90569,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/syringes,
-/obj/item/gun/syringe,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -90581,6 +90580,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cWv" = (
@@ -106576,11 +106576,11 @@
 /obj/item/clothing/mask/muzzle,
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/item/clothing/ears/earmuffs,
-/obj/item/gun/syringe,
 /obj/item/clothing/glasses/eyepatch,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "dyE" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22793,9 +22793,6 @@
 	pixel_y = 4
 	},
 /obj/item/storage/box/beakers,
-/obj/item/gun/syringe{
-	pixel_y = 5
-	},
 /obj/item/reagent_containers/spray/cleaner,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -22804,6 +22801,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
 "aKZ" = (

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -265,7 +265,6 @@
 /area/space)
 "aaT" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
@@ -380,7 +379,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -536,7 +534,6 @@
 	dir = 4
 	},
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -628,9 +625,7 @@
 /obj/machinery/button/door{
 	id = "permawindows";
 	name = "Emergency Shutters";
-	normaldoorcontrol = 0;
-	pixel_y = 25;
-	specialfunctions = 1
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -698,7 +693,6 @@
 /area/science/research)
 "acb" = (
 /obj/machinery/doppler_array/research/science{
-	icon_state = "tdoppler";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -743,7 +737,6 @@
 	dir = 5
 	},
 /obj/machinery/button/massdriver{
-	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = 24;
 	pixel_y = 24
@@ -1016,15 +1009,13 @@
 /obj/effect/decal/cleanable/tomato_smudge,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "acK" = (
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -1062,7 +1053,6 @@
 	desc = "In Space, no one can hear you scream, especially if the microphone has been disabled.";
 	name = "Prison Intercom";
 	pixel_x = 32;
-	pixel_y = 0;
 	prison_radio = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -1238,7 +1228,6 @@
 /area/security/prison)
 "adm" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "SecJusticeChamber";
 	name = "Justice Vent"
 	},
@@ -1391,7 +1380,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1469,9 +1457,9 @@
 /area/science/research)
 "adR" = (
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/fore";
 	dir = 1;
 	name = "Fore Maintenance APC";
-	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1631,7 +1619,6 @@
 "aeh" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
@@ -1649,10 +1636,8 @@
 "aej" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1665,7 +1650,6 @@
 /area/security/prison)
 "ael" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "executionburn";
 	pixel_x = -25
 	},
@@ -1943,7 +1927,6 @@
 /area/science/nanite)
 "aeN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1991,8 +1974,7 @@
 	dir = 9
 	},
 /obj/machinery/status_display/ai{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -2014,7 +1996,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -2089,8 +2070,7 @@
 /area/security/prison)
 "afj" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -2110,7 +2090,6 @@
 /area/security/execution/education)
 "afm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2;
 	name = "justice injector"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2221,7 +2200,6 @@
 /area/security/processing)
 "aft" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -2299,7 +2277,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/table/reinforced,
@@ -2485,7 +2462,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -2567,7 +2543,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Justice Chamber";
 	req_access_txt = "3"
 	},
@@ -2627,7 +2602,6 @@
 "agg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2831,7 +2805,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -3108,7 +3081,6 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "SecJusticeChamber";
 	layer = 4;
 	name = "Justice Vent Control";
@@ -3136,7 +3108,6 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/light/small{
@@ -3379,7 +3350,6 @@
 	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/science/storage";
-	dir = 2;
 	name = "Toxins Storage APC";
 	pixel_y = -25
 	},
@@ -3403,7 +3373,6 @@
 /area/maintenance/fore/secondary)
 "aht" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3431,7 +3400,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -3482,7 +3450,6 @@
 /obj/item/radio/intercom{
 	desc = "In Space, no one can hear you scream, especially if the  microphone has been disabled.";
 	name = "Prison Intercom";
-	pixel_x = 0;
 	pixel_y = -32;
 	prison_radio = 1
 	},
@@ -3501,7 +3468,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -3599,7 +3565,6 @@
 /area/security/processing)
 "ahN" = (
 /obj/machinery/computer/shuttle/labor{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3636,7 +3601,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -3652,7 +3616,6 @@
 /area/science/xenobiology)
 "ahU" = (
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
@@ -3667,9 +3630,8 @@
 /area/science/xenobiology)
 "ahX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	name = "euthanization chamber freezer";
-	icon_state = "freezer_1";
-	dir = 4
+	dir = 4;
+	name = "euthanization chamber freezer"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -3740,7 +3702,6 @@
 /area/science/nanite)
 "aif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3872,7 +3833,6 @@
 /area/maintenance/fore/secondary)
 "ait" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4195,7 +4155,6 @@
 /area/science/nanite)
 "ajd" = (
 /obj/machinery/computer/nanite_chamber_control{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -4233,9 +4192,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
 	dir = 8;
 	name = "Toxins Lab APC";
-	areastring = "/area/science/mixing";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -4319,7 +4278,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
@@ -4489,7 +4447,6 @@
 	department = "Robotics";
 	departmentType = 2;
 	name = "Robotics RC";
-	pixel_x = 0;
 	pixel_y = 31;
 	receive_ore_updates = 1
 	},
@@ -4499,8 +4456,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/mecha_part_fabricator,
 /obj/item/radio/intercom{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
@@ -4576,7 +4531,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4606,7 +4560,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4648,7 +4601,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair,
@@ -4663,7 +4615,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4683,7 +4634,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair,
@@ -4713,9 +4663,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "gas ports"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4735,7 +4683,6 @@
 /area/security/execution/education)
 "ajT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -4747,10 +4694,8 @@
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	dir = 8;
-	icon_state = "sink_alt";
 	name = "old sink";
-	pixel_x = 15;
-	pixel_y = 0
+	pixel_x = 15
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4849,7 +4794,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4914,7 +4858,6 @@
 /area/science/xenobiology)
 "akj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -4983,7 +4926,6 @@
 /area/science/misc_lab/range)
 "aks" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -5071,7 +5013,6 @@
 /area/science/mixing)
 "akA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -5123,7 +5064,6 @@
 /obj/item/storage/box/monkeycubes,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -5152,7 +5092,6 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -5179,7 +5118,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5196,7 +5134,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5274,7 +5211,6 @@
 "akU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/education";
-	dir = 2;
 	name = "Prisoner Education Chamber APC";
 	pixel_y = -24
 	},
@@ -5326,14 +5262,12 @@
 "ala" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/computer/security/labor{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -5583,12 +5517,10 @@
 	pixel_x = -4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Fore";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -5639,7 +5571,6 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5658,7 +5589,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5666,7 +5596,6 @@
 "alC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5675,7 +5604,6 @@
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5785,7 +5713,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5829,7 +5756,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5850,7 +5776,6 @@
 /area/science/robotics/lab)
 "alY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5940,7 +5865,6 @@
 "amf" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6012,9 +5936,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	dir = 2;
-	pixel_x = -29;
-	pixel_y = 0
+	pixel_x = -29
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -6097,7 +6019,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -6113,7 +6034,6 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -6123,7 +6043,6 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6132,7 +6051,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6249,7 +6167,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6405,8 +6322,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
-	dir = 2
+	c_tag = "Armory Motion Sensor"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6479,8 +6395,7 @@
 	pixel_y = 1
 	},
 /obj/item/grenade/barrier{
-	pixel_x = 6;
-	pixel_y = 0
+	pixel_x = 6
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6714,7 +6629,6 @@
 /area/science/robotics/lab)
 "anE" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6825,7 +6739,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6864,7 +6777,6 @@
 /area/science/robotics/lab)
 "anU" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6872,7 +6784,6 @@
 "anV" = (
 /obj/machinery/turnstile{
 	dir = 1;
-	icon_state = "turnstile_map";
 	name = "Genpop Exit Turnstile";
 	req_access_txt = "70"
 	},
@@ -6894,7 +6805,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6923,7 +6833,6 @@
 /area/security/prison)
 "anY" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -6946,7 +6855,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7254,7 +7162,6 @@
 /area/security/armory)
 "aoo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7377,7 +7284,6 @@
 /area/science/xenobiology)
 "aoy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -7396,7 +7302,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7452,7 +7357,6 @@
 "aoE" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -7462,7 +7366,6 @@
 /area/science/xenobiology)
 "aoF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7491,7 +7394,6 @@
 /area/science/xenobiology)
 "aoI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -7562,7 +7464,6 @@
 	idDoor = "xeno_airlock_exterior";
 	idSelf = "xeno_airlock_control";
 	name = "Access Button";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/machinery/door/firedoor,
@@ -7637,7 +7538,6 @@
 /area/science/research)
 "aoQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7652,7 +7552,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7672,7 +7571,6 @@
 /area/maintenance/fore)
 "aoU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7719,11 +7617,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7781,7 +7677,6 @@
 /area/security/prison)
 "api" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -7881,7 +7776,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -7947,7 +7841,6 @@
 /area/security/prison)
 "apu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8009,7 +7902,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8023,14 +7915,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "apB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -8117,7 +8007,6 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
-	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8169,7 +8058,6 @@
 /area/science/xenobiology)
 "apK" = (
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
@@ -8278,7 +8166,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8293,11 +8180,9 @@
 	areastring = "/area/science/xenobiology";
 	dir = 4;
 	name = "Xenobiology APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -8362,11 +8247,9 @@
 /area/science/misc_lab/range)
 "aqe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8439,7 +8322,6 @@
 /area/science/robotics/lab)
 "aqm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8470,7 +8352,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8513,7 +8394,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -8542,7 +8422,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8572,7 +8451,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8597,7 +8475,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8724,7 +8601,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -8735,7 +8611,6 @@
 "aqN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
@@ -9006,7 +8881,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -9040,14 +8914,12 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ark" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -9064,7 +8936,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -9084,7 +8955,6 @@
 /area/science/mixing)
 "arq" = (
 /obj/machinery/sparker/toxmix{
-	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -9162,7 +9032,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9263,24 +9132,20 @@
 "arF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "arG" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -9489,7 +9354,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -9520,7 +9384,6 @@
 "arW" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -10069,7 +9932,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10106,7 +9968,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10139,7 +10000,6 @@
 /area/science/misc_lab/range)
 "asS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -10167,7 +10027,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10185,9 +10044,7 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "asY" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -10204,7 +10061,6 @@
 /area/science/mixing)
 "atb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -10359,7 +10215,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -10436,7 +10291,6 @@
 /area/security/armory)
 "aty" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10477,7 +10331,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10508,7 +10361,6 @@
 	dir = 10
 	},
 /obj/machinery/computer/camera_advanced/xenobio{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10541,7 +10393,6 @@
 	dir = 6
 	},
 /obj/machinery/computer/camera_advanced/xenobio{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10577,7 +10428,6 @@
 "atI" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10622,14 +10472,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "atM" = (
 /obj/machinery/sparker/toxmix{
-	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -10760,14 +10608,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "atW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -10778,7 +10624,6 @@
 	sortType = 14
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10786,9 +10631,9 @@
 "atY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/science/robotics/mechbay";
 	dir = 1;
 	name = "Mech Bay APC";
-	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 28
 	},
 /obj/structure/cable{
@@ -10821,7 +10666,6 @@
 /area/science/robotics/mechbay)
 "auc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -10862,7 +10706,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10917,11 +10760,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11032,7 +10873,6 @@
 "aut" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -11042,7 +10882,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11109,7 +10948,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/armory";
-	dir = 2;
 	name = "Armoury APC";
 	pixel_y = -26
 	},
@@ -11247,7 +11085,6 @@
 /area/science/server)
 "auM" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -11261,7 +11098,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11336,7 +11172,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -11386,7 +11221,6 @@
 /area/science/robotics/mechbay)
 "ava" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -11413,7 +11247,6 @@
 /area/hallway/primary/fore)
 "avc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -11439,7 +11272,6 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/item/paper/guides/jobs/security/range{
@@ -11472,7 +11304,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11545,7 +11376,6 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/rack,
@@ -11553,8 +11383,7 @@
 	areastring = "/area/science/misc_lab/range";
 	dir = 4;
 	name = "Research Firing Range APC";
-	pixel_x = 28;
-	pixel_y = 0
+	pixel_x = 28
 	},
 /obj/item/target,
 /obj/item/target,
@@ -11615,7 +11444,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11739,7 +11567,6 @@
 "avB" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
-	dir = 2;
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -11762,7 +11589,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11805,11 +11631,9 @@
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -11825,7 +11649,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11843,7 +11666,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -11859,11 +11681,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -11879,7 +11699,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -11890,7 +11709,6 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -11904,7 +11722,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11915,25 +11732,21 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "avO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "avP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -12247,7 +12060,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -12265,7 +12077,6 @@
 /area/science/server)
 "aws" = (
 /obj/machinery/computer/rdservercontrol{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -12274,7 +12085,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/science/server";
-	dir = 2;
 	name = "Server Room APC";
 	pixel_y = -23
 	},
@@ -12286,7 +12096,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -12679,7 +12488,6 @@
 /area/science/robotics/mechbay)
 "awP" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12727,7 +12535,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12739,7 +12546,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -12757,7 +12563,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12769,8 +12574,7 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -12829,7 +12633,6 @@
 	},
 /obj/machinery/turnstile{
 	dir = 1;
-	icon_state = "turnstile_map";
 	name = "Genpop Exit Turnstile";
 	req_access_txt = "70"
 	},
@@ -12896,7 +12699,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -12934,9 +12736,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/warden";
 	dir = 4;
 	name = "Warden's Office APC";
-	areastring = "/area/security/warden";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -12945,7 +12747,6 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	name = "Security RC";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -12968,7 +12769,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -12988,7 +12788,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -13043,11 +12842,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13067,11 +12864,9 @@
 /area/science/research)
 "axo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -13084,11 +12879,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13173,7 +12966,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13192,7 +12984,6 @@
 /obj/structure/bed,
 /obj/machinery/flasher{
 	id = "insaneflash";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/freezer,
@@ -13221,7 +13012,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13231,7 +13021,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/button/door{
@@ -13251,7 +13040,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -13282,7 +13070,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13297,7 +13084,6 @@
 	layer = 2.9
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -13313,14 +13099,12 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -13400,11 +13184,9 @@
 /area/crew_quarters/heads/hor)
 "axS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13453,7 +13235,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13483,7 +13264,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13569,9 +13349,9 @@
 "ayd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/power/apc{
+	areastring = "/area/security/range";
 	dir = 4;
 	name = "Shooting Range APC";
-	areastring = "/area/security/range";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -13687,7 +13467,6 @@
 	areastring = "/area/crew_quarters/heads/hos";
 	dir = 1;
 	name = "Head of Security's Office APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -13703,7 +13482,6 @@
 	},
 /obj/machinery/recharger,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
@@ -13743,8 +13521,7 @@
 "ayq" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Quarters";
-	dir = 2
+	c_tag = "Security - Head of Security's Quarters"
 	},
 /obj/item/bedsheet/hos,
 /obj/machinery/status_display{
@@ -13769,11 +13546,9 @@
 /obj/machinery/button/door{
 	id = "hosspace";
 	name = "Space Shutters Control";
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -13783,14 +13558,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ayu" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13872,7 +13645,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
-	id_tag = null;
 	name = "Break Room";
 	req_one_access_txt = "47"
 	},
@@ -13902,7 +13674,6 @@
 /obj/machinery/computer/security/research,
 /obj/machinery/camera{
 	c_tag = "Research Director's Office Fore";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -13954,11 +13725,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -13981,7 +13750,6 @@
 /area/science/research)
 "ayR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -14057,7 +13825,6 @@
 /area/security/range)
 "ayZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -14172,7 +13939,6 @@
 "azk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14253,7 +14019,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14523,7 +14288,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14554,7 +14318,6 @@
 "azS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14604,7 +14367,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14856,9 +14618,9 @@
 /area/security/brig)
 "aAo" = (
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/science/research";
 	dir = 1;
 	name = "Research Division APC";
-	areastring = "/area/science/research";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -14991,7 +14753,6 @@
 /area/crew_quarters/heads/hos)
 "aAy" = (
 /obj/machinery/computer/prisoner{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -15038,7 +14799,6 @@
 /area/security/checkpoint/science)
 "aAB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -15052,7 +14812,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15160,7 +14919,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15217,7 +14975,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -15225,11 +14982,9 @@
 /area/science/research)
 "aAV" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15310,11 +15065,9 @@
 /area/hallway/primary/fore)
 "aBe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15374,7 +15127,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -15384,11 +15136,9 @@
 /area/hallway/primary/fore)
 "aBn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15407,25 +15157,21 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aBp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aBq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15445,7 +15191,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15458,7 +15203,6 @@
 /area/security/prison)
 "aBs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15490,7 +15234,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15500,7 +15243,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -15532,7 +15274,6 @@
 /area/crew_quarters/heads/hos)
 "aBz" = (
 /obj/machinery/computer/security/hos{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -15573,9 +15314,8 @@
 /area/security/checkpoint/science)
 "aBC" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Science Security APC";
 	areastring = "/area/security/checkpoint/science";
+	name = "Science Security APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -15644,17 +15384,14 @@
 "aBH" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15682,8 +15419,6 @@
 	},
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -15697,9 +15432,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "RD Office APC";
 	areastring = "/area/crew_quarters/heads/hor";
+	name = "RD Office APC";
 	pixel_y = -27
 	},
 /obj/structure/cable{
@@ -15723,7 +15457,6 @@
 /area/crew_quarters/heads/hor)
 "aBO" = (
 /obj/item/storage/secure/safe{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/table,
@@ -15740,7 +15473,6 @@
 /area/crew_quarters/heads/hor)
 "aBP" = (
 /obj/machinery/computer/aifixer{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -15764,7 +15496,6 @@
 /area/crew_quarters/heads/hor)
 "aBS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -15792,7 +15523,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15824,7 +15554,6 @@
 "aBZ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15853,7 +15582,6 @@
 "aCb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -15864,9 +15592,9 @@
 /area/maintenance/fore/secondary)
 "aCd" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/detectives_office";
 	dir = 8;
 	name = "Detective APC";
-	areastring = "/area/security/detectives_office";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -15921,7 +15649,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/camera{
 	c_tag = "Science Hallway Fore";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -15957,7 +15684,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16144,7 +15870,6 @@
 	},
 /obj/structure/noticeboard{
 	dir = 1;
-	icon_state = "nboard00";
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
@@ -16197,7 +15922,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16458,8 +16182,7 @@
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
 /obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -16601,7 +16324,6 @@
 "aDq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -16616,11 +16338,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16634,32 +16354,26 @@
 	},
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aDu" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 26;
 	pixel_y = 6;
 	req_one_access_txt = "29"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aDv" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = -26;
@@ -16670,11 +16384,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16704,11 +16416,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16779,14 +16489,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16854,7 +16562,6 @@
 /area/security/brig)
 "aDN" = (
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -16881,11 +16588,9 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -16902,7 +16607,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -17057,11 +16761,9 @@
 "aEf" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -17087,11 +16789,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17111,16 +16811,15 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/fore";
 	dir = 8;
 	name = "Fore Primary Hallway APC";
-	areastring = "/area/hallway/primary/fore";
 	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17268,7 +16967,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17325,7 +17023,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17441,7 +17138,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17454,7 +17150,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17569,7 +17264,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17679,9 +17373,8 @@
 /area/science/explab)
 "aFe" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Experimentation Lab APC";
 	areastring = "/area/science/explab";
+	name = "Experimentation Lab APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -17700,9 +17393,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/brig";
 	dir = 1;
 	name = "Brig APC";
-	areastring = "/area/security/brig";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -17739,7 +17432,6 @@
 /area/science/lab)
 "aFk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -17760,7 +17452,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -17844,7 +17535,6 @@
 /area/security/brig)
 "aFv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17954,7 +17644,6 @@
 /area/quartermaster/office)
 "aFH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -17986,20 +17675,17 @@
 /area/asteroid/nearstation)
 "aFM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aFN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -18029,7 +17715,6 @@
 "aFR" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18046,7 +17731,6 @@
 /area/science/research)
 "aFT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18093,11 +17777,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -18130,12 +17812,10 @@
 /area/hallway/primary/fore)
 "aFZ" = (
 /obj/structure/chair/sofa{
-	icon_state = "sofamiddle";
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
@@ -18321,11 +18001,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18444,11 +18122,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18459,7 +18135,6 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18547,7 +18222,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18601,7 +18275,6 @@
 	light_color = "#c1caff"
 	},
 /obj/structure/chair/sofa{
-	icon_state = "sofamiddle";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18737,7 +18410,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18916,11 +18588,9 @@
 "aHr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18932,11 +18602,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18958,14 +18626,12 @@
 /area/science/lab)
 "aHu" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
 "aHv" = (
 /obj/structure/chair/sofa/corner{
-	icon_state = "sofacorner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18973,9 +18639,9 @@
 "aHw" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
+	areastring = "/area/storage/art";
 	dir = 8;
 	name = "Art Storage APC";
-	areastring = "/area/storage/art";
 	pixel_x = -25
 	},
 /obj/item/paper_bin,
@@ -19008,14 +18674,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aHB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19025,14 +18689,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aHD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -19040,7 +18702,6 @@
 "aHE" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19057,7 +18718,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19113,7 +18773,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19122,7 +18781,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19139,7 +18797,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -19178,14 +18835,13 @@
 /area/security/courtroom)
 "aHS" = (
 /obj/docking_port/stationary{
-	name = "mining shuttle bay";
-	icon_state = "pinonalert";
-	dir = 1;
-	id = "mining_home";
-	width = 7;
-	height = 5;
 	dwidth = 3;
-	roundstart_template = /datum/map_template/shuttle/mining/box
+	height = 5;
+	icon_state = "pinonalert";
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/box;
+	width = 7
 	},
 /turf/open/space,
 /area/space)
@@ -19202,7 +18858,6 @@
 /area/hallway/primary/fore)
 "aHW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19239,7 +18894,6 @@
 /area/hallway/primary/fore)
 "aIc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -19350,7 +19004,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19655,11 +19308,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19677,9 +19328,9 @@
 /area/security/brig)
 "aIy" = (
 /obj/machinery/power/apc{
+	areastring = "/area/lawoffice";
 	dir = 1;
 	name = "Law Office APC";
-	areastring = "/area/lawoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -19775,7 +19426,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -19806,7 +19456,6 @@
 /area/crew_quarters/heads/hor)
 "aIK" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 5;
 	height = 7;
 	id = "supply_home";
@@ -19872,7 +19521,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19904,7 +19552,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19914,7 +19561,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19922,7 +19568,6 @@
 "aIV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -19932,7 +19577,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19983,7 +19627,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20017,11 +19660,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/red{
@@ -20031,7 +19672,6 @@
 /area/security/brig)
 "aJe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20039,7 +19679,6 @@
 "aJf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20054,7 +19693,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20076,7 +19714,6 @@
 /area/lawoffice)
 "aJj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20084,8 +19721,7 @@
 "aJk" = (
 /obj/machinery/requests_console{
 	department = "Law office";
-	pixel_x = 31;
-	pixel_y = 0
+	pixel_x = 31
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
@@ -20151,7 +19787,6 @@
 /area/security/courtroom)
 "aJr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20176,7 +19811,6 @@
 	id = "QMLoad"
 	},
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
@@ -20197,7 +19831,6 @@
 /area/quartermaster/storage)
 "aJx" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
@@ -20268,7 +19901,6 @@
 /area/hallway/primary/fore)
 "aJG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -20294,7 +19926,6 @@
 /area/hallway/primary/fore)
 "aJI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20312,7 +19943,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20361,7 +19991,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20376,11 +20005,9 @@
 "aJQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -20400,7 +20027,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -20456,7 +20082,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -20503,7 +20128,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20542,7 +20166,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20657,11 +20280,9 @@
 /area/maintenance/fore)
 "aKu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20694,7 +20315,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20702,7 +20322,6 @@
 "aKx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -20710,11 +20329,9 @@
 /area/hallway/primary/fore)
 "aKy" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20733,15 +20350,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20758,7 +20372,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20768,7 +20381,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20778,7 +20390,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20791,11 +20402,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
-	icon_state = "trimline_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20808,11 +20417,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20832,15 +20439,12 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
-	icon_state = "trimline_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20859,11 +20463,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20882,7 +20484,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -20909,7 +20510,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -20926,7 +20526,6 @@
 /area/hallway/primary/fore)
 "aKJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -20946,11 +20545,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21005,7 +20602,6 @@
 /area/security/brig)
 "aKP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21017,7 +20613,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21053,7 +20648,6 @@
 /area/security/brig)
 "aKU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -21102,7 +20696,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21144,7 +20737,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21245,30 +20837,27 @@
 "aLn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aLo" = (
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/miningoffice";
 	dir = 1;
 	name = "Mining APC";
-	areastring = "/area/quartermaster/miningoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/item/radio/intercom{
@@ -21310,11 +20899,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21336,7 +20923,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21361,7 +20947,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -21384,7 +20969,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/navbeacon{
@@ -21540,7 +21124,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -21553,7 +21136,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -21566,7 +21148,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -21581,7 +21162,6 @@
 	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
 	name = "Outer Window"
 	},
@@ -21725,7 +21305,6 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
@@ -21734,14 +21313,12 @@
 	req_access_txt = "31"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aLZ" = (
 /obj/machinery/conveyor/inverted{
-	icon_state = "conveyor_map_inverted";
 	dir = 9;
 	id = "QMLoad2"
 	},
@@ -21768,7 +21345,6 @@
 "aMc" = (
 /obj/machinery/conveyor{
 	dir = 6;
-	icon_state = "conveyor_map";
 	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
@@ -21845,7 +21421,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21910,14 +21485,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aMr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
-	icon_state = "connector_map-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -21928,7 +21501,6 @@
 	},
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 4;
-	icon_state = "telescreen";
 	layer = 4;
 	pixel_x = -28
 	},
@@ -21944,14 +21516,12 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
 	prison_radio = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21970,7 +21540,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21978,7 +21547,6 @@
 "aMx" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -21988,7 +21556,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21998,7 +21565,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -22016,9 +21582,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/westleft{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
 	name = "Outer Window"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -22092,14 +21655,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light_switch{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "aME" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -22116,9 +21677,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Courtroom APC";
 	areastring = "/area/security/courtroom";
+	name = "Courtroom APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -22188,7 +21748,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -22242,7 +21801,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -22254,7 +21812,6 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -22313,14 +21870,12 @@
 /area/quartermaster/storage)
 "aMX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aMY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/rack,
@@ -22329,7 +21884,6 @@
 /area/quartermaster/miningoffice)
 "aMZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22340,7 +21894,6 @@
 "aNb" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22348,7 +21901,6 @@
 "aNc" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22367,7 +21919,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -22449,11 +22000,9 @@
 "aNn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -22566,8 +22115,7 @@
 "aNy" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/poster/official/enlist{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -22685,24 +22233,20 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -22716,11 +22260,9 @@
 	areastring = "/area/quartermaster/qm";
 	dir = 8;
 	name = "Quartermaster's Office APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22864,7 +22406,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22887,7 +22428,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22913,7 +22453,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22967,11 +22506,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -23003,7 +22540,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23015,9 +22551,9 @@
 	dir = 5
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/lab";
 	dir = 8;
 	name = "Research and Development Lab APC";
-	areastring = "/area/science/lab";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -23025,7 +22561,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23179,8 +22714,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/grunge{
-	name = "Courtroom";
-	opacity = 1
+	name = "Courtroom"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -23195,7 +22729,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23220,7 +22753,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23234,7 +22766,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23293,7 +22824,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -23304,7 +22834,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23317,7 +22846,6 @@
 /area/quartermaster/miningoffice)
 "aOP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23426,7 +22954,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23440,14 +22967,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aPe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -23468,14 +22993,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aPh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -23496,7 +23019,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23523,7 +23045,6 @@
 /area/security/brig)
 "aPl" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23531,7 +23052,6 @@
 "aPm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -23546,7 +23066,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -23605,7 +23124,6 @@
 /area/quartermaster/qm)
 "aPt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23639,7 +23157,6 @@
 "aPv" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23650,7 +23167,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23666,7 +23182,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23683,7 +23198,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23700,7 +23214,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23711,7 +23224,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23719,7 +23231,6 @@
 "aPF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -23778,7 +23289,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -23856,7 +23366,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23865,7 +23374,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -24229,7 +23737,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -24270,7 +23777,6 @@
 	pixel_x = -5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24280,7 +23786,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -24360,8 +23865,7 @@
 	areastring = "/area/maintenance/fore/secondary";
 	dir = 4;
 	name = "Fore Maintenance APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -24381,11 +23885,9 @@
 /area/crew_quarters/heads/captain/private)
 "aQG" = (
 /obj/structure/chair/sofa{
-	icon_state = "sofamiddle";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /obj/item/radio/intercom{
@@ -24406,7 +23908,6 @@
 /area/science/explab)
 "aQI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -24414,7 +23915,6 @@
 "aQJ" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/hor/private";
-	dir = 2;
 	name = "Research Director's Quarters APC";
 	pixel_y = -24
 	},
@@ -24475,8 +23975,7 @@
 	req_access_txt = "63"
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -24485,7 +23984,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24493,7 +23991,6 @@
 "aQR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -24546,12 +24043,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -24570,7 +24064,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24585,14 +24078,12 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aRa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24603,12 +24094,10 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24616,7 +24105,6 @@
 "aRc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24632,7 +24120,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -24643,7 +24130,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -24720,11 +24206,9 @@
 	},
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/machinery/light/small{
@@ -24738,9 +24222,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
+	name = "Captain's Quarters APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -24767,7 +24250,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -24779,7 +24261,6 @@
 /area/hallway/primary/fore)
 "aRt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24821,9 +24302,7 @@
 /obj/item/aiModule/core/freeformcore,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
@@ -24846,9 +24325,7 @@
 	dir = 1
 	},
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 2;
-	icon_state = "left";
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access_txt = "16"
@@ -25144,7 +24621,6 @@
 "aSa" = (
 /obj/structure/noticeboard/qm{
 	dir = 1;
-	icon_state = "nboard00";
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -25152,11 +24628,9 @@
 /area/quartermaster/qm)
 "aSb" = (
 /obj/machinery/computer/security/qm{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -25168,7 +24642,6 @@
 "aSc" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25321,8 +24794,6 @@
 "aSs" = (
 /obj/structure/dresser,
 /obj/item/radio/intercom{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/carpet/blue,
@@ -25359,11 +24830,9 @@
 "aSw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25402,11 +24871,9 @@
 "aSA" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25538,8 +25005,7 @@
 	},
 /obj/item/lighter,
 /obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 2
+	c_tag = "Bar"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -25578,9 +25044,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/bar";
 	dir = 1;
 	name = "Bar APC";
-	areastring = "/area/crew_quarters/bar";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -25595,7 +25061,6 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/drinks{
-	icon_state = "soda_dispenser";
 	dir = 8
 	},
 /obj/structure/table,
@@ -25642,7 +25107,6 @@
 "aSU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -25670,7 +25134,6 @@
 /area/hydroponics)
 "aSY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25753,7 +25216,6 @@
 "aTg" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -25764,7 +25226,6 @@
 "aTi" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25772,7 +25233,6 @@
 "aTj" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -25808,7 +25268,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -25821,28 +25280,24 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTq" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aTr" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25850,7 +25305,6 @@
 /area/quartermaster/storage)
 "aTs" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -26062,11 +25516,9 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aTS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -26155,7 +25607,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26199,7 +25650,6 @@
 	dir = 4
 	},
 /obj/machinery/chem_dispenser/drinks/beer{
-	icon_state = "booze_dispenser";
 	dir = 8
 	},
 /obj/structure/table,
@@ -26208,7 +25658,6 @@
 "aUd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -26224,7 +25673,6 @@
 /area/hydroponics)
 "aUf" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26238,7 +25686,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26257,7 +25704,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -26367,7 +25813,6 @@
 /area/hallway/primary/central)
 "aUx" = (
 /obj/vehicle/ridden/scooter{
-	icon_state = "scooter";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -26375,7 +25820,6 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26438,11 +25882,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26515,8 +25957,7 @@
 	areastring = "/area/crew_quarters/heads/captain";
 	dir = 8;
 	name = "Captain's Office APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -26555,7 +25996,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -26643,7 +26083,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26659,13 +26098,11 @@
 /area/crew_quarters/bar/atrium)
 "aVg" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26760,7 +26197,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
@@ -26770,7 +26206,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26800,7 +26235,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26811,7 +26245,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26863,7 +26296,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -26882,9 +26314,8 @@
 /area/hallway/primary/central)
 "aVz" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Bay APC";
 	areastring = "/area/quartermaster/storage";
+	name = "Cargo Bay APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -26916,11 +26347,9 @@
 /area/quartermaster/office)
 "aVB" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26976,7 +26405,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27005,12 +26433,10 @@
 /obj/structure/table,
 /obj/item/export_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
-	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel,
@@ -27028,11 +26454,9 @@
 "aVO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27177,7 +26601,6 @@
 /area/crew_quarters/bar)
 "aWh" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27188,7 +26611,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27202,7 +26624,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -27214,7 +26635,6 @@
 /obj/structure/table/glass,
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27225,7 +26645,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/status_display/ai{
@@ -27257,7 +26676,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27277,7 +26695,6 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27302,7 +26719,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -27322,7 +26738,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -27344,7 +26759,6 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27371,7 +26785,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27390,7 +26803,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27417,7 +26829,6 @@
 /area/quartermaster/office)
 "aWD" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27425,20 +26836,18 @@
 "aWE" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowsiding"
 	},
 /area/quartermaster/office)
 "aWF" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aWG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27461,7 +26870,6 @@
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -27478,7 +26886,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27500,7 +26907,6 @@
 /area/maintenance/fore)
 "aWO" = (
 /obj/structure/chair/sofa/corp/left{
-	icon_state = "corp_sofaend_left";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -27570,7 +26976,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -27616,7 +27021,6 @@
 /area/hallway/primary/central)
 "aXa" = (
 /obj/machinery/computer/security/telescreen/aiupload{
-	icon_state = "telescreen";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -27637,9 +27041,8 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "AI Upload Access APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
+	name = "AI Upload Access APC";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
@@ -27684,11 +27087,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27730,7 +27131,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27761,7 +27161,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27815,11 +27214,9 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Hydroponics APC";
-	pixel_x = 0;
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27839,9 +27236,9 @@
 /area/hydroponics)
 "aXr" = (
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/central/secondary";
 	dir = 8;
 	name = "Central Maintenance APC";
-	areastring = "/area/maintenance/central/secondary";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -27886,8 +27283,7 @@
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control";
 	pixel_x = 3;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -27925,7 +27321,6 @@
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -27938,7 +27333,6 @@
 /area/maintenance/fore)
 "aXz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -27966,7 +27360,6 @@
 "aXB" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27980,7 +27373,6 @@
 /area/hallway/primary/central)
 "aXD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -28024,7 +27416,6 @@
 /area/quartermaster/warehouse)
 "aXL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28128,7 +27519,6 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/corp/right{
-	icon_state = "corp_sofaend_right";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -28138,7 +27528,6 @@
 /area/crew_quarters/heads/captain)
 "aXX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28198,7 +27587,6 @@
 "aYc" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -28359,7 +27747,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28404,7 +27791,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28433,7 +27819,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet{
@@ -28454,7 +27839,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28463,7 +27847,6 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28505,14 +27888,12 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aYB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -28536,7 +27917,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28547,11 +27927,9 @@
 /area/hallway/primary/central)
 "aYF" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28596,11 +27974,9 @@
 /area/quartermaster/warehouse)
 "aYL" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28670,7 +28046,6 @@
 /area/crew_quarters/heads/captain)
 "aYS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -28699,7 +28074,6 @@
 "aYW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28708,7 +28082,6 @@
 "aYX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -28721,7 +28094,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28732,11 +28104,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -28746,7 +28116,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28761,7 +28130,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28772,7 +28140,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /mob/living/simple_animal/bot/medbot{
@@ -28790,7 +28157,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28845,7 +28211,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -28947,7 +28312,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28975,9 +28339,9 @@
 /area/hallway/primary/central)
 "aZx" = (
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
-	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -28985,7 +28349,6 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29004,7 +28367,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29016,14 +28378,12 @@
 	sortType = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29051,7 +28411,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29073,7 +28432,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29121,7 +28479,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29156,12 +28513,10 @@
 /obj/item/folder/red,
 /obj/item/taperecorder,
 /obj/item/radio/intercom{
-	anyai = 1;
 	broadcasting = 1;
 	frequency = 1423;
 	listening = 0;
 	name = "Interrogation Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -29193,7 +28548,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -29239,7 +28593,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29262,7 +28615,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29277,9 +28629,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aZW" = (
@@ -29301,8 +28651,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -29310,7 +28659,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -29326,7 +28674,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29344,7 +28691,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -29370,7 +28716,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29389,7 +28734,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29418,9 +28762,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/hallway/secondary/command";
 	dir = 1;
 	name = "Command Hallway APC";
-	areastring = "/area/hallway/secondary/command";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -29436,7 +28780,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29461,7 +28804,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29480,11 +28822,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29513,7 +28853,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29684,9 +29023,9 @@
 	pixel_x = 32
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
 	dir = 1;
 	name = "Theatre APC";
-	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -29711,9 +29050,6 @@
 /area/crew_quarters/bar)
 "baB" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -29725,7 +29061,6 @@
 /area/crew_quarters/bar)
 "baC" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -29753,7 +29088,6 @@
 "baG" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29794,7 +29128,6 @@
 "baK" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29804,14 +29137,12 @@
 /obj/item/folder/yellow,
 /obj/structure/disposalpipe/junction/flip,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baM" = (
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
@@ -29824,7 +29155,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29833,14 +29163,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29848,7 +29176,6 @@
 "baQ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -29859,14 +29186,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baS" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -29877,14 +29202,12 @@
 /area/quartermaster/office)
 "baT" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29897,7 +29220,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29910,7 +29232,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29920,7 +29241,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29932,7 +29252,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -30020,14 +29339,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bbf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -30170,7 +29487,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -30206,7 +29522,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -30279,7 +29594,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -30289,7 +29603,6 @@
 "bbz" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -30461,7 +29774,6 @@
 	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -30473,7 +29785,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30489,7 +29800,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -30499,7 +29809,6 @@
 /area/hallway/secondary/service)
 "bbW" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -30575,7 +29884,6 @@
 /area/quartermaster/office)
 "bcf" = (
 /obj/machinery/computer/card{
-	icon_state = "computer";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -30595,7 +29903,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -30642,11 +29949,9 @@
 /area/bridge/meeting_room)
 "bcp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30793,7 +30098,6 @@
 "bcK" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -30824,7 +30128,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -30838,7 +30141,6 @@
 /area/security/prison)
 "bcQ" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30889,11 +30191,9 @@
 /area/maintenance/department/cargo)
 "bcV" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -30901,22 +30201,18 @@
 /area/quartermaster/sorting)
 "bcW" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bcX" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -30932,11 +30228,9 @@
 /area/quartermaster/sorting)
 "bcY" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/hand_labeler_refill,
@@ -30950,11 +30244,9 @@
 /area/quartermaster/sorting)
 "bcZ" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -31010,7 +30302,6 @@
 /area/maintenance/department/cargo)
 "bdg" = (
 /obj/machinery/computer/communications{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -31116,7 +30407,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -31148,9 +30438,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/teleporter";
 	dir = 1;
 	name = "Teleporter APC";
-	areastring = "/area/teleporter";
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -31355,7 +30645,6 @@
 "bdK" = (
 /obj/machinery/requests_console{
 	department = "EVA";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -31383,8 +30672,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/motion{
-	c_tag = "E.V.A. Storage";
-	dir = 2
+	c_tag = "E.V.A. Storage"
 	},
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -31409,7 +30697,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31495,7 +30782,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31523,7 +30809,6 @@
 /area/crew_quarters/bar)
 "bdZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31554,7 +30839,6 @@
 "bed" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31633,11 +30917,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -31646,7 +30928,6 @@
 /obj/structure/disposaloutlet,
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "trashsort"
 	},
@@ -31663,14 +30944,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31691,14 +30970,12 @@
 /area/quartermaster/sorting)
 "bep" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beq" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -31710,7 +30987,6 @@
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "trashsort"
 	},
@@ -31742,7 +31018,6 @@
 /area/maintenance/department/cargo)
 "bev" = (
 /obj/machinery/modular_computer/console/preset/command{
-	icon_state = "console";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -31814,11 +31089,9 @@
 /area/bridge)
 "beA" = (
 /obj/machinery/computer/cargo/request{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -31848,7 +31121,6 @@
 /area/teleporter)
 "beD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31865,8 +31137,7 @@
 	areastring = "/area/bridge/meeting_room";
 	dir = 8;
 	name = "Council Chambers APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
@@ -31880,7 +31151,6 @@
 /area/bridge/meeting_room)
 "beG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -31895,7 +31165,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31973,9 +31242,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/storage/eva";
 	dir = 8;
 	name = "E.V.A. Storage APC";
-	areastring = "/area/ai_monitored/storage/eva";
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
@@ -32039,7 +31308,6 @@
 "beX" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -32154,7 +31422,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -32167,14 +31434,12 @@
 "bfp" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32182,7 +31447,6 @@
 "bfr" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32190,7 +31454,6 @@
 "bfs" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -32241,8 +31504,7 @@
 	areastring = "/area/security/checkpoint/supply";
 	dir = 8;
 	name = "Cargo Security APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
@@ -32252,7 +31514,6 @@
 /area/security/checkpoint/supply)
 "bfy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -32279,7 +31540,6 @@
 /area/maintenance/department/cargo)
 "bfC" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -32290,11 +31550,9 @@
 /area/quartermaster/sorting)
 "bfD" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -32463,7 +31721,6 @@
 "bfT" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32516,7 +31773,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32585,9 +31841,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/bridge/showroom/corporate";
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
-	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
@@ -32678,7 +31934,6 @@
 /area/crew_quarters/cafeteria)
 "bgq" = (
 /obj/machinery/computer/arcade/battle{
-	icon_state = "arcade";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32720,7 +31975,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -32729,7 +31983,6 @@
 	pixel_x = -28
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -32761,11 +32014,9 @@
 /area/crew_quarters/kitchen/backroom)
 "bgB" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -32783,11 +32034,9 @@
 /area/crew_quarters/kitchen)
 "bgD" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -32828,7 +32077,6 @@
 "bgH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
-	icon_state = "conveyor_map_inverted";
 	id = "trashsort"
 	},
 /turf/open/floor/plating,
@@ -32847,7 +32095,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32927,7 +32174,6 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
-	icon_state = "conveyor_map";
 	dir = 6;
 	id = "garbage"
 	},
@@ -33001,7 +32247,6 @@
 /area/bridge)
 "bgV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -33011,7 +32256,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -33047,7 +32291,6 @@
 /area/teleporter)
 "bgZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33069,7 +32312,6 @@
 /area/maintenance/fore)
 "bhc" = (
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Bridge Deliveries";
 	req_access_txt = "19"
 	},
@@ -33113,7 +32355,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33170,11 +32411,9 @@
 "bhn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33223,7 +32462,6 @@
 	},
 /obj/structure/rack,
 /obj/machinery/door/window/northleft{
-	dir = 1;
 	name = "Jetpack Storage";
 	pixel_x = -1;
 	req_access_txt = "19"
@@ -33258,7 +32496,6 @@
 	pixel_y = -3
 	},
 /obj/machinery/door/window/northleft{
-	dir = 1;
 	name = "Magboot Storage";
 	pixel_x = -1;
 	req_access_txt = "19"
@@ -33358,7 +32595,6 @@
 /area/crew_quarters/cafeteria)
 "bhD" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -33375,11 +32611,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/storage/box/donkpockets,
@@ -33387,11 +32621,9 @@
 /area/crew_quarters/kitchen)
 "bhG" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33401,22 +32633,18 @@
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bhI" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33427,11 +32655,9 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33439,22 +32665,18 @@
 "bhK" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bhL" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -33528,7 +32750,6 @@
 "bhU" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
-	icon_state = "conveyor_map_inverted";
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -33539,7 +32760,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/conveyor{
-	icon_state = "conveyor_map";
 	dir = 10;
 	id = "garbage"
 	},
@@ -33609,7 +32829,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -33627,7 +32846,6 @@
 	},
 /obj/item/storage/box/zipties,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -33690,7 +32908,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33741,22 +32958,18 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bir" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -33888,7 +33101,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33946,7 +33158,6 @@
 "biO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -33960,7 +33171,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -34019,22 +33229,18 @@
 "biW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "biX" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -34043,11 +33249,9 @@
 "biY" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34058,22 +33262,18 @@
 /obj/item/hand_labeler_refill,
 /obj/item/stack/packageWrap,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bja" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34084,22 +33284,18 @@
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bjc" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34115,11 +33311,9 @@
 /area/crew_quarters/kitchen)
 "bjd" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34164,11 +33358,9 @@
 "bjh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/storage/bag/tray,
@@ -34212,7 +33404,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34256,7 +33447,6 @@
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -34408,7 +33598,6 @@
 /area/crew_quarters/cafeteria)
 "bjK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/rack,
@@ -34438,7 +33627,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34469,7 +33657,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34487,11 +33674,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34500,11 +33685,9 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34518,11 +33701,9 @@
 	layer = 5
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34530,11 +33711,9 @@
 "bjU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/reagentgrinder,
@@ -34543,11 +33722,9 @@
 "bjV" = (
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -34557,11 +33734,9 @@
 "bjW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34571,11 +33746,9 @@
 /area/crew_quarters/kitchen)
 "bjX" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/vending/dinnerware,
@@ -34645,7 +33818,6 @@
 /mob/living/simple_animal/bot/cleanbot{
 	auto_patrol = 1;
 	icon_state = "cleanbot1";
-	mode = 0;
 	name = "Mopficcer Sweepsky"
 	},
 /turf/open/floor/plasteel,
@@ -34715,11 +33887,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -34818,11 +33988,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34832,11 +34000,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34846,11 +34012,9 @@
 /area/crew_quarters/kitchen)
 "bks" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -34860,11 +34024,9 @@
 "bkt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34877,7 +34039,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -34944,7 +34105,6 @@
 "bkA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -34989,14 +34149,12 @@
 	},
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -35015,13 +34173,11 @@
 /area/maintenance/disposal)
 "bkG" = (
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -35030,7 +34186,6 @@
 "bkH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
-	icon_state = "conveyor_map_inverted";
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -35151,11 +34306,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35169,7 +34322,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35179,11 +34331,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35194,11 +34344,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35209,11 +34357,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35231,11 +34377,9 @@
 /area/crew_quarters/cafeteria)
 "bkY" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -35317,7 +34461,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35504,7 +34647,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/security{
@@ -35514,7 +34656,6 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
-	icon_state = "direction_sci";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
@@ -35604,11 +34745,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35639,11 +34778,9 @@
 /area/crew_quarters/kitchen)
 "blE" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -35654,11 +34791,9 @@
 /area/crew_quarters/kitchen)
 "blF" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/processor,
@@ -35666,11 +34801,9 @@
 /area/crew_quarters/kitchen)
 "blG" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -35795,11 +34928,9 @@
 /area/crew_quarters/kitchen)
 "blX" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -35962,8 +35093,7 @@
 "bmo" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Gateway - Atrium";
-	dir = 2
+	c_tag = "Gateway - Atrium"
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -35981,7 +35111,6 @@
 "bmq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36010,7 +35139,6 @@
 "bms" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36019,7 +35147,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36030,7 +35157,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36041,11 +35167,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36059,7 +35183,6 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36067,7 +35190,6 @@
 "bmy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36075,7 +35197,6 @@
 "bmz" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36089,7 +35210,6 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36145,18 +35265,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmJ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36192,11 +35309,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
@@ -36209,7 +35324,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36220,7 +35334,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -36233,7 +35346,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
@@ -36244,16 +35356,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -36264,7 +35375,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -36278,7 +35388,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36290,7 +35399,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36300,7 +35408,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -36311,7 +35418,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36375,8 +35481,7 @@
 	areastring = "/area/gateway";
 	dir = 8;
 	name = "Gateway APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -36424,7 +35529,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -36505,7 +35609,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36683,12 +35786,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/sign/directions/supply{
 	dir = 4;
-	icon_state = "direction_supply";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/medical{
@@ -36919,7 +36020,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Port";
-	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/chapel{
@@ -36953,7 +36053,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bnM" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36977,7 +36076,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37035,7 +36133,6 @@
 "bnU" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -37055,8 +36152,8 @@
 /obj/structure/closet/crate/goldcrate,
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	network = list("vault");
-	dir = 1
+	dir = 1;
+	network = list("vault")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
@@ -37156,7 +36253,6 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37167,7 +36263,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37181,7 +36276,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -37191,7 +36285,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37234,7 +36327,6 @@
 /area/storage/emergency/starboard)
 "bop" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37276,7 +36368,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bou" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37363,7 +36454,6 @@
 "boE" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -37373,7 +36463,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -37389,7 +36478,6 @@
 /area/science/xenobiology)
 "boH" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37408,7 +36496,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boJ" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37416,14 +36503,12 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "boK" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37434,7 +36519,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boL" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37448,7 +36532,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37460,7 +36543,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boP" = (
 /obj/docking_port/stationary{
-	dheight = 0;
 	dir = 4;
 	dwidth = 9;
 	height = 25;
@@ -37504,7 +36586,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37534,7 +36615,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37583,7 +36663,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37612,7 +36691,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37632,7 +36710,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpk" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37665,7 +36742,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpn" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37676,7 +36752,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpo" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37720,7 +36795,6 @@
 /area/maintenance/port/fore)
 "bpu" = (
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8;
 	pixel_x = 32
 	},
@@ -37728,7 +36802,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -37794,7 +36867,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37808,7 +36880,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -37820,14 +36891,12 @@
 "bpF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -37893,7 +36962,6 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -37918,7 +36986,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpN" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37982,7 +37049,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpS" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38039,7 +37105,6 @@
 "bpZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38049,13 +37114,12 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
 	dir = 1;
 	name = "Genetics Lab APC";
-	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38073,7 +37137,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -38085,13 +37148,10 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -38105,7 +37165,6 @@
 /area/medical/genetics)
 "bqe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -38113,7 +37172,6 @@
 "bqf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -38132,7 +37190,6 @@
 "bqg" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/noticeboard{
@@ -38213,7 +37270,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38298,7 +37354,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38320,15 +37375,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38352,7 +37404,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38490,7 +37541,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqK" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -38514,7 +37564,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqN" = (
 /obj/machinery/computer/scan_consolenew{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -38541,7 +37590,6 @@
 /area/medical/genetics)
 "bqQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38567,11 +37615,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38637,22 +37683,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "brb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38683,7 +37725,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38700,7 +37741,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38738,7 +37778,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -38756,7 +37795,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Creamatorium";
-	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/dark,
@@ -38889,14 +37927,12 @@
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bru" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38944,7 +37980,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38978,7 +38013,6 @@
 /area/library)
 "brE" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -39041,7 +38075,6 @@
 /area/medical/genetics)
 "brL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/table/glass,
@@ -39080,7 +38113,6 @@
 "brN" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "5"
 	},
 /obj/structure/cable{
@@ -39111,7 +38143,6 @@
 "brO" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -39119,7 +38150,6 @@
 "brP" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39142,7 +38172,6 @@
 /area/medical/morgue)
 "brT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39179,7 +38208,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -39258,7 +38286,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/sign/directions/evac{
@@ -39273,7 +38300,6 @@
 /area/library)
 "bsh" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39287,7 +38313,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsi" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39295,14 +38320,12 @@
 	},
 /obj/structure/chair,
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bsj" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39313,7 +38336,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsk" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39357,7 +38379,6 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39379,15 +38400,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39400,7 +38418,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39435,7 +38452,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39470,7 +38486,6 @@
 	pixel_x = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39480,7 +38495,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -39511,14 +38525,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsC" = (
 /obj/structure/chair/comfy/teal{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -39561,9 +38573,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/library";
 	dir = 4;
 	name = "Library APC";
-	areastring = "/area/library";
 	pixel_x = 24
 	},
 /turf/open/floor/carpet,
@@ -39598,7 +38610,6 @@
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -39631,7 +38642,6 @@
 "bsT" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39639,7 +38649,6 @@
 "bsU" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -39667,7 +38676,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39690,7 +38698,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39721,7 +38728,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39763,7 +38769,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/gun/syringe,
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
 	dir = 4;
@@ -39771,15 +38776,14 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "btd" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -39789,16 +38793,15 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/medical/virology";
 	dir = 1;
 	name = "Virology APC";
-	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39808,7 +38811,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39818,7 +38820,6 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39826,7 +38827,6 @@
 "bth" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39841,9 +38841,8 @@
 "btj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Abandoned Medical Lab APC";
 	areastring = "/area/medical/abandoned";
+	name = "Abandoned Medical Lab APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -39897,7 +38896,6 @@
 	location = "9.2-Escape-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39965,7 +38963,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -39973,7 +38970,6 @@
 "btu" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -40010,7 +39006,6 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40020,7 +39015,6 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -40028,22 +39022,18 @@
 "btB" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40053,7 +39043,6 @@
 	layer = 2.7
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40082,7 +39071,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40099,18 +39087,15 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40125,28 +39110,24 @@
 /area/crew_quarters/kitchen/backroom)
 "btK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40194,7 +39175,6 @@
 /area/medical/storage)
 "btT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40221,11 +39201,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40248,7 +39226,6 @@
 /area/library)
 "bua" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40260,7 +39237,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bub" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40269,7 +39245,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buc" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40283,7 +39258,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bud" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40292,7 +39266,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bue" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40303,7 +39276,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buf" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40316,7 +39288,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bug" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40325,12 +39296,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buh" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/computer/arcade,
@@ -40338,7 +39307,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bui" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40369,7 +39337,6 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40464,11 +39431,9 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40490,11 +39455,9 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40503,7 +39466,6 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40533,12 +39495,10 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 2;
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
@@ -40561,7 +39521,6 @@
 "buC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40569,7 +39528,6 @@
 "buD" = (
 /obj/effect/landmark/start/geneticist,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40612,7 +39570,6 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40630,11 +39587,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40645,7 +39600,6 @@
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40696,11 +39650,9 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = -32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -40774,7 +39726,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40789,11 +39740,9 @@
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/book/manual/wiki/grenades,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40802,11 +39751,9 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40826,7 +39773,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40848,11 +39794,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40889,7 +39833,6 @@
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -40897,7 +39840,6 @@
 "bvg" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40925,9 +39867,8 @@
 /area/medical/storage)
 "bvk" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Medbay Storage APC";
 	areastring = "/area/medical/storage";
+	name = "Medbay Storage APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -40997,7 +39938,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -41030,9 +39970,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bvw" = (
 /obj/structure/table/wood,
@@ -41043,9 +39981,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bvx" = (
 /obj/effect/landmark/carpspawn,
@@ -41066,9 +40002,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Head of Personnel APC";
 	areastring = "/area/crew_quarters/heads/hop";
+	name = "Head of Personnel APC";
 	pixel_y = -24
 	},
 /turf/open/floor/wood,
@@ -41106,7 +40041,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -41117,7 +40051,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41129,7 +40062,6 @@
 "bvE" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -41151,7 +40083,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -41172,7 +40103,6 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -41182,20 +40112,18 @@
 /area/hallway/secondary/command)
 "bvI" = (
 /obj/structure/table,
-/obj/item/gun/syringe,
 /obj/machinery/camera{
 	c_tag = "Chemistry";
 	dir = 4;
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvJ" = (
@@ -41205,11 +40133,9 @@
 "bvK" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41255,7 +40181,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -41275,7 +40200,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -41311,15 +40235,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -41332,7 +40253,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41373,26 +40293,19 @@
 /obj/machinery/door/morgue{
 	name = "Study"
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bvZ" = (
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bwa" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32;
-	pixel_y = 0
+	pixel_x = 32
 	},
 /obj/item/folder,
 /obj/item/folder,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bwb" = (
 /obj/machinery/light/small{
@@ -41408,11 +40321,9 @@
 "bwd" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -41442,7 +40353,6 @@
 "bwf" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "5"
 	},
 /obj/structure/cable{
@@ -41481,7 +40391,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41492,7 +40401,6 @@
 /area/maintenance/port/fore)
 "bwi" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -41546,7 +40454,6 @@
 /area/medical/virology)
 "bwr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -41558,11 +40465,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -41581,18 +40486,15 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -41607,7 +40509,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41618,7 +40519,6 @@
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41629,7 +40529,6 @@
 	},
 /obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41641,7 +40540,6 @@
 	},
 /obj/structure/chair/sofa,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41684,14 +40582,12 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41729,7 +40625,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41835,7 +40730,6 @@
 "bwS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -41879,7 +40773,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -41913,7 +40806,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -41921,7 +40813,6 @@
 "bwY" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -41932,7 +40823,6 @@
 	location = "9.3-Escape-3"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41952,7 +40842,6 @@
 "bxd" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41963,11 +40852,9 @@
 /area/medical/chemistry)
 "bxf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -42019,7 +40906,6 @@
 /area/medical/medbay/central)
 "bxm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42033,7 +40919,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42054,7 +40939,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42107,22 +40991,18 @@
 "bxt" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42277,7 +41157,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -42290,7 +41169,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -42298,7 +41176,6 @@
 "bxQ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -42312,7 +41189,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -42326,7 +41202,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42358,7 +41233,6 @@
 /area/medical/virology)
 "bxX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42371,7 +41245,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42381,7 +41254,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42395,7 +41267,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42413,7 +41284,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42423,14 +41293,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bye" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42449,7 +41317,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42466,7 +41333,6 @@
 /area/medical/cryo)
 "byh" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -42499,7 +41365,6 @@
 /area/hallway/primary/starboard)
 "byj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42509,7 +41374,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -42523,7 +41387,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42542,7 +41405,6 @@
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42553,7 +41415,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42740,7 +41601,6 @@
 /area/medical/cryo)
 "byH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -42760,7 +41620,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42813,7 +41672,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42844,11 +41702,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42880,14 +41736,12 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "byW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -42930,11 +41784,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42971,11 +41823,9 @@
 "bzf" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -43224,7 +42074,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
-	dir = 2;
 	name = "Chemistry Lab APC";
 	pixel_y = -25
 	},
@@ -43249,18 +42098,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bzH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -43399,7 +42245,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -43416,7 +42261,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -43451,7 +42295,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -43463,7 +42306,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -43473,11 +42315,9 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -43495,7 +42335,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -43513,7 +42352,6 @@
 /area/maintenance/disposal)
 "bAf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43532,7 +42370,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43548,7 +42385,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43561,7 +42397,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43584,7 +42419,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43614,7 +42448,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -43625,7 +42458,6 @@
 "bAp" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43644,7 +42476,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction/yjunction{
-	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -43699,7 +42530,6 @@
 "bAu" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43712,11 +42542,9 @@
 	areastring = "/area/medical/genetics/cloning";
 	dir = 8;
 	name = "Cloning Lab APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -43742,7 +42570,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -43761,7 +42588,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -43783,7 +42609,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43791,7 +42616,6 @@
 "bAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43827,7 +42651,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -43838,14 +42661,12 @@
 "bAD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bAE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43853,7 +42674,6 @@
 "bAF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43866,11 +42686,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43880,7 +42698,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43888,7 +42705,6 @@
 "bAI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43945,9 +42761,7 @@
 	name = "Private Study";
 	req_access_txt = "37"
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bAO" = (
 /obj/machinery/airalarm/directional/west,
@@ -43967,11 +42781,9 @@
 "bAQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43990,7 +42802,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -44002,7 +42813,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -44123,7 +42933,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44133,7 +42942,6 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
-	icon_state = "closed";
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock";
 	req_access_txt = "39"
@@ -44304,7 +43112,6 @@
 "bBu" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/cryo";
-	dir = 2;
 	name = "Cryogenics APC";
 	pixel_y = -24
 	},
@@ -44322,7 +43129,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -44353,7 +43159,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44392,7 +43197,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44406,7 +43210,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44457,7 +43260,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44475,7 +43277,6 @@
 /area/medical/medbay/lobby)
 "bBG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44509,7 +43310,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -44522,7 +43322,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -44532,7 +43331,6 @@
 /area/medical/medbay/central)
 "bBM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -44558,9 +43356,7 @@
 	pixel_x = -30
 	},
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bBQ" = (
 /obj/structure/chair/comfy/brown{
@@ -44568,12 +43364,9 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bBR" = (
 /obj/structure/rack{
@@ -44586,9 +43379,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bBS" = (
 /obj/structure/chair/office/dark{
@@ -44656,7 +43447,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -44679,7 +43469,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44699,7 +43488,6 @@
 /area/medical/medbay/central)
 "bCd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44744,7 +43532,6 @@
 "bCj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44778,7 +43565,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44797,7 +43583,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44808,7 +43593,6 @@
 "bCr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44822,14 +43606,12 @@
 /area/security/checkpoint/medical)
 "bCu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bCv" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44840,7 +43622,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -44852,7 +43633,6 @@
 	id = "cmoshutter";
 	name = "CMO Office Shutters";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "40"
 	},
 /turf/open/floor/plasteel/white,
@@ -44866,7 +43646,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -44884,7 +43663,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44898,7 +43676,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /mob/living/simple_animal/pet/penguin/emperor{
@@ -44909,7 +43686,6 @@
 /area/crew_quarters/heads/cmo)
 "bCA" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -44930,7 +43706,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/cmo{
@@ -44970,25 +43745,19 @@
 /area/maintenance/department/medical)
 "bCF" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCG" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/clothing/under/suit_jacket/red,
 /obj/item/book/codex_gigas,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCH" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCI" = (
 /obj/structure/table/wood,
@@ -45000,18 +43769,14 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCJ" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/storage/photo_album,
 /obj/item/camera,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCK" = (
 /obj/machinery/firealarm{
@@ -45103,7 +43868,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45111,7 +43875,6 @@
 "bCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45151,7 +43914,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45162,7 +43924,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45175,7 +43936,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45189,16 +43949,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45230,7 +43987,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -45240,7 +43996,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45366,7 +44121,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -45395,7 +44149,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45421,7 +44174,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -45441,7 +44193,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -45451,7 +44202,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -45472,14 +44222,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 30
 	},
 /obj/machinery/computer/med_data{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45572,7 +44320,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45598,7 +44345,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45610,7 +44356,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -45647,7 +44392,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -45687,7 +44431,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -45715,7 +44458,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -45728,14 +44470,12 @@
 	},
 /obj/item/pen,
 /obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
-	dir = 2
+	c_tag = "Security Post - Engineering"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45746,7 +44486,6 @@
 /area/hallway/secondary/command)
 "bDU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -45756,7 +44495,6 @@
 /area/crew_quarters/heads/hop/private)
 "bDV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -45776,7 +44514,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45790,14 +44527,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bDZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -45806,7 +44541,6 @@
 /obj/structure/chair,
 /obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -45816,7 +44550,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -45910,7 +44643,6 @@
 /area/medical/medbay/front_office)
 "bEi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -45948,7 +44680,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -45969,7 +44700,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/holopad,
@@ -45988,7 +44718,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -46009,7 +44738,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_medical_officer,
@@ -46033,7 +44761,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
@@ -46164,7 +44891,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber Fore";
-	dir = 2;
 	network = list("aicore")
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -46255,7 +44981,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -46289,7 +45014,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46320,7 +45044,6 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46337,7 +45060,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46361,7 +45083,6 @@
 /area/medical/cryo)
 "bEV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46381,7 +45102,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46393,7 +45113,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46403,16 +45122,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bFa" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Medbay Security APC";
-	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -46442,11 +45160,9 @@
 /area/security/checkpoint/medical)
 "bFc" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46477,7 +45193,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/cmo,
@@ -46485,7 +45200,6 @@
 /area/crew_quarters/heads/cmo)
 "bFf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -46505,7 +45219,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -46525,11 +45238,9 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/computer/card/minor/cmo{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/machinery/requests_console{
@@ -46704,7 +45415,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46732,13 +45442,12 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
 	dir = 8;
 	name = "Engineering Security APC";
-	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46758,7 +45467,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46782,7 +45490,6 @@
 "bFL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
-	dir = 2;
 	name = "Medbay Lobby APC";
 	pixel_y = -24
 	},
@@ -46800,7 +45507,6 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -46813,7 +45519,6 @@
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/quartermaster/qm/private";
-	dir = 2;
 	name = "Quartermaster's Quarters APC";
 	pixel_y = -24
 	},
@@ -46850,11 +45555,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46883,11 +45586,9 @@
 "bFX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -46910,11 +45611,9 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -30;
-	pixel_y = 0
+	pixel_x = -30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -46963,7 +45662,6 @@
 	},
 /obj/item/radio/off,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -46975,7 +45673,6 @@
 	pixel_y = 10
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -46988,7 +45685,6 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Central Hall APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -47014,7 +45710,6 @@
 "bGi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/front_office";
-	dir = 2;
 	name = "Medbay Front Office APC";
 	pixel_y = -24
 	},
@@ -47055,14 +45750,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -47070,7 +45763,6 @@
 "bGn" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47136,7 +45828,6 @@
 /obj/machinery/light,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -47158,11 +45849,9 @@
 /area/storage/emergency/starboard)
 "bGu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47172,7 +45861,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -47184,7 +45872,6 @@
 "bGw" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/hop/private";
-	dir = 2;
 	name = "Head of Personnel's Quarters APC";
 	pixel_y = -24
 	},
@@ -47546,7 +46233,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -47566,7 +46252,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47657,7 +46342,6 @@
 "bHn" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -47670,7 +46354,6 @@
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47680,10 +46363,10 @@
 /obj/machinery/door/window{
 	base_state = "rightsecure";
 	dir = 4;
-	obj_integrity = 300;
 	icon_state = "rightsecure";
 	layer = 4.1;
 	name = "Secondary AI Core Access";
+	obj_integrity = 300;
 	pixel_x = 4;
 	req_access_txt = "16"
 	},
@@ -47724,14 +46407,12 @@
 	pixel_y = 7
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = 27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47758,7 +46439,6 @@
 "bHs" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -47771,7 +46451,6 @@
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47781,10 +46460,10 @@
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 8;
-	obj_integrity = 300;
 	icon_state = "leftsecure";
 	layer = 4.1;
 	name = "Tertiary AI Core Access";
+	obj_integrity = 300;
 	pixel_x = -3;
 	req_access_txt = "16"
 	},
@@ -47813,10 +46492,8 @@
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	dir = 8;
-	icon_state = "sink_alt";
 	name = "old sink";
-	pixel_x = 15;
-	pixel_y = 0
+	pixel_x = 15
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -47844,7 +46521,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -47853,7 +46529,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -47861,7 +46536,6 @@
 "bHD" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47873,7 +46547,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47881,7 +46554,6 @@
 "bHF" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47901,7 +46573,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47919,7 +46590,6 @@
 "bHI" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47930,7 +46600,6 @@
 	light_color = "#706891"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47938,14 +46607,12 @@
 "bHK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -47965,7 +46632,6 @@
 /obj/item/wrench,
 /obj/item/multitool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -48065,9 +46731,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/solars/starboard/aft";
 	dir = 8;
 	name = "Starboard Quarter Solar APC";
-	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -48111,7 +46777,6 @@
 	dir = 1
 	},
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -48120,7 +46785,6 @@
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
-	dir = 2;
 	pixel_x = -30;
 	pixel_y = -30
 	},
@@ -48155,9 +46819,9 @@
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 8;
-	obj_integrity = 300;
 	icon_state = "leftsecure";
 	name = "Primary AI Core Access";
+	obj_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/newscaster/security_unit{
@@ -48180,14 +46844,13 @@
 /obj/machinery/door/window{
 	base_state = "rightsecure";
 	dir = 4;
-	obj_integrity = 300;
 	icon_state = "rightsecure";
 	name = "Primary AI Core Access";
+	obj_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
-	dir = 2;
 	network = list("aicore")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48276,7 +46939,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -48317,7 +46979,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -48337,7 +46998,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48356,7 +47016,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48365,7 +47024,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -48421,9 +47079,9 @@
 /area/maintenance/department/cargo)
 "bII" = (
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/starboard";
 	dir = 4;
 	name = "Starboard Maintenance APC";
-	areastring = "/area/maintenance/starboard";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -48683,7 +47341,6 @@
 /area/maintenance/bar)
 "bJn" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48807,9 +47464,8 @@
 /area/medical/medbay/central)
 "bJz" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Surgery APC";
 	areastring = "/area/medical/surgery";
+	name = "Surgery APC";
 	pixel_y = -26
 	},
 /obj/machinery/light,
@@ -48834,7 +47490,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -48923,7 +47578,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -48936,7 +47590,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -48949,7 +47602,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -48969,7 +47621,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -48979,7 +47630,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -49000,7 +47650,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49013,7 +47662,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49027,7 +47675,6 @@
 	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49041,7 +47688,6 @@
 	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -49054,7 +47700,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49070,7 +47715,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49161,7 +47805,6 @@
 /area/maintenance/solars/starboard/aft)
 "bJW" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -49174,8 +47817,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -49199,7 +47841,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49216,7 +47857,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -49308,7 +47948,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -49324,7 +47963,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49344,7 +47982,6 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49377,7 +48014,6 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49392,7 +48028,6 @@
 /obj/machinery/microwave,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49408,14 +48043,12 @@
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bKu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49440,11 +48073,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49455,7 +48086,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49489,7 +48119,6 @@
 "bKD" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49531,11 +48160,9 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49554,7 +48181,6 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49566,7 +48192,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49593,9 +48218,8 @@
 /area/maintenance/port)
 "bKO" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
+	name = "Port Maintenance APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -49631,7 +48255,6 @@
 	pixel_x = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49639,14 +48262,12 @@
 "bKS" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Abandoned Garden APC";
 	areastring = "/area/hydroponics/garden/abandoned";
+	name = "Abandoned Garden APC";
 	pixel_y = -26
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -49659,7 +48280,6 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49676,11 +48296,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49692,7 +48310,6 @@
 	},
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49706,7 +48323,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -49721,7 +48337,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -49775,14 +48390,13 @@
 /area/medical)
 "bLf" = (
 /obj/machinery/power/apc{
+	areastring = "/area/medical/patients_rooms/room_a";
 	dir = 8;
 	name = "Patient Room A APC";
-	areastring = "/area/medical/patients_rooms/room_a";
 	pixel_x = -26
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49798,7 +48412,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49809,7 +48422,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -49855,7 +48467,6 @@
 /area/maintenance/central)
 "bLo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -49865,7 +48476,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49883,7 +48493,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49900,7 +48509,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49911,7 +48519,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49927,7 +48534,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49940,7 +48546,6 @@
 	},
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49969,11 +48574,9 @@
 "bLw" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/wallmed{
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -49986,7 +48589,6 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -49994,7 +48596,6 @@
 "bLy" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -50033,7 +48634,6 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/item/surgical_drapes,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50043,7 +48643,6 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/item/surgical_drapes,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -50069,7 +48668,6 @@
 "bLG" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50084,7 +48682,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50107,7 +48704,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50117,7 +48713,6 @@
 /area/quartermaster/qm/private)
 "bLN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -50145,7 +48740,6 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -50159,7 +48753,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -50294,9 +48887,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bMa" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
@@ -50315,7 +48906,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -50394,9 +48984,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bMi" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
 	pixel_x = 28
@@ -50409,7 +48997,6 @@
 "bMj" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50468,11 +49055,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50562,7 +49147,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50662,11 +49246,9 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50680,14 +49262,12 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	dir = 1;
 	name = "MiniSat Antechamber APC";
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50697,7 +49277,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50734,7 +49313,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50742,7 +49320,6 @@
 "bMM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50769,7 +49346,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bMQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50781,7 +49357,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50833,7 +49408,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical";
-	dir = 2;
 	name = "Breakroom APC";
 	pixel_y = -24
 	},
@@ -50906,7 +49480,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50923,7 +49496,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bNi" = (
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -50940,7 +49512,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -50964,11 +49535,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -51003,15 +49572,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -51033,7 +49599,6 @@
 "bNp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -51162,7 +49727,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51216,7 +49780,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bNE" = (
 /obj/structure/transit_tube/diagonal{
-	icon_state = "diagonal";
 	dir = 8
 	},
 /turf/open/space,
@@ -51228,7 +49791,6 @@
 "bNG" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -51244,11 +49806,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -51261,28 +49821,24 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -51296,7 +49852,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51304,11 +49859,9 @@
 "bNP" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51317,7 +49870,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51328,7 +49880,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51337,7 +49888,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51345,11 +49895,9 @@
 "bNT" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51359,7 +49907,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51367,7 +49914,6 @@
 "bNV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51404,7 +49950,6 @@
 /area/hallway/secondary/exit)
 "bNX" = (
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -51418,14 +49963,12 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bNZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51434,7 +49977,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -51657,9 +50199,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bOm" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -51829,7 +50369,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
-	enabled = 1;
 	icon_state = "control_stun";
 	name = "Antechamber Turret Control";
 	pixel_x = -32;
@@ -51914,7 +50453,6 @@
 "bOA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/junction{
-	icon_state = "junction0";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -52004,7 +50542,6 @@
 /area/space/nearstation)
 "bOI" = (
 /obj/structure/transit_tube/junction{
-	icon_state = "junction0";
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
@@ -52191,7 +50728,6 @@
 /area/hallway/primary/aft)
 "bOW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -52325,7 +50861,6 @@
 /area/hallway/primary/aft)
 "bPc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -52513,7 +51048,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52523,7 +51057,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52643,7 +51176,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52673,11 +51205,9 @@
 	sortType = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52706,11 +51236,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52841,7 +51369,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52854,10 +51381,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
-	dir = 2;
 	name = "MiniSat Foyer APC";
-	pixel_x = -29;
-	pixel_y = 0
+	pixel_x = -29
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52866,7 +51391,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -52875,7 +51399,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52890,7 +51413,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52903,14 +51425,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bPP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52924,11 +51444,9 @@
 	areastring = "/area/aisat";
 	dir = 8;
 	name = "MiniSat Exterior APC";
-	pixel_x = -24;
-	pixel_y = 0
+	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52939,7 +51457,6 @@
 /area/space/nearstation)
 "bPS" = (
 /obj/structure/transit_tube/diagonal{
-	icon_state = "diagonal";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -52976,14 +51493,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -53077,14 +51592,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway Port";
-	dir = 4;
-	name = "security camera";
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -53102,7 +51614,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -53128,7 +51639,6 @@
 /area/ai_monitored/storage/satellite)
 "bQm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -53160,7 +51670,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53170,14 +51679,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bQq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -53191,7 +51698,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -53301,7 +51807,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -53340,24 +51845,19 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 1;
-	icon_state = "connector_map-1";
 	name = "Auxiliary MiniSat Distribution Port"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/satellite)
 "bQL" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bQM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -53367,11 +51867,9 @@
 /area/hallway/primary/starboard)
 "bQN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53400,11 +51898,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -53427,7 +51923,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -53443,7 +51938,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53454,7 +51948,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "N2O to Pure"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -53473,7 +51966,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -53487,7 +51979,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -53582,8 +52073,6 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/folder/yellow,
@@ -53647,7 +52136,6 @@
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/carpet,
@@ -53664,7 +52152,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -53697,11 +52184,9 @@
 /area/crew_quarters/dorms)
 "bRo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/carpet,
@@ -53715,14 +52200,12 @@
 "bRq" = (
 /obj/structure/showcase/mecha/ripley,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
 "bRr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53733,7 +52216,6 @@
 /area/crew_quarters/fitness/recreation)
 "bRt" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -53744,7 +52226,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/loading_area{
@@ -53757,7 +52238,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53887,7 +52367,6 @@
 "bRM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -53907,7 +52386,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -53926,14 +52404,12 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bRR" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -53953,7 +52429,6 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
-	icon_state = "direction_sci";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/command{
@@ -53968,18 +52443,15 @@
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bRU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -54001,7 +52473,6 @@
 /area/crew_quarters/fitness/recreation)
 "bRW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54019,11 +52490,9 @@
 "bRY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54031,11 +52500,9 @@
 "bRZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54085,7 +52552,6 @@
 /area/tcommsat/computer)
 "bSh" = (
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54147,7 +52613,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -54207,7 +52672,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54215,7 +52679,6 @@
 "bSv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -54239,7 +52702,6 @@
 "bSx" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54269,7 +52731,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -54290,18 +52751,15 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bSD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54315,7 +52773,6 @@
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54325,7 +52782,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -54345,7 +52801,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54430,11 +52885,9 @@
 /area/tcommsat/computer)
 "bSW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54510,9 +52963,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/computer";
 	dir = 4;
 	name = "Telecomms Control Room APC";
-	areastring = "/area/tcommsat/computer";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54661,7 +53114,6 @@
 /area/storage/primary)
 "bTp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -54695,11 +53147,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -54712,11 +53162,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -54733,11 +53181,9 @@
 /area/crew_quarters/fitness/recreation)
 "bTv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54793,7 +53239,6 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54809,15 +53254,12 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54825,14 +53267,12 @@
 "bTC" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bTD" = (
 /obj/effect/turf_decal/trimline/green/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54870,9 +53310,9 @@
 /area/storage/tech)
 "bTI" = (
 /obj/machinery/power/apc{
+	areastring = "/area/storage/tech";
 	dir = 8;
 	name = "Tech Storage APC";
-	areastring = "/area/storage/tech";
 	pixel_x = -27
 	},
 /obj/structure/cable{
@@ -54964,7 +53404,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54987,11 +53426,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55085,8 +53522,7 @@
 	areastring = "/area/storage/primary";
 	dir = 8;
 	name = "Tool Storage APC";
-	pixel_x = -25;
-	pixel_y = 0
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -55252,7 +53688,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55281,11 +53716,9 @@
 "bUo" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -55316,16 +53749,13 @@
 /area/crew_quarters/fitness/recreation)
 "bUr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -55340,7 +53770,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -55392,7 +53821,6 @@
 /area/crew_quarters/fitness/recreation)
 "bUx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -55406,7 +53834,6 @@
 "bUy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -55431,11 +53858,9 @@
 "bUA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55513,14 +53938,12 @@
 /area/storage/tech)
 "bUN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55531,7 +53954,6 @@
 /obj/machinery/door/window/westright,
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/trimline/blue/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -55614,18 +54036,15 @@
 "bUY" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bUZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -55654,7 +54073,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/supply{
@@ -55765,7 +54183,6 @@
 "bVk" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -55773,7 +54190,6 @@
 	location = "aft1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55784,11 +54200,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55814,7 +54228,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55830,18 +54243,15 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bVp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -55855,7 +54265,6 @@
 	uses = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -55880,7 +54289,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
-	dir = 2;
 	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -55890,7 +54298,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/arcade/orion_trail{
-	icon_state = "arcade";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55942,7 +54349,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55957,8 +54363,7 @@
 	},
 /obj/machinery/announcement_system,
 /obj/machinery/status_display/ai{
-	pixel_x = 31;
-	pixel_y = 0
+	pixel_x = 31
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -56045,18 +54450,15 @@
 /area/medical/morgue)
 "bVI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -56067,14 +54469,12 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bVK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -56082,7 +54482,6 @@
 	location = "starboard3"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -56181,11 +54580,9 @@
 /area/library)
 "bVQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -56226,7 +54623,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/light_switch{
@@ -56252,7 +54648,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/sign/directions/evac{
@@ -56274,26 +54669,21 @@
 "bVX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bVY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56384,7 +54774,6 @@
 /area/tcommsat/computer)
 "bWm" = (
 /obj/machinery/computer/message_monitor{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -56465,11 +54854,9 @@
 /area/crew_quarters/fitness/recreation)
 "bWs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -56485,7 +54872,6 @@
 /area/crew_quarters/dorms)
 "bWu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56504,7 +54890,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -56528,14 +54913,12 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "bWy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -56558,7 +54941,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -56586,11 +54968,9 @@
 "bWF" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -56645,7 +55025,6 @@
 /obj/machinery/telecomms/processor/preset_three,
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
-	dir = 2;
 	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -56671,7 +55050,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -56754,7 +55132,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -56810,11 +55187,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56832,7 +55207,6 @@
 "bXb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56865,12 +55239,10 @@
 /area/tcommsat/server)
 "bXh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56939,18 +55311,15 @@
 "bXr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bXs" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -57010,7 +55379,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -57059,11 +55427,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57076,11 +55442,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57090,11 +55454,9 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -57218,7 +55580,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57237,7 +55598,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -57291,14 +55651,12 @@
 	pixel_x = 3
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 31;
-	pixel_y = 0
+	pixel_x = 31
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
 "bXT" = (
 /obj/structure/transit_tube/station{
-	icon_state = "closed_station0";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -57311,7 +55669,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -57319,11 +55676,9 @@
 "bXU" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/machinery/camera/autoname,
@@ -57331,7 +55686,6 @@
 /area/medical/virology)
 "bXV" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57339,7 +55693,6 @@
 "bXW" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57430,24 +55783,20 @@
 "bYe" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bYf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -57479,7 +55828,6 @@
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -38;
-	pixel_y = 0;
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel,
@@ -57509,7 +55857,6 @@
 "bYk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -57563,7 +55910,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57603,7 +55949,6 @@
 /area/engine/break_room)
 "bYs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57626,9 +55971,8 @@
 /area/maintenance/starboard/aft)
 "bYw" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Starboard Quarter Maintenance APC";
 	areastring = "/area/maintenance/starboard/aft";
+	name = "Starboard Quarter Maintenance APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -57658,7 +56002,6 @@
 /area/maintenance/starboard/aft)
 "bYA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -57693,9 +56036,9 @@
 /area/tcommsat/server)
 "bYF" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/server";
 	dir = 4;
 	name = "Telecomms Server Room APC";
-	areastring = "/area/tcommsat/server";
 	pixel_x = 25
 	},
 /obj/machinery/light/small{
@@ -57716,12 +56059,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57740,8 +56081,7 @@
 	dir = 4;
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -57812,7 +56152,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -57866,7 +56205,6 @@
 "bYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -57881,7 +56219,6 @@
 	},
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58001,7 +56338,6 @@
 "bZk" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/item/flashlight,
@@ -58045,7 +56381,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58174,11 +56509,9 @@
 "bZA" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/computer/card/minor/ce{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -58186,7 +56519,6 @@
 /area/crew_quarters/heads/chief)
 "bZB" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -58195,11 +56527,9 @@
 "bZC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -58218,7 +56548,6 @@
 	dir = 8
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -58263,7 +56592,6 @@
 /area/engine/break_room)
 "bZG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -58292,12 +56620,10 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -58305,7 +56631,6 @@
 "bZJ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -58355,7 +56680,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -58380,11 +56704,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -58405,7 +56727,6 @@
 /area/crew_quarters/fitness/recreation)
 "bZT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -58420,7 +56741,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -58450,7 +56770,6 @@
 "bZY" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/toilet";
-	dir = 2;
 	name = "Restrooms APC";
 	pixel_y = -26
 	},
@@ -58462,7 +56781,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -58475,7 +56793,6 @@
 	dir = 8
 	},
 /obj/machinery/computer/station_alert{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -58553,8 +56870,7 @@
 	areastring = "/area/crew_quarters/heads/chief";
 	dir = 4;
 	name = "Chief Engineer's APC";
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -58594,7 +56910,6 @@
 "cah" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58616,7 +56931,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -58646,7 +56960,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -58678,8 +56991,7 @@
 	areastring = "/area/crew_quarters/locker";
 	dir = 8;
 	name = "Locker Room APC";
-	pixel_x = -28;
-	pixel_y = 0
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -58698,7 +57010,6 @@
 /area/crew_quarters/locker)
 "cav" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -58778,14 +57089,12 @@
 "caB" = (
 /obj/structure/urinal{
 	dir = 8;
-	icon_state = "urinal";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "caC" = (
 /obj/machinery/computer/apc_control{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -58845,7 +57154,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -59028,9 +57336,9 @@
 "caP" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
+	areastring = "/area/storage/tcom";
 	dir = 8;
 	name = "Telecomms Storage APC";
-	areastring = "/area/storage/tcom";
 	pixel_x = -28
 	},
 /obj/structure/cable,
@@ -59105,7 +57413,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -59162,7 +57469,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -59177,7 +57483,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59191,7 +57496,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59228,7 +57532,6 @@
 "cbh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59257,11 +57560,9 @@
 /area/crew_quarters/fitness/recreation)
 "cbk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59288,14 +57589,12 @@
 	areastring = "/area/crew_quarters/dorms";
 	dir = 4;
 	name = "Dormitories APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59409,7 +57708,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59440,7 +57738,6 @@
 "cbx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -59490,7 +57787,6 @@
 /area/space)
 "cbD" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -59498,7 +57794,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -59551,7 +57846,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59570,7 +57864,6 @@
 /area/medical/patients_rooms/room_a)
 "cbK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -59633,7 +57926,6 @@
 /area/crew_quarters/fitness/recreation)
 "cbO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -59641,7 +57933,6 @@
 "cbP" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59657,7 +57948,6 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59686,7 +57976,6 @@
 /area/science/robotics/lab)
 "cbU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -59705,7 +57994,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -59806,7 +58094,6 @@
 "cch" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -59814,7 +58101,6 @@
 "cci" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -59871,7 +58157,6 @@
 /area/crew_quarters/fitness/recreation)
 "ccn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59881,7 +58166,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59909,14 +58193,12 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/dorms)
 "ccr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/camera{
@@ -59932,7 +58214,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59943,7 +58224,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
@@ -59963,7 +58243,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60058,7 +58337,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60079,7 +58357,6 @@
 /area/asteroid/nearstation)
 "ccI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -60129,7 +58406,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -60143,7 +58419,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -60180,7 +58455,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -60223,8 +58497,7 @@
 	areastring = "/area/crew_quarters/heads/cmo/private";
 	dir = 4;
 	name = "Chief Medical Officer's Quarters APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60241,7 +58514,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -60254,7 +58526,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60265,7 +58536,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -60292,7 +58562,6 @@
 /obj/machinery/recharger,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60408,7 +58677,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -60549,7 +58817,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
@@ -60560,7 +58827,6 @@
 "cdI" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/dormitory";
-	dir = 2;
 	name = "Dormitory Maintenance APC";
 	pixel_y = -28
 	},
@@ -60595,7 +58861,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -60609,7 +58874,6 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -60618,7 +58882,6 @@
 /obj/machinery/microwave,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60660,7 +58923,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -60671,7 +58933,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -60733,7 +58994,6 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60771,7 +59031,6 @@
 /area/crew_quarters/toilet)
 "ceh" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC"
@@ -60938,7 +59197,6 @@
 /area/maintenance/aft)
 "ceH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/camera/autoname,
@@ -60955,7 +59213,6 @@
 	},
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60969,7 +59226,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "ceK" = (
 /obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -60986,7 +59242,6 @@
 /area/engine/break_room)
 "ceM" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	name = "Engineering Deliveries";
 	req_access_txt = "10"
 	},
@@ -61002,11 +59257,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -61016,15 +59269,13 @@
 /obj/item/bedsheet/cmo,
 /obj/structure/bed,
 /obj/machinery/status_display/ai{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo/private)
 "ceP" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61032,7 +59283,6 @@
 "ceQ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61040,7 +59290,6 @@
 "ceR" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61061,7 +59310,6 @@
 /area/hallway/primary/aft)
 "ceU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61074,7 +59322,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61183,7 +59430,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61193,7 +59439,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61236,7 +59481,6 @@
 /area/maintenance/aft)
 "cfq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61258,7 +59502,6 @@
 /area/crew_quarters/locker)
 "cfs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61268,7 +59511,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -61278,7 +59520,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61299,7 +59540,6 @@
 /area/engine/gravity_generator)
 "cfx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -61320,7 +59560,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -61407,7 +59646,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61421,7 +59659,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61450,7 +59687,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61461,7 +59697,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -61490,7 +59725,6 @@
 	areastring = "/area/chapel/main";
 	dir = 1;
 	name = "Chapel APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -61594,7 +59828,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61607,7 +59840,6 @@
 "cgl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -61664,7 +59896,6 @@
 /area/engine/gravity_generator)
 "cgs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61725,7 +59956,6 @@
 	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61837,7 +60067,6 @@
 /area/chapel/main)
 "cgP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -61929,9 +60158,9 @@
 /area/crew_quarters/heads/chief)
 "chd" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/gravity_generator";
 	dir = 1;
 	name = "Gravity Generator APC";
-	areastring = "/area/engine/gravity_generator";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -61954,7 +60183,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61991,7 +60219,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -62064,7 +60291,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62113,7 +60339,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -62162,7 +60387,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62223,7 +60447,6 @@
 "chK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62293,29 +60516,24 @@
 "chR" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "chS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "chT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light{
@@ -62436,18 +60654,15 @@
 /area/engine/break_room)
 "cif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "cig" = (
 /obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62457,11 +60672,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62578,7 +60791,6 @@
 "cis" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	icon_state = "filter_on";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -62615,7 +60827,6 @@
 "civ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	icon_state = "filter_on";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62709,7 +60920,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	icon_state = "filter_on";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62742,7 +60952,6 @@
 /area/maintenance/port)
 "ciE" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -62771,12 +60980,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway Stern";
-	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -62830,7 +61037,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62867,7 +61073,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -62914,14 +61119,12 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ciZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62996,7 +61199,6 @@
 "cjg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63131,7 +61333,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63144,7 +61345,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63157,7 +61357,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63194,7 +61393,6 @@
 /area/maintenance/aft)
 "cjC" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/lipstick/black,
@@ -63239,7 +61437,6 @@
 "cjG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -63255,7 +61452,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -63446,7 +61642,6 @@
 /area/engine/atmos)
 "ckg" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Pure to Fuel Pipe"
 	},
 /turf/open/floor/plasteel,
@@ -63458,7 +61653,6 @@
 "cki" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/checkpoint/customs";
-	dir = 2;
 	name = "Customs APC";
 	pixel_x = 1;
 	pixel_y = -24
@@ -63499,7 +61693,6 @@
 /area/chapel/main)
 "cko" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -63533,8 +61726,7 @@
 "ckr" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -63570,8 +61762,7 @@
 	areastring = "/area/engine/engine_smes";
 	dir = 1;
 	name = "SMES room APC";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -63724,7 +61915,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63833,8 +62023,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -63884,9 +62073,9 @@
 /area/security/vacantoffice/a)
 "clb" = (
 /obj/machinery/power/apc{
+	areastring = "/area/vacant_room/office";
 	dir = 8;
 	name = "Vacant Office APC";
-	areastring = "/area/vacant_room/office";
 	pixel_x = -25
 	},
 /obj/structure/cable{
@@ -63969,7 +62158,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64112,7 +62300,6 @@
 /area/engine/atmos)
 "clA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
-	icon_state = "filter_on";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64122,11 +62309,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -64165,7 +62350,6 @@
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -64173,7 +62357,6 @@
 "clG" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/engine/break_room";
-	dir = 2;
 	name = "Engineering Foyer APC";
 	pixel_y = -24
 	},
@@ -64219,7 +62402,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64227,7 +62409,6 @@
 "clL" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64245,12 +62426,10 @@
 "clO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64271,11 +62450,9 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -64312,7 +62489,6 @@
 	broadcasting = 1;
 	frequency = 1481;
 	name = "Confessional Intercom";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light/small{
@@ -64333,7 +62509,6 @@
 	broadcasting = 1;
 	frequency = 1481;
 	name = "Confessional Intercom";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light/small{
@@ -64393,7 +62568,6 @@
 /area/crew_quarters/heads/chief)
 "cmf" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -64427,14 +62601,12 @@
 "cmi" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64473,7 +62645,6 @@
 "cmm" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -64487,7 +62658,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64540,7 +62710,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64587,7 +62756,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64602,7 +62770,6 @@
 /obj/item/wrench,
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -64623,7 +62790,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64632,7 +62798,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Office";
-	opacity = 1;
 	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64675,7 +62840,6 @@
 /area/security/vacantoffice/a)
 "cmJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -64694,14 +62858,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64717,14 +62879,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64847,11 +63007,9 @@
 	areastring = "/area/engine/atmos";
 	dir = 1;
 	name = "Atmospherics APC";
-	pixel_x = -27;
-	pixel_y = 0
+	pixel_x = -27
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64897,7 +63055,6 @@
 	pixel_x = -28
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64929,7 +63086,6 @@
 /area/engine/atmos)
 "cnj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
@@ -65002,7 +63158,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65037,7 +63192,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65066,7 +63220,6 @@
 /area/security/vacantoffice/a)
 "cnz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -65089,7 +63242,6 @@
 /area/chapel/office)
 "cnC" = (
 /obj/machinery/computer/arcade{
-	icon_state = "arcade";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -65097,14 +63249,12 @@
 "cnD" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
@@ -65159,11 +63309,9 @@
 "cnH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -65241,11 +63389,9 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -65258,15 +63404,12 @@
 /area/hydroponics/garden)
 "cnQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65281,7 +63424,6 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -65317,7 +63459,6 @@
 	products = list(/obj/item/clothing/under/rank/engineer = 4, /obj/item/clothing/shoes/sneakers/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/storage/belt/utility = 4, /obj/item/clothing/glasses/meson/engine = 4, /obj/item/clothing/gloves/color/yellow = 2, /obj/item/screwdriver = 12, /obj/item/crowbar = 12, /obj/item/wirecutters = 12, /obj/item/multitool = 12, /obj/item/wrench = 12, /obj/item/t_scanner = 12, /obj/item/stock_parts/cell = 8, /obj/item/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/light/tube = 10, /obj/item/clothing/suit/fire = 4, /obj/item/stock_parts/scanning_module = 5, /obj/item/stock_parts/micro_laser = 5, /obj/item/stock_parts/matter_bin = 5, /obj/item/stock_parts/manipulator = 5)
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -65466,7 +63607,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65476,14 +63616,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "col" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -65491,7 +63629,6 @@
 "com" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65537,7 +63674,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -65553,11 +63689,9 @@
 /area/chapel/office)
 "cou" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65568,7 +63702,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -65625,11 +63758,9 @@
 /area/crew_quarters/dorms)
 "coE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65652,11 +63783,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -65768,7 +63897,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -65781,7 +63909,6 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -65826,7 +63953,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66078,7 +64204,6 @@
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -66157,10 +64282,8 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	lighting = 3;
-	name = "Chapel Office APC";
 	areastring = "/area/chapel/office";
+	name = "Chapel Office APC";
 	pixel_y = -25
 	},
 /turf/open/floor/plasteel/grimy,
@@ -66182,8 +64305,8 @@
 /area/chapel/office)
 "cpB" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "crematoriumChapel";
-	dir = 1
+	dir = 1;
+	id = "crematoriumChapel"
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -66227,7 +64350,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -66243,7 +64365,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66254,7 +64375,6 @@
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66277,7 +64397,6 @@
 /area/maintenance/port/fore)
 "cpM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
@@ -66319,7 +64438,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66362,7 +64480,6 @@
 "cpT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -66384,7 +64501,6 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66461,7 +64577,6 @@
 /area/hallway/secondary/entry)
 "cqh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66502,7 +64617,6 @@
 /area/hallway/secondary/entry)
 "cql" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66510,7 +64624,6 @@
 "cqm" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -66643,7 +64756,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -66668,7 +64780,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /obj/machinery/light{
@@ -66705,7 +64816,6 @@
 "cqF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
@@ -66922,11 +65032,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66941,7 +65049,6 @@
 "crh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Fuel Pipe to Incinerator"
 	},
 /obj/structure/cable/yellow{
@@ -66975,18 +65082,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "crl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67227,7 +65331,6 @@
 /area/hallway/primary/fore)
 "crL" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/chair{
@@ -67243,7 +65346,6 @@
 /area/hallway/secondary/entry)
 "crM" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67295,7 +65397,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67457,7 +65558,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67480,7 +65580,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67496,7 +65595,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -67583,7 +65681,6 @@
 "csu" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -67596,14 +65693,12 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67625,7 +65720,6 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67798,7 +65892,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/chair{
@@ -67821,7 +65914,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67834,15 +65926,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67857,15 +65946,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67873,7 +65959,6 @@
 "ctc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67884,7 +65969,6 @@
 "ctd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -67892,7 +65976,6 @@
 /area/hallway/secondary/entry)
 "cte" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67908,7 +65991,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67924,7 +66006,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68013,7 +66094,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68029,7 +66109,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68049,7 +66128,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68065,7 +66143,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68087,7 +66164,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68125,14 +66201,12 @@
 /area/engine/engine_smes)
 "ctw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ctx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
@@ -68148,7 +66222,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68161,7 +66234,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68236,7 +66308,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68273,7 +66344,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68296,7 +66366,6 @@
 "ctP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve{
-	dir = 2;
 	name = "output gas to space"
 	},
 /turf/open/floor/plasteel,
@@ -68361,7 +66430,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68446,7 +66514,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68473,9 +66540,7 @@
 "cuk" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hydroponics/garden";
-	dir = 2;
 	name = "Garden APC";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable{
@@ -68503,7 +66568,6 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -68583,7 +66647,6 @@
 /area/engine/atmos)
 "cuA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -68617,7 +66680,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68631,7 +66693,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -68649,7 +66710,6 @@
 /area/engine/atmos)
 "cuH" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68672,11 +66732,15 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cuL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/obj/structure/fans/tiny/invisible,
+/turf/open/space,
+/area/space)
 "cuM" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -68717,7 +66781,6 @@
 "cuS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68726,7 +66789,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68738,7 +66800,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68750,7 +66811,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -68760,7 +66820,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68839,7 +66898,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -68853,7 +66911,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -68948,7 +67005,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space,
@@ -68996,9 +67052,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump/on,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69023,7 +67077,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -69119,7 +67172,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -69146,7 +67198,6 @@
 "cvR" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -69190,13 +67241,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/camera/autoname{
@@ -69246,8 +67295,7 @@
 	areastring = "/area/construction/mining/aux_base";
 	dir = 4;
 	name = "Auxillary Base Construction APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -69260,7 +67308,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -69315,9 +67362,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/entry";
 	dir = 4;
 	name = "Entry Hall APC";
-	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -69485,7 +67532,6 @@
 /area/construction/mining/aux_base)
 "cwE" = (
 /obj/docking_port/stationary/public_mining_dock{
-	icon_state = "pinonfar";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -69584,7 +67630,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargobay Fore";
-	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plating,
@@ -69637,7 +67682,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69667,7 +67711,6 @@
 "cwZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -69675,7 +67718,6 @@
 /area/hallway/secondary/entry)
 "cxa" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -69746,11 +67788,9 @@
 /area/hallway/secondary/entry)
 "cxi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -69779,7 +67819,6 @@
 "cxl" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
@@ -69923,7 +67962,6 @@
 /area/space/nearstation)
 "cxC" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70022,9 +68060,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cxN" = (
-/obj/structure/disposaloutlet{
-	dir = 2
-	},
+/obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -70047,7 +68083,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70146,7 +68181,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70155,7 +68189,6 @@
 "cyc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -70191,7 +68224,6 @@
 "cyh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70200,7 +68232,6 @@
 "cyi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70228,7 +68259,6 @@
 "cym" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -70252,8 +68282,7 @@
 	pixel_y = 26
 	},
 /obj/item/radio/intercom{
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /obj/item/stack/cable_coil/white{
 	pixel_x = 3;
@@ -70436,11 +68465,9 @@
 /area/engine/storage_shared)
 "cyF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70468,7 +68495,6 @@
 "cyJ" = (
 /obj/machinery/rnd/production/protolathe/department/cargo,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -70630,12 +68656,12 @@
 /area/space)
 "cze" = (
 /obj/docking_port/stationary{
-	icon_state = "pinonalert";
 	dir = 8;
-	width = 3;
-	height = 4;
 	dwidth = 1;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default
+	height = 4;
+	icon_state = "pinonalert";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -70773,17 +68799,16 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "czu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
+/obj/machinery/door/poddoor{
+	id = "SecJusticeChamber";
+	name = "Justice Vent"
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/area/security/execution/education)
 "czv" = (
 /obj/item/storage/toolbox/artistic,
 /turf/open/floor/plating,
@@ -70843,15 +68868,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -70898,7 +68920,6 @@
 /area/gateway)
 "czF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/sign/departments/science{
@@ -70992,7 +69013,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71028,7 +69048,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71052,11 +69071,9 @@
 /area/bridge)
 "czV" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71094,7 +69111,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/camera/autoname{
@@ -71141,21 +69157,18 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "cAb" = (
 /obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71174,7 +69187,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -71182,7 +69194,6 @@
 "cAd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71193,7 +69204,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71209,11 +69219,9 @@
 "cAh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71265,7 +69273,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -71346,11 +69353,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71363,7 +69368,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -71402,7 +69406,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -71427,11 +69430,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71456,7 +69457,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71480,11 +69480,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71492,11 +69490,9 @@
 "cAD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71511,7 +69507,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -71539,11 +69534,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71553,11 +69546,9 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71582,11 +69573,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71610,11 +69599,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71640,11 +69627,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71667,11 +69652,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71696,11 +69679,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71725,11 +69706,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71740,7 +69719,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -71764,11 +69742,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71798,11 +69774,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71848,7 +69822,6 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -71898,7 +69871,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71906,7 +69878,6 @@
 "cBb" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71931,7 +69902,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -71986,11 +69956,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72003,7 +69971,6 @@
 "cBj" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -72014,7 +69981,6 @@
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72024,8 +69990,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = 26;
-	pixel_y = 0
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
@@ -72035,14 +70000,12 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72052,7 +70015,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -72061,7 +70023,6 @@
 "cBo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72071,18 +70032,15 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cBq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72092,7 +70050,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72109,7 +70066,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72119,7 +70075,6 @@
 	uses = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72130,7 +70085,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72141,14 +70095,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -72158,7 +70110,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72168,8 +70119,7 @@
 	areastring = "/area/hallway/primary/starboard";
 	dir = 4;
 	name = "Starboard Hallway APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -72178,14 +70128,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72198,7 +70146,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72206,7 +70153,6 @@
 "cBC" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72220,7 +70166,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72231,7 +70176,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -72242,7 +70186,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72256,7 +70199,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72266,16 +70208,15 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/primary/aft";
 	dir = 4;
 	name = "Aft Hallway APC";
-	areastring = "/area/hallway/primary/aft";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72292,11 +70233,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -72362,7 +70301,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/navbeacon{
@@ -72376,7 +70314,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -72446,14 +70383,12 @@
 /area/hallway/primary/aft)
 "cBZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cCa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/navbeacon{
@@ -72468,11 +70403,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72481,11 +70414,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72496,7 +70427,6 @@
 	},
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72515,21 +70445,18 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/dorms)
 "cCf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cCg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -72537,7 +70464,6 @@
 "cCh" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72546,7 +70472,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72556,7 +70481,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72565,7 +70489,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72578,7 +70501,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72621,8 +70543,7 @@
 	dir = 8;
 	name = "Auxillary Base Monitor";
 	network = list("auxbase");
-	pixel_x = 25;
-	pixel_y = 0
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -72633,7 +70554,6 @@
 "cCp" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72649,7 +70569,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/yjunction{
-	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -72670,7 +70589,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72681,7 +70599,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72705,7 +70622,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72730,18 +70646,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cCx" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -72755,7 +70668,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72800,11 +70712,9 @@
 /area/hallway/primary/aft)
 "cCD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72816,7 +70726,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72866,7 +70775,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72891,7 +70799,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72911,7 +70818,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72948,7 +70854,6 @@
 /area/crew_quarters/fitness/recreation)
 "cCQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72988,7 +70893,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -72999,7 +70903,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73015,7 +70918,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73025,7 +70927,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73039,11 +70940,9 @@
 /area/aisat)
 "cCY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73074,14 +70973,12 @@
 /area/ai_monitored/turret_protected/ai)
 "cDc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDd" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -73093,7 +70990,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73103,7 +70999,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -73118,7 +71013,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73128,7 +71022,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73147,7 +71040,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73158,14 +71050,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cDl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73177,7 +71067,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73187,25 +71076,21 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73213,7 +71098,6 @@
 "cDq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73223,7 +71107,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -73231,7 +71114,6 @@
 "cDs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -73324,7 +71206,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -73332,7 +71213,6 @@
 /area/hallway/secondary/command)
 "cDA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -73463,7 +71343,6 @@
 "cDR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73484,7 +71363,6 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
@@ -73606,7 +71484,6 @@
 /area/medical/morgue)
 "cEf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
-	icon_state = "vent_map_siphon_on-2";
 	dir = 1
 	},
 /turf/open/floor/engine/air,
@@ -73630,9 +71507,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/morgue";
 	dir = 4;
 	name = "Morgue APC";
-	areastring = "/area/medical/morgue";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -73746,7 +71623,6 @@
 "cEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73907,7 +71783,6 @@
 /area/medical/morgue)
 "cEy" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/bot,
@@ -73915,11 +71790,9 @@
 /area/science/mixing)
 "cEz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -73927,18 +71800,15 @@
 	light_color = "#cee5d2"
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cEA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/chemical,
@@ -73952,7 +71822,6 @@
 /obj/item/wrench/medical,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -73962,7 +71831,6 @@
 /area/medical/cryo)
 "cEC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/computer/pandemic,
@@ -74063,14 +71931,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74097,7 +71963,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74110,7 +71975,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74144,11 +72008,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74161,7 +72023,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -74172,7 +72033,6 @@
 /area/hallway/primary/starboard)
 "cER" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74185,14 +72045,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cET" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74223,7 +72081,6 @@
 /area/crew_quarters/locker)
 "cEW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74233,11 +72090,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -74311,7 +72166,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -74334,7 +72188,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74344,11 +72197,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74356,7 +72207,6 @@
 "cFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -74406,7 +72256,6 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -74422,7 +72271,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/monkey_recycler,
@@ -74496,11 +72344,9 @@
 "cFv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/fireaxecabinet{
-	pixel_x = -31;
-	pixel_y = 0
+	pixel_x = -31
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74528,18 +72374,15 @@
 /area/engine/atmos)
 "cFA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74563,7 +72406,6 @@
 /area/crew_quarters/fitness/recreation)
 "cFD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/closet/crate,
@@ -74584,11 +72426,9 @@
 "cFG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74613,7 +72453,6 @@
 /area/crew_quarters/fitness/recreation)
 "cFK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -74879,14 +72718,12 @@
 "cFX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74964,7 +72801,6 @@
 "cGe" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74977,12 +72813,9 @@
 	c_tag = "Locker Room Aft";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/vending/kink,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75000,7 +72833,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dorms - Port Fore";
-	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/structure/sign/poster/official/no_erp{
@@ -75026,7 +72858,6 @@
 /area/crew_quarters/fitness/recreation)
 "cGi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -75055,7 +72886,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75066,7 +72896,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75118,7 +72947,6 @@
 "cGp" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75141,7 +72969,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -75166,11 +72993,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -75241,7 +73066,6 @@
 "cGy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75261,7 +73085,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75271,11 +73094,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/light/small,
@@ -75296,7 +73117,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -75338,14 +73158,12 @@
 /area/medical/virology)
 "cGG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "cGH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75355,7 +73173,6 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/camera{
@@ -75377,7 +73194,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75400,7 +73216,6 @@
 /area/engine/atmos)
 "cGL" = (
 /obj/machinery/computer/camera_advanced/base_construction{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -75408,7 +73223,6 @@
 /area/construction/mining/aux_base)
 "cGM" = (
 /obj/machinery/computer/shuttle/mining{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75445,7 +73259,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -75458,7 +73271,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -75482,7 +73294,6 @@
 "cGT" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -75505,7 +73316,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75514,21 +73324,18 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cGX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cGY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -75570,7 +73377,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75586,7 +73392,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75611,7 +73416,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75632,7 +73436,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -75656,7 +73459,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -75672,7 +73474,6 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -75748,7 +73549,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/navbeacon{
@@ -75759,7 +73559,6 @@
 /area/hallway/primary/aft)
 "cHs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/navbeacon{
@@ -75773,7 +73572,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -75801,7 +73599,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75809,7 +73606,6 @@
 "cHv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -75820,7 +73616,6 @@
 /area/hallway/primary/aft)
 "cHw" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -75850,7 +73645,6 @@
 /area/hallway/secondary/entry)
 "cHy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -75903,7 +73697,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75928,11 +73721,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -75948,7 +73739,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75961,7 +73751,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75981,7 +73770,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75992,7 +73780,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76003,7 +73790,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -76015,7 +73801,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -76037,7 +73822,6 @@
 /area/engine/break_room)
 "cHM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76125,7 +73909,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -76135,7 +73918,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76147,7 +73929,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76158,7 +73939,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76168,7 +73948,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76199,7 +73978,6 @@
 	},
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/screwdriver,
@@ -76316,7 +74094,6 @@
 /area/maintenance/starboard/aft)
 "cIi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -76331,14 +74108,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cIk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -76348,7 +74123,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -76363,11 +74137,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar_control{
-	name = "Port Bow Solar Control";
-	icon_state = "computer";
 	dir = 4;
 	id = "foreport";
-	track = 0
+	name = "Port Bow Solar Control"
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
@@ -76393,7 +74165,6 @@
 /area/security/brig)
 "cIo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -76413,15 +74184,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/flasher{
 	id = "brigflashdoor";
-	pixel_x = -26;
-	pixel_y = 0
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cIq" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -76434,11 +74203,9 @@
 /area/security/brig)
 "cIr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76481,7 +74248,6 @@
 "cIw" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -76490,7 +74256,6 @@
 "cIx" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -76538,42 +74303,36 @@
 /area/gateway)
 "cID" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cII" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -76584,7 +74343,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -76607,7 +74365,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -76617,11 +74374,9 @@
 /area/hallway/primary/starboard)
 "cIM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -76629,12 +74384,10 @@
 /area/hallway/primary/starboard)
 "cIN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -76653,7 +74406,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -76676,7 +74428,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76689,11 +74440,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -76705,12 +74454,10 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76805,7 +74552,6 @@
 	},
 /obj/structure/chair/sofa/left,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76818,7 +74564,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/status_display/evac{
@@ -76859,7 +74604,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76877,7 +74621,6 @@
 "cJi" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -76887,7 +74630,6 @@
 /area/medical/medbay/central)
 "cJj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76970,8 +74712,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Office";
-	dir = 2
+	c_tag = "Security - Head of Security's Office"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -77025,8 +74766,7 @@
 /obj/structure/closet/secure_closet/hos,
 /obj/effect/turf_decal/tile/red,
 /obj/item/storage/secure/safe/HoS{
-	pixel_x = 36;
-	pixel_y = 0
+	pixel_x = 36
 	},
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -77052,7 +74792,6 @@
 /obj/machinery/light,
 /obj/structure/closet/wardrobe/green,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -77069,7 +74808,6 @@
 /area/crew_quarters/locker)
 "cJC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/chair/stool,
@@ -77096,7 +74834,6 @@
 "cJG" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -77151,7 +74888,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77215,15 +74951,12 @@
 /area/maintenance/starboard/aft)
 "cJS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -77355,7 +75088,6 @@
 /area/engine/break_room)
 "cKd" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -77373,7 +75105,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -77381,7 +75112,6 @@
 /area/medical/surgery)
 "cKf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/disposal/bin,
@@ -77574,11 +75304,9 @@
 "cKA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -77589,7 +75317,6 @@
 /area/crew_quarters/fitness/recreation)
 "cKC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -77652,8 +75379,8 @@
 /area/construction)
 "cKI" = (
 /obj/machinery/power/apc{
-	name = "Construction Area APC";
 	areastring = "/area/construction";
+	name = "Construction Area APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -77923,7 +75650,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77932,29 +75658,24 @@
 "cLa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cLb" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cLc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77964,7 +75685,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77975,7 +75695,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77985,7 +75704,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77995,7 +75713,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78005,7 +75722,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78018,7 +75734,6 @@
 "cLj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78027,7 +75742,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78035,7 +75749,6 @@
 "cLl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78046,12 +75759,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cLn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -78075,7 +75785,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -78128,7 +75837,6 @@
 /area/engine/storage_shared)
 "cLv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -78137,7 +75845,6 @@
 "cLw" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -78154,7 +75861,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -78195,7 +75901,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -78207,7 +75912,6 @@
 /area/security/brig)
 "cLA" = (
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78297,33 +76001,27 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -78331,28 +76029,23 @@
 "cLM" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -78364,7 +76057,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -78412,7 +76104,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -78434,7 +76125,6 @@
 "cLW" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -78456,15 +76146,12 @@
 /area/maintenance/fore)
 "cLZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78481,15 +76168,12 @@
 "cMb" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78500,7 +76184,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -78526,15 +76209,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 4;
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
-	pixel_x = 30;
-	pixel_y = 0
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -78545,7 +76226,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -78603,7 +76283,6 @@
 /area/security/range)
 "cMi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -78621,7 +76300,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -78647,12 +76325,10 @@
 /area/crew_quarters/heads/captain/private)
 "cMl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Science Entrance";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -78662,7 +76338,6 @@
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -78761,22 +76436,18 @@
 /area/crew_quarters/fitness/recreation)
 "cMy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cMz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -78885,7 +76556,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -78921,14 +76591,12 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cMM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -78971,7 +76639,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78998,7 +76665,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79029,7 +76695,6 @@
 /obj/machinery/plantgenes,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -79040,7 +76705,6 @@
 /area/hydroponics)
 "cMU" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -79058,15 +76722,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cMV" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge - Starboard Fore";
-	dir = 2
+	c_tag = "Departure Lounge - Starboard Fore"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -79077,7 +76739,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/camera{
 	c_tag = "Escape Hallway";
-	dir = 2;
 	name = "departures camera"
 	},
 /turf/open/floor/plasteel,
@@ -79088,7 +76749,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library";
-	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/wood,
@@ -79117,7 +76777,6 @@
 "cNa" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79156,11 +76815,9 @@
 "cNd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79168,7 +76825,6 @@
 "cNe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -79192,7 +76848,6 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79203,7 +76858,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -79239,7 +76893,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -79257,7 +76910,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -79268,7 +76920,6 @@
 /area/engine/atmos)
 "cNm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79287,7 +76938,6 @@
 /area/engine/atmos)
 "cNo" = (
 /obj/machinery/computer/arcade{
-	icon_state = "arcade";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -79304,7 +76954,6 @@
 /area/security/vacantoffice/a)
 "cNr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -79312,11 +76961,9 @@
 "cNs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -79326,7 +76973,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -79348,7 +76994,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79368,7 +77013,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -79378,7 +77022,6 @@
 /area/engine/storage)
 "cNz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -79388,7 +77031,6 @@
 	id = "ewradiation";
 	name = "Shutters Control";
 	pixel_x = 33;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /turf/open/floor/plasteel,
@@ -79404,7 +77046,6 @@
 "cNB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -79421,7 +77062,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -79448,11 +77088,9 @@
 	},
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79460,9 +77098,8 @@
 "cNF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	name = "Upload APC";
 	pixel_y = -24
 	},
 /obj/machinery/camera/motion{
@@ -79546,7 +77183,6 @@
 /area/teleporter)
 "cNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -79571,7 +77207,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79579,7 +77214,6 @@
 "cNO" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -79610,7 +77244,6 @@
 /area/medical/virology)
 "cNS" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
@@ -79629,7 +77262,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79650,14 +77282,12 @@
 /area/crew_quarters/toilet)
 "cNV" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "cNW" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79670,7 +77300,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79693,7 +77322,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -79706,14 +77334,12 @@
 	pixel_x = 30
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -79722,7 +77348,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79742,7 +77367,6 @@
 "cOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -79771,7 +77395,6 @@
 "cOg" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -79917,7 +77540,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -79956,7 +77578,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -79994,7 +77615,6 @@
 /area/engine/engineering)
 "cOJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -80157,7 +77777,6 @@
 "cPe" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80223,7 +77842,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -80254,7 +77872,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -80421,11 +78038,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -80529,7 +78144,6 @@
 /area/maintenance/fore/secondary)
 "cPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80656,9 +78270,8 @@
 "cQo" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
+	name = "Cargo Office APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -80666,7 +78279,6 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80728,7 +78340,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -80777,7 +78388,6 @@
 "cQE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80833,7 +78443,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -80877,7 +78486,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80888,14 +78496,12 @@
 /area/hallway/primary/central)
 "cQP" = (
 /obj/structure/chair/sofa/corp{
-	icon_state = "corp_sofamiddle";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cQQ" = (
 /obj/structure/chair/sofa/corp/left{
-	icon_state = "corp_sofaend_left";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80953,7 +78559,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81010,16 +78615,13 @@
 "cRe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/food_cart,
@@ -81078,12 +78680,10 @@
 /area/engine/transit_tube)
 "cRl" = (
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
 	dir = 1
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/engine/transit_tube";
-	dir = 2;
 	name = "Transit Tube APC";
 	pixel_y = -26
 	},
@@ -81220,7 +78820,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81262,7 +78861,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81274,7 +78872,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/yjunction{
-	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -81291,7 +78888,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81314,7 +78910,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81343,7 +78938,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81403,7 +78997,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81436,7 +79029,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81469,7 +79061,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81499,7 +79090,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81533,7 +79123,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81560,7 +79149,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81584,7 +79172,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81612,7 +79199,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81677,8 +79263,6 @@
 "cSi" = (
 /obj/structure/bed/dogbed/ian,
 /obj/item/radio/intercom{
-	dir = 2;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/wood,
@@ -81737,46 +79321,39 @@
 /area/crew_quarters/fitness/recreation)
 "cSo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cSq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81784,7 +79361,6 @@
 "cSs" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81792,7 +79368,6 @@
 "cSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -81804,7 +79379,6 @@
 "cSu" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81817,7 +79391,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -81841,7 +79414,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -81851,7 +79423,6 @@
 /area/engine/atmos)
 "cSy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -81862,11 +79433,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -81874,11 +79443,9 @@
 "cSA" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/mint,
@@ -81890,7 +79457,6 @@
 /area/crew_quarters/kitchen)
 "cSB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -81904,7 +79470,6 @@
 /area/maintenance/port/aft)
 "cSE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81914,19 +79479,16 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -81962,7 +79524,6 @@
 /area/hallway/primary/central)
 "cSK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -81980,7 +79541,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/engineering{
@@ -81993,7 +79553,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -82288,7 +79847,6 @@
 /area/engine/atmos)
 "cTA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82299,7 +79857,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82414,7 +79971,6 @@
 "cTP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/sign/departments/restroom{
@@ -82424,7 +79980,6 @@
 /area/crew_quarters/fitness/recreation)
 "cTQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/sign/departments/restroom{
@@ -82450,12 +80005,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_x = 32
 	},
 /obj/structure/sign/directions/engineering{
@@ -82495,7 +80048,6 @@
 	},
 /obj/structure/sign/directions/medical{
 	dir = 1;
-	icon_state = "direction_med";
 	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
@@ -82505,16 +80057,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/structure/sign/directions/medical{
 	dir = 1;
-	icon_state = "direction_med";
 	pixel_x = 32;
 	pixel_y = 40
 	},
@@ -82525,7 +80074,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/departments/engineering{
@@ -82538,7 +80086,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/departments/engineering{
@@ -82554,7 +80101,6 @@
 /area/maintenance/department/cargo)
 "cUb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -82575,7 +80121,6 @@
 "cUc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/departments/holy{
@@ -82620,7 +80165,6 @@
 "cUi" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -82664,7 +80208,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -82675,7 +80218,6 @@
 /area/medical/virology)
 "cUp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -82691,13 +80233,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/doorButtons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
 	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
 	name = "Virology Access Console";
 	pixel_x = 26;
 	pixel_y = 26;
@@ -82812,7 +80353,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -82882,7 +80422,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "cUR" = (
 /obj/structure/chair/sofa/corp/right{
-	icon_state = "corp_sofaend_right";
 	dir = 8
 	},
 /obj/item/storage/daki,
@@ -82931,7 +80470,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -82945,7 +80483,6 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -82963,7 +80500,6 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -83016,7 +80552,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -83043,7 +80578,6 @@
 	},
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
@@ -83435,7 +80969,6 @@
 "cWo" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/crowbar,
@@ -83453,15 +80986,12 @@
 /area/crew_quarters/fitness/recreation)
 "cWr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/pool/Rboard,
@@ -83518,7 +81048,6 @@
 /area/maintenance/solars/starboard/aft)
 "cWx" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -83544,7 +81073,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
@@ -83563,7 +81091,6 @@
 /area/engine/break_room)
 "cWB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/warning/enginesafety{
@@ -83645,7 +81172,6 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -83661,9 +81187,7 @@
 "cWL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/storage";
-	dir = 2;
 	name = "Engineering Storage APC";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable,
@@ -83758,7 +81282,6 @@
 /area/crew_quarters/locker)
 "cWV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -83786,7 +81309,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -83808,7 +81330,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -83827,7 +81348,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -83843,7 +81363,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -84049,8 +81568,7 @@
 	areastring = "/area/maintenance/department/electrical";
 	dir = 4;
 	name = "Electrical Maintenance APC";
-	pixel_x = 24;
-	pixel_y = 0
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -84150,7 +81668,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/vending/medical{
@@ -84167,14 +81684,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
@@ -84208,7 +81723,6 @@
 /area/medical/medbay/central)
 "cXL" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -84231,12 +81745,10 @@
 /area/crew_quarters/heads/chief/private)
 "cXO" = (
 /obj/machinery/status_display/ai{
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/chief/private";
-	dir = 2;
 	name = "Chief Engineer's Quarters APC";
 	pixel_y = -24
 	},
@@ -84321,7 +81833,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -84336,23 +81847,19 @@
 /obj/machinery/camera/autoname,
 /obj/item/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "cYa" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Kitchen Starboard";
-	dir = 2
+	c_tag = "Kitchen Starboard"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -84360,7 +81867,6 @@
 	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -84370,7 +81876,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -84385,7 +81890,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -84419,6 +81923,8790 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft)
+"cYG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"cYW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"dbI" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dbN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"dcb" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ddM" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ddU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"deI" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"dfb" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dfP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"dgK" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"dhT" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dji" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"djk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"djl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dlH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"dlL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"doc" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"doE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dtJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"duy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dxj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dxn" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dxR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dxT" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dzN" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dAn" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dDQ" = (
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
+"dEN" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dFk" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"dFK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dFM" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"dIh" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dID" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dJm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"dJo" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dJp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dMg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dMR" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dMX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dPm" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dTJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dUE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"dZh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"eaj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"eas" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"eds" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"egx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"egW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ekd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ekq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ekT" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ela" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"emv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eom" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"eoG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"eqo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"euD" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"evn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"eyZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ezd" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"ezq" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eAr" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"eAO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eCr" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"eDK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"eFK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"eGo" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"eHh" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eJb" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"eJc" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"eJu" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eKe" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eLn" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eNu" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"eNX" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eSj" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eUM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"eVw" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eXE" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fay" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"fcg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fcR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"fdv" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fdP" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fel" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"fhw" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"fkc" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fkT" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"flu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"flN" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	backwards = 1;
+	forwards = 2;
+	id = "trashsort"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"fmE" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fmQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"fnb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"fpA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"frQ" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ftq" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"fue" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fxw" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fxS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fBV" = (
+/turf/open/floor/plasteel/cult,
+/area/library)
+"fDa" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"fEx" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"fFu" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"fHX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"fIj" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fIn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fIM" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fJc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"fJB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"fKt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fKN" = (
+/obj/structure/bed,
+/obj/machinery/flasher{
+	id = "insaneflash";
+	pixel_y = -26
+	},
+/turf/open/floor/plasteel/freezer,
+/area/security/prison)
+"fKY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
+"fNb" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"fPR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fQS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
+"fRz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fRZ" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fTH" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"fVm" = (
+/obj/effect/turf_decal/caution{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"fWa" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fWH" = (
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
+"fXC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gaN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"gcj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"gcv" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gfs" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gfV" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gin" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gjs" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gkf" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gkk" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"gox" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"gqw" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gtA" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"gtD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"guI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gva" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"gzM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"gBD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gEp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gFd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gGZ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gJc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"gJh" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gKr" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gNp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gPS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"gSt" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gSu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"gTB" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gVQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"gWO" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gXF" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"gZa" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gZN" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
+	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "Supply Dock Loading Door"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"hba" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"hbP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"hcw" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hcP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hdg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hdo" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hgS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hjh" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hkb" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"hkc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hke" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hkh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"hkl" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"hkI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hmz" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"hnv" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hnY" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"hof" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hpj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hpR" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"hpY" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"hri" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hsf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hvC" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hxK" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"hyd" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hBp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hBT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hCm" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hCK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"hEk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hEy" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hIv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hIz" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hJg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hJE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hJG" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hKb" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hKk" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hKC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hLe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hNR" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"hNU" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"hOi" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"hOq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"hPF" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hRb" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hRg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"hRZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hSh" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hSl" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"hTl" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"hTn" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"hXa" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hYb" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hZb" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"ibw" = (
+/obj/machinery/deepfryer,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"ifC" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ihL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ihQ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iir" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"iiF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ijc" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
+"ijq" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ijS" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"ikh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ikD" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"imk" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"imo" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"inV" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"ion" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"iqU" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"isz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"ivv" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"ixo" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"iBq" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"iFL" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iGv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"iHh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"iHx" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"iJy" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iJS" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"iMA" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iPK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iQe" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iRH" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"iSP" = (
+/turf/open/floor/plasteel/cult,
+/area/library)
+"iUr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"iWy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iXB" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"iZm" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"iZo" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iZx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jaf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"jaF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jdu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"jeo" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jiJ" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"jjz" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"jlb" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jlf" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"jlO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"joi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jpV" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"jqQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jsb" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"jsA" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"jtv" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"jtz" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"jux" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jvg" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jwB" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jyh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jyj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jBF" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"jCj" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"jCo" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"jEx" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jGS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jGT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jKw" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"jLs" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jLu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jMn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jRe" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jSw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jSQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"jTf" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"jTl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jTG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jUM" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"jVS" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jWH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"jXg" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"jYK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"jYP" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jZz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"jZR" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kaB" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"kbw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"kcR" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"kdz" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kky" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"klt" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"klW" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kpN" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"krf" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"krk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"krq" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"krM" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"kvO" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kwA" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kwC" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kAs" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"kDN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kGC" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"kGW" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"kKA" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"kNn" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kOb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"kOg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kOs" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kQF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"kUD" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kWh" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"kWi" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kWj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"kWL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"kWY" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"kYi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"lay" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"laA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"lea" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lgr" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"liE" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"liN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lkb" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"lkm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lkQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"lnd" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"lnz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lpm" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"lpp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lpv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"lpO" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"lpU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ltT" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"luj" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"lzh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lDA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lGQ" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lGY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lHi" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"lHI" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lIc" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lIF" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"lKd" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lLK" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lNf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lOV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"lQl" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"lSo" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"lUz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"lVV" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lWO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lYt" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mae" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mex" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"meZ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"mfa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"mfq" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mgC" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mgK" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"mhj" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mjc" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mjj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"mjR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"mjU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"mko" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"mnx" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mqW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"mrb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"msK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mvn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mvM" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"mAh" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"mAt" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mCd" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"mEI" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"mFj" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"mFl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mHy" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"mKL" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mLe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mNf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mPj" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"mRS" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mRW" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"mTN" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"mUo" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nbf" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"nbz" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ncr" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ndf" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ndn" = (
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nfH" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ngs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ngM" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nik" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"niM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"nna" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"noo" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nop" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"noP" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nqb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nqv" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nuj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nuy" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nvN" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"nyJ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"nzJ" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nBJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nCI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"nCM" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nEe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nED" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nEL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"nIk" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"nIw" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nIP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"nJg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"nLA" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nLT" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nPD" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nRG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nSy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nTh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nTi" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"nTx" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nVQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"nYK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oav" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"obw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"obY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"oem" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ofK" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ogz" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oiH" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"ojz" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"okh" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"olD" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ond" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"ooi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ooW" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"opU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oqN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"osV" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ouq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"owe" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oxw" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oyJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oAf" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oAP" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"oBI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oBK" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"oCc" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oCy" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oCM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oDk" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oFd" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"oFi" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oFt" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"oFv" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oIJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"oLT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"oMk" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"oMp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oOy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oPb" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"oPn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"oPY" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oQL" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oRe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oRh" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"oTG" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oVK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"oYK" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oYL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oZQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oZT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"pae" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"pal" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"paG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pbV" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"pcB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pcG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"pdu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pfL" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"pfM" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pge" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pji" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"pjD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"pjM" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"pkV" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"poB" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pru" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"prS" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"psj" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"psL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ptj" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"ptC" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"puf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"pyn" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"pyt" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"pzD" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pBI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"pCz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pCJ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"pGd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"pGK" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pIn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pKy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pLZ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pMp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pOU" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"pQc" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"pRA" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"pRP" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"pSr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pSL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"pUa" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pVA" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pVY" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"pWR" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pXD" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pXZ" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"pYW" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qaq" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qbf" = (
+/obj/machinery/door/poddoor{
+	id = "SecJusticeChamber";
+	name = "Justice Vent"
+	},
+/turf/open/floor/plating,
+/area/security/execution/education)
+"qcU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qdW" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qeR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qga" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qgY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qhd" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"qhK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qhL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qhW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qid" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qkB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"qkH" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qld" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qmh" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"qnP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qoL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qpF" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"qqn" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qrM" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"qrY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qsh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"qsj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qty" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"quK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"qwr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qxr" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qyB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qyN" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qzM" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qzS" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qBl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qBA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"qEy" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"qER" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qHo" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"qIA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qIR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qJZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qKy" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qMj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qMz" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"qNB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"qRf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"qTq" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"qWC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rct" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"reB" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rkC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rmF" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rqB" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"rqZ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rrF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"ruT" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"rvc" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"rvU" = (
+/obj/structure/closet/wardrobe/cargotech,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"rys" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rzH" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rzT" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"rAT" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rBg" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"rBi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rBM" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"rCO" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"rDY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rEJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"rFD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rJn" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rJC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rJH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"rKh" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rKU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rMG" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rNc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rNk" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rNz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"rNU" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rPi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rQo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rQr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rQJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"rQQ" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rRa" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rRq" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rRI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"rVW" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"rZb" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"saw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"saV" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"scp" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"scP" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"sfx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sgi" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"sjm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"skd" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"slz" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"som" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"soD" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sqt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"srh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"svn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"syR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"sCn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"sCy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sCA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sCO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"sFi" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"sHG" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"sJt" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sMm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"sNK" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"sOO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sRj" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sUi" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sUU" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"tad" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"taE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"tcs" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tcx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tcS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tet" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"tfU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"tgh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"thd" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"tif" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tiD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tji" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tkM" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tmC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"tmN" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"tmP" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"tmQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"tnE" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"tor" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"tpN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tqJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tqX" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tsg" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ttr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tBF" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"tEZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tFB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tFQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"tOa" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"tPy" = (
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tQT" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tSS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tYa" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tYM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"uae" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"uai" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"uaM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ubz" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"udc" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"udk" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"udl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"udt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"udJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ugz" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ukc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"ulA" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"umN" = (
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"uoE" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"urz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"urW" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uvi" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"uxM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uxT" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uxX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uyQ" = (
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor2";
+	name = "Supply Dock Loading Door"
+	},
+/obj/machinery/conveyor{
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"uBF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uBU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uCj" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uCU" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uDO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"uFq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uGa" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uHa" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"uHw" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uIB" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uLi" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uMi" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uMt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uOb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uOG" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uPw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uPZ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uQc" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"uQG" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"uRx" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"uRR" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uSf" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uSk" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"uTm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"uVU" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uYx" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"uZv" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vcI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
+"vfi" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"vha" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"vhd" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vhp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vhQ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"vhY" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vjf" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vju" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"vke" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"vls" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"vlz" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"vnA" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"vof" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"von" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"voB" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vqp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vsg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vtB" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vvl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vwg" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"vyn" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"vyC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vyR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"vzC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vzE" = (
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"vFl" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vGN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"vHf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vIo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"vJl" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vNw" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vOp" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"vPe" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vPB" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"vQR" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"vTn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vTQ" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vUT" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"vVh" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vVt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"vXw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"waF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wbJ" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"wbT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wcG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wdz" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"wgh" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"whS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"wiA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"wiL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wjk" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"wma" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wpK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"wrm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wtY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wwC" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wxw" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"wyb" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wyh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wzf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wzk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"wAA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wBC" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"wCd" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"wDD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wET" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wFK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"wHE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"wIT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wLf" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"wLm" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wLn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wNz" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wVY" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"wXh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wYn" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xaf" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xdo" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xdI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"xfj" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xfK" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xio" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"xiq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"xjv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xkf" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"xkP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xmi" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"xmN" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"xmW" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xpN" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"xqb" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"xrE" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xrW" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"xsy" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xuk" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xvf" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xxH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xyQ" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xzt" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xzN" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xAN" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xBm" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xBI" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xCL" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"xDD" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xDF" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"xGX" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xJy" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xKT" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"xNi" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"xNo" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xOy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xOF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xPK" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xQM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"xRn" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xRH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xRS" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"xSR" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xTF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xUc" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"xUe" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xUO" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"xVm" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xWn" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xXJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xXO" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xZI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ycq" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ydS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"yeD" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"yhm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"yiZ" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"yjg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 
 (1,1,1) = {"
 aaa
@@ -94609,9 +100897,9 @@ bIY
 bIY
 bIY
 byU
-bAS
+vqp
 bVp
-bAa
+noP
 bKd
 bIY
 bIY
@@ -94859,23 +101147,23 @@ aaa
 aaa
 aaa
 bxN
-bAS
-bLI
-bLI
-bLI
-bLI
-bLI
-bLI
+vqp
+jRe
+jRe
+jRe
+jRe
+jRe
+jRe
 bPK
 bRU
 bYA
-bLI
-bLI
-bLI
-bLI
-bLI
-bLI
-bAa
+jRe
+jRe
+jRe
+jRe
+jRe
+jRe
+noP
 bzY
 aab
 aab
@@ -95115,25 +101403,25 @@ aab
 aab
 aab
 bzS
-bAS
-bEK
-bLL
-bLL
-bLL
-bMM
-bNg
+vqp
+nik
+tcs
+tcs
+tcs
+guI
+gGZ
 bOa
 bPL
 bVq
 caW
-bMM
-bNg
-bMM
-bLL
-bLL
-bLL
+guI
+gGZ
+guI
+tcs
+tcs
+tcs
 cAh
-cAE
+xmW
 bzY
 aab
 aav
@@ -95371,9 +101659,9 @@ aab
 aab
 aab
 bzS
-bzU
-bEK
-bKZ
+qty
+nik
+xfK
 bBW
 bJg
 bJg
@@ -95389,9 +101677,9 @@ bBX
 bSd
 bSS
 bAc
-cAn
-cAG
-cAE
+uZv
+jGS
+xmW
 bzY
 aav
 aab
@@ -95627,9 +101915,9 @@ aav
 aab
 aab
 bzS
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 bzV
 aav
 aaa
@@ -95647,9 +101935,9 @@ aab
 aav
 aab
 bAc
-cAN
-cAG
-cAE
+nTx
+jGS
+xmW
 bBY
 aab
 aab
@@ -95883,9 +102171,9 @@ aab
 aav
 aab
 bzS
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 bzV
 aab
 aav
@@ -95905,9 +102193,9 @@ aav
 aab
 aab
 bAc
-cAN
-cAG
-cAE
+nTx
+jGS
+xmW
 bzY
 aab
 aab
@@ -96139,9 +102427,9 @@ aab
 aab
 aav
 bzS
-bzU
-bEK
-bKZ
+qty
+nik
+xfK
 bzV
 aab
 aab
@@ -96163,9 +102451,9 @@ aab
 aab
 aab
 bAc
-cAn
-cAG
-cAE
+uZv
+jGS
+xmW
 bzY
 aab
 aab
@@ -96395,8 +102683,8 @@ aab
 aab
 aab
 bDC
-bAS
-bEK
+vqp
+nik
 bKY
 bzV
 aab
@@ -96421,9 +102709,9 @@ aab
 aab
 aab
 bAc
-cAN
-cAG
-cAE
+nTx
+jGS
+xmW
 bzY
 aab
 aaa
@@ -96651,8 +102939,8 @@ aab
 aab
 aab
 bzS
-bAS
-bEK
+vqp
+nik
 bJF
 bBW
 aab
@@ -96667,7 +102955,7 @@ bBX
 bBX
 bNC
 bOg
-cuS
+hmz
 bBX
 bBX
 bBX
@@ -96681,7 +102969,7 @@ aab
 bAc
 cBd
 cBh
-bAa
+noP
 bzY
 aaa
 aaa
@@ -96907,8 +103195,8 @@ aac
 aab
 aab
 bzS
-bzU
-byW
+qty
+gSt
 bKy
 bzV
 aav
@@ -96924,7 +103212,7 @@ aab
 bBX
 bNC
 bOg
-cuT
+mRW
 bBX
 aab
 aab
@@ -96938,8 +103226,8 @@ aab
 aab
 bAc
 clQ
-cBq
-bAa
+uxT
+noP
 bzY
 aaa
 aaa
@@ -97163,9 +103451,9 @@ aaa
 aac
 aab
 bzS
-bAS
-byW
-bzZ
+vqp
+gSt
+pkV
 bzV
 aab
 aav
@@ -97181,7 +103469,7 @@ aab
 bBX
 bNC
 bOg
-cuS
+hmz
 bBX
 aab
 aab
@@ -97195,9 +103483,9 @@ aab
 aab
 aab
 bYB
-cAN
-cBq
-bAa
+nTx
+uxT
+noP
 bJf
 aaa
 aac
@@ -97419,9 +103707,9 @@ aaa
 aaa
 aac
 bzS
-bAS
-byW
-bzZ
+vqp
+gSt
+pkV
 bBW
 aav
 aav
@@ -97453,9 +103741,9 @@ aav
 aav
 aav
 bYB
-cAN
-cBq
-bAa
+nTx
+uxT
+noP
 bJf
 aac
 aaa
@@ -97675,9 +103963,9 @@ aaa
 aab
 aaa
 byU
-bzU
-byW
-bzZ
+qty
+gSt
+pkV
 bBW
 aab
 aab
@@ -97711,9 +103999,9 @@ aab
 aav
 aab
 bAc
-cAn
-cBq
-bAa
+uZv
+uxT
+noP
 bKd
 aaa
 aab
@@ -97932,8 +104220,8 @@ aaa
 aab
 bxN
 byV
-byW
-bzZ
+gSt
+pkV
 bBW
 aav
 aav
@@ -97952,7 +104240,7 @@ aab
 bBX
 bNC
 bOh
-cuS
+hmz
 bBX
 aab
 aab
@@ -97969,9 +104257,9 @@ bST
 bST
 aav
 bYB
-cAN
-cBq
-bAa
+nTx
+uxT
+noP
 bJf
 aab
 aab
@@ -98188,8 +104476,8 @@ aaa
 aaa
 bwP
 bxO
-byW
-bzZ
+gSt
+pkV
 bzV
 aab
 aav
@@ -98209,7 +104497,7 @@ bBX
 bBX
 bNC
 bOg
-cuT
+mRW
 bBX
 aab
 aab
@@ -98227,9 +104515,9 @@ bBX
 bBX
 bST
 bAc
-cAN
-cBq
-bAa
+nTx
+uxT
+noP
 bzX
 aab
 aaa
@@ -98444,7 +104732,7 @@ aaa
 aaa
 aaa
 bwP
-bxP
+oDk
 byX
 bzV
 aab
@@ -98466,7 +104754,7 @@ bBX
 bME
 bNC
 bOg
-cuS
+hmz
 bBX
 aab
 bBX
@@ -98485,7 +104773,7 @@ bUP
 bST
 aab
 bAc
-bxQ
+lIc
 byX
 cdz
 aab
@@ -98701,7 +104989,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byX
 bzW
 aav
@@ -98742,7 +105030,7 @@ bUP
 bST
 aab
 cbC
-bxP
+oDk
 byX
 cdz
 aab
@@ -98958,7 +105246,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byX
 bzX
 aab
@@ -98982,7 +105270,7 @@ bOx
 bOj
 cuW
 can
-bQL
+vzE
 bLJ
 bSf
 bZG
@@ -98999,7 +105287,7 @@ bUP
 bST
 aab
 cbC
-bxQ
+lIc
 byX
 cdz
 aab
@@ -99215,7 +105503,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byX
 bzX
 aab
@@ -99256,7 +105544,7 @@ bUP
 bST
 aab
 cbC
-bxQ
+lIc
 byX
 cdz
 aab
@@ -99472,7 +105760,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byX
 bzX
 aab
@@ -99495,10 +105783,10 @@ bNj
 bNq
 bOk
 bPD
-cDo
+hkh
 ccT
 bLJ
-bSh
+dDQ
 bSY
 bTU
 bUR
@@ -99513,7 +105801,7 @@ bUP
 bST
 aab
 cbC
-bxQ
+lIc
 byX
 cdz
 aab
@@ -99729,7 +106017,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byX
 bzX
 aab
@@ -99770,7 +106058,7 @@ bUP
 bST
 aab
 cbC
-bxP
+oDk
 byX
 cdz
 aab
@@ -100243,7 +106531,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byZ
 bzX
 aab
@@ -100266,7 +106554,7 @@ bNp
 bNt
 bQm
 bOj
-cDd
+lUz
 cDs
 bLJ
 bSi
@@ -100284,7 +106572,7 @@ bUP
 bST
 aab
 cbC
-cCU
+pGK
 byX
 cdz
 aab
@@ -100500,7 +106788,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byZ
 bzX
 aab
@@ -100523,10 +106811,10 @@ bNj
 bNu
 bOn
 bPG
-cDo
+hkh
 cvc
 bLJ
-bSh
+dDQ
 bTb
 bSV
 bUP
@@ -100541,7 +106829,7 @@ bUP
 bST
 aab
 cbC
-cCU
+pGK
 byX
 cdz
 aab
@@ -100757,7 +107045,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byZ
 bzX
 aab
@@ -100779,7 +107067,7 @@ bNX
 bNw
 bPc
 bOj
-cDd
+lUz
 cDq
 cvd
 bLJ
@@ -101014,7 +107302,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byZ
 bzX
 aab
@@ -101038,7 +107326,7 @@ bPs
 bOj
 cDe
 cBc
-bQL
+vzE
 bLJ
 bSl
 bTc
@@ -101055,7 +107343,7 @@ bSU
 bST
 bSc
 bzS
-cCU
+pGK
 byX
 cdz
 aab
@@ -101271,7 +107559,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+lIc
 byZ
 bzW
 aav
@@ -101310,8 +107598,8 @@ bUS
 bSV
 bZP
 bZO
-bLI
-bLI
+jRe
+jRe
 cCW
 byX
 cdz
@@ -101528,7 +107816,7 @@ aaa
 aaa
 aaa
 bwP
-bxP
+oDk
 byZ
 bzY
 aab
@@ -101550,7 +107838,7 @@ bBX
 bME
 bPv
 bOt
-cDh
+ptC
 bBX
 aab
 bBX
@@ -101787,7 +108075,7 @@ aaa
 bwP
 bxS
 bzb
-bAa
+noP
 bzY
 aab
 aav
@@ -101807,7 +108095,7 @@ bBX
 bBX
 bPv
 bOo
-cDg
+xCL
 bBX
 aab
 aab
@@ -101825,9 +108113,9 @@ bBX
 bBX
 bST
 caY
-bxQ
+lIc
 cCX
-bzZ
+pkV
 bzX
 aab
 aaa
@@ -102044,8 +108332,8 @@ aaa
 aab
 bxT
 bzT
-bAb
-bAa
+lWO
+noP
 bBY
 aav
 aav
@@ -102064,7 +108352,7 @@ aab
 bBX
 bPv
 bOp
-cDh
+ptC
 bBX
 aab
 aab
@@ -102081,9 +108369,9 @@ bST
 bST
 aav
 cap
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 cbE
 aab
 aab
@@ -102301,9 +108589,9 @@ aaa
 aab
 aaa
 bxT
-bAR
-bAb
-bAa
+uOG
+lWO
+noP
 bBY
 aab
 aab
@@ -102337,9 +108625,9 @@ aab
 aav
 aab
 bzS
-bzU
-bEK
-bKZ
+qty
+nik
+xfK
 cbE
 aaa
 aab
@@ -102559,9 +108847,9 @@ aab
 aaa
 aaa
 bAc
-bDJ
-bAb
-bAa
+nLA
+lWO
+noP
 bBY
 aav
 aav
@@ -102593,9 +108881,9 @@ aav
 aav
 aav
 bDC
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 cbE
 aaa
 aaa
@@ -102817,9 +109105,9 @@ aaa
 aaa
 aab
 bAc
-bDJ
-bAb
-bAa
+nLA
+lWO
+noP
 bzY
 aab
 aav
@@ -102835,7 +109123,7 @@ aab
 bBX
 bPv
 bOo
-cDh
+ptC
 bBX
 aab
 aab
@@ -102849,9 +109137,9 @@ aab
 aab
 aab
 bDC
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 caZ
 aac
 aac
@@ -103075,8 +109363,8 @@ aaa
 aab
 aab
 bAc
-bAR
-bAb
+uOG
+lWO
 bKH
 bzY
 aav
@@ -103092,7 +109380,7 @@ aab
 bBX
 bPv
 bOo
-cDg
+xCL
 bBX
 aab
 aab
@@ -103106,8 +109394,8 @@ aab
 aab
 bzS
 cnO
-bEK
-bKZ
+nik
+xfK
 bzV
 aaa
 aaa
@@ -103249,7 +109537,7 @@ cMv
 cOq
 abY
 ahd
-ahU
+ikD
 aiN
 aiN
 alm
@@ -103333,7 +109621,7 @@ aab
 aab
 aab
 bAc
-bDJ
+nLA
 bFX
 bKa
 bBY
@@ -103349,7 +109637,7 @@ bBX
 bBX
 bPv
 bOo
-cDh
+ptC
 bBX
 bBX
 bBX
@@ -103363,7 +109651,7 @@ aaa
 bzS
 cCT
 cBn
-bKZ
+xfK
 bzV
 aab
 aaa
@@ -103591,9 +109879,9 @@ aab
 aab
 aab
 bAc
-bDJ
-bAb
-bAa
+nLA
+lWO
+noP
 bzY
 aab
 aab
@@ -103617,9 +109905,9 @@ aaa
 aaa
 aaa
 bxN
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 bzV
 aab
 aab
@@ -103849,9 +110137,9 @@ aab
 aab
 aab
 bAc
-bAR
-bAb
-bAa
+uOG
+lWO
+noP
 bzY
 aab
 aaa
@@ -103873,9 +110161,9 @@ aaa
 aaa
 aaa
 bxN
-bzU
-bEK
-bKZ
+qty
+nik
+xfK
 bzV
 aab
 aab
@@ -104107,9 +110395,9 @@ aab
 aab
 aab
 bAc
-bDJ
-bAb
-bAa
+nLA
+lWO
+noP
 bzY
 aaa
 aac
@@ -104129,9 +110417,9 @@ aac
 aaa
 aaa
 bxN
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 bzV
 aab
 aab
@@ -104277,7 +110565,7 @@ aeG
 acw
 abY
 ahd
-ahU
+ikD
 aiN
 aiN
 alp
@@ -104365,9 +110653,9 @@ aab
 aab
 aab
 bAc
-bDJ
-bAb
-bAa
+nLA
+lWO
+noP
 bJf
 aac
 aaa
@@ -104385,9 +110673,9 @@ aab
 aac
 aaa
 bxN
-bAS
-bEK
-bKZ
+vqp
+nik
+xfK
 bzV
 aab
 aaa
@@ -104623,9 +110911,9 @@ aab
 aab
 aab
 bAc
-bAR
-bAb
-bAa
+uOG
+lWO
+noP
 bKd
 bIY
 chv
@@ -104641,9 +110929,9 @@ bBX
 bSc
 bTe
 bzS
-bzU
-bEK
-bKZ
+qty
+nik
+xfK
 bBW
 aav
 aac
@@ -104881,25 +111169,25 @@ aaa
 aaa
 aaa
 bxT
-bDJ
-bAb
-bLI
-bLI
+nLA
+lWO
+jRe
+jRe
 bMG
-bMQ
+ezq
 bNY
 bRT
 bPQ
 bXM
 cuV
-bMQ
+ezq
 cve
-bMQ
-bLI
-bLI
-bLI
-bEK
-bKZ
+ezq
+jRe
+jRe
+jRe
+nik
+xfK
 bzV
 aav
 aab
@@ -105139,23 +111427,23 @@ aaa
 aaa
 aaa
 bxT
-bDJ
-bLL
-bLL
+nLA
+tcs
+tcs
 bML
-bMR
-bMR
+noo
+noo
 bPH
 bQT
 bOw
 caX
-bMR
+noo
 cvf
-bLL
-bLL
-bLL
-bLL
-bKZ
+tcs
+tcs
+tcs
+tcs
+xfK
 bzV
 aab
 aav
@@ -105305,7 +111593,7 @@ aeG
 acw
 abY
 ahd
-ahU
+ikD
 aiN
 aiN
 als
@@ -106333,7 +112621,7 @@ acw
 aeJ
 abY
 ahd
-ahU
+ikD
 aiN
 aiN
 alv
@@ -110424,7 +116712,7 @@ aaN
 aab
 aaa
 aaa
-aaT
+cuL
 aaX
 abb
 agk
@@ -110716,7 +117004,7 @@ aqc
 aqc
 avE
 awv
-aBs
+ukc
 axl
 aaQ
 azx
@@ -110963,7 +117251,7 @@ aif
 aja
 akp
 anU
-aoQ
+wbJ
 apa
 arj
 atb
@@ -110973,7 +117261,7 @@ avO
 atW
 ayR
 aPu
-aBs
+ukc
 aCU
 aaV
 azy
@@ -111488,7 +117776,7 @@ aqd
 azd
 awy
 axS
-aoQ
+wbJ
 aaV
 azA
 aAO
@@ -111744,7 +118032,7 @@ avU
 aqd
 azd
 aww
-aBs
+ukc
 abt
 aaV
 azB
@@ -112001,7 +118289,7 @@ avL
 aqd
 azd
 aww
-aBs
+ukc
 aUi
 aaQ
 aaQ
@@ -112258,7 +118546,7 @@ abJ
 abJ
 azf
 aww
-aBs
+ukc
 abt
 any
 azC
@@ -112515,7 +118803,7 @@ arn
 bJo
 azd
 awz
-aBs
+ukc
 aCU
 any
 azD
@@ -112905,12 +119193,12 @@ cvC
 cvC
 cwK
 cqk
-cFB
+oav
 cqk
 cqk
 cqk
 cyK
-cGH
+ubz
 cqk
 cza
 cvG
@@ -113029,7 +119317,7 @@ aro
 abJ
 azd
 aww
-aBs
+ukc
 aFN
 any
 azF
@@ -113286,7 +119574,7 @@ asV
 abJ
 aCi
 awB
-aBs
+ukc
 axl
 any
 azG
@@ -113543,7 +119831,7 @@ atM
 abJ
 bdT
 aww
-aBs
+ukc
 axL
 axL
 axL
@@ -113800,7 +120088,7 @@ arr
 abJ
 azd
 aww
-aBZ
+tet
 axM
 aIJ
 azH
@@ -114057,7 +120345,7 @@ atN
 auP
 azh
 awC
-aBs
+ukc
 axN
 ayE
 azI
@@ -114089,7 +120377,7 @@ aVS
 aWR
 aYS
 aYT
-bad
+cYW
 bbq
 bcu
 bcu
@@ -114314,7 +120602,7 @@ arr
 abJ
 azd
 awz
-aBs
+ukc
 axO
 ayF
 azJ
@@ -114571,7 +120859,7 @@ atO
 abJ
 azi
 awz
-aBs
+ukc
 axL
 ayG
 ayN
@@ -115085,7 +121373,7 @@ apY
 abJ
 azd
 awz
-aBs
+ukc
 axL
 ayI
 azK
@@ -115342,7 +121630,7 @@ abJ
 abJ
 azd
 awz
-aBs
+ukc
 axP
 ayJ
 azL
@@ -115465,7 +121753,7 @@ clH
 clH
 cdL
 cpn
-crM
+tPy
 cqk
 cqk
 cth
@@ -115722,7 +122010,7 @@ cmB
 cnr
 cBo
 cpo
-crM
+tPy
 cqk
 cqk
 cti
@@ -115854,9 +122142,9 @@ arx
 akt
 atS
 auQ
-azk
+ptj
 awz
-aBZ
+tet
 axL
 ayL
 azM
@@ -115942,7 +122230,7 @@ bMp
 bNa
 cLB
 bOS
-cLK
+fTH
 boU
 bQY
 bRG
@@ -115979,7 +122267,7 @@ cVi
 cdd
 cdN
 cpp
-crM
+tPy
 cqk
 cqk
 cth
@@ -116113,7 +122401,7 @@ atT
 auR
 azQ
 awE
-aBs
+ukc
 axQ
 ayM
 azN
@@ -116145,7 +122433,7 @@ aVY
 aTF
 aTF
 aSt
-bad
+cYW
 cGw
 cGy
 cGA
@@ -116241,7 +122529,7 @@ cqk
 csh
 ctj
 cub
-cwZ
+pfL
 cvF
 cqg
 cqg
@@ -116370,7 +122658,7 @@ atS
 auS
 azS
 awz
-aBs
+ukc
 axN
 ayN
 azO
@@ -116456,7 +122744,7 @@ bMq
 boU
 cLD
 bOU
-cLK
+fTH
 boU
 bRa
 bRI
@@ -116474,31 +122762,31 @@ cKF
 cKH
 boU
 cCz
-bNU
-bNU
-cCr
-bZn
-bZn
-bZn
-bZn
-bZn
+liN
+liN
+fdP
+vIo
+vIo
+vIo
+vIo
+vIo
 bkT
 bQg
-bZn
-bZn
-bZn
-bZn
+vIo
+vIo
+vIo
+vIo
 cCK
-bZn
+vIo
 cHc
-bZn
-cCr
+vIo
+fdP
 cEM
 cHw
 cER
 cth
 cub
-cxa
+mEI
 cvH
 cwj
 cqg
@@ -116627,7 +122915,7 @@ avA
 auQ
 azZ
 awF
-aBs
+ukc
 axR
 aTE
 azO
@@ -116660,7 +122948,7 @@ aTH
 aTH
 boB
 bam
-bvr
+eom
 bcs
 bdz
 beK
@@ -116713,7 +123001,7 @@ bMr
 boU
 cLE
 bOU
-cLK
+fTH
 boU
 bRb
 bRJ
@@ -116732,23 +123020,23 @@ cKE
 boU
 cCA
 cML
-cfS
-cHu
-cRJ
-cRL
-cRJ
-cRL
+wLn
+tkM
+eFK
+jaf
+eFK
+jaf
 cRP
-cRL
+jaf
 cRR
-cRL
+jaf
 cRT
-cRL
-cRJ
+jaf
+eFK
 cRV
 cRX
 cRY
-cRJ
+eFK
 cRZ
 cSa
 cHx
@@ -116884,7 +123172,7 @@ afU
 afU
 aAo
 awG
-aBs
+ukc
 axL
 axL
 azP
@@ -116988,25 +123276,25 @@ cKt
 cKI
 boU
 cBI
-cMP
-cCg
-cCs
-cfj
-cfO
-cfj
-cfj
+uHw
+ddU
+hdo
+udJ
+kYi
+udJ
+udJ
 crf
-cfj
+udJ
 cjw
-cfj
+udJ
 cnv
-cfj
-cfO
+udJ
+kYi
 cSN
 cHb
-cfj
-cfj
-cCs
+udJ
+udJ
+hdo
 cEO
 cHy
 cET
@@ -117139,15 +123427,15 @@ avo
 atf
 awJ
 auT
-azk
+ptj
 awH
 aCb
-aDq
+luj
 aDz
 aFW
 aHr
-aDq
-aDq
+luj
+luj
 aJQ
 aKK
 aNn
@@ -117174,7 +123462,7 @@ aTJ
 aTJ
 brk
 bao
-bvr
+eom
 bcs
 bdB
 beK
@@ -117227,7 +123515,7 @@ bJs
 boU
 cJk
 bOU
-cLK
+fTH
 boU
 bRd
 bRJ
@@ -117246,7 +123534,7 @@ cKJ
 boU
 cWR
 cMQ
-cCh
+okh
 boU
 cqg
 cqg
@@ -117407,7 +123695,7 @@ aBU
 axn
 aEs
 aEn
-aBs
+ukc
 aPf
 aaQ
 cMl
@@ -117502,8 +123790,8 @@ cKt
 cKK
 boU
 cgm
-cMP
-cCh
+uHw
+okh
 boU
 cPF
 chI
@@ -117526,7 +123814,7 @@ cqk
 cqk
 ctn
 cuf
-cwZ
+pfL
 cvG
 aab
 aab
@@ -117688,7 +123976,7 @@ aTL
 aTJ
 brk
 bam
-bvr
+eom
 bct
 bdD
 beK
@@ -117741,7 +124029,7 @@ cVB
 boU
 cLG
 bOU
-cLO
+sOO
 boU
 bRf
 bSo
@@ -117760,7 +124048,7 @@ cKL
 boU
 cCC
 cQV
-cCh
+okh
 boU
 bYa
 ced
@@ -117783,7 +124071,7 @@ baC
 ctd
 cto
 cuf
-cwZ
+pfL
 cvG
 cvG
 cvG
@@ -117945,7 +124233,7 @@ aTL
 aTJ
 brk
 bam
-bJH
+thd
 bcl
 bcl
 bcl
@@ -117998,7 +124286,7 @@ bJs
 boU
 cLH
 bOU
-cLO
+sOO
 boU
 bRg
 bRK
@@ -118038,9 +124326,9 @@ cla
 cqq
 cqg
 cqg
-ctM
+jsA
 cuf
-cwZ
+pfL
 cvJ
 cwl
 cwO
@@ -118202,7 +124490,7 @@ aTL
 aTJ
 brl
 bbi
-bxn
+ivv
 bcl
 bdp
 bhl
@@ -118255,7 +124543,7 @@ bJs
 boU
 cLI
 bOV
-cLO
+sOO
 boU
 bDb
 boU
@@ -118297,7 +124585,7 @@ crm
 cqg
 cXa
 cuf
-cwZ
+pfL
 cvG
 cvG
 cvG
@@ -118441,9 +124729,9 @@ aGH
 aCL
 cXq
 aJF
-aFH
-aKH
-aYW
+wzk
+rqB
+dlH
 apg
 aab
 aab
@@ -118459,7 +124747,7 @@ aTK
 aTJ
 brr
 bam
-bvr
+eom
 bcl
 bdq
 beC
@@ -118512,26 +124800,26 @@ bJs
 boU
 cWN
 bOU
-cCf
-cCr
-bNU
+rmF
+fdP
+liN
 bSp
 bTl
 bUk
 bZm
 cCx
-bNU
-bNU
-btX
-bNU
-bNU
+liN
+liN
+lnz
+liN
+liN
 cMK
-cfP
-bNU
-cCr
+mgC
+liN
+fdP
 cHr
-cMP
-cCi
+uHw
+fkT
 boU
 cdB
 cRW
@@ -118554,7 +124842,7 @@ bYa
 cqg
 ctW
 cuf
-cwZ
+pfL
 cvG
 aab
 aab
@@ -118698,9 +124986,9 @@ aGI
 aBX
 cXq
 aJF
-aFH
-aKH
-aYW
+wzk
+rqB
+dlH
 bym
 aab
 aab
@@ -118716,7 +125004,7 @@ aSt
 aSt
 bdC
 bbj
-bxo
+xdI
 beN
 bdr
 bij
@@ -118769,24 +125057,24 @@ bLS
 boU
 cBK
 cCm
-cbI
+uFq
 cfi
-cbI
-cfS
+uFq
+wLn
 cju
 czN
 cCL
-cfS
-cbI
-cfS
+wLn
+uFq
+wLn
 cEL
-cfS
-cbI
+wLn
+uFq
 cEN
-cbI
+uFq
 cHd
-cHu
-cfS
+tkM
+wLn
 cRI
 cCE
 boU
@@ -118809,9 +125097,9 @@ cla
 cqt
 crn
 cqg
-ctM
+jsA
 cuf
-cwZ
+pfL
 cvF
 cqg
 cwN
@@ -118955,7 +125243,7 @@ aPi
 aHt
 aHV
 aJF
-aFH
+wzk
 bwV
 aYX
 bBZ
@@ -119027,22 +125315,22 @@ boU
 cBI
 bOX
 cCa
-cCs
-cBy
-cBy
+hdo
+tFB
+tFB
 bWZ
-cBy
-cBy
-cBy
-cBy
-cBy
-cBy
-cBG
+tFB
+tFB
+tFB
+tFB
+tFB
+tFB
+vhY
 cUG
-cBy
+tFB
 cFf
-bKW
-cCs
+opU
+hdo
 cBR
 bOX
 cHv
@@ -119068,7 +125356,7 @@ cUl
 cqg
 cXb
 cuf
-cxa
+mEI
 cvH
 cwm
 cvH
@@ -119196,8 +125484,8 @@ ati
 auG
 auY
 aBc
-aBp
-aBp
+fQS
+fQS
 aDu
 ayS
 azY
@@ -119212,9 +125500,9 @@ aGK
 aBX
 aIb
 aJF
-aFH
-aKH
-aYW
+wzk
+rqB
+dlH
 cye
 aab
 aab
@@ -119283,7 +125571,7 @@ cRh
 boU
 cBI
 bOX
-cqm
+qKy
 bQz
 bQz
 bQz
@@ -119323,13 +125611,13 @@ ceG
 cqt
 cRy
 cqg
-ctM
+jsA
 cug
 cyh
 cvK
 cvK
 cue
-cFB
+oav
 cqk
 cqk
 cqk
@@ -119471,7 +125759,7 @@ aIc
 aJG
 aKx
 aKI
-aYY
+wjk
 apg
 aab
 aab
@@ -119540,16 +125828,16 @@ cTt
 boU
 cBN
 bOX
-cCi
+fkT
 bQz
 cUy
 bRh
 cFn
-cIr
+qsh
 cKA
-cIr
-cIr
-cIr
+qsh
+qsh
+qsh
 cLb
 cLL
 bQz
@@ -119559,7 +125847,7 @@ bZQ
 car
 cFF
 cFO
-cFY
+dUE
 bYJ
 cdB
 bYa
@@ -119590,11 +125878,11 @@ cxm
 cvK
 cvK
 cvK
-cGH
+ubz
 cqk
 cza
 czi
-czu
+cwl
 czw
 aab
 aab
@@ -119706,28 +125994,28 @@ anR
 arG
 auk
 bXs
-avM
-avM
+nqv
+nqv
 axC
-aBe
-aBq
-aBq
+lHi
+jUM
+jUM
 aDv
 aEk
 aGJ
 aHA
 aXd
-avM
-avM
-avM
-avM
+nqv
+nqv
+nqv
+nqv
 aPg
 aPj
-aBe
-aBq
-aBq
+lHi
+jUM
+jUM
 aKy
-aKH
+rqB
 cNB
 apg
 aab
@@ -119744,7 +126032,7 @@ aXa
 aWY
 btl
 bam
-bvr
+eom
 bcw
 bdK
 beT
@@ -119753,8 +126041,8 @@ bgk
 bcw
 cIA
 cNM
-cIE
-cIE
+iHh
+iHh
 cIG
 bjC
 bmj
@@ -119797,7 +126085,7 @@ cRh
 boU
 cBI
 bOX
-cCh
+okh
 bQA
 cmx
 bRh
@@ -119808,7 +126096,7 @@ cWp
 cJx
 cJx
 cJx
-cLZ
+lpO
 bQz
 cWQ
 bZg
@@ -119816,7 +126104,7 @@ bZg
 bZg
 cJI
 cNb
-cFY
+dUE
 bYJ
 cdB
 bYa
@@ -119985,7 +126273,7 @@ aCM
 aJH
 aJM
 aPW
-aYW
+dlH
 apg
 aab
 aab
@@ -120001,7 +126289,7 @@ aXb
 aWY
 brk
 bpH
-bxo
+xdI
 bcx
 bdL
 beU
@@ -120012,7 +126300,7 @@ cIB
 bjz
 bkk
 bkL
-cIH
+fay
 biQ
 bmk
 bne
@@ -120028,17 +126316,17 @@ box
 cPo
 bsN
 bte
-btT
-btT
-bwi
+vnA
+vnA
+hNR
 bwR
 byh
 bAi
-bAy
+qNB
 bWT
-bAy
+qNB
 bDa
-bwi
+hNR
 bsN
 aaA
 aaA
@@ -120054,7 +126342,7 @@ cPB
 boU
 cBI
 bOX
-cCh
+okh
 bQA
 cUz
 bRh
@@ -120222,27 +126510,27 @@ aWv
 avG
 aYm
 axi
-axE
-aBm
+rJH
+tSS
 aJX
-aBm
-aBm
-aBm
-aPN
+tSS
+tSS
+tSS
+vTn
 aDQ
 aDF
 bku
-axE
-aPN
-aBm
-aBm
-aBm
-aBm
-aBm
-aBm
+rJH
+vTn
+tSS
+tSS
+tSS
+tSS
+tSS
+tSS
 aLw
-aOn
-aYW
+hBT
+dlH
 apg
 aab
 aab
@@ -120258,7 +126546,7 @@ aXc
 aYf
 btE
 cGt
-bvr
+eom
 bcw
 bdM
 beV
@@ -120269,7 +126557,7 @@ cIC
 bjA
 bkl
 bkM
-cIH
+fay
 blP
 bml
 bnf
@@ -120295,7 +126583,7 @@ bAz
 bBx
 bCr
 bFS
-bwr
+uai
 bsN
 aaA
 aaA
@@ -120311,7 +126599,7 @@ bFI
 boU
 cIy
 bOX
-cCh
+okh
 bQA
 cmx
 bRh
@@ -120498,8 +126786,8 @@ apk
 aHX
 apk
 bPB
-aOn
-aYW
+hBT
+dlH
 apg
 aab
 aab
@@ -120526,7 +126814,7 @@ cIB
 bjB
 bkm
 bkN
-cIH
+fay
 biQ
 bmm
 bre
@@ -120568,7 +126856,7 @@ boU
 cFZ
 cBI
 bOX
-cCh
+okh
 bQA
 bRh
 bRh
@@ -120579,7 +126867,7 @@ cJx
 cJx
 cJx
 cWs
-cLZ
+lpO
 bQz
 bZj
 cJB
@@ -120755,8 +127043,8 @@ aEv
 aHY
 aFl
 aJD
-aOn
-aYW
+hBT
+dlH
 apg
 aab
 aab
@@ -120772,7 +127060,7 @@ aWY
 aWY
 brk
 bam
-bJH
+thd
 bcw
 bdO
 biG
@@ -120780,9 +127068,9 @@ bfa
 bhs
 bcw
 cID
-cIF
-cIF
-cIF
+vyR
+vyR
+vyR
 cII
 bjC
 bmn
@@ -120805,13 +127093,13 @@ bwT
 bwR
 byk
 bAp
-btT
+vnA
 bBz
 bFc
 bwR
 bDP
 bEX
-btT
+vnA
 bGr
 bsN
 bsN
@@ -120836,7 +127124,7 @@ cJx
 cWq
 cJx
 cJx
-cLZ
+lpO
 bQz
 cjU
 cJA
@@ -121012,8 +127300,8 @@ aHu
 aHY
 aFl
 aJD
-aOn
-aYW
+hBT
+dlH
 apg
 aab
 aab
@@ -121029,7 +127317,7 @@ aWY
 aWY
 buq
 bam
-bvr
+eom
 bcw
 bdQ
 cJK
@@ -121082,21 +127370,21 @@ boU
 cGb
 cBI
 bOX
-cCh
+okh
 bQz
 cUB
 bRh
 cFG
-cJS
-cJS
-cJS
+xUe
+xUe
+xUe
 cWr
-cJS
-cJS
+xUe
+xUe
 cMy
 cFI
-cfq
-cfq
+pru
+pru
 cJC
 cJG
 cFK
@@ -121269,8 +127557,8 @@ aHv
 aHY
 aFl
 aJD
-aOn
-aYW
+hBT
+dlH
 apg
 aab
 aab
@@ -121286,7 +127574,7 @@ cEU
 aWY
 buu
 ban
-bvr
+eom
 bcw
 bht
 beY
@@ -121339,7 +127627,7 @@ bMs
 boU
 cIz
 bOX
-cCh
+okh
 bQA
 cUC
 bRh
@@ -121526,8 +127814,8 @@ aGO
 aGO
 aGO
 aKv
-aOn
-aYY
+hBT
+wjk
 apg
 aab
 aab
@@ -121543,7 +127831,7 @@ aOW
 aSt
 brk
 bam
-bvr
+eom
 bcw
 bdR
 bfa
@@ -121596,26 +127884,26 @@ cVD
 boU
 cgm
 bOX
-cCh
+okh
 bQA
 cUC
 bRh
 bXb
 bSw
 bVM
-bRW
-cbk
-cbk
+dFk
+kGW
+kGW
 chS
 ccm
 cFI
 cfs
-cFA
+dji
 cnQ
-cFA
+dji
 cFM
 cFV
-cLW
+kWh
 bYJ
 cVK
 chI
@@ -121784,7 +128072,7 @@ aHZ
 aIR
 aLt
 aPc
-aYW
+dlH
 apg
 aOl
 aPa
@@ -121800,7 +128088,7 @@ aPV
 aSt
 brl
 bbi
-bxn
+ivv
 bcw
 bdS
 bfb
@@ -121835,7 +128123,7 @@ byo
 cUo
 cUp
 cUq
-bwr
+uai
 bsN
 bEa
 bEY
@@ -121853,7 +128141,7 @@ bFI
 boU
 cBI
 bOX
-cCh
+okh
 bQA
 cUC
 bRh
@@ -121872,7 +128160,7 @@ cEV
 cEV
 cEV
 cFW
-cLW
+kWh
 bYJ
 cdB
 chI
@@ -122042,34 +128330,34 @@ aIS
 aTf
 aTY
 aKJ
-aZa
-aZa
+kbw
+kbw
 aZd
-aZv
+eAO
 aQm
 bvQ
-boX
-aZv
-aZv
+djk
+eAO
+eAO
 bEb
-aZv
+eAO
 biP
-aZv
+eAO
 brX
 bbm
 bvB
 bNH
-bvS
-bvS
-bwg
-aZv
-aZv
+uxM
+uxM
+rPi
+eAO
+eAO
 cQx
-bvS
-bvS
-bwg
-boX
-aZv
+uxM
+uxM
+rPi
+djk
+eAO
 bqS
 bMu
 bNJ
@@ -122110,7 +128398,7 @@ bKj
 bNb
 cBO
 bOZ
-cCh
+okh
 bQz
 cUC
 bRN
@@ -122124,10 +128412,10 @@ cbP
 cMz
 cFI
 cEW
-cGi
+oAP
 cQH
 cSp
-cGi
+oAP
 cQH
 cMm
 bYJ
@@ -122298,9 +128586,9 @@ aIQ
 aIR
 aJD
 aXg
-aXi
-aXi
-aXi
+tqJ
+tqJ
+tqJ
 aZT
 aZU
 bkc
@@ -122329,7 +128617,7 @@ blq
 aQO
 bmr
 bAr
-bNK
+msK
 bTr
 aRZ
 cRb
@@ -122367,7 +128655,7 @@ bIt
 boU
 cBI
 bOX
-cCi
+fkT
 bQB
 bQB
 bQB
@@ -122383,10 +128671,10 @@ bQB
 cIv
 cJI
 cQH
-cFY
+dUE
 cJI
 cQH
-cLW
+kWh
 bYJ
 cVL
 bYN
@@ -122562,31 +128850,31 @@ brh
 aZY
 aRY
 bkA
-bpf
+owe
 aVO
 biO
-bpF
-bpF
-bpF
-bpF
+ofK
+ofK
+ofK
+ofK
 bsp
 blr
-bpF
-bpF
-bpF
-bpF
+ofK
+ofK
+ofK
+ofK
 bmv
 cQE
-bpF
-bpF
-bpF
-bpF
+ofK
+ofK
+ofK
+ofK
 bSv
-bpf
-bpF
+owe
+ofK
 bDV
 bnn
-bNK
+msK
 bON
 aRZ
 boR
@@ -122624,7 +128912,7 @@ bFI
 boU
 cBI
 bOX
-cCh
+okh
 bQB
 bRl
 bWv
@@ -122818,7 +129106,7 @@ axa
 axa
 bap
 aPY
-blg
+gWO
 aRH
 aRH
 aRH
@@ -122843,7 +129131,7 @@ bgp
 bgp
 bRS
 aPY
-bNK
+msK
 aOz
 aRZ
 boR
@@ -122881,7 +129169,7 @@ bFI
 boU
 cWO
 bOX
-cCh
+okh
 bQB
 coD
 bRP
@@ -123043,12 +129331,12 @@ adx
 adx
 ama
 aNh
-aqx
+qHo
 asO
 aFn
-aqx
-aqx
-aqx
+qHo
+qHo
+qHo
 axI
 awa
 awS
@@ -123056,16 +129344,16 @@ axw
 aye
 aIw
 aWt
-aHC
+jGT
 aMq
-auu
-auu
-axq
-auu
+uBU
+uBU
+wVY
+uBU
 aZj
-aHC
-aHC
-aHC
+jGT
+jGT
+jGT
 aQX
 aqG
 aKL
@@ -123075,7 +129363,7 @@ aMn
 axa
 bap
 aPY
-bwS
+fWa
 aRH
 bBv
 cck
@@ -123100,7 +129388,7 @@ bPX
 bgp
 cJa
 aPY
-bNK
+msK
 aOy
 aRZ
 boR
@@ -123138,10 +129426,10 @@ bFH
 boU
 cBM
 bPa
-cCh
+okh
 bQB
 bRn
-bWx
+ijc
 bQB
 bUw
 bWW
@@ -123323,7 +129611,7 @@ aBl
 aGT
 aBl
 aWQ
-aHE
+iBq
 aqG
 aKM
 aKO
@@ -123332,7 +129620,7 @@ aKO
 axa
 cHZ
 aPY
-bms
+oFv
 aRI
 aSF
 aTT
@@ -123357,7 +129645,7 @@ bgr
 bii
 bgn
 aPY
-bnl
+iWy
 aRZ
 aRZ
 bpt
@@ -123395,7 +129683,7 @@ aaA
 boU
 cBK
 bOX
-cCh
+okh
 bQB
 bQB
 bQB
@@ -123558,10 +129846,10 @@ afi
 abA
 aWS
 aob
-asQ
-asQ
-asQ
-asQ
+wpK
+wpK
+wpK
+wpK
 axj
 axK
 awc
@@ -123573,14 +129861,14 @@ aAe
 aHD
 aEi
 bpE
-auO
-auO
-auO
+jEx
+jEx
+jEx
 bZZ
-auO
-aFM
+jEx
+hKk
 aIe
-aHG
+xWn
 aJT
 aKN
 aKN
@@ -123589,7 +129877,7 @@ cND
 axa
 bap
 aPY
-bms
+oFv
 aRJ
 aSG
 aSG
@@ -123614,7 +129902,7 @@ bko
 blT
 bDW
 bno
-bnl
+iWy
 aRZ
 cAs
 bpr
@@ -123652,7 +129940,7 @@ aaA
 boU
 cBI
 bOX
-cqm
+qKy
 bQB
 cph
 cCe
@@ -123837,7 +130125,7 @@ aqG
 aqG
 aPp
 aIe
-aIT
+jaF
 aqG
 aKO
 aLy
@@ -123871,7 +130159,7 @@ bls
 blU
 bFm
 bnp
-cGD
+fXC
 aRZ
 boR
 bpr
@@ -123909,7 +130197,7 @@ aaA
 boU
 cBL
 bOX
-cCh
+okh
 bQB
 cpR
 cEZ
@@ -124084,7 +130372,7 @@ axz
 aqG
 aEu
 aAe
-aHE
+iBq
 aqG
 aCV
 aDI
@@ -124128,7 +130416,7 @@ blt
 blV
 bFJ
 bnq
-bSF
+paG
 aRZ
 boR
 bps
@@ -124166,7 +130454,7 @@ aaA
 boU
 cBI
 bOX
-cCh
+okh
 bQB
 cpX
 cFc
@@ -124337,11 +130625,11 @@ aul
 aul
 aul
 awW
-axA
+fKN
 aqG
 cDE
 aAe
-aHG
+xWn
 aCl
 aqJ
 aDJ
@@ -124354,13 +130642,13 @@ aIf
 aKX
 aqG
 aNv
-cIo
-cIo
-cIo
+wxw
+wxw
+wxw
 axa
 btt
 aPY
-bms
+oFv
 aRI
 aSG
 aTW
@@ -124385,7 +130673,7 @@ bjH
 bii
 bgn
 aPY
-bnl
+iWy
 aRZ
 boU
 boU
@@ -124423,7 +130711,7 @@ boU
 boU
 cBP
 bPb
-cCk
+rqZ
 bQB
 bQB
 bQB
@@ -124436,14 +130724,14 @@ bQB
 bQB
 bQB
 cGm
-bRr
+svn
 bXu
 cQH
 cco
 cor
 cQH
 bXu
-bRr
+svn
 cSq
 bQz
 cdB
@@ -124608,7 +130896,7 @@ aGb
 aGV
 aPr
 aIg
-aMy
+ouq
 aJU
 aQY
 aXQ
@@ -124642,45 +130930,45 @@ bqt
 bgp
 bnu
 bAs
-bNL
-boX
-bNU
+ncr
+djk
+liN
 bTt
-bNU
-bNU
+liN
+liN
 cec
-cfP
+mgC
 cPl
-bNU
-bNU
-bNU
-bNU
+liN
+liN
+liN
+liN
 bVI
-bUN
+gin
 cBm
-cCb
+hdg
 cEv
 bNv
 bBr
 byf
-cCb
-bUN
-bUN
-bUN
-bNU
+hdg
+gin
+gin
+gin
+liN
 bZR
-cfP
-bNU
+mgC
+liN
 cjv
-bNU
-btX
+liN
+lnz
 cBF
-bNU
-bNU
-bNU
+liN
+liN
+liN
 cBQ
 bOX
-cCh
+okh
 bQB
 bRl
 bWN
@@ -124851,11 +131139,11 @@ aum
 ayn
 awe
 awW
-axA
+fKN
 aqG
 aFf
 aAg
-aHE
+iBq
 aqG
 aCX
 aDL
@@ -124874,7 +131162,7 @@ aZN
 axa
 bbt
 aPY
-bmq
+som
 aRH
 aSK
 aTX
@@ -124901,20 +131189,20 @@ bgn
 bqv
 bqx
 bqz
-brz
+ddM
 bsB
-brz
-bPk
-brz
-bPk
+ddM
+pCz
+ddM
+pCz
 cPm
-bPk
-brz
+pCz
+ddM
 cAB
-brz
-bPk
-brz
-bPk
+ddM
+pCz
+ddM
+pCz
 bQQ
 cAm
 cuX
@@ -125122,7 +131410,7 @@ aCV
 aqG
 aQn
 aIh
-aIT
+jaF
 aqG
 aXP
 aXQ
@@ -125131,7 +131419,7 @@ aYP
 axa
 cCB
 aPY
-bmq
+som
 aRM
 aSL
 aZV
@@ -125157,47 +131445,47 @@ bii
 cGC
 bns
 bNM
-bpf
-bNV
-bNV
-bSu
-bNV
-bNV
+owe
+dMR
+dMR
+qld
+dMR
+dMR
 bUo
 clK
-bNV
-bSu
+dMR
+qld
 bAQ
-bNV
-bXh
+dMR
+uaM
 cSG
-bXh
-cCc
+uaM
+eXE
 cEw
 byf
 bBC
 cGd
-cCc
-bXh
-bXh
+eXE
+uaM
+uaM
 cIR
-bKW
-cBy
-cBy
-cBy
+opU
+tFB
+tFB
+tFB
 cBB
-cBy
-cBy
-cBG
+tFB
+tFB
+vhY
 clB
 cBH
-cBy
+tFB
 bVV
 bOY
 bVk
 bQB
 bRn
-bWx
+ijc
 bQB
 bSw
 bXX
@@ -125208,12 +131496,12 @@ bWV
 bQB
 cWP
 bSw
-cNa
+jsb
 cbS
 ckT
 cTK
 cMx
-cSy
+fmE
 bSw
 cSu
 bQz
@@ -125379,7 +131667,7 @@ aqG
 aqG
 cDV
 aIe
-aKP
+xsy
 aqG
 aqG
 aLA
@@ -125388,7 +131676,7 @@ aLA
 axa
 bap
 aPY
-bmq
+som
 aRN
 aSM
 aTZ
@@ -125413,7 +131701,7 @@ blx
 bii
 bgn
 bns
-bnl
+iWy
 aRZ
 boU
 boU
@@ -125451,7 +131739,7 @@ boU
 boU
 cTW
 bOX
-cCh
+okh
 bQB
 bQB
 bQB
@@ -125465,12 +131753,12 @@ bQB
 bQB
 bTw
 bSw
-cNa
+jsb
 cSn
 cSn
 cSn
 cSn
-cSy
+fmE
 bSw
 cSE
 bQz
@@ -125626,7 +131914,7 @@ axB
 ayh
 aFi
 aAj
-aKP
+xsy
 aCn
 aCY
 aDM
@@ -125636,7 +131924,7 @@ aGc
 aGW
 aEq
 aIe
-aMy
+ouq
 aJV
 aKR
 aKR
@@ -125645,7 +131933,7 @@ aNo
 axa
 bap
 aPY
-bmq
+som
 aRN
 aSN
 aUa
@@ -125670,7 +131958,7 @@ blv
 bii
 bgn
 bns
-bnl
+iWy
 aRZ
 czI
 bpw
@@ -125688,11 +131976,11 @@ bws
 bxt
 bzf
 bsV
-bAE
+pCJ
 bBE
 bCU
-bDg
-bDg
+hNU
+hNU
 bEZ
 bFK
 bHC
@@ -125708,32 +131996,32 @@ bMv
 boU
 cBS
 bOX
-cCf
+rmF
 bQC
-bRr
-bSC
+svn
+rVW
 bZT
 bSw
 bWQ
-cav
-bRr
-bSC
+uQc
+svn
+rVW
 cbQ
 bZU
 ccV
 cGh
 cPH
-cSo
+hba
 cSr
-cSo
-cSo
+hba
+hba
 cSz
 cGh
 cSF
 cUb
 cSK
 cUc
-bRr
+svn
 chT
 czC
 bSw
@@ -125893,7 +132181,7 @@ aGd
 aGX
 cDE
 aIe
-aIT
+jaF
 aqG
 aKS
 aLB
@@ -125902,7 +132190,7 @@ aKR
 axa
 bap
 aPY
-bRM
+gKr
 aRN
 aSO
 aUb
@@ -125927,7 +132215,7 @@ bkX
 bii
 bGO
 bnt
-bnl
+iWy
 aRZ
 boZ
 cAg
@@ -125945,7 +132233,7 @@ btG
 btG
 bzg
 bzq
-bAE
+pCJ
 bBw
 bCm
 bCm
@@ -125994,9 +132282,9 @@ bSw
 csZ
 czC
 bSw
-cav
-bRr
-bRr
+uQc
+svn
+svn
 cmb
 cmW
 brT
@@ -126140,7 +132428,7 @@ aqG
 aqG
 cXc
 aAl
-aIT
+jaF
 aqG
 aDa
 aEJ
@@ -126150,7 +132438,7 @@ aGe
 aGY
 cDF
 aIi
-aHE
+iBq
 aqG
 aqG
 aqG
@@ -126159,7 +132447,7 @@ aqG
 axa
 bap
 aPY
-blg
+gWO
 aRN
 aSP
 aUc
@@ -126184,7 +132472,7 @@ blx
 bii
 bgn
 bns
-bSF
+paG
 aRZ
 boZ
 cOS
@@ -126204,8 +132492,8 @@ bzh
 bzr
 bAF
 bBF
-bCV
-bCV
+pae
+pae
 bGu
 bFN
 bFK
@@ -126224,7 +132512,7 @@ cBT
 bPe
 bYs
 bQC
-bRW
+dFk
 bSD
 bUq
 bVc
@@ -126407,7 +132695,7 @@ aGf
 aqG
 aPp
 aIj
-aRa
+kWL
 aJW
 bRj
 aLC
@@ -126441,7 +132729,7 @@ blv
 bii
 bgn
 bns
-cGD
+fXC
 aRZ
 boZ
 bDx
@@ -126459,7 +132747,7 @@ bwk
 btG
 bzl
 bsV
-bAE
+pCJ
 bBH
 bCo
 bDm
@@ -126486,30 +132774,30 @@ bSw
 bYo
 bVc
 bYO
-cbh
-cbh
-cbh
-cbh
-cbh
+ijS
+ijS
+ijS
+ijS
+ijS
 cFg
 ccv
 cEY
 bZS
 cTP
 cSt
-cbh
+ijS
 cGk
-cbh
+ijS
 cGl
-cbh
+ijS
 bUy
 cay
 cft
-ccn
+uDO
 cGp
-ccn
-ccn
-ccn
+uDO
+uDO
+uDO
 cyF
 cmb
 cmX
@@ -126654,7 +132942,7 @@ aqG
 aqG
 aFh
 aAl
-aIT
+jaF
 aqG
 aqG
 aDH
@@ -126681,11 +132969,11 @@ aRO
 cJN
 aSY
 aWq
-aVs
+inV
 aYw
 cMT
 cAV
-aVs
+inV
 bcK
 bgp
 bhM
@@ -126698,7 +132986,7 @@ bly
 bii
 bgn
 bns
-bnl
+iWy
 aRZ
 boZ
 bDx
@@ -126716,7 +133004,7 @@ bwl
 bxa
 bzp
 bsQ
-bAE
+pCJ
 bBH
 bCW
 bDo
@@ -126736,7 +133024,7 @@ bCD
 boU
 cBS
 bOU
-cCg
+ddU
 bQC
 bSx
 bSE
@@ -126761,7 +133049,7 @@ bWB
 bWB
 bTw
 bVc
-cfu
+meZ
 cNW
 bRh
 bRh
@@ -126901,23 +133189,23 @@ apj
 aoC
 asS
 aNf
-avH
-auu
-auu
-axq
-auu
-auu
+rvc
+uBU
+uBU
+wVY
+uBU
+uBU
 aCk
-avH
+rvc
 aFk
 aAl
 aIU
 aYZ
-auu
-auu
-auu
-auu
-auu
+uBU
+uBU
+uBU
+uBU
+uBU
 cLx
 aQQ
 aIl
@@ -126925,7 +133213,7 @@ aKu
 aqJ
 aBk
 aLE
-aMw
+tsg
 aNq
 aOr
 bap
@@ -126955,7 +133243,7 @@ blx
 bii
 bgn
 bns
-bnl
+iWy
 aRZ
 czK
 bpx
@@ -126993,7 +133281,7 @@ bCD
 boU
 cBS
 bOU
-cCh
+okh
 boU
 bQB
 bQB
@@ -127018,7 +133306,7 @@ cdE
 bWB
 bTw
 bVc
-cfu
+meZ
 bQz
 cmT
 bQz
@@ -127143,7 +133431,7 @@ aab
 aab
 aab
 acS
-adm
+qbf
 adF
 ael
 afk
@@ -127178,7 +133466,7 @@ ayi
 cLy
 cdt
 cEt
-aRa
+kWL
 aqJ
 cDx
 aqG
@@ -127230,14 +133518,14 @@ bwn
 bxc
 bzF
 bsQ
-bwC
+xio
 bCc
 bCX
 bDE
 bEk
 bGk
 bCq
-bwC
+xio
 bGU
 bJe
 bIy
@@ -127250,15 +133538,15 @@ bMx
 boU
 cBV
 bOU
-cCh
+okh
 boU
-bRt
-bRt
-bRt
+fFu
+fFu
+fFu
 bSH
-bRt
-bRt
-bRt
+fFu
+fFu
+fFu
 bWB
 bWY
 bWY
@@ -127400,7 +133688,7 @@ aab
 aab
 aab
 acS
-adm
+qbf
 adG
 aem
 afl
@@ -127415,27 +133703,27 @@ apj
 aoe
 aqe
 bdo
-auO
-auO
-auO
-auO
-auO
-auO
+jEx
+jEx
+jEx
+jEx
+jEx
+jEx
 aCF
-auO
-aFM
+jEx
+hKk
 aAn
 aIV
 aJf
-aJO
+jyj
 aKa
 aGo
-aJO
-aJO
+jyj
+jyj
 cLz
 aQR
 aIn
-aRa
+kWL
 aqJ
 aBk
 aLF
@@ -127444,7 +133732,7 @@ aNr
 aOs
 bbv
 aPY
-bmz
+hYb
 aRQ
 cnj
 aUj
@@ -127469,7 +133757,7 @@ bjH
 bgp
 bFQ
 bns
-bnl
+iWy
 aRZ
 boZ
 bpx
@@ -127494,7 +133782,7 @@ bDh
 bEE
 bDh
 bCq
-bwC
+xio
 bGV
 bJy
 bJC
@@ -127507,7 +133795,7 @@ cPC
 boU
 cBW
 bOV
-cCi
+fkT
 boU
 bRu
 bRX
@@ -127657,7 +133945,7 @@ aab
 aab
 aab
 acS
-adm
+qbf
 cif
 aen
 afm
@@ -127703,7 +133991,7 @@ bbv
 aQb
 aSA
 aRR
-aUf
+xUc
 cAw
 aVm
 aWk
@@ -127726,13 +134014,13 @@ blz
 bgw
 bGg
 bHj
-bnl
+iWy
 aRZ
 boZ
 bpx
 bfs
 bqP
-bru
+fJc
 bqT
 bpx
 bsV
@@ -127757,14 +134045,14 @@ bJe
 bIy
 bJL
 bKp
-bRO
+qBA
 bLB
 bIx
 bCD
 boU
 cBX
 bPf
-cCk
+rqZ
 boU
 bRv
 bRY
@@ -127927,7 +134215,7 @@ akV
 abA
 apl
 aEI
-atI
+mTN
 aqK
 arY
 atq
@@ -127949,21 +134237,21 @@ aGg
 aqG
 cDW
 aIp
-aRa
+kWL
 azm
 aKV
 aLE
-aMw
+tsg
 aNs
 aOr
 bbw
 aPY
-bmz
+hYb
 aRR
-aUf
+xUc
 czO
 aVm
-aUf
+xUc
 aXl
 aYq
 aYq
@@ -127983,13 +134271,13 @@ blA
 blW
 bJT
 bnv
-bnl
+iWy
 aRZ
 boZ
 bpx
 cNO
 buC
-bru
+fJc
 brs
 bsu
 brP
@@ -128021,7 +134309,7 @@ bCD
 boU
 cBS
 bPg
-cqm
+qKy
 boU
 bRw
 bRw
@@ -128184,7 +134472,7 @@ akW
 amd
 apn
 aof
-atI
+mTN
 aqK
 arZ
 atr
@@ -128217,10 +134505,10 @@ btR
 aQd
 bmI
 aRT
-aUh
+lay
 cAy
 aUA
-aUh
+lay
 aXm
 aYs
 aYs
@@ -128230,11 +134518,11 @@ aYs
 aZo
 bfn
 aVo
-bhG
-bhG
-bhG
-bhG
-bkr
+mFj
+mFj
+mFj
+mFj
+rrF
 bki
 bgw
 bgw
@@ -128278,7 +134566,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+okh
 boU
 bRx
 bRx
@@ -128293,9 +134581,9 @@ bXz
 bXz
 bWB
 bZw
-caB
-caB
-caB
+nIk
+nIk
+nIk
 bWB
 cXf
 bWB
@@ -128472,12 +134760,12 @@ aNt
 aOt
 bby
 aQe
-bmz
+hYb
 aRU
-aUf
+xUc
 cAw
 aVn
-aUf
+xUc
 aXn
 aSX
 aSX
@@ -128488,16 +134776,16 @@ cNJ
 aRO
 bgw
 bhH
-bhG
-bhG
-bhG
-bkr
-bkU
+mFj
+mFj
+mFj
+rrF
+lea
 blB
 aPb
 bmB
 bnw
-bog
+emv
 aRZ
 bpa
 bpy
@@ -128522,7 +134810,7 @@ bDl
 bEg
 bFd
 bCs
-bwC
+xio
 bGZ
 bJe
 bIy
@@ -128535,7 +134823,7 @@ cVC
 boU
 cBU
 bPg
-cCh
+okh
 boU
 bQB
 bQB
@@ -128688,14 +134976,14 @@ acT
 bsn
 adI
 acT
-akL
-akL
-akL
+xBm
+xBm
+xBm
 aqM
-akL
-akL
+xBm
+xBm
 aqt
-akL
+xBm
 apz
 aoh
 att
@@ -128722,19 +135010,19 @@ bdE
 bwH
 aJZ
 cAo
-cLA
+ndn
 aLI
 aEG
 aNu
-cLA
+ndn
 bbz
 aQf
-bmz
+hYb
 aRR
-aUf
+xUc
 cAx
 aVm
-aUf
+xUc
 aXn
 aYq
 aYq
@@ -128744,23 +135032,23 @@ aYq
 bfo
 aRR
 bgB
-bhG
-bhG
+mFj
+mFj
 biX
-bhG
-bkr
-cGB
+mFj
+rrF
+gaN
 blB
 aPb
 bmC
 bnx
-bnl
+iWy
 aRZ
 boZ
 bpx
 bqc
-bqe
-bqe
+tOa
+tOa
 brL
 bsu
 bsU
@@ -128785,14 +135073,14 @@ bJe
 bIy
 bJO
 bKp
-bRO
+qBA
 bLE
 bIx
 bCD
 boU
 cBY
 bPg
-cCh
+okh
 boU
 bRy
 bRy
@@ -128826,7 +135114,7 @@ cks
 cjM
 czV
 cfv
-ceU
+tor
 cCp
 cpH
 cku
@@ -128938,7 +135226,7 @@ abr
 aaa
 aaa
 aaa
-aaT
+cuL
 abX
 acq
 acU
@@ -128986,12 +135274,12 @@ cIq
 aOu
 bbW
 aQg
-bmz
+hYb
 aRR
-aUf
+xUc
 cAw
 aVm
-aUf
+xUc
 aXo
 aYt
 aZk
@@ -129000,13 +135288,13 @@ aSX
 aSX
 cAw
 bft
-bhI
-bhG
+iir
+mFj
 blF
-biY
-biY
-bkr
-bkU
+ibw
+ibw
+rrF
+lea
 blC
 aTh
 bmD
@@ -129036,7 +135324,7 @@ bDF
 bET
 bGl
 bGp
-bwG
+nEL
 bHa
 bJA
 bJD
@@ -129090,13 +135378,13 @@ cku
 crt
 cDp
 cBp
-cCj
+vcI
 cHg
 cNy
-cCj
-cHC
+vcI
+xiq
 cHE
-cHC
+xiq
 cHF
 cHG
 cHH
@@ -129203,14 +135491,14 @@ ado
 ayv
 acT
 akM
-alB
+pYW
 aSU
-alC
-alC
+eNu
+eNu
 amO
-alB
+pYW
 anZ
-alC
+eNu
 aqA
 atV
 aqL
@@ -129243,7 +135531,7 @@ aNw
 axa
 cIs
 aPY
-bmz
+hYb
 aSQ
 cNE
 cAz
@@ -129258,17 +135546,17 @@ aSX
 cAw
 bfu
 bhJ
-bhG
+mFj
 biq
 biZ
 bjS
-bkr
+rrF
 bkV
 blD
 aTh
 bmE
 bnz
-bwS
+fWa
 aRZ
 boZ
 bpx
@@ -129293,7 +135581,7 @@ bDn
 bEj
 bCl
 bFM
-bwC
+xio
 bHb
 bJe
 bIy
@@ -129306,7 +135594,7 @@ bMx
 boU
 cBS
 bPg
-cCi
+fkT
 boU
 bRA
 bRA
@@ -129491,7 +135779,7 @@ aGm
 arX
 aFh
 aIv
-aHE
+iBq
 aKc
 aLa
 aLL
@@ -129514,18 +135802,18 @@ aYq
 aYq
 cAw
 bgy
-bhI
-bhG
-bhG
+iir
+mFj
+mFj
 bjh
 bjT
-bkr
-bkU
+rrF
+lea
 blD
 aTh
 bmF
 bnA
-bRM
+gKr
 aRZ
 boZ
 bpx
@@ -129563,7 +135851,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+okh
 boU
 aaA
 aaA
@@ -129597,23 +135885,23 @@ cjO
 cjN
 ciV
 cfv
-ceU
+tor
 cKc
 cKd
 cKf
 cJZ
-ctz
+qqn
 cnR
-col
-col
+kWY
+kWY
 cNz
-col
-col
-col
-col
-col
-col
-col
+kWY
+kWY
+kWY
+kWY
+kWY
+kWY
+kWY
 cLv
 cmZ
 cVW
@@ -129757,7 +136045,7 @@ aNy
 axa
 bcy
 aPY
-bnl
+iWy
 aRO
 aSS
 cAS
@@ -129772,17 +136060,17 @@ aSX
 cAw
 aRR
 bhK
-bhG
-bhG
+mFj
+mFj
 bjb
 bjU
-bkr
-cGB
+rrF
+gaN
 blB
 aPo
 bmG
 bnB
-bmq
+som
 aRZ
 boZ
 bpx
@@ -129796,7 +136084,7 @@ cEu
 btS
 bvh
 bvM
-bwC
+xio
 bxk
 byy
 bzw
@@ -129807,7 +136095,7 @@ bDI
 bBI
 bBI
 bBI
-bwC
+xio
 bHb
 bCl
 bIx
@@ -129820,7 +136108,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+okh
 boU
 bRB
 bRB
@@ -129854,12 +136142,12 @@ ciV
 ciV
 bJn
 cfv
-ceU
+tor
 coJ
 cjS
 cjS
 cjS
-ctz
+qqn
 cxt
 cmZ
 cmZ
@@ -130014,7 +136302,7 @@ aHL
 aHM
 cWH
 aQh
-bnl
+iWy
 aRO
 aSW
 aUk
@@ -130029,7 +136317,7 @@ bbR
 bfp
 aRO
 bhL
-bhG
+mFj
 bir
 bjV
 bks
@@ -130039,7 +136327,7 @@ blB
 aPo
 bmH
 bnC
-bmq
+som
 aRZ
 boZ
 bpx
@@ -130053,7 +136341,7 @@ btS
 buG
 bvi
 bwe
-bwG
+nEL
 bxl
 byz
 bzx
@@ -130077,7 +136365,7 @@ bCD
 boU
 cBU
 bPg
-cCh
+okh
 boU
 bRB
 aaA
@@ -130111,7 +136399,7 @@ cfv
 cfv
 cfv
 cfv
-ceU
+tor
 coJ
 cqC
 csu
@@ -130334,7 +136622,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+okh
 boU
 bRB
 aaA
@@ -130361,14 +136649,14 @@ ceM
 cfz
 che
 cig
-ciZ
-ciZ
-ciZ
+hpR
+hpR
+hpR
 cmJ
 cNm
-ciZ
-ciZ
-cgs
+hpR
+hpR
+jSQ
 coJ
 cqC
 csv
@@ -130528,7 +136816,7 @@ aNA
 aOx
 bgn
 aPY
-bog
+emv
 aRO
 aSV
 aUe
@@ -130553,7 +136841,7 @@ aTa
 aRZ
 bgn
 bns
-bmq
+som
 aRZ
 cOQ
 bpx
@@ -130591,7 +136879,7 @@ bMy
 boU
 cBV
 bPg
-cCh
+okh
 boU
 bRB
 bRB
@@ -130615,7 +136903,7 @@ cWm
 cXO
 bXe
 cdO
-cgs
+jSQ
 cgt
 chf
 chY
@@ -130624,8 +136912,8 @@ cNk
 cmA
 ciX
 cjb
-cmn
-cmn
+pBI
+pBI
 cpG
 cmZ
 cur
@@ -130848,7 +137136,7 @@ bCD
 boU
 cBW
 bPi
-cCi
+fkT
 boU
 ccG
 bRB
@@ -131067,7 +137355,7 @@ aTa
 aRZ
 bgn
 bns
-bmq
+som
 aRZ
 czP
 bpA
@@ -131105,7 +137393,7 @@ bCD
 boU
 cod
 bPg
-cCh
+okh
 bDb
 ccK
 bRB
@@ -131299,7 +137587,7 @@ aHM
 aHM
 bih
 aPY
-bnl
+iWy
 aRV
 aRZ
 aUp
@@ -131324,7 +137612,7 @@ cKk
 cKl
 cKm
 cKn
-bmq
+som
 aRZ
 bpc
 bpA
@@ -131362,7 +137650,7 @@ cVC
 boU
 cBS
 bPg
-cCh
+okh
 bDb
 cdj
 bRB
@@ -131556,7 +137844,7 @@ aND
 aOy
 bgn
 aPY
-bnl
+iWy
 aRW
 aRZ
 aUq
@@ -131581,7 +137869,7 @@ bit
 cXT
 bvp
 bns
-bmq
+som
 aRZ
 bpc
 bpA
@@ -131619,7 +137907,7 @@ bCD
 boU
 cBU
 bPg
-cCh
+okh
 bDb
 cep
 bRB
@@ -131642,7 +137930,7 @@ bDR
 bFE
 bGb
 cei
-ceQ
+jjz
 bYV
 cgw
 cJY
@@ -131813,7 +138101,7 @@ aND
 aOz
 bgn
 aPY
-bnl
+iWy
 cla
 cla
 aUr
@@ -131838,7 +138126,7 @@ blH
 bit
 cWM
 bnt
-bmq
+som
 aRZ
 bpc
 bpA
@@ -131876,7 +138164,7 @@ bCD
 boU
 cGq
 bPg
-cCh
+okh
 bDb
 ceX
 bRB
@@ -131899,7 +138187,7 @@ bDS
 cpI
 bGc
 cej
-ceQ
+jjz
 cfE
 bYq
 chj
@@ -132070,7 +138358,7 @@ aND
 aOy
 bgn
 aPY
-bog
+emv
 cla
 aTc
 aUt
@@ -132095,7 +138383,7 @@ bka
 bit
 cIt
 bns
-bmq
+som
 aRZ
 bpc
 bpA
@@ -132133,7 +138421,7 @@ bCE
 boU
 cBS
 bPg
-cCh
+okh
 bDb
 cBs
 bRB
@@ -132327,7 +138615,7 @@ aND
 aND
 cMA
 aPY
-bnl
+iWy
 cla
 aTd
 aUu
@@ -132352,7 +138640,7 @@ blI
 bit
 bgn
 bns
-blg
+gWO
 aRZ
 bpd
 bpB
@@ -132390,7 +138678,7 @@ bpc
 boU
 cBS
 bPg
-cCh
+okh
 bDb
 ccK
 bRB
@@ -132407,7 +138695,7 @@ cEG
 cEH
 cbv
 caJ
-ccP
+mjU
 cbY
 bES
 bFG
@@ -132584,7 +138872,7 @@ cGW
 aND
 bgn
 aPY
-bnl
+iWy
 cla
 aTe
 aVu
@@ -132609,7 +138897,7 @@ blJ
 bit
 bgn
 bns
-bmq
+som
 aRZ
 czR
 bpA
@@ -132904,7 +139192,7 @@ cED
 bpe
 cBX
 bPf
-cCk
+rqZ
 boU
 bpe
 bSb
@@ -132921,13 +139209,13 @@ cAT
 cAT
 cbv
 caL
-ccP
+mjU
 bYn
 cNf
 cdi
 cdP
 cel
-ceU
+tor
 cqh
 bYq
 chg
@@ -133099,92 +139387,92 @@ aOA
 biu
 aQl
 boF
-bph
-bpD
-bpD
-bpD
-bpZ
-bpZ
+fIj
+ngs
+ngs
+ngs
+kwC
+kwC
 bBK
 bsr
-bpD
+ngs
 bvC
-bpD
-bpD
-bph
-cSB
-cSB
-bpD
+ngs
+ngs
+fIj
+tcS
+tcS
+ngs
 bya
 byJ
 bsA
 bCb
-bph
-bpD
+fIj
+ngs
 bLo
 bns
-bNL
-aZv
-bPl
-bPl
-bPl
-bPl
-bPl
-bPl
+ncr
+eAO
+dbN
+dbN
+dbN
+dbN
+dbN
+dbN
 cmE
 bUt
 cWz
-bQM
-bQP
-bQM
+vPB
+mCd
+vPB
 cAD
 abN
 bVw
 bxv
 cIL
-bQP
-bQM
+mCd
+vPB
 cIN
-bQM
+vPB
 cBt
-cBv
+hcw
 cBa
-bPl
-bPl
-cBA
-cBA
-bPl
+dbN
+dbN
+rRq
+rRq
+dbN
 ceN
-bPl
-bPl
-bPl
+dbN
+dbN
+dbN
 cOC
 cBZ
 bPj
 cHs
-cBv
+hcw
 cTY
-bPl
-bPl
+dbN
+dbN
 cCw
-bPl
-bPl
-bPl
+dbN
+dbN
+dbN
 cHt
 bXe
-bfq
+jtv
 bYW
-cah
-cah
+hnY
+hnY
 ccI
 caL
 cdT
 coE
-bfq
+jtv
 cCN
 cdP
 cem
-ceU
+tor
 bYq
 bYq
 cii
@@ -133193,10 +139481,10 @@ clI
 cjT
 ckD
 cns
-coj
+qzS
 coP
 cNt
-coj
+qzS
 cpP
 cqK
 crC
@@ -133386,48 +139674,48 @@ bsq
 bNn
 bvR
 bNl
-bTQ
-bTQ
+mjj
+mjj
 cAu
 cAA
-bTQ
-bTQ
-bTQ
-bTQ
+mjj
+mjj
+mjj
+mjj
 cAC
 bPA
 cAF
 bPz
-bTQ
-bTQ
-bTQ
-bTQ
-bTQ
+mjj
+mjj
+mjj
+mjj
+mjj
 cAH
 cAI
-bTQ
+mjj
 cAJ
-cAK
-cAK
+ooi
+ooi
 cAL
-cAK
-cAK
-cAK
-cAK
-cAK
-cAK
+ooi
+ooi
+ooi
+ooi
+ooi
+ooi
 cAM
 cEP
-cAK
+ooi
 cAO
-cAK
-cAK
+ooi
+ooi
 coF
 cAP
 cHD
-cAK
-cAK
-cAK
+ooi
+ooi
+ooi
 cIc
 bXJ
 bYr
@@ -133612,42 +139900,42 @@ bLO
 aND
 bjm
 aZc
-boV
-boV
+xxH
+xxH
 aTn
-bzH
+voB
 bFf
 brb
 brd
 bcp
-bzH
-bzH
+voB
+voB
 cGQ
-boV
+xxH
 bRk
-boV
-boV
+xxH
+xxH
 cQO
-bxY
-boV
-boV
+dAn
+xxH
+xxH
 bBg
-boV
-boV
-boV
-boV
-boV
-bxY
+xxH
+xxH
+xxH
+xxH
+xxH
+dAn
 bTs
 bVb
 bsf
 byi
 bTp
 cSM
-chC
-bPV
+reB
+syR
 byR
-bPV
+syR
 bQN
 bwJ
 bwJ
@@ -133655,45 +139943,45 @@ cUi
 cBJ
 bDc
 bVK
-cIM
-cIM
-cIM
-cIM
+wbT
+wbT
+wbT
+wbT
 cIQ
-cEX
-cBw
-bPV
+mko
+iHx
+syR
 cBz
-bPV
-chC
+syR
+reB
 bMo
 cBD
-bPV
-bPV
-bPV
-bPV
+syR
+syR
+syR
+syR
 cTT
 cTX
 cEQ
-chC
-cBw
+reB
+iHx
 cTZ
-bPV
+syR
 bYG
-cEX
+mko
 cvO
 cCy
-bPV
-bPV
+syR
+syR
 bXe
-bZJ
+uQG
 clO
 cak
 cbu
 cHJ
 cHN
 cHS
-bZJ
+uQG
 cdq
 cdS
 cdR
@@ -133707,12 +139995,12 @@ cSv
 cjT
 cTF
 cnR
-cok
-col
+ftq
+kWY
 cWB
-col
+kWY
 cKZ
-cok
+ftq
 ctw
 cjS
 ctF
@@ -134159,9 +140447,9 @@ bzJ
 bUl
 brA
 brY
-bsC
-bsC
-bsC
+dFM
+dFM
+dFM
 buL
 bsg
 bsg
@@ -134670,7 +140958,7 @@ cAf
 bpi
 bQc
 bHi
-bVn
+oIJ
 brB
 bsa
 bsE
@@ -134739,7 +141027,7 @@ cTH
 coS
 cnd
 cKO
-cLc
+ikh
 cqO
 crF
 csG
@@ -134927,7 +141215,7 @@ aRj
 bpi
 bQb
 bFn
-bVn
+oIJ
 brB
 bsa
 bsF
@@ -134987,12 +141275,12 @@ cdx
 ceZ
 cgA
 chr
-cjg
+rCO
 cTB
-cjg
+rCO
 cmt
 ckI
-cjg
+rCO
 coT
 cpT
 cKP
@@ -135154,8 +141442,8 @@ aOc
 aOP
 aPD
 cym
-aSc
-aSc
+rvU
+rvU
 aUx
 aUB
 aWz
@@ -135166,8 +141454,8 @@ baR
 baX
 bcb
 bel
-ber
-ber
+flN
+flN
 bgH
 bda
 cce
@@ -135253,7 +141541,7 @@ cng
 coY
 cpU
 cKQ
-cLe
+pjM
 cqP
 crI
 csG
@@ -135455,7 +141743,7 @@ bxC
 bsE
 bzK
 brA
-bvZ
+iSP
 bCG
 brA
 bEt
@@ -135510,7 +141798,7 @@ cdy
 cnf
 cdy
 cKQ
-cLf
+hkl
 coU
 crO
 csI
@@ -135698,7 +141986,7 @@ aRj
 bpi
 cMW
 bHi
-bVn
+oIJ
 brA
 bsc
 bsE
@@ -135712,7 +142000,7 @@ bxD
 bDt
 bzL
 brA
-bvZ
+iSP
 bCH
 brA
 bEq
@@ -135767,7 +142055,7 @@ cni
 cnf
 cpV
 cKQ
-cLg
+frQ
 chu
 crJ
 csJ
@@ -136024,7 +142312,7 @@ cNp
 cnf
 cpV
 cKQ
-cLe
+pjM
 coW
 ciw
 csH
@@ -136173,9 +142461,9 @@ aaa
 aaa
 aab
 aab
-aJu
+gZN
 aKl
-aJu
+gZN
 aLW
 aMT
 aNR
@@ -136212,7 +142500,7 @@ bix
 bpi
 bQb
 bHi
-bVn
+oIJ
 brB
 bsa
 bsH
@@ -136281,7 +142569,7 @@ cnY
 cnf
 cqx
 cKQ
-cLe
+pjM
 coW
 cix
 csG
@@ -136445,8 +142733,8 @@ aUG
 cyJ
 aWL
 aYF
-aWD
-aWD
+fVm
+fVm
 baS
 cQo
 bce
@@ -136469,7 +142757,7 @@ aRj
 bpi
 bQb
 bFn
-bVn
+oIJ
 brB
 bsa
 bsH
@@ -136538,7 +142826,7 @@ cmu
 cnf
 csx
 cKQ
-cLe
+pjM
 coX
 crG
 csI
@@ -136726,7 +143014,7 @@ aQz
 bpi
 bQf
 bJS
-bVn
+oIJ
 brB
 bsa
 bsH
@@ -136795,7 +143083,7 @@ cmu
 cnf
 csx
 cKQ
-cLg
+frQ
 cpS
 crN
 csJ
@@ -136959,8 +143247,8 @@ aVz
 aUH
 aXz
 aYL
-aWF
-aWF
+fWH
+fWH
 baT
 bpG
 aUH
@@ -136983,7 +143271,7 @@ ccA
 bpi
 bQb
 bFn
-bVn
+oIJ
 brA
 bse
 bsH
@@ -137052,7 +143340,7 @@ cdy
 cnf
 cdy
 cNY
-cLf
+hkl
 cqQ
 cta
 csK
@@ -137201,9 +143489,9 @@ aab
 aab
 aab
 aab
-aJx
+uyQ
 aKn
-aJx
+uyQ
 aLZ
 aMT
 aNR
@@ -137309,7 +143597,7 @@ cnZ
 cpa
 cuo
 cKQ
-cLf
+hkl
 cqP
 ctb
 csG
@@ -138080,7 +144368,7 @@ cdx
 cdx
 cvj
 cKQ
-cLc
+ikh
 cgB
 crR
 ctH
@@ -138271,12 +144559,12 @@ bqB
 bnL
 brE
 bsh
-bpS
-bpS
+mAh
+mAh
 bua
 blZ
 bvv
-bvZ
+iSP
 brA
 aaA
 aaA
@@ -138337,7 +144625,7 @@ cdy
 cdy
 cdy
 cKQ
-cLc
+ikh
 cqV
 crS
 csN
@@ -138851,7 +145139,7 @@ cXh
 cpc
 cpc
 cKQ
-cLc
+ikh
 cqV
 crU
 cdy
@@ -139108,7 +145396,7 @@ cMg
 cpd
 cpc
 cKT
-cLc
+ikh
 cqV
 crV
 cdy
@@ -139296,9 +145584,9 @@ boI
 bpk
 bpN
 bqF
-bqK
-bpo
-bnM
+mHy
+iJS
+xRS
 bsL
 bnL
 bue
@@ -139365,7 +145653,7 @@ coe
 cpc
 cpc
 cKT
-cLc
+ikh
 cqV
 cOf
 cdy
@@ -139622,7 +145910,7 @@ cXi
 cpc
 cpc
 cKQ
-cLc
+ikh
 cqV
 crU
 ccS
@@ -139803,19 +146091,19 @@ aac
 aaa
 aab
 bma
-bmU
+hkb
 bnL
 bot
-boK
+eAr
 bpl
 bpP
 bqH
 brn
 brG
-bsj
+hZb
 bsL
 bnL
-boK
+eAr
 bma
 aaa
 aaa
@@ -139879,7 +146167,7 @@ coH
 cpQ
 cdy
 cKU
-cLc
+ikh
 cqV
 crV
 cgF
@@ -140060,19 +146348,19 @@ aac
 aaa
 aab
 bma
-bmU
+hkb
 bnL
 bot
-boK
+eAr
 bpm
 bpQ
 bnL
 bro
 bpm
-bsj
+hZb
 bsL
 bnL
-boK
+eAr
 bma
 aaa
 aaa
@@ -140136,7 +146424,7 @@ cdy
 cdy
 cdy
 cKQ
-cLc
+ikh
 cqX
 crU
 cgF
@@ -140289,7 +146577,7 @@ aJy
 aKo
 aNa
 aMf
-aMZ
+fKY
 aPy
 aNa
 aQq
@@ -140329,7 +146617,7 @@ blZ
 bsk
 bsL
 bnL
-boK
+eAr
 bma
 aaa
 aaa
@@ -140546,7 +146834,7 @@ aJz
 aKp
 aLm
 aMe
-aMZ
+fKY
 aOb
 aNa
 aQq
@@ -140578,11 +146866,11 @@ bmW
 bnL
 bot
 boL
-bpn
-bpS
-bpS
-bpS
-bpn
+dgK
+mAh
+mAh
+mAh
+dgK
 bsl
 bsL
 bnL
@@ -140832,7 +147120,7 @@ aac
 aav
 bma
 bmX
-bnM
+xRS
 btm
 bnL
 bnL
@@ -140907,7 +147195,7 @@ cdx
 cdx
 cvj
 cKX
-cLc
+ikh
 cra
 crX
 csP
@@ -141092,12 +147380,12 @@ bmY
 cMV
 bnL
 boM
-bpo
+iJS
 bnL
-bqK
+mHy
 bnL
-bpo
-bnM
+iJS
+xRS
 bnL
 btu
 bui
@@ -141346,17 +147634,17 @@ aaa
 aab
 aab
 bma
-bnO
+jTf
 bov
-boN
+mgK
 cHm
 bpT
 bqL
 brq
 cHm
-bnO
+jTf
 bov
-boN
+mgK
 bma
 aab
 aaa
@@ -142454,9 +148742,9 @@ cre
 csb
 csT
 ctR
-cuL
+cuN
 cvv
-cuL
+cuN
 cwz
 cnp
 cnp

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -265,6 +265,7 @@
 /area/space)
 "aaT" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 1;
 	height = 4;
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
@@ -379,6 +380,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -534,6 +536,7 @@
 	dir = 4
 	},
 /obj/structure/disposaloutlet{
+	icon_state = "outlet";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -625,7 +628,9 @@
 /obj/machinery/button/door{
 	id = "permawindows";
 	name = "Emergency Shutters";
-	pixel_y = 25
+	normaldoorcontrol = 0;
+	pixel_y = 25;
+	specialfunctions = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -693,6 +698,7 @@
 /area/science/research)
 "acb" = (
 /obj/machinery/doppler_array/research/science{
+	icon_state = "tdoppler";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -737,6 +743,7 @@
 	dir = 5
 	},
 /obj/machinery/button/massdriver{
+	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = 24;
 	pixel_y = 24
@@ -1009,13 +1016,15 @@
 /obj/effect/decal/cleanable/tomato_smudge,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "acK" = (
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -1053,6 +1062,7 @@
 	desc = "In Space, no one can hear you scream, especially if the microphone has been disabled.";
 	name = "Prison Intercom";
 	pixel_x = 32;
+	pixel_y = 0;
 	prison_radio = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -1228,6 +1238,7 @@
 /area/security/prison)
 "adm" = (
 /obj/machinery/door/poddoor{
+	density = 1;
 	id = "SecJusticeChamber";
 	name = "Justice Vent"
 	},
@@ -1380,6 +1391,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1457,9 +1469,9 @@
 /area/science/research)
 "adR" = (
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore";
 	dir = 1;
 	name = "Fore Maintenance APC";
+	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1619,6 +1631,7 @@
 "aeh" = (
 /obj/structure/table,
 /obj/machinery/microwave{
+	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
@@ -1636,8 +1649,10 @@
 "aej" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
+	dir = 8;
 	icon_state = "right";
-	name = "Unisex Showers"
+	name = "Unisex Showers";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1650,6 +1665,7 @@
 /area/security/prison)
 "ael" = (
 /obj/machinery/sparker{
+	dir = 2;
 	id = "executionburn";
 	pixel_x = -25
 	},
@@ -1927,6 +1943,7 @@
 /area/science/nanite)
 "aeN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1974,7 +1991,8 @@
 	dir = 9
 	},
 /obj/machinery/status_display/ai{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -1996,6 +2014,7 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -2070,7 +2089,8 @@
 /area/security/prison)
 "afj" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom"
+	name = "Unisex Restroom";
+	req_access_txt = "0"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -2090,6 +2110,7 @@
 /area/security/execution/education)
 "afm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
+	dir = 2;
 	name = "justice injector"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2200,6 +2221,7 @@
 /area/security/processing)
 "aft" = (
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -2277,6 +2299,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/table/reinforced,
@@ -2462,6 +2485,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -2543,6 +2567,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/window/brigdoor{
+	dir = 2;
 	name = "Justice Chamber";
 	req_access_txt = "3"
 	},
@@ -2602,6 +2627,7 @@
 "agg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2805,6 +2831,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -3081,6 +3108,7 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "SecJusticeChamber";
 	layer = 4;
 	name = "Justice Vent Control";
@@ -3108,6 +3136,7 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/radio/intercom{
+	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/light/small{
@@ -3350,6 +3379,7 @@
 	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/science/storage";
+	dir = 2;
 	name = "Toxins Storage APC";
 	pixel_y = -25
 	},
@@ -3373,6 +3403,7 @@
 /area/maintenance/fore/secondary)
 "aht" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3400,6 +3431,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -3450,6 +3482,7 @@
 /obj/item/radio/intercom{
 	desc = "In Space, no one can hear you scream, especially if the  microphone has been disabled.";
 	name = "Prison Intercom";
+	pixel_x = 0;
 	pixel_y = -32;
 	prison_radio = 1
 	},
@@ -3468,6 +3501,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -3565,6 +3599,7 @@
 /area/security/processing)
 "ahN" = (
 /obj/machinery/computer/shuttle/labor{
+	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3601,6 +3636,7 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -3616,6 +3652,7 @@
 /area/science/xenobiology)
 "ahU" = (
 /obj/structure/disposaloutlet{
+	icon_state = "outlet";
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
@@ -3630,8 +3667,9 @@
 /area/science/xenobiology)
 "ahX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	dir = 4;
-	name = "euthanization chamber freezer"
+	name = "euthanization chamber freezer";
+	icon_state = "freezer_1";
+	dir = 4
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -3702,6 +3740,7 @@
 /area/science/nanite)
 "aif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3833,6 +3872,7 @@
 /area/maintenance/fore/secondary)
 "ait" = (
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4155,6 +4195,7 @@
 /area/science/nanite)
 "ajd" = (
 /obj/machinery/computer/nanite_chamber_control{
+	icon_state = "computer";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -4192,9 +4233,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/mixing";
 	dir = 8;
 	name = "Toxins Lab APC";
+	areastring = "/area/science/mixing";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -4278,6 +4319,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
@@ -4447,6 +4489,7 @@
 	department = "Robotics";
 	departmentType = 2;
 	name = "Robotics RC";
+	pixel_x = 0;
 	pixel_y = 31;
 	receive_ore_updates = 1
 	},
@@ -4456,6 +4499,8 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/mecha_part_fabricator,
 /obj/item/radio/intercom{
+	dir = 2;
+	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
@@ -4531,6 +4576,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4560,6 +4606,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4601,6 +4648,7 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair,
@@ -4615,6 +4663,7 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4634,6 +4683,7 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
+	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair,
@@ -4663,7 +4713,9 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/door/window/westleft{
+	base_state = "left";
 	dir = 4;
+	icon_state = "left";
 	name = "gas ports"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4683,6 +4735,7 @@
 /area/security/execution/education)
 "ajT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -4694,8 +4747,10 @@
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	dir = 8;
+	icon_state = "sink_alt";
 	name = "old sink";
-	pixel_x = 15
+	pixel_x = 15;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4794,6 +4849,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4832,11 +4888,11 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
+	name = "Xenobiology Maintenance";
 	req_access_txt = "47"
 	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "akh" = (
@@ -4858,6 +4914,7 @@
 /area/science/xenobiology)
 "akj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
+	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -4926,6 +4983,7 @@
 /area/science/misc_lab/range)
 "aks" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -5013,6 +5071,7 @@
 /area/science/mixing)
 "akA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -5064,6 +5123,7 @@
 /obj/item/storage/box/monkeycubes,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -5092,6 +5152,7 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -5118,6 +5179,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5134,6 +5196,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5211,6 +5274,7 @@
 "akU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/education";
+	dir = 2;
 	name = "Prisoner Education Chamber APC";
 	pixel_y = -24
 	},
@@ -5262,12 +5326,14 @@
 "ala" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/computer/security/labor{
+	icon_state = "computer";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -5517,10 +5583,12 @@
 	pixel_x = -4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Fore";
+	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -5571,6 +5639,7 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5589,6 +5658,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5596,6 +5666,7 @@
 "alC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5604,6 +5675,7 @@
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5713,6 +5785,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5756,6 +5829,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5776,6 +5850,7 @@
 /area/science/robotics/lab)
 "alY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5865,6 +5940,7 @@
 "amf" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5936,7 +6012,9 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = -29
+	dir = 2;
+	pixel_x = -29;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -6019,6 +6097,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -6034,6 +6113,7 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -6043,6 +6123,7 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6051,6 +6132,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/trimline/white/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6167,6 +6249,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6322,7 +6405,8 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor"
+	c_tag = "Armory Motion Sensor";
+	dir = 2
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6395,7 +6479,8 @@
 	pixel_y = 1
 	},
 /obj/item/grenade/barrier{
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6629,6 +6714,7 @@
 /area/science/robotics/lab)
 "anE" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6739,6 +6825,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6777,6 +6864,7 @@
 /area/science/robotics/lab)
 "anU" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6784,6 +6872,7 @@
 "anV" = (
 /obj/machinery/turnstile{
 	dir = 1;
+	icon_state = "turnstile_map";
 	name = "Genpop Exit Turnstile";
 	req_access_txt = "70"
 	},
@@ -6805,6 +6894,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6833,6 +6923,7 @@
 /area/security/prison)
 "anY" = (
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -6855,6 +6946,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -7162,6 +7254,7 @@
 /area/security/armory)
 "aoo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7284,6 +7377,7 @@
 /area/science/xenobiology)
 "aoy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -7302,6 +7396,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7357,6 +7452,7 @@
 "aoE" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -7366,6 +7462,7 @@
 /area/science/xenobiology)
 "aoF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7394,6 +7491,7 @@
 /area/science/xenobiology)
 "aoI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -7464,6 +7562,7 @@
 	idDoor = "xeno_airlock_exterior";
 	idSelf = "xeno_airlock_control";
 	name = "Access Button";
+	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/machinery/door/firedoor,
@@ -7538,6 +7637,7 @@
 /area/science/research)
 "aoQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7552,6 +7652,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7571,6 +7672,7 @@
 /area/maintenance/fore)
 "aoU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7617,9 +7719,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7677,6 +7781,7 @@
 /area/security/prison)
 "api" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -7776,6 +7881,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -7841,6 +7947,7 @@
 /area/security/prison)
 "apu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -7902,6 +8009,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -7915,12 +8023,14 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "apB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -8007,6 +8117,7 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
+	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8058,6 +8169,7 @@
 /area/science/xenobiology)
 "apK" = (
 /obj/structure/disposaloutlet{
+	icon_state = "outlet";
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
@@ -8166,6 +8278,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8180,9 +8293,11 @@
 	areastring = "/area/science/xenobiology";
 	dir = 4;
 	name = "Xenobiology APC";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -8247,9 +8362,11 @@
 /area/science/misc_lab/range)
 "aqe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8322,6 +8439,7 @@
 /area/science/robotics/lab)
 "aqm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8352,6 +8470,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8394,6 +8513,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -8422,6 +8542,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8451,6 +8572,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8475,6 +8597,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8601,6 +8724,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -8611,6 +8735,7 @@
 "aqN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
@@ -8881,6 +9006,7 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -8914,12 +9040,14 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ark" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -8936,6 +9064,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -8955,6 +9084,7 @@
 /area/science/mixing)
 "arq" = (
 /obj/machinery/sparker/toxmix{
+	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -9032,6 +9162,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/trimline/white/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9132,20 +9263,24 @@
 "arF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "arG" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -9354,6 +9489,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -9384,6 +9520,7 @@
 "arW" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -9932,6 +10069,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -9968,6 +10106,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10000,6 +10139,7 @@
 /area/science/misc_lab/range)
 "asS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -10027,6 +10167,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10044,7 +10185,9 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "asY" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
+	dir = 2
+	},
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -10061,6 +10204,7 @@
 /area/science/mixing)
 "atb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -10215,6 +10359,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -10291,6 +10436,7 @@
 /area/security/armory)
 "aty" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10331,6 +10477,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10361,6 +10508,7 @@
 	dir = 10
 	},
 /obj/machinery/computer/camera_advanced/xenobio{
+	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10393,6 +10541,7 @@
 	dir = 6
 	},
 /obj/machinery/computer/camera_advanced/xenobio{
+	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10428,6 +10577,7 @@
 "atI" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10472,12 +10622,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "atM" = (
 /obj/machinery/sparker/toxmix{
+	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -10608,12 +10760,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "atW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -10624,6 +10778,7 @@
 	sortType = 14
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10631,9 +10786,9 @@
 "atY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/science/robotics/mechbay";
 	dir = 1;
 	name = "Mech Bay APC";
+	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 28
 	},
 /obj/structure/cable{
@@ -10666,6 +10821,7 @@
 /area/science/robotics/mechbay)
 "auc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -10706,16 +10862,17 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "auf" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
@@ -10760,9 +10917,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10873,6 +11032,7 @@
 "aut" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -10882,6 +11042,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10948,6 +11109,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/armory";
+	dir = 2;
 	name = "Armoury APC";
 	pixel_y = -26
 	},
@@ -11085,6 +11247,7 @@
 /area/science/server)
 "auM" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
+	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -11098,6 +11261,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11172,6 +11336,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -11221,6 +11386,7 @@
 /area/science/robotics/mechbay)
 "ava" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -11247,6 +11413,7 @@
 /area/hallway/primary/fore)
 "avc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -11272,6 +11439,7 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/item/paper/guides/jobs/security/range{
@@ -11304,6 +11472,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11376,6 +11545,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/rack,
@@ -11383,7 +11553,8 @@
 	areastring = "/area/science/misc_lab/range";
 	dir = 4;
 	name = "Research Firing Range APC";
-	pixel_x = 28
+	pixel_x = 28;
+	pixel_y = 0
 	},
 /obj/item/target,
 /obj/item/target,
@@ -11444,6 +11615,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11567,6 +11739,7 @@
 "avB" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
+	dir = 2;
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -11589,6 +11762,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11631,9 +11805,11 @@
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -11649,6 +11825,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11666,6 +11843,7 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -11681,9 +11859,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -11699,6 +11879,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -11709,6 +11890,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -11722,6 +11904,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11732,21 +11915,25 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "avO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "avP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -12060,6 +12247,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -12077,6 +12265,7 @@
 /area/science/server)
 "aws" = (
 /obj/machinery/computer/rdservercontrol{
+	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -12085,6 +12274,7 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/science/server";
+	dir = 2;
 	name = "Server Room APC";
 	pixel_y = -23
 	},
@@ -12096,6 +12286,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -12488,6 +12679,7 @@
 /area/science/robotics/mechbay)
 "awP" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12535,6 +12727,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12546,6 +12739,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -12563,6 +12757,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12574,7 +12769,8 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -12633,6 +12829,7 @@
 	},
 /obj/machinery/turnstile{
 	dir = 1;
+	icon_state = "turnstile_map";
 	name = "Genpop Exit Turnstile";
 	req_access_txt = "70"
 	},
@@ -12699,6 +12896,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -12736,9 +12934,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/warden";
 	dir = 4;
 	name = "Warden's Office APC";
+	areastring = "/area/security/warden";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -12747,6 +12945,7 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	name = "Security RC";
+	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -12769,6 +12968,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -12788,6 +12988,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -12842,9 +13043,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12864,9 +13067,11 @@
 /area/science/research)
 "axo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -12879,9 +13084,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12966,6 +13173,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -12984,6 +13192,7 @@
 /obj/structure/bed,
 /obj/machinery/flasher{
 	id = "insaneflash";
+	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/freezer,
@@ -13012,6 +13221,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13021,6 +13231,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/button/door{
@@ -13040,6 +13251,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -13070,6 +13282,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13084,6 +13297,7 @@
 	layer = 2.9
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -13099,12 +13313,14 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -13184,9 +13400,11 @@
 /area/crew_quarters/heads/hor)
 "axS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13235,6 +13453,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13264,6 +13483,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13349,9 +13569,9 @@
 "ayd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/power/apc{
-	areastring = "/area/security/range";
 	dir = 4;
 	name = "Shooting Range APC";
+	areastring = "/area/security/range";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -13467,6 +13687,7 @@
 	areastring = "/area/crew_quarters/heads/hos";
 	dir = 1;
 	name = "Head of Security's Office APC";
+	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -13482,6 +13703,7 @@
 	},
 /obj/machinery/recharger,
 /obj/structure/reagent_dispensers/peppertank{
+	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
@@ -13521,7 +13743,8 @@
 "ayq" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Quarters"
+	c_tag = "Security - Head of Security's Quarters";
+	dir = 2
 	},
 /obj/item/bedsheet/hos,
 /obj/machinery/status_display{
@@ -13546,9 +13769,11 @@
 /obj/machinery/button/door{
 	id = "hosspace";
 	name = "Space Shutters Control";
-	pixel_x = 25
+	pixel_x = 25;
+	pixel_y = 0
 	},
 /obj/machinery/status_display/evac{
+	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -13558,12 +13783,14 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ayu" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
+	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13645,6 +13872,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
+	id_tag = null;
 	name = "Break Room";
 	req_one_access_txt = "47"
 	},
@@ -13674,6 +13902,7 @@
 /obj/machinery/computer/security/research,
 /obj/machinery/camera{
 	c_tag = "Research Director's Office Fore";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -13725,9 +13954,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -13750,6 +13981,7 @@
 /area/science/research)
 "ayR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -13825,6 +14057,7 @@
 /area/security/range)
 "ayZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13939,6 +14172,7 @@
 "azk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14019,6 +14253,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14288,6 +14523,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14318,6 +14554,7 @@
 "azS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14367,6 +14604,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14618,9 +14856,9 @@
 /area/security/brig)
 "aAo" = (
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/science/research";
 	dir = 1;
 	name = "Research Division APC";
+	areastring = "/area/science/research";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -14753,6 +14991,7 @@
 /area/crew_quarters/heads/hos)
 "aAy" = (
 /obj/machinery/computer/prisoner{
+	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -14799,6 +15038,7 @@
 /area/security/checkpoint/science)
 "aAB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -14812,6 +15052,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14919,6 +15160,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -14975,6 +15217,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -14982,9 +15225,11 @@
 /area/science/research)
 "aAV" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15065,9 +15310,11 @@
 /area/hallway/primary/fore)
 "aBe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15127,6 +15374,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -15136,9 +15384,11 @@
 /area/hallway/primary/fore)
 "aBn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15157,21 +15407,25 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aBp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aBq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15191,6 +15445,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15203,6 +15458,7 @@
 /area/security/prison)
 "aBs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15234,6 +15490,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15243,6 +15500,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -15274,6 +15532,7 @@
 /area/crew_quarters/heads/hos)
 "aBz" = (
 /obj/machinery/computer/security/hos{
+	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -15314,8 +15573,9 @@
 /area/security/checkpoint/science)
 "aBC" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/science";
+	dir = 2;
 	name = "Science Security APC";
+	areastring = "/area/security/checkpoint/science";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -15384,14 +15644,17 @@
 "aBH" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15419,6 +15682,8 @@
 	},
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
+	freerange = 0;
+	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -15432,8 +15697,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hor";
+	dir = 2;
 	name = "RD Office APC";
+	areastring = "/area/crew_quarters/heads/hor";
 	pixel_y = -27
 	},
 /obj/structure/cable{
@@ -15457,6 +15723,7 @@
 /area/crew_quarters/heads/hor)
 "aBO" = (
 /obj/item/storage/secure/safe{
+	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/table,
@@ -15473,6 +15740,7 @@
 /area/crew_quarters/heads/hor)
 "aBP" = (
 /obj/machinery/computer/aifixer{
+	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -15496,6 +15764,7 @@
 /area/crew_quarters/heads/hor)
 "aBS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -15523,6 +15792,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15554,6 +15824,7 @@
 "aBZ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15582,6 +15853,7 @@
 "aCb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -15592,9 +15864,9 @@
 /area/maintenance/fore/secondary)
 "aCd" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/detectives_office";
 	dir = 8;
 	name = "Detective APC";
+	areastring = "/area/security/detectives_office";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -15649,6 +15921,7 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/camera{
 	c_tag = "Science Hallway Fore";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -15684,6 +15957,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15870,6 +16144,7 @@
 	},
 /obj/structure/noticeboard{
 	dir = 1;
+	icon_state = "nboard00";
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
@@ -15922,6 +16197,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16182,7 +16458,8 @@
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
 /obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -16324,6 +16601,7 @@
 "aDq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -16338,9 +16616,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/status_display/evac{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16354,26 +16634,32 @@
 	},
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aDu" = (
 /obj/machinery/button/door{
+	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 26;
 	pixel_y = 6;
 	req_one_access_txt = "29"
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aDv" = (
 /obj/machinery/button/door{
+	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = -26;
@@ -16384,9 +16670,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16416,9 +16704,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16489,12 +16779,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16562,6 +16854,7 @@
 /area/security/brig)
 "aDN" = (
 /obj/machinery/turnstile{
+	icon_state = "turnstile_map";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -16588,9 +16881,11 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -16607,6 +16902,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -16761,9 +17057,11 @@
 "aEf" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -16789,9 +17087,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16811,15 +17111,16 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/primary/fore";
 	dir = 8;
 	name = "Fore Primary Hallway APC";
+	areastring = "/area/hallway/primary/fore";
 	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16967,6 +17268,7 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17023,6 +17325,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17138,6 +17441,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17150,6 +17454,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17264,6 +17569,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17373,8 +17679,9 @@
 /area/science/explab)
 "aFe" = (
 /obj/machinery/power/apc{
-	areastring = "/area/science/explab";
+	dir = 2;
 	name = "Experimentation Lab APC";
+	areastring = "/area/science/explab";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -17393,9 +17700,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/brig";
 	dir = 1;
 	name = "Brig APC";
+	areastring = "/area/security/brig";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -17432,6 +17739,7 @@
 /area/science/lab)
 "aFk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -17452,6 +17760,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -17535,6 +17844,7 @@
 /area/security/brig)
 "aFv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17644,6 +17954,7 @@
 /area/quartermaster/office)
 "aFH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -17675,17 +17986,20 @@
 /area/asteroid/nearstation)
 "aFM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aFN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -17715,6 +18029,7 @@
 "aFR" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17731,6 +18046,7 @@
 /area/science/research)
 "aFT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17777,9 +18093,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -17812,10 +18130,12 @@
 /area/hallway/primary/fore)
 "aFZ" = (
 /obj/structure/chair/sofa{
+	icon_state = "sofamiddle";
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
@@ -18001,9 +18321,11 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18122,9 +18444,11 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18135,6 +18459,7 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18222,6 +18547,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18275,6 +18601,7 @@
 	light_color = "#c1caff"
 	},
 /obj/structure/chair/sofa{
+	icon_state = "sofamiddle";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18410,6 +18737,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18588,9 +18916,11 @@
 "aHr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18602,9 +18932,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18626,12 +18958,14 @@
 /area/science/lab)
 "aHu" = (
 /obj/structure/chair/sofa/left{
+	icon_state = "sofaend_left";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
 "aHv" = (
 /obj/structure/chair/sofa/corner{
+	icon_state = "sofacorner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18639,9 +18973,9 @@
 "aHw" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	areastring = "/area/storage/art";
 	dir = 8;
 	name = "Art Storage APC";
+	areastring = "/area/storage/art";
 	pixel_x = -25
 	},
 /obj/item/paper_bin,
@@ -18674,12 +19008,14 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aHB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18689,12 +19025,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aHD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -18702,6 +19040,7 @@
 "aHE" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18718,6 +19057,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18773,6 +19113,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18781,6 +19122,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -18797,6 +19139,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18835,13 +19178,14 @@
 /area/security/courtroom)
 "aHS" = (
 /obj/docking_port/stationary{
-	dwidth = 3;
-	height = 5;
-	icon_state = "pinonalert";
-	id = "mining_home";
 	name = "mining shuttle bay";
-	roundstart_template = /datum/map_template/shuttle/mining/box;
-	width = 7
+	icon_state = "pinonalert";
+	dir = 1;
+	id = "mining_home";
+	width = 7;
+	height = 5;
+	dwidth = 3;
+	roundstart_template = /datum/map_template/shuttle/mining/box
 	},
 /turf/open/space,
 /area/space)
@@ -18858,6 +19202,7 @@
 /area/hallway/primary/fore)
 "aHW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18894,6 +19239,7 @@
 /area/hallway/primary/fore)
 "aIc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -19004,6 +19350,7 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19308,9 +19655,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19328,9 +19677,9 @@
 /area/security/brig)
 "aIy" = (
 /obj/machinery/power/apc{
-	areastring = "/area/lawoffice";
 	dir = 1;
 	name = "Law Office APC";
+	areastring = "/area/lawoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -19426,6 +19775,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -19456,6 +19806,7 @@
 /area/crew_quarters/heads/hor)
 "aIK" = (
 /obj/docking_port/stationary{
+	dir = 1;
 	dwidth = 5;
 	height = 7;
 	id = "supply_home";
@@ -19521,6 +19872,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19552,6 +19904,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19561,6 +19914,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19568,6 +19922,7 @@
 "aIV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -19577,6 +19932,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19627,6 +19983,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19660,9 +20017,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19672,6 +20031,7 @@
 /area/security/brig)
 "aJe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19679,6 +20039,7 @@
 "aJf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19693,6 +20054,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19714,6 +20076,7 @@
 /area/lawoffice)
 "aJj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19721,7 +20084,8 @@
 "aJk" = (
 /obj/machinery/requests_console{
 	department = "Law office";
-	pixel_x = 31
+	pixel_x = 31;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
@@ -19787,6 +20151,7 @@
 /area/security/courtroom)
 "aJr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19811,6 +20176,7 @@
 	id = "QMLoad"
 	},
 /obj/machinery/door/poddoor{
+	density = 1;
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
@@ -19831,6 +20197,7 @@
 /area/quartermaster/storage)
 "aJx" = (
 /obj/machinery/door/poddoor{
+	density = 1;
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
@@ -19901,6 +20268,7 @@
 /area/hallway/primary/fore)
 "aJG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -19926,6 +20294,7 @@
 /area/hallway/primary/fore)
 "aJI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19943,6 +20312,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -19991,6 +20361,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20005,9 +20376,11 @@
 "aJQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -20027,6 +20400,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -20082,6 +20456,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -20128,6 +20503,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20166,6 +20542,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20280,9 +20657,11 @@
 /area/maintenance/fore)
 "aKu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20315,6 +20694,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20322,6 +20702,7 @@
 "aKx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -20329,9 +20710,11 @@
 /area/hallway/primary/fore)
 "aKy" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20350,12 +20733,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20372,6 +20758,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20381,6 +20768,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20390,6 +20778,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20402,9 +20791,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
+	icon_state = "trimline_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20417,9 +20808,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20439,12 +20832,15 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
+	icon_state = "trimline_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20463,9 +20859,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20484,6 +20882,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -20510,6 +20909,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -20526,6 +20926,7 @@
 /area/hallway/primary/fore)
 "aKJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -20545,9 +20946,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20602,6 +21005,7 @@
 /area/security/brig)
 "aKP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -20613,6 +21017,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -20648,6 +21053,7 @@
 /area/security/brig)
 "aKU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -20696,6 +21102,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -20737,6 +21144,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20837,27 +21245,30 @@
 "aLn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aLo" = (
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/miningoffice";
 	dir = 1;
 	name = "Mining APC";
+	areastring = "/area/quartermaster/miningoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/item/radio/intercom{
@@ -20899,9 +21310,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20923,6 +21336,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20947,6 +21361,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -20969,6 +21384,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/navbeacon{
@@ -21124,6 +21540,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -21136,6 +21553,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -21148,6 +21566,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -21162,6 +21581,7 @@
 	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
+	dir = 8;
 	icon_state = "right";
 	name = "Outer Window"
 	},
@@ -21305,6 +21725,7 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/button/door{
+	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
@@ -21313,12 +21734,14 @@
 	req_access_txt = "31"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aLZ" = (
 /obj/machinery/conveyor/inverted{
+	icon_state = "conveyor_map_inverted";
 	dir = 9;
 	id = "QMLoad2"
 	},
@@ -21345,6 +21768,7 @@
 "aMc" = (
 /obj/machinery/conveyor{
 	dir = 6;
+	icon_state = "conveyor_map";
 	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
@@ -21410,17 +21834,19 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	name = "Xenobiology Maintenance";
+	req_access_txt = "47"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/maintenance/fore)
+/area/science/xenobiology)
 "aMm" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21485,12 +21911,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aMr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
+	icon_state = "connector_map-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -21501,6 +21929,7 @@
 	},
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 4;
+	icon_state = "telescreen";
 	layer = 4;
 	pixel_x = -28
 	},
@@ -21516,12 +21945,14 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
 	prison_radio = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21540,6 +21971,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21547,6 +21979,7 @@
 "aMx" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
+	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -21556,6 +21989,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21565,6 +21999,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21582,6 +22017,9 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/westleft{
+	base_state = "left";
+	dir = 8;
+	icon_state = "left";
 	name = "Outer Window"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -21655,12 +22093,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light_switch{
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "aME" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -21677,8 +22117,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/courtroom";
+	dir = 2;
 	name = "Courtroom APC";
+	areastring = "/area/security/courtroom";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -21748,6 +22189,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -21801,6 +22243,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -21812,6 +22255,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -21870,12 +22314,14 @@
 /area/quartermaster/storage)
 "aMX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aMY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/rack,
@@ -21884,6 +22330,7 @@
 /area/quartermaster/miningoffice)
 "aMZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21894,6 +22341,7 @@
 "aNb" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21901,6 +22349,7 @@
 "aNc" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21919,6 +22368,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -22000,9 +22450,11 @@
 "aNn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -22115,7 +22567,8 @@
 "aNy" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/poster/official/enlist{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -22233,20 +22686,24 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -22260,9 +22717,11 @@
 	areastring = "/area/quartermaster/qm";
 	dir = 8;
 	name = "Quartermaster's Office APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22406,6 +22865,7 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22428,6 +22888,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22453,6 +22914,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22506,9 +22968,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -22540,6 +23004,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22551,9 +23016,9 @@
 	dir = 5
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/science/lab";
 	dir = 8;
 	name = "Research and Development Lab APC";
+	areastring = "/area/science/lab";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -22561,6 +23026,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -22714,7 +23180,8 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/grunge{
-	name = "Courtroom"
+	name = "Courtroom";
+	opacity = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -22729,6 +23196,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22753,6 +23221,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22766,6 +23235,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22824,6 +23294,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -22834,6 +23305,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22846,6 +23318,7 @@
 /area/quartermaster/miningoffice)
 "aOP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22954,6 +23427,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22967,12 +23441,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aPe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -22993,12 +23469,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aPh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -23019,6 +23497,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23045,6 +23524,7 @@
 /area/security/brig)
 "aPl" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23052,6 +23532,7 @@
 "aPm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -23066,6 +23547,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -23124,6 +23606,7 @@
 /area/quartermaster/qm)
 "aPt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23157,6 +23640,7 @@
 "aPv" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23167,6 +23651,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23182,6 +23667,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23198,6 +23684,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23214,6 +23701,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23224,6 +23712,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23231,6 +23720,7 @@
 "aPF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -23289,6 +23779,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -23366,6 +23857,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23374,6 +23866,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -23737,6 +24230,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -23777,6 +24271,7 @@
 	pixel_x = -5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -23786,6 +24281,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -23859,16 +24355,14 @@
 /area/maintenance/fore)
 "aQC" = (
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "1-2"
 	},
-/obj/machinery/power/apc{
-	areastring = "/area/maintenance/fore/secondary";
-	dir = 4;
-	name = "Fore Maintenance APC";
-	pixel_x = 24
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/cable{
+	icon_state = "1-4"
 	},
-/turf/open/floor/plating,
-/area/maintenance/fore)
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "aQD" = (
 /turf/closed/wall,
 /area/crew_quarters/heads/captain/private)
@@ -23885,9 +24379,11 @@
 /area/crew_quarters/heads/captain/private)
 "aQG" = (
 /obj/structure/chair/sofa{
+	icon_state = "sofamiddle";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /obj/item/radio/intercom{
@@ -23908,6 +24404,7 @@
 /area/science/explab)
 "aQI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23915,6 +24412,7 @@
 "aQJ" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/hor/private";
+	dir = 2;
 	name = "Research Director's Quarters APC";
 	pixel_y = -24
 	},
@@ -23975,7 +24473,8 @@
 	req_access_txt = "63"
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -23984,6 +24483,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -23991,6 +24491,7 @@
 "aQR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -24043,9 +24544,12 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/item/radio/intercom{
+	freerange = 0;
+	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -24064,6 +24568,7 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24078,12 +24583,14 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aRa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24094,10 +24601,12 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24105,6 +24614,7 @@
 "aRc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24120,6 +24630,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -24130,6 +24641,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -24206,9 +24718,11 @@
 	},
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /obj/structure/extinguisher_cabinet{
+	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/machinery/light/small{
@@ -24222,8 +24736,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/crew_quarters/heads/captain/private";
+	dir = 2;
 	name = "Captain's Quarters APC";
+	areastring = "/area/crew_quarters/heads/captain/private";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -24250,6 +24765,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -24261,6 +24777,7 @@
 /area/hallway/primary/fore)
 "aRt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24302,7 +24819,9 @@
 /obj/item/aiModule/core/freeformcore,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window{
+	base_state = "left";
 	dir = 4;
+	icon_state = "left";
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
@@ -24325,7 +24844,9 @@
 	dir = 1
 	},
 /obj/machinery/door/window/westleft{
+	base_state = "left";
 	dir = 2;
+	icon_state = "left";
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access_txt = "16"
@@ -24621,6 +25142,7 @@
 "aSa" = (
 /obj/structure/noticeboard/qm{
 	dir = 1;
+	icon_state = "nboard00";
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -24628,9 +25150,11 @@
 /area/quartermaster/qm)
 "aSb" = (
 /obj/machinery/computer/security/qm{
+	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -24642,6 +25166,7 @@
 "aSc" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24794,6 +25319,8 @@
 "aSs" = (
 /obj/structure/dresser,
 /obj/item/radio/intercom{
+	dir = 2;
+	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/carpet/blue,
@@ -24830,9 +25357,11 @@
 "aSw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24871,9 +25400,11 @@
 "aSA" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25005,7 +25536,8 @@
 	},
 /obj/item/lighter,
 /obj/machinery/camera{
-	c_tag = "Bar"
+	c_tag = "Bar";
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -25044,9 +25576,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/crew_quarters/bar";
 	dir = 1;
 	name = "Bar APC";
+	areastring = "/area/crew_quarters/bar";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -25061,6 +25593,7 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/drinks{
+	icon_state = "soda_dispenser";
 	dir = 8
 	},
 /obj/structure/table,
@@ -25107,6 +25640,7 @@
 "aSU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -25134,6 +25668,7 @@
 /area/hydroponics)
 "aSY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25216,6 +25751,7 @@
 "aTg" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -25226,6 +25762,7 @@
 "aTi" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25233,6 +25770,7 @@
 "aTj" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -25268,6 +25806,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -25280,24 +25819,28 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTq" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aTr" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25305,6 +25848,7 @@
 /area/quartermaster/storage)
 "aTs" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -25516,9 +26060,11 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aTS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -25607,6 +26153,7 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25650,6 +26197,7 @@
 	dir = 4
 	},
 /obj/machinery/chem_dispenser/drinks/beer{
+	icon_state = "booze_dispenser";
 	dir = 8
 	},
 /obj/structure/table,
@@ -25658,6 +26206,7 @@
 "aUd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -25673,6 +26222,7 @@
 /area/hydroponics)
 "aUf" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25686,6 +26236,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25704,6 +26255,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -25770,15 +26322,15 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "aUr" = (
-/obj/machinery/door/airlock/maintenance{
-	id_tag = "commissarydoor";
-	req_one_access_txt = "12;63;48;50"
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/central)
+/area/maintenance/fore)
 "aUs" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/door/airlock{
@@ -25813,6 +26365,7 @@
 /area/hallway/primary/central)
 "aUx" = (
 /obj/vehicle/ridden/scooter{
+	icon_state = "scooter";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -25820,6 +26373,7 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25882,9 +26436,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25957,7 +26513,8 @@
 	areastring = "/area/crew_quarters/heads/captain";
 	dir = 8;
 	name = "Captain's Office APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -25996,6 +26553,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -26083,6 +26641,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26098,11 +26657,13 @@
 /area/crew_quarters/bar/atrium)
 "aVg" = (
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26197,6 +26758,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
@@ -26206,6 +26768,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26235,6 +26798,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26245,6 +26809,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26296,6 +26861,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -26314,8 +26880,9 @@
 /area/hallway/primary/central)
 "aVz" = (
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/storage";
+	dir = 2;
 	name = "Cargo Bay APC";
+	areastring = "/area/quartermaster/storage";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -26347,9 +26914,11 @@
 /area/quartermaster/office)
 "aVB" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26405,6 +26974,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26433,10 +27003,12 @@
 /obj/structure/table,
 /obj/item/export_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
+	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel,
@@ -26454,9 +27026,11 @@
 "aVO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26601,6 +27175,7 @@
 /area/crew_quarters/bar)
 "aWh" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26611,6 +27186,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26624,6 +27200,7 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -26635,6 +27212,7 @@
 /obj/structure/table/glass,
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26645,6 +27223,7 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/status_display/ai{
@@ -26676,6 +27255,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26695,6 +27275,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26719,6 +27300,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -26738,6 +27320,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -26759,6 +27342,7 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26785,6 +27369,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26803,6 +27388,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26829,6 +27415,7 @@
 /area/quartermaster/office)
 "aWD" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26836,18 +27423,20 @@
 "aWE" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plasteel{
-	dir = 1;
-	icon_state = "yellowsiding"
+	icon_state = "yellowsiding";
+	dir = 1
 	},
 /area/quartermaster/office)
 "aWF" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aWG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26870,6 +27459,7 @@
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -26886,6 +27476,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26896,7 +27487,7 @@
 "aWN" = (
 /obj/machinery/door/airlock/command{
 	name = "Emergency Escape";
-	req_access_txt = "20"
+	req_access_txt = "19"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
@@ -26907,6 +27498,7 @@
 /area/maintenance/fore)
 "aWO" = (
 /obj/structure/chair/sofa/corp/left{
+	icon_state = "corp_sofaend_left";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -26976,6 +27568,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -27021,6 +27614,7 @@
 /area/hallway/primary/central)
 "aXa" = (
 /obj/machinery/computer/security/telescreen/aiupload{
+	icon_state = "telescreen";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -27041,8 +27635,9 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
+	dir = 2;
 	name = "AI Upload Access APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
@@ -27087,9 +27682,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27131,6 +27728,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27161,6 +27759,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27214,9 +27813,11 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Hydroponics APC";
+	pixel_x = 0;
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27236,9 +27837,9 @@
 /area/hydroponics)
 "aXr" = (
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/central/secondary";
 	dir = 8;
 	name = "Central Maintenance APC";
+	areastring = "/area/maintenance/central/secondary";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -27283,7 +27884,8 @@
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control";
 	pixel_x = 3;
-	pixel_y = -25
+	pixel_y = -25;
+	req_access_txt = "0"
 	},
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -27321,6 +27923,7 @@
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -27333,6 +27936,7 @@
 /area/maintenance/fore)
 "aXz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -27360,6 +27964,7 @@
 "aXB" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27373,6 +27978,7 @@
 /area/hallway/primary/central)
 "aXD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27416,6 +28022,7 @@
 /area/quartermaster/warehouse)
 "aXL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27519,6 +28126,7 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/corp/right{
+	icon_state = "corp_sofaend_right";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -27528,6 +28136,7 @@
 /area/crew_quarters/heads/captain)
 "aXX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27587,6 +28196,7 @@
 "aYc" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -27747,6 +28357,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -27791,6 +28402,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27819,6 +28431,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet{
@@ -27839,6 +28452,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27847,6 +28461,7 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27888,12 +28503,14 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aYB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27917,6 +28534,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27927,9 +28545,11 @@
 /area/hallway/primary/central)
 "aYF" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27974,9 +28594,11 @@
 /area/quartermaster/warehouse)
 "aYL" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28046,6 +28668,7 @@
 /area/crew_quarters/heads/captain)
 "aYS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -28074,6 +28697,7 @@
 "aYW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28082,6 +28706,7 @@
 "aYX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -28094,6 +28719,7 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28104,9 +28730,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -28116,6 +28744,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28130,6 +28759,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28140,6 +28770,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /mob/living/simple_animal/bot/medbot{
@@ -28157,6 +28788,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28211,6 +28843,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -28303,7 +28936,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
@@ -28312,6 +28945,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28339,9 +28973,9 @@
 /area/hallway/primary/central)
 "aZx" = (
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
+	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -28349,6 +28983,7 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28367,6 +29002,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28378,12 +29014,14 @@
 	sortType = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28411,6 +29049,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28432,6 +29071,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28479,6 +29119,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28513,10 +29154,12 @@
 /obj/item/folder/red,
 /obj/item/taperecorder,
 /obj/item/radio/intercom{
+	anyai = 1;
 	broadcasting = 1;
 	frequency = 1423;
 	listening = 0;
 	name = "Interrogation Intercom";
+	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -28548,6 +29191,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -28593,6 +29237,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28615,6 +29260,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28629,7 +29275,9 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/clothing/head/that,
+/obj/item/clothing/head/that{
+	throwforce = 1
+	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aZW" = (
@@ -28651,7 +29299,8 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -28659,6 +29308,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -28674,6 +29324,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28691,6 +29342,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -28716,6 +29368,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28734,37 +29387,45 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "baf" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/door/airlock/command{
-	name = "Command Hallway"
+/obj/machinery/button{
+	id = "bridgespace";
+	name = "Bridge External Shutters";
+	pixel_x = -25;
+	pixel_y = 35
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
+/obj/machinery/button{
+	id = "bridgespace";
+	name = "Bridge Access Shutters";
+	pixel_x = -25;
+	pixel_y = 26;
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel/dark,
+/area/bridge)
 "bag" = (
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/hallway/secondary/command";
 	dir = 1;
 	name = "Command Hallway APC";
+	areastring = "/area/hallway/secondary/command";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -28780,6 +29441,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28804,6 +29466,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28822,9 +29485,11 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28853,6 +29518,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29023,9 +29689,9 @@
 	pixel_x = 32
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/theatre";
 	dir = 1;
 	name = "Theatre APC";
+	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -29050,6 +29716,9 @@
 /area/crew_quarters/bar)
 "baB" = (
 /obj/machinery/door/window/southleft{
+	base_state = "left";
+	dir = 2;
+	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -29061,6 +29730,7 @@
 /area/crew_quarters/bar)
 "baC" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -29088,6 +29758,7 @@
 "baG" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29128,6 +29799,7 @@
 "baK" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29137,12 +29809,14 @@
 /obj/item/folder/yellow,
 /obj/structure/disposalpipe/junction/flip,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baM" = (
 /obj/machinery/door/window/westleft{
+	dir = 8;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
@@ -29155,6 +29829,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29163,12 +29838,14 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29176,6 +29853,7 @@
 "baQ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -29186,12 +29864,14 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baS" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -29202,12 +29882,14 @@
 /area/quartermaster/office)
 "baT" = (
 /obj/effect/turf_decal/caution{
+	icon_state = "caution";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29220,6 +29902,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29232,6 +29915,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29241,6 +29925,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29252,6 +29937,7 @@
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -29339,12 +30025,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bbf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -29487,6 +30175,7 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -29522,23 +30211,43 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bbs" = (
-/obj/structure/disposalpipe/segment{
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/door/firedoor,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/preopen{
+	id = "bridgedoors";
+	name = "Bridge Access Blast door"
+	},
+/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/machinery/door/airlock/command{
-	name = "Command Hallway"
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
 	},
-/obj/machinery/door/firedoor,
-/turf/open/floor/plasteel,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/door/airlock/command{
+	name = "Bridge";
+	req_access_txt = "19"
+	},
+/turf/open/floor/plasteel/dark,
 /area/hallway/secondary/command)
 "bbt" = (
 /obj/machinery/light{
@@ -29594,6 +30303,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -29603,6 +30313,7 @@
 "bbz" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/turf_decal/stripes/red/line{
+	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -29774,6 +30485,7 @@
 	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -29785,6 +30497,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29800,6 +30513,7 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -29809,6 +30523,7 @@
 /area/hallway/secondary/service)
 "bbW" = (
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -29884,6 +30599,7 @@
 /area/quartermaster/office)
 "bcf" = (
 /obj/machinery/computer/card{
+	icon_state = "computer";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -29903,6 +30619,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -29949,9 +30666,11 @@
 /area/bridge/meeting_room)
 "bcp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30098,6 +30817,7 @@
 "bcK" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -30128,6 +30848,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -30141,6 +30862,7 @@
 /area/security/prison)
 "bcQ" = (
 /obj/effect/turf_decal/arrows/red{
+	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30191,9 +30913,11 @@
 /area/maintenance/department/cargo)
 "bcV" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -30201,18 +30925,22 @@
 /area/quartermaster/sorting)
 "bcW" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bcX" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -30228,9 +30956,11 @@
 /area/quartermaster/sorting)
 "bcY" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/hand_labeler_refill,
@@ -30244,9 +30974,11 @@
 /area/quartermaster/sorting)
 "bcZ" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -30302,6 +31034,7 @@
 /area/maintenance/department/cargo)
 "bdg" = (
 /obj/machinery/computer/communications{
+	icon_state = "computer";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -30311,15 +31044,25 @@
 /turf/open/floor/carpet,
 /area/bridge)
 "bdh" = (
-/obj/structure/chair/comfy/black{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/machinery/button{
-	pixel_x = 35;
-	pixel_y = 30
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/turf/open/floor/carpet,
-/area/bridge)
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/machinery/door/airlock/command{
+	name = "Command Hallway";
+	req_access_txt = "19"
+	},
+/obj/machinery/door/firedoor,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
 "bdi" = (
 /obj/machinery/door/window/eastright,
 /turf/open/floor/carpet,
@@ -30407,6 +31150,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -30438,9 +31182,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	areastring = "/area/teleporter";
 	dir = 1;
 	name = "Teleporter APC";
+	areastring = "/area/teleporter";
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -30645,6 +31389,7 @@
 "bdK" = (
 /obj/machinery/requests_console{
 	department = "EVA";
+	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -30672,7 +31417,8 @@
 	dir = 8
 	},
 /obj/machinery/camera/motion{
-	c_tag = "E.V.A. Storage"
+	c_tag = "E.V.A. Storage";
+	dir = 2
 	},
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -30697,6 +31443,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -30782,6 +31529,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30809,6 +31557,7 @@
 /area/crew_quarters/bar)
 "bdZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30839,6 +31588,7 @@
 "bed" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30917,9 +31667,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -30928,6 +31680,7 @@
 /obj/structure/disposaloutlet,
 /obj/machinery/conveyor{
 	backwards = 1;
+	dir = 2;
 	forwards = 2;
 	id = "trashsort"
 	},
@@ -30944,12 +31697,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -30970,12 +31725,14 @@
 /area/quartermaster/sorting)
 "bep" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beq" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -30987,6 +31744,7 @@
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
+	dir = 2;
 	forwards = 2;
 	id = "trashsort"
 	},
@@ -31018,6 +31776,7 @@
 /area/maintenance/department/cargo)
 "bev" = (
 /obj/machinery/modular_computer/console/preset/command{
+	icon_state = "console";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -31053,18 +31812,13 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bey" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/door/firedoor,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/machinery/door/airlock/command{
-	name = "Bridge"
+	name = "Bridge";
+	req_access_txt = "19"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "bridgedoors";
@@ -31089,9 +31843,11 @@
 /area/bridge)
 "beA" = (
 /obj/machinery/computer/cargo/request{
+	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -31121,6 +31877,7 @@
 /area/teleporter)
 "beD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31137,7 +31894,8 @@
 	areastring = "/area/bridge/meeting_room";
 	dir = 8;
 	name = "Council Chambers APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
@@ -31151,6 +31909,7 @@
 /area/bridge/meeting_room)
 "beG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -31165,6 +31924,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31242,9 +32002,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/power/apc{
-	areastring = "/area/ai_monitored/storage/eva";
 	dir = 8;
 	name = "E.V.A. Storage APC";
+	areastring = "/area/ai_monitored/storage/eva";
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
@@ -31308,6 +32068,7 @@
 "beX" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -31422,6 +32183,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -31434,12 +32196,14 @@
 "bfp" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31447,6 +32211,7 @@
 "bfr" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -31454,6 +32219,7 @@
 "bfs" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -31504,7 +32270,8 @@
 	areastring = "/area/security/checkpoint/supply";
 	dir = 8;
 	name = "Cargo Security APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
@@ -31514,6 +32281,7 @@
 /area/security/checkpoint/supply)
 "bfy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -31534,12 +32302,14 @@
 /area/quartermaster/sorting)
 "bfB" = (
 /obj/machinery/door/airlock/maintenance{
+	name = "Sorting Maintenance";
 	req_access_txt = "31"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
 "bfC" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -31550,9 +32320,11 @@
 /area/quartermaster/sorting)
 "bfD" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -31721,6 +32493,7 @@
 "bfT" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31773,6 +32546,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31841,9 +32615,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/bridge/showroom/corporate";
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
+	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
@@ -31934,6 +32708,7 @@
 /area/crew_quarters/cafeteria)
 "bgq" = (
 /obj/machinery/computer/arcade/battle{
+	icon_state = "arcade";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -31975,6 +32750,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -31983,6 +32759,7 @@
 	pixel_x = -28
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -32014,9 +32791,11 @@
 /area/crew_quarters/kitchen/backroom)
 "bgB" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -32034,9 +32813,11 @@
 /area/crew_quarters/kitchen)
 "bgD" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -32077,6 +32858,7 @@
 "bgH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
+	icon_state = "conveyor_map_inverted";
 	id = "trashsort"
 	},
 /turf/open/floor/plating,
@@ -32095,6 +32877,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32174,6 +32957,7 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
+	icon_state = "conveyor_map";
 	dir = 6;
 	id = "garbage"
 	},
@@ -32207,29 +32991,18 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bgT" = (
-/obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/door/airlock/command{
-	name = "Bridge"
-	},
-/obj/machinery/door/poddoor/preopen{
-	id = "bridgedoors";
-	name = "Bridge Access Blast door"
-	},
-/obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/machinery/door/firedoor,
+/obj/machinery/door/airlock/command{
+	name = "Command Hallway";
+	req_access_txt = "19"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hallway/secondary/command)
 "bgU" = (
 /obj/structure/disposalpipe/segment,
@@ -32247,6 +33020,7 @@
 /area/bridge)
 "bgV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -32256,6 +33030,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -32291,6 +33066,7 @@
 /area/teleporter)
 "bgZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32312,6 +33088,7 @@
 /area/maintenance/fore)
 "bhc" = (
 /obj/machinery/door/window/westleft{
+	dir = 8;
 	name = "Bridge Deliveries";
 	req_access_txt = "19"
 	},
@@ -32355,6 +33132,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32411,9 +33189,11 @@
 "bhn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -32462,6 +33242,7 @@
 	},
 /obj/structure/rack,
 /obj/machinery/door/window/northleft{
+	dir = 1;
 	name = "Jetpack Storage";
 	pixel_x = -1;
 	req_access_txt = "19"
@@ -32496,6 +33277,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/door/window/northleft{
+	dir = 1;
 	name = "Magboot Storage";
 	pixel_x = -1;
 	req_access_txt = "19"
@@ -32595,6 +33377,7 @@
 /area/crew_quarters/cafeteria)
 "bhD" = (
 /obj/machinery/newscaster{
+	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -32611,9 +33394,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/storage/box/donkpockets,
@@ -32621,9 +33406,11 @@
 /area/crew_quarters/kitchen)
 "bhG" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -32633,18 +33420,22 @@
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bhI" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -32655,9 +33446,11 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -32665,18 +33458,22 @@
 "bhK" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bhL" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -32750,6 +33547,7 @@
 "bhU" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
+	icon_state = "conveyor_map_inverted";
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -32760,6 +33558,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/conveyor{
+	icon_state = "conveyor_map";
 	dir = 10;
 	id = "garbage"
 	},
@@ -32829,6 +33628,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -32846,6 +33646,7 @@
 	},
 /obj/item/storage/box/zipties,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -32908,6 +33709,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -32958,18 +33760,22 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bir" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -33101,6 +33907,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33158,6 +33965,7 @@
 "biO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -33171,6 +33979,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -33229,18 +34038,22 @@
 "biW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "biX" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -33249,9 +34062,11 @@
 "biY" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33262,18 +34077,22 @@
 /obj/item/hand_labeler_refill,
 /obj/item/stack/packageWrap,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bja" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -33284,18 +34103,22 @@
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bjc" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -33311,9 +34134,11 @@
 /area/crew_quarters/kitchen)
 "bjd" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -33358,9 +34183,11 @@
 "bjh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/storage/bag/tray,
@@ -33404,6 +34231,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33447,6 +34275,7 @@
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
+	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -33598,6 +34427,7 @@
 /area/crew_quarters/cafeteria)
 "bjK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/rack,
@@ -33627,6 +34457,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33657,6 +34488,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33674,9 +34506,11 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33685,9 +34519,11 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33701,9 +34537,11 @@
 	layer = 5
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33711,9 +34549,11 @@
 "bjU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/reagentgrinder,
@@ -33722,9 +34562,11 @@
 "bjV" = (
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -33734,9 +34576,11 @@
 "bjW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -33746,9 +34590,11 @@
 /area/crew_quarters/kitchen)
 "bjX" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/vending/dinnerware,
@@ -33818,6 +34664,7 @@
 /mob/living/simple_animal/bot/cleanbot{
 	auto_patrol = 1;
 	icon_state = "cleanbot1";
+	mode = 0;
 	name = "Mopficcer Sweepsky"
 	},
 /turf/open/floor/plasteel,
@@ -33887,9 +34734,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -33988,9 +34837,11 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34000,9 +34851,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34012,9 +34865,11 @@
 /area/crew_quarters/kitchen)
 "bks" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -34024,9 +34879,11 @@
 "bkt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34039,6 +34896,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -34105,6 +34963,7 @@
 "bkA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -34114,7 +34973,7 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/cargo)
@@ -34149,12 +35008,14 @@
 	},
 /obj/machinery/door/window/eastright{
 	base_state = "left";
+	dir = 4;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
+	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -34173,11 +35034,13 @@
 /area/maintenance/disposal)
 "bkG" = (
 /obj/machinery/door/window/eastright{
+	dir = 4;
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
+	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -34186,6 +35049,7 @@
 "bkH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
+	icon_state = "conveyor_map_inverted";
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -34306,9 +35170,11 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34322,6 +35188,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -34331,9 +35198,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34344,9 +35213,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34357,9 +35228,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34377,9 +35250,11 @@
 /area/crew_quarters/cafeteria)
 "bkY" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -34398,7 +35273,10 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bla" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/machinery/door/airlock/maintenance{
+	name = "Janitor Maintenance";
+	req_access_txt = "26"
+	},
 /turf/open/floor/plating,
 /area/maintenance/central)
 "blb" = (
@@ -34461,6 +35339,7 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34647,6 +35526,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/security{
@@ -34656,6 +35536,7 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
+	icon_state = "direction_sci";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
@@ -34745,9 +35626,11 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34778,9 +35661,11 @@
 /area/crew_quarters/kitchen)
 "blE" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -34791,9 +35676,11 @@
 /area/crew_quarters/kitchen)
 "blF" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/processor,
@@ -34801,9 +35688,11 @@
 /area/crew_quarters/kitchen)
 "blG" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34928,9 +35817,11 @@
 /area/crew_quarters/kitchen)
 "blX" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -34941,15 +35832,15 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "blY" = (
-/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/layer_manifold,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/cargo)
+/area/maintenance/central)
 "blZ" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
@@ -35093,7 +35984,8 @@
 "bmo" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Gateway - Atrium"
+	c_tag = "Gateway - Atrium";
+	dir = 2
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -35111,6 +36003,7 @@
 "bmq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35139,6 +36032,7 @@
 "bms" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35147,6 +36041,7 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35157,6 +36052,7 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35167,9 +36063,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -35183,6 +36081,7 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35190,6 +36089,7 @@
 "bmy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35197,6 +36097,7 @@
 "bmz" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35210,6 +36111,7 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35265,15 +36167,18 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmJ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35309,9 +36214,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
@@ -35324,6 +36231,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35334,6 +36242,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -35346,6 +36255,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
@@ -35356,15 +36266,16 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -35375,6 +36286,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -35388,6 +36300,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35399,6 +36312,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35408,6 +36322,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -35418,6 +36333,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -35481,7 +36397,8 @@
 	areastring = "/area/gateway";
 	dir = 8;
 	name = "Gateway APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -35529,6 +36446,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -35609,6 +36527,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35786,10 +36705,12 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/sign/directions/supply{
 	dir = 4;
+	icon_state = "direction_supply";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
+	icon_state = "direction_evac";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/medical{
@@ -36020,6 +36941,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Port";
+	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/chapel{
@@ -36053,6 +36975,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bnM" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36076,6 +36999,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36133,6 +37057,7 @@
 "bnU" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -36152,8 +37077,8 @@
 /obj/structure/closet/crate/goldcrate,
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	dir = 1;
-	network = list("vault")
+	network = list("vault");
+	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
@@ -36253,6 +37178,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36263,6 +37189,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36276,6 +37203,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -36285,6 +37213,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36327,6 +37256,7 @@
 /area/storage/emergency/starboard)
 "bop" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -36368,6 +37298,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bou" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36454,6 +37385,7 @@
 "boE" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -36463,6 +37395,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -36478,6 +37411,7 @@
 /area/science/xenobiology)
 "boH" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -36496,6 +37430,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boJ" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36503,12 +37438,14 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
+	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "boK" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36519,6 +37456,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boL" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36532,6 +37470,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36543,6 +37482,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boP" = (
 /obj/docking_port/stationary{
+	dheight = 0;
 	dir = 4;
 	dwidth = 9;
 	height = 25;
@@ -36586,6 +37526,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36615,6 +37556,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36663,6 +37605,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36691,6 +37634,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36710,6 +37654,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpk" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36742,6 +37687,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpn" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -36752,6 +37698,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpo" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36795,6 +37742,7 @@
 /area/maintenance/port/fore)
 "bpu" = (
 /obj/machinery/mineral/stacking_unit_console{
+	dir = 2;
 	machinedir = 8;
 	pixel_x = 32
 	},
@@ -36802,6 +37750,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -36867,6 +37816,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36880,6 +37830,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -36891,12 +37842,14 @@
 "bpF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -36962,6 +37915,7 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -36986,6 +37940,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpN" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37049,6 +38004,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpS" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37105,6 +38061,7 @@
 "bpZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37114,12 +38071,13 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/medical/genetics";
 	dir = 1;
 	name = "Genetics Lab APC";
+	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37137,6 +38095,7 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -37148,10 +38107,13 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
+	departmentType = 0;
 	name = "Genetics Requests Console";
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -37165,6 +38127,7 @@
 /area/medical/genetics)
 "bqe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -37172,6 +38135,7 @@
 "bqf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -37190,6 +38154,7 @@
 "bqg" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/noticeboard{
@@ -37270,6 +38235,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37354,6 +38320,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37375,12 +38342,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37404,6 +38374,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37541,6 +38512,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqK" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37564,6 +38536,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqN" = (
 /obj/machinery/computer/scan_consolenew{
+	icon_state = "computer";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -37590,6 +38563,7 @@
 /area/medical/genetics)
 "bqQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37615,9 +38589,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37683,18 +38659,22 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "brb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37725,6 +38705,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37741,6 +38722,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37778,6 +38760,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -37795,6 +38778,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Creamatorium";
+	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/dark,
@@ -37927,12 +38911,14 @@
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bru" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -37980,6 +38966,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38013,6 +39000,7 @@
 /area/library)
 "brE" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -38075,6 +39063,7 @@
 /area/medical/genetics)
 "brL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/table/glass,
@@ -38113,6 +39102,7 @@
 "brN" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
+	opacity = 1;
 	req_access_txt = "5"
 	},
 /obj/structure/cable{
@@ -38143,6 +39133,7 @@
 "brO" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -38150,6 +39141,7 @@
 "brP" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -38172,6 +39164,7 @@
 /area/medical/morgue)
 "brT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38208,6 +39201,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -38286,6 +39280,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/sign/directions/evac{
@@ -38300,6 +39295,7 @@
 /area/library)
 "bsh" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38313,6 +39309,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsi" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38320,12 +39317,14 @@
 	},
 /obj/structure/chair,
 /obj/item/radio/intercom{
+	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bsj" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38336,6 +39335,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsk" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38379,6 +39379,7 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38400,12 +39401,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38418,6 +39422,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38452,6 +39457,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38486,6 +39492,7 @@
 	pixel_x = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -38495,6 +39502,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -38525,12 +39533,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsC" = (
 /obj/structure/chair/comfy/teal{
+	icon_state = "comfychair";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -38573,9 +39583,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/library";
 	dir = 4;
 	name = "Library APC";
+	areastring = "/area/library";
 	pixel_x = 24
 	},
 /turf/open/floor/carpet,
@@ -38610,6 +39620,7 @@
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -38642,6 +39653,7 @@
 "bsT" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38649,6 +39661,7 @@
 "bsU" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -38676,6 +39689,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -38698,6 +39712,7 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38728,6 +39743,7 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38776,14 +39792,15 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "btd" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -38793,15 +39810,16 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/medical/virology";
 	dir = 1;
 	name = "Virology APC";
+	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -38811,6 +39829,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38820,6 +39839,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38827,6 +39847,7 @@
 "bth" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38841,8 +39862,9 @@
 "btj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	areastring = "/area/medical/abandoned";
+	dir = 2;
 	name = "Abandoned Medical Lab APC";
+	areastring = "/area/medical/abandoned";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -38896,6 +39918,7 @@
 	location = "9.2-Escape-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38963,6 +39986,7 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -38970,6 +39994,7 @@
 "btu" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -39006,6 +40031,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39015,6 +40041,7 @@
 /obj/item/folder/white,
 /obj/item/folder/white,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -39022,18 +40049,22 @@
 "btB" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39043,6 +40074,7 @@
 	layer = 2.7
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39071,6 +40103,7 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39087,15 +40120,18 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -39110,24 +40146,28 @@
 /area/crew_quarters/kitchen/backroom)
 "btK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39175,6 +40215,7 @@
 /area/medical/storage)
 "btT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39201,9 +40242,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39226,6 +40269,7 @@
 /area/library)
 "bua" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39237,6 +40281,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bub" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39245,6 +40290,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buc" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39258,6 +40304,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bud" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39266,6 +40313,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bue" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39276,6 +40324,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buf" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39288,6 +40337,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bug" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39296,10 +40346,12 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buh" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/computer/arcade,
@@ -39307,6 +40359,7 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bui" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -39337,6 +40390,7 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39431,9 +40485,11 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39455,9 +40511,11 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39466,6 +40524,7 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39495,10 +40554,12 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
+	dir = 2;
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
@@ -39521,6 +40582,7 @@
 "buC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39528,6 +40590,7 @@
 "buD" = (
 /obj/effect/landmark/start/geneticist,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39570,6 +40633,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39587,9 +40651,11 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39600,6 +40666,7 @@
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39650,9 +40717,11 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = -32;
+	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -39726,6 +40795,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39740,9 +40810,11 @@
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/book/manual/wiki/grenades,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -39751,9 +40823,11 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -39773,6 +40847,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -39794,9 +40869,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -39833,6 +40910,7 @@
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -39840,6 +40918,7 @@
 "bvg" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -39867,8 +40946,9 @@
 /area/medical/storage)
 "bvk" = (
 /obj/machinery/power/apc{
-	areastring = "/area/medical/storage";
+	dir = 2;
 	name = "Medbay Storage APC";
+	areastring = "/area/medical/storage";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -39938,6 +41018,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -39970,7 +41051,9 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bvw" = (
 /obj/structure/table/wood,
@@ -39981,7 +41064,9 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bvx" = (
 /obj/effect/landmark/carpspawn,
@@ -40002,8 +41087,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/crew_quarters/heads/hop";
+	dir = 2;
 	name = "Head of Personnel APC";
+	areastring = "/area/crew_quarters/heads/hop";
 	pixel_y = -24
 	},
 /turf/open/floor/wood,
@@ -40041,6 +41127,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -40051,6 +41138,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40062,13 +41150,15 @@
 "bvE" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bvF" = (
 /obj/machinery/door/airlock/grunge{
-	name = "Virology Maintenance Access"
+	name = "Virology Maintenance Access";
+	req_access_txt = "39"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -40083,6 +41173,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -40103,6 +41194,7 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -40118,12 +41210,13 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvJ" = (
@@ -40133,9 +41226,11 @@
 "bvK" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40181,6 +41276,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -40200,6 +41296,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -40235,12 +41332,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -40253,6 +41353,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40293,19 +41394,26 @@
 /obj/machinery/door/morgue{
 	name = "Study"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bvZ" = (
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bwa" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32
+	pixel_x = 32;
+	pixel_y = 0
 	},
 /obj/item/folder,
 /obj/item/folder,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bwb" = (
 /obj/machinery/light/small{
@@ -40321,9 +41429,11 @@
 "bwd" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -40353,6 +41463,7 @@
 "bwf" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
+	opacity = 1;
 	req_access_txt = "5"
 	},
 /obj/structure/cable{
@@ -40391,6 +41502,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40401,6 +41513,7 @@
 /area/maintenance/port/fore)
 "bwi" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40454,6 +41567,7 @@
 /area/medical/virology)
 "bwr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -40465,9 +41579,11 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40486,15 +41602,18 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -40509,6 +41628,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40519,6 +41639,7 @@
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40529,6 +41650,7 @@
 	},
 /obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40540,6 +41662,7 @@
 	},
 /obj/structure/chair/sofa,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40582,12 +41705,14 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40625,6 +41750,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40730,6 +41856,7 @@
 "bwS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -40773,6 +41900,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -40806,6 +41934,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -40813,6 +41942,7 @@
 "bwY" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -40823,6 +41953,7 @@
 	location = "9.3-Escape-3"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -40842,6 +41973,7 @@
 "bxd" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40852,9 +41984,11 @@
 /area/medical/chemistry)
 "bxf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -40906,6 +42040,7 @@
 /area/medical/medbay/central)
 "bxm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40919,6 +42054,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -40939,6 +42075,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -40991,18 +42128,22 @@
 "bxt" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -41037,14 +42178,15 @@
 /turf/open/floor/plating/asteroid,
 /area/maintenance/fore)
 "bxx" = (
+/obj/structure/disposalpipe/segment,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/starboard)
+/area/maintenance/department/cargo)
 "bxy" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -41157,6 +42299,7 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -41169,6 +42312,7 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -41176,6 +42320,7 @@
 "bxQ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -41189,6 +42334,7 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -41202,6 +42348,7 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -41233,6 +42380,7 @@
 /area/medical/virology)
 "bxX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -41245,6 +42393,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41254,6 +42403,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -41267,6 +42417,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41284,6 +42435,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41293,12 +42445,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bye" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -41317,6 +42471,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -41333,6 +42488,7 @@
 /area/medical/cryo)
 "byh" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -41365,6 +42521,7 @@
 /area/hallway/primary/starboard)
 "byj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -41374,6 +42531,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -41387,6 +42545,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41405,6 +42564,7 @@
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41415,6 +42575,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -41601,6 +42762,7 @@
 /area/medical/cryo)
 "byH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -41620,6 +42782,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41672,6 +42835,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -41702,9 +42866,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41736,12 +42902,14 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "byW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -41784,9 +42952,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -41823,9 +42993,11 @@
 "bzf" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -42074,6 +43246,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
+	dir = 2;
 	name = "Chemistry Lab APC";
 	pixel_y = -25
 	},
@@ -42098,15 +43271,18 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bzH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -42245,6 +43421,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42261,6 +43438,7 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -42295,6 +43473,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -42306,6 +43485,7 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -42315,9 +43495,11 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42335,6 +43517,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -42352,6 +43535,7 @@
 /area/maintenance/disposal)
 "bAf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -42370,6 +43554,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42385,6 +43570,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42397,6 +43583,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42419,6 +43606,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42448,6 +43636,7 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -42458,6 +43647,7 @@
 "bAp" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42476,6 +43666,7 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction/yjunction{
+	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -42530,6 +43721,7 @@
 "bAu" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42542,9 +43734,11 @@
 	areastring = "/area/medical/genetics/cloning";
 	dir = 8;
 	name = "Cloning Lab APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -42570,6 +43764,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -42588,6 +43783,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -42609,6 +43805,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42616,6 +43813,7 @@
 "bAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42651,6 +43849,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -42661,12 +43860,14 @@
 "bAD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bAE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42674,6 +43875,7 @@
 "bAF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42686,9 +43888,11 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42698,6 +43902,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42705,6 +43910,7 @@
 "bAI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42761,7 +43967,9 @@
 	name = "Private Study";
 	req_access_txt = "37"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bAO" = (
 /obj/machinery/airalarm/directional/west,
@@ -42781,9 +43989,11 @@
 "bAQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42802,6 +44012,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42813,6 +44024,7 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -42933,6 +44145,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42942,6 +44155,7 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
+	icon_state = "closed";
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock";
 	req_access_txt = "39"
@@ -43112,6 +44326,7 @@
 "bBu" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/cryo";
+	dir = 2;
 	name = "Cryogenics APC";
 	pixel_y = -24
 	},
@@ -43129,6 +44344,7 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -43159,6 +44375,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43197,6 +44414,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43210,6 +44428,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43260,6 +44479,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43277,6 +44497,7 @@
 /area/medical/medbay/lobby)
 "bBG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43310,6 +44531,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -43322,6 +44544,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -43331,6 +44554,7 @@
 /area/medical/medbay/central)
 "bBM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -43356,7 +44580,9 @@
 	pixel_x = -30
 	},
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bBQ" = (
 /obj/structure/chair/comfy/brown{
@@ -43364,9 +44590,12 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
+	pixel_x = 0;
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bBR" = (
 /obj/structure/rack{
@@ -43379,7 +44608,9 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bBS" = (
 /obj/structure/chair/office/dark{
@@ -43447,6 +44678,7 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
+	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -43469,6 +44701,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -43488,6 +44721,7 @@
 /area/medical/medbay/central)
 "bCd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43532,6 +44766,7 @@
 "bCj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43565,6 +44800,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43583,6 +44819,7 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43593,6 +44830,7 @@
 "bCr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43606,12 +44844,14 @@
 /area/security/checkpoint/medical)
 "bCu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bCv" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43622,6 +44862,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -43633,6 +44874,7 @@
 	id = "cmoshutter";
 	name = "CMO Office Shutters";
 	pixel_x = -25;
+	pixel_y = 0;
 	req_access_txt = "40"
 	},
 /turf/open/floor/plasteel/white,
@@ -43646,6 +44888,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -43663,6 +44906,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43676,6 +44920,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /mob/living/simple_animal/pet/penguin/emperor{
@@ -43686,6 +44931,7 @@
 /area/crew_quarters/heads/cmo)
 "bCA" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -43706,6 +44952,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/cmo{
@@ -43745,19 +44992,25 @@
 /area/maintenance/department/medical)
 "bCF" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bCG" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/clothing/under/suit_jacket/red,
 /obj/item/book/codex_gigas,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bCH" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bCI" = (
 /obj/structure/table/wood,
@@ -43769,14 +45022,18 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bCJ" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/storage/photo_album,
 /obj/item/camera,
-/turf/open/floor/plasteel/cult,
+/turf/open/floor/plasteel/cult{
+	dir = 2
+	},
 /area/library)
 "bCK" = (
 /obj/machinery/firealarm{
@@ -43868,6 +45125,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43875,6 +45133,7 @@
 "bCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43914,6 +45173,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43924,6 +45184,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43936,6 +45197,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43949,13 +45211,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -43987,6 +45252,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -43996,6 +45262,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44121,6 +45388,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -44149,6 +45417,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -44174,6 +45443,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -44193,6 +45463,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -44202,6 +45473,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -44222,12 +45494,14 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 30
 	},
 /obj/machinery/computer/med_data{
+	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44320,6 +45594,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44345,6 +45620,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44356,6 +45632,7 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -44392,6 +45669,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -44431,6 +45709,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -44458,6 +45737,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -44470,12 +45750,14 @@
 	},
 /obj/item/pen,
 /obj/machinery/camera{
-	c_tag = "Security Post - Engineering"
+	c_tag = "Security Post - Engineering";
+	dir = 2
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -44486,6 +45768,7 @@
 /area/hallway/secondary/command)
 "bDU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -44495,6 +45778,7 @@
 /area/crew_quarters/heads/hop/private)
 "bDV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -44514,6 +45798,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44527,12 +45812,14 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bDZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -44541,6 +45828,7 @@
 /obj/structure/chair,
 /obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -44550,6 +45838,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -44643,6 +45932,7 @@
 /area/medical/medbay/front_office)
 "bEi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -44680,6 +45970,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -44700,6 +45991,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/holopad,
@@ -44718,6 +46010,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -44738,6 +46031,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_medical_officer,
@@ -44761,6 +46055,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
@@ -44891,6 +46186,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber Fore";
+	dir = 2;
 	network = list("aicore")
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -44981,6 +46277,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -45014,6 +46311,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45044,6 +46342,7 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -45060,6 +46359,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45083,6 +46383,7 @@
 /area/medical/cryo)
 "bEV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45102,6 +46403,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45113,6 +46415,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45122,15 +46425,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bFa" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Medbay Security APC";
+	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -45160,9 +46464,11 @@
 /area/security/checkpoint/medical)
 "bFc" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45193,6 +46499,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/cmo,
@@ -45200,6 +46507,7 @@
 /area/crew_quarters/heads/cmo)
 "bFf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -45219,6 +46527,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -45238,9 +46547,11 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/computer/card/minor/cmo{
+	icon_state = "computer";
 	dir = 1
 	},
 /obj/machinery/requests_console{
@@ -45415,6 +46726,7 @@
 /area/ai_monitored/turret_protected/ai)
 "bFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45442,12 +46754,13 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/engineering";
 	dir = 8;
 	name = "Engineering Security APC";
+	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45467,6 +46780,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -45490,6 +46804,7 @@
 "bFL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
+	dir = 2;
 	name = "Medbay Lobby APC";
 	pixel_y = -24
 	},
@@ -45507,6 +46822,7 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -45519,6 +46835,7 @@
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/quartermaster/qm/private";
+	dir = 2;
 	name = "Quartermaster's Quarters APC";
 	pixel_y = -24
 	},
@@ -45555,9 +46872,11 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45586,9 +46905,11 @@
 "bFX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -45611,9 +46932,11 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -30
+	pixel_x = -30;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -45662,21 +46985,23 @@
 	},
 /obj/item/radio/off,
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/security/checkpoint/engineering)
 "bGf" = (
-/obj/item/radio/off,
-/obj/item/crowbar,
-/obj/item/screwdriver{
-	pixel_y = 10
+/obj/machinery/power/apc{
+	areastring = "/area/science/robotics/lab";
+	dir = 1;
+	name = "Robotics Lab APC";
+	pixel_y = 25
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 9
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/science/robotics/lab)
 "bGg" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -45685,6 +47010,7 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Central Hall APC";
+	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -45710,6 +47036,7 @@
 "bGi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/front_office";
+	dir = 2;
 	name = "Medbay Front Office APC";
 	pixel_y = -24
 	},
@@ -45750,12 +47077,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -45763,6 +47092,7 @@
 "bGn" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45828,6 +47158,7 @@
 /obj/machinery/light,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -45849,9 +47180,11 @@
 /area/storage/emergency/starboard)
 "bGu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45861,6 +47194,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -45872,6 +47206,7 @@
 "bGw" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/hop/private";
+	dir = 2;
 	name = "Head of Personnel's Quarters APC";
 	pixel_y = -24
 	},
@@ -46083,21 +47418,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/landmark/start/paramedic,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGW" = (
@@ -46233,6 +47559,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -46252,6 +47579,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -46342,6 +47670,7 @@
 "bHn" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -46354,6 +47683,7 @@
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -46363,10 +47693,10 @@
 /obj/machinery/door/window{
 	base_state = "rightsecure";
 	dir = 4;
+	obj_integrity = 300;
 	icon_state = "rightsecure";
 	layer = 4.1;
 	name = "Secondary AI Core Access";
-	obj_integrity = 300;
 	pixel_x = 4;
 	req_access_txt = "16"
 	},
@@ -46407,12 +47737,14 @@
 	pixel_y = 7
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = 27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -46439,6 +47771,7 @@
 "bHs" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -46451,6 +47784,7 @@
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
+	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -46460,10 +47794,10 @@
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 8;
+	obj_integrity = 300;
 	icon_state = "leftsecure";
 	layer = 4.1;
 	name = "Tertiary AI Core Access";
-	obj_integrity = 300;
 	pixel_x = -3;
 	req_access_txt = "16"
 	},
@@ -46492,8 +47826,10 @@
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	dir = 8;
+	icon_state = "sink_alt";
 	name = "old sink";
-	pixel_x = 15
+	pixel_x = 15;
+	pixel_y = 0
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -46521,6 +47857,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -46529,6 +47866,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -46536,6 +47874,7 @@
 "bHD" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46547,6 +47886,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46554,6 +47894,7 @@
 "bHF" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46573,6 +47914,7 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46590,6 +47932,7 @@
 "bHI" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46600,6 +47943,7 @@
 	light_color = "#706891"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46607,12 +47951,14 @@
 "bHK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -46632,6 +47978,7 @@
 /obj/item/wrench,
 /obj/item/multitool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -46731,9 +48078,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/solars/starboard/aft";
 	dir = 8;
 	name = "Starboard Quarter Solar APC";
+	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -46777,6 +48124,7 @@
 	dir = 1
 	},
 /obj/machinery/turnstile{
+	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -46785,6 +48133,7 @@
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
+	dir = 2;
 	pixel_x = -30;
 	pixel_y = -30
 	},
@@ -46819,9 +48168,9 @@
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 8;
+	obj_integrity = 300;
 	icon_state = "leftsecure";
 	name = "Primary AI Core Access";
-	obj_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/newscaster/security_unit{
@@ -46844,13 +48193,14 @@
 /obj/machinery/door/window{
 	base_state = "rightsecure";
 	dir = 4;
+	obj_integrity = 300;
 	icon_state = "rightsecure";
 	name = "Primary AI Core Access";
-	obj_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
+	dir = 2;
 	network = list("aicore")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -46939,6 +48289,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -46979,6 +48330,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -46998,6 +48350,7 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -47016,6 +48369,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47024,6 +48378,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -47079,9 +48434,9 @@
 /area/maintenance/department/cargo)
 "bII" = (
 /obj/machinery/power/apc{
-	areastring = "/area/maintenance/starboard";
 	dir = 4;
 	name = "Starboard Maintenance APC";
+	areastring = "/area/maintenance/starboard";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -47341,6 +48696,7 @@
 /area/maintenance/bar)
 "bJn" = (
 /obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -47406,10 +48762,10 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port)
+/area/maintenance/starboard)
 "bJv" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -47464,8 +48820,9 @@
 /area/medical/medbay/central)
 "bJz" = (
 /obj/machinery/power/apc{
-	areastring = "/area/medical/surgery";
+	dir = 2;
 	name = "Surgery APC";
+	areastring = "/area/medical/surgery";
 	pixel_y = -26
 	},
 /obj/machinery/light,
@@ -47490,6 +48847,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -47578,6 +48936,7 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -47590,6 +48949,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -47602,6 +48962,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -47621,6 +48982,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -47630,6 +48992,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -47650,6 +49013,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47662,6 +49026,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47675,6 +49040,7 @@
 	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -47688,6 +49054,7 @@
 	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -47700,6 +49067,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47715,6 +49083,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47805,6 +49174,7 @@
 /area/maintenance/solars/starboard/aft)
 "bJW" = (
 /obj/machinery/power/terminal{
+	icon_state = "term";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -47817,7 +49187,8 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control"
+	name = "Starboard Quarter Solar Control";
+	track = 0
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -47841,6 +49212,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -47857,6 +49229,7 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -47948,6 +49321,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -47963,6 +49337,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47982,6 +49357,7 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48014,6 +49390,7 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48028,6 +49405,7 @@
 /obj/machinery/microwave,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -48043,12 +49421,14 @@
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bKu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -48073,9 +49453,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -48086,6 +49468,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48119,6 +49502,7 @@
 "bKD" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48160,9 +49544,11 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48181,6 +49567,7 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48192,6 +49579,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -48218,8 +49606,9 @@
 /area/maintenance/port)
 "bKO" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/maintenance/port";
+	dir = 2;
 	name = "Port Maintenance APC";
+	areastring = "/area/maintenance/port";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -48255,6 +49644,7 @@
 	pixel_x = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48262,12 +49652,14 @@
 "bKS" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/power/apc{
-	areastring = "/area/hydroponics/garden/abandoned";
+	dir = 2;
 	name = "Abandoned Garden APC";
+	areastring = "/area/hydroponics/garden/abandoned";
 	pixel_y = -26
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -48280,6 +49672,7 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48296,9 +49689,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -48310,6 +49705,7 @@
 	},
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48323,6 +49719,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -48337,6 +49734,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -48390,13 +49788,14 @@
 /area/medical)
 "bLf" = (
 /obj/machinery/power/apc{
-	areastring = "/area/medical/patients_rooms/room_a";
 	dir = 8;
 	name = "Patient Room A APC";
+	areastring = "/area/medical/patients_rooms/room_a";
 	pixel_x = -26
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48412,6 +49811,7 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48422,6 +49822,7 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -48467,6 +49868,7 @@
 /area/maintenance/central)
 "bLo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -48476,6 +49878,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48493,6 +49896,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48509,6 +49913,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48519,6 +49924,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48534,6 +49940,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48546,6 +49953,7 @@
 	},
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48574,9 +49982,11 @@
 "bLw" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/wallmed{
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -48589,6 +49999,7 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -48596,6 +50007,7 @@
 "bLy" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -48634,6 +50046,7 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/item/surgical_drapes,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -48643,6 +50056,7 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/item/surgical_drapes,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -48668,6 +50082,7 @@
 "bLG" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -48682,6 +50097,7 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -48704,6 +50120,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48713,6 +50130,7 @@
 /area/quartermaster/qm/private)
 "bLN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -48740,6 +50158,7 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -48753,6 +50172,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -48887,7 +50307,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bMa" = (
-/obj/machinery/porta_turret/ai,
+/obj/machinery/porta_turret/ai{
+	dir = 2
+	},
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
@@ -48906,6 +50328,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -48984,7 +50407,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bMi" = (
-/obj/machinery/porta_turret/ai,
+/obj/machinery/porta_turret/ai{
+	dir = 2
+	},
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
 	pixel_x = 28
@@ -48997,6 +50422,7 @@
 "bMj" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -49055,9 +50481,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49147,6 +50575,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49246,9 +50675,11 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
+	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49262,12 +50693,14 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	dir = 1;
 	name = "MiniSat Antechamber APC";
+	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49277,6 +50710,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49313,6 +50747,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49320,6 +50755,7 @@
 "bMM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49346,6 +50782,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bMQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49357,6 +50794,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49408,6 +50846,7 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical";
+	dir = 2;
 	name = "Breakroom APC";
 	pixel_y = -24
 	},
@@ -49425,13 +50864,11 @@
 /area/engine/transit_tube)
 "bNa" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/port)
 "bNb" = (
@@ -49480,6 +50917,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49496,6 +50934,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bNi" = (
 /obj/structure/showcase/cyborg/old{
+	dir = 2;
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -49512,6 +50951,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -49535,9 +50975,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -49572,12 +51014,15 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -49599,6 +51044,7 @@
 "bNp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -49727,6 +51173,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49780,6 +51227,7 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bNE" = (
 /obj/structure/transit_tube/diagonal{
+	icon_state = "diagonal";
 	dir = 8
 	},
 /turf/open/space,
@@ -49791,6 +51239,7 @@
 "bNG" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -49806,9 +51255,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -49821,24 +51272,28 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -49852,6 +51307,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49859,9 +51315,11 @@
 "bNP" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49870,6 +51328,7 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49880,6 +51339,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49888,6 +51348,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49895,9 +51356,11 @@
 "bNT" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49907,6 +51370,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -49914,6 +51378,7 @@
 "bNV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49950,6 +51415,7 @@
 /area/hallway/secondary/exit)
 "bNX" = (
 /obj/structure/showcase/cyborg/old{
+	dir = 2;
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -49963,12 +51429,14 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bNZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49977,6 +51445,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50199,7 +51668,9 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bOm" = (
-/obj/machinery/porta_turret/ai,
+/obj/machinery/porta_turret/ai{
+	dir = 2
+	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -50369,6 +51840,7 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
+	enabled = 1;
 	icon_state = "control_stun";
 	name = "Antechamber Turret Control";
 	pixel_x = -32;
@@ -50453,6 +51925,7 @@
 "bOA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/junction{
+	icon_state = "junction0";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -50542,6 +52015,7 @@
 /area/space/nearstation)
 "bOI" = (
 /obj/structure/transit_tube/junction{
+	icon_state = "junction0";
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
@@ -50728,6 +52202,7 @@
 /area/hallway/primary/aft)
 "bOW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -50861,6 +52336,7 @@
 /area/hallway/primary/aft)
 "bPc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -51048,6 +52524,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51057,6 +52534,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51176,6 +52654,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51205,9 +52684,11 @@
 	sortType = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51236,9 +52717,11 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51369,6 +52852,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -51381,8 +52865,10 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
+	dir = 2;
 	name = "MiniSat Foyer APC";
-	pixel_x = -29
+	pixel_x = -29;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -51391,6 +52877,7 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -51399,6 +52886,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -51413,6 +52901,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51425,12 +52914,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bPP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51444,9 +52935,11 @@
 	areastring = "/area/aisat";
 	dir = 8;
 	name = "MiniSat Exterior APC";
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51457,6 +52950,7 @@
 /area/space/nearstation)
 "bPS" = (
 /obj/structure/transit_tube/diagonal{
+	icon_state = "diagonal";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -51493,12 +52987,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -51592,11 +53088,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway Port";
-	dir = 4
+	dir = 4;
+	name = "security camera";
+	network = list("ss13")
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -51614,6 +53113,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -51639,6 +53139,7 @@
 /area/ai_monitored/storage/satellite)
 "bQm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -51670,6 +53171,7 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51679,12 +53181,14 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bQq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -51698,6 +53202,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -51747,11 +53252,13 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/port/aft)
+/area/maintenance/port)
 "bQy" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -51792,10 +53299,10 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/department/crew_quarters/dorms)
+/area/maintenance/port/aft)
 "bQG" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51807,6 +53314,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51845,19 +53353,24 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 1;
+	icon_state = "connector_map-1";
 	name = "Auxiliary MiniSat Distribution Port"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/satellite)
 "bQL" = (
-/obj/machinery/porta_turret/ai,
+/obj/machinery/porta_turret/ai{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bQM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -51867,9 +53380,11 @@
 /area/hallway/primary/starboard)
 "bQN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51898,9 +53413,11 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -51923,6 +53440,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -51938,6 +53456,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -51948,6 +53467,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "N2O to Pure"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -51966,6 +53486,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -51979,6 +53500,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -52073,6 +53595,8 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
+	departmentType = 0;
+	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/folder/yellow,
@@ -52136,6 +53660,7 @@
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/carpet,
@@ -52152,6 +53677,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -52184,9 +53710,11 @@
 /area/crew_quarters/dorms)
 "bRo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/carpet,
@@ -52200,12 +53728,14 @@
 "bRq" = (
 /obj/structure/showcase/mecha/ripley,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
 "bRr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52216,6 +53746,7 @@
 /area/crew_quarters/fitness/recreation)
 "bRt" = (
 /obj/machinery/cryopod{
+	icon_state = "cryopod-open";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52226,6 +53757,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/newscaster{
+	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/loading_area{
@@ -52238,6 +53770,7 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52367,6 +53900,7 @@
 "bRM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -52386,6 +53920,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -52404,12 +53939,14 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bRR" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -52429,6 +53966,7 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
+	icon_state = "direction_sci";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/command{
@@ -52443,15 +53981,18 @@
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bRU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52473,6 +54014,7 @@
 /area/crew_quarters/fitness/recreation)
 "bRW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -52490,9 +54032,11 @@
 "bRY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52500,9 +54044,11 @@
 "bRZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52552,6 +54098,7 @@
 /area/tcommsat/computer)
 "bSh" = (
 /obj/structure/showcase/cyborg/old{
+	dir = 2;
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/grimy,
@@ -52613,6 +54160,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -52672,6 +54220,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52679,6 +54228,7 @@
 "bSv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -52702,6 +54252,7 @@
 "bSx" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52731,6 +54282,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -52751,15 +54303,18 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bSD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52773,6 +54328,7 @@
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52782,6 +54338,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -52801,6 +54358,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -52885,9 +54443,11 @@
 /area/tcommsat/computer)
 "bSW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -52963,9 +54523,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/computer";
 	dir = 4;
 	name = "Telecomms Control Room APC";
+	areastring = "/area/tcommsat/computer";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
@@ -53114,6 +54674,7 @@
 /area/storage/primary)
 "bTp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53147,9 +54708,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -53162,9 +54725,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -53181,9 +54746,11 @@
 /area/crew_quarters/fitness/recreation)
 "bTv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -53239,6 +54806,7 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53254,12 +54822,15 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -53267,22 +54838,27 @@
 "bTC" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bTD" = (
 /obj/effect/turf_decal/trimline/green/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bTE" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/dorms)
+/area/maintenance/department/crew_quarters/dorms)
 "bTF" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -53310,9 +54886,9 @@
 /area/storage/tech)
 "bTI" = (
 /obj/machinery/power/apc{
-	areastring = "/area/storage/tech";
 	dir = 8;
 	name = "Tech Storage APC";
+	areastring = "/area/storage/tech";
 	pixel_x = -27
 	},
 /obj/structure/cable{
@@ -53404,6 +54980,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53426,9 +55003,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53522,7 +55101,8 @@
 	areastring = "/area/storage/primary";
 	dir = 8;
 	name = "Tool Storage APC";
-	pixel_x = -25
+	pixel_x = -25;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -53688,6 +55268,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53716,9 +55297,11 @@
 "bUo" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53749,13 +55332,16 @@
 /area/crew_quarters/fitness/recreation)
 "bUr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
+	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -53770,6 +55356,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -53821,6 +55408,7 @@
 /area/crew_quarters/fitness/recreation)
 "bUx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -53834,6 +55422,7 @@
 "bUy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -53858,9 +55447,11 @@
 "bUA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53938,26 +55529,31 @@
 /area/storage/tech)
 "bUN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bUO" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/machinery/door/window/westright,
-/obj/structure/fans/tiny,
-/obj/effect/turf_decal/trimline/blue/filled/end{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/power/apc{
+	areastring = "/area/maintenance/fore";
+	dir = 4;
+	name = "Fore Maintenance APC";
+	pixel_x = 24;
+	pixel_y = 0
+	},
+/turf/open/floor/plating,
+/area/maintenance/fore)
 "bUP" = (
 /turf/closed/wall/r_wall,
 /area/tcommsat/server)
@@ -54036,15 +55632,18 @@
 "bUY" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bUZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -54073,6 +55672,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/supply{
@@ -54183,6 +55783,7 @@
 "bVk" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -54190,6 +55791,7 @@
 	location = "aft1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54200,9 +55802,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54228,30 +55832,43 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit)
 "bVo" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced/spawner,
-/obj/machinery/door/window/eastright,
-/obj/machinery/light/small{
+/obj/machinery/light{
 	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
+	light_color = "#706891"
 	},
-/obj/effect/turf_decal/trimline/blue/filled/line,
-/obj/effect/turf_decal/trimline/blue/filled/line{
+/obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/sign/directions/medical{
+	dir = 4;
+	icon_state = "direction_med";
+	pixel_y = 40
+	},
+/obj/structure/sign/directions/engineering{
+	dir = 4;
+	pixel_y = 32
+	},
+/obj/structure/sign/directions/evac{
+	dir = 4;
+	pixel_x = 0;
+	pixel_y = 24
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bVp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -54265,6 +55882,7 @@
 	uses = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -54289,6 +55907,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
+	dir = 2;
 	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -54298,6 +55917,7 @@
 	dir = 4
 	},
 /obj/machinery/computer/arcade/orion_trail{
+	icon_state = "arcade";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54349,6 +55969,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54363,7 +55984,8 @@
 	},
 /obj/machinery/announcement_system,
 /obj/machinery/status_display/ai{
-	pixel_x = 31
+	pixel_x = 31;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -54450,15 +56072,18 @@
 /area/medical/morgue)
 "bVI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -54469,12 +56094,14 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bVK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -54482,6 +56109,7 @@
 	location = "starboard3"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -54580,9 +56208,11 @@
 /area/library)
 "bVQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -54623,6 +56253,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/light_switch{
@@ -54648,6 +56279,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/sign/directions/evac{
@@ -54669,21 +56301,26 @@
 "bVX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bVY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54774,6 +56411,7 @@
 /area/tcommsat/computer)
 "bWm" = (
 /obj/machinery/computer/message_monitor{
+	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -54854,9 +56492,11 @@
 /area/crew_quarters/fitness/recreation)
 "bWs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54872,6 +56512,7 @@
 /area/crew_quarters/dorms)
 "bWu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54890,6 +56531,7 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -54913,12 +56555,14 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "bWy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -54941,6 +56585,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -54968,9 +56613,11 @@
 "bWF" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -55025,6 +56672,7 @@
 /obj/machinery/telecomms/processor/preset_three,
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
+	dir = 2;
 	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -55050,6 +56698,7 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -55132,6 +56781,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -55187,9 +56837,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55207,6 +56859,7 @@
 "bXb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55239,10 +56892,12 @@
 /area/tcommsat/server)
 "bXh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55311,15 +56966,18 @@
 "bXr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bXs" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -55379,6 +57037,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -55427,9 +57086,11 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55442,9 +57103,11 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55454,9 +57117,11 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -55580,6 +57245,7 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55598,6 +57264,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -55651,12 +57318,14 @@
 	pixel_x = 3
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 31
+	pixel_x = 31;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
 "bXT" = (
 /obj/structure/transit_tube/station{
+	icon_state = "closed_station0";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -55669,6 +57338,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -55676,9 +57346,11 @@
 "bXU" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/machinery/camera/autoname,
@@ -55686,6 +57358,7 @@
 /area/medical/virology)
 "bXV" = (
 /obj/structure/chair/sofa/left{
+	icon_state = "sofaend_left";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -55693,6 +57366,7 @@
 "bXW" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/chair/sofa/right{
+	icon_state = "sofaend_right";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -55752,12 +57426,11 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bYc" = (
-/obj/machinery/door/airlock/maintenance,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/crew_quarters/dorms)
 "bYd" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
 	dir = 4
@@ -55783,20 +57456,24 @@
 "bYe" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bYf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -55828,6 +57505,7 @@
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -38;
+	pixel_y = 0;
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel,
@@ -55857,6 +57535,7 @@
 "bYk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -55910,6 +57589,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55949,14 +57629,23 @@
 /area/engine/break_room)
 "bYs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYt" = (
-/obj/machinery/door/airlock/maintenance,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
 /turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/area/hallway/primary/starboard)
 "bYu" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -55971,8 +57660,9 @@
 /area/maintenance/starboard/aft)
 "bYw" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/maintenance/starboard/aft";
+	dir = 2;
 	name = "Starboard Quarter Maintenance APC";
+	areastring = "/area/maintenance/starboard/aft";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -56002,6 +57692,7 @@
 /area/maintenance/starboard/aft)
 "bYA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -56036,9 +57727,9 @@
 /area/tcommsat/server)
 "bYF" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/tcommsat/server";
 	dir = 4;
 	name = "Telecomms Server Room APC";
+	areastring = "/area/tcommsat/server";
 	pixel_x = 25
 	},
 /obj/machinery/light/small{
@@ -56059,10 +57750,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56081,7 +57774,8 @@
 	dir = 4;
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
-	pixel_x = 30
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -56152,6 +57846,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -56205,6 +57900,7 @@
 "bYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -56219,6 +57915,7 @@
 	},
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56338,6 +58035,7 @@
 "bZk" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/item/flashlight,
@@ -56381,6 +58079,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56481,13 +58180,11 @@
 /area/crew_quarters/toilet)
 "bZx" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
+	name = "Engineering Maintenance";
+	req_access_txt = "10"
 	},
 /turf/open/floor/plating,
-/area/crew_quarters/toilet)
+/area/maintenance/starboard/aft)
 "bZy" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -56509,9 +58206,11 @@
 "bZA" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/computer/card/minor/ce{
+	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -56519,6 +58218,7 @@
 /area/crew_quarters/heads/chief)
 "bZB" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -56527,9 +58227,11 @@
 "bZC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -56548,6 +58250,7 @@
 	dir = 8
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
+	icon_state = "console";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -56592,6 +58295,7 @@
 /area/engine/break_room)
 "bZG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -56620,10 +58324,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -56631,6 +58337,7 @@
 "bZJ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -56659,15 +58366,14 @@
 /turf/open/floor/plasteel,
 /area/security/nuke_storage)
 "bZM" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/structure/disposalpipe/segment,
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
 /turf/open/floor/plating,
-/area/maintenance/aft)
+/area/crew_quarters/toilet)
 "bZN" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
@@ -56680,6 +58386,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -56704,9 +58411,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -56727,6 +58436,7 @@
 /area/crew_quarters/fitness/recreation)
 "bZT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -56741,6 +58451,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -56770,6 +58481,7 @@
 "bZY" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/toilet";
+	dir = 2;
 	name = "Restrooms APC";
 	pixel_y = -26
 	},
@@ -56781,6 +58493,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -56793,6 +58506,7 @@
 	dir = 8
 	},
 /obj/machinery/computer/station_alert{
+	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -56870,7 +58584,8 @@
 	areastring = "/area/crew_quarters/heads/chief";
 	dir = 4;
 	name = "Chief Engineer's APC";
-	pixel_x = 26
+	pixel_x = 26;
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -56910,6 +58625,7 @@
 "cah" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56931,6 +58647,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -56960,6 +58677,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -56991,7 +58709,8 @@
 	areastring = "/area/crew_quarters/locker";
 	dir = 8;
 	name = "Locker Room APC";
-	pixel_x = -28
+	pixel_x = -28;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -57010,6 +58729,7 @@
 /area/crew_quarters/locker)
 "cav" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -57089,12 +58809,14 @@
 "caB" = (
 /obj/structure/urinal{
 	dir = 8;
+	icon_state = "urinal";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "caC" = (
 /obj/machinery/computer/apc_control{
+	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -57154,6 +58876,7 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -57336,9 +59059,9 @@
 "caP" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	areastring = "/area/storage/tcom";
 	dir = 8;
 	name = "Telecomms Storage APC";
+	areastring = "/area/storage/tcom";
 	pixel_x = -28
 	},
 /obj/structure/cable,
@@ -57413,6 +59136,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -57453,22 +59177,24 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "cbb" = (
-/obj/machinery/power/apc{
-	areastring = "/area/";
-	dir = 4;
-	name = "Aft Port Maintenance APC";
-	pixel_x = 24
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/door/window/westright{
+	req_one_access_txt = "32;19"
 	},
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/structure/fans/tiny,
+/obj/effect/turf_decal/trimline/blue/filled/end{
+	icon_state = "trimline_end_fill";
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/port/aft)
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "cbc" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -57483,6 +59209,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57496,6 +59223,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57532,6 +59260,7 @@
 "cbh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57560,9 +59289,11 @@
 /area/crew_quarters/fitness/recreation)
 "cbk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57589,12 +59320,14 @@
 	areastring = "/area/crew_quarters/dorms";
 	dir = 4;
 	name = "Dormitories APC";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57708,6 +59441,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57738,6 +59472,7 @@
 "cbx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -57787,6 +59522,7 @@
 /area/space)
 "cbD" = (
 /obj/structure/transit_tube/curved/flipped{
+	icon_state = "curved1";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -57794,6 +59530,7 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -57814,7 +59551,7 @@
 /area/maintenance/port/aft)
 "cbG" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -57846,6 +59583,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57864,6 +59602,7 @@
 /area/medical/patients_rooms/room_a)
 "cbK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -57926,6 +59665,7 @@
 /area/crew_quarters/fitness/recreation)
 "cbO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -57933,6 +59673,7 @@
 "cbP" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57948,6 +59689,7 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57976,6 +59718,7 @@
 /area/science/robotics/lab)
 "cbU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -57994,6 +59737,7 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -58094,6 +59838,7 @@
 "cch" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -58101,6 +59846,7 @@
 "cci" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -58157,6 +59903,7 @@
 /area/crew_quarters/fitness/recreation)
 "ccn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58166,6 +59913,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58193,12 +59941,14 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/dorms)
 "ccr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/camera{
@@ -58214,6 +59964,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -58224,6 +59975,7 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
@@ -58243,6 +59995,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -58337,6 +60090,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -58357,6 +60111,7 @@
 /area/asteroid/nearstation)
 "ccI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -58406,6 +60161,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -58419,6 +60175,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -58444,9 +60201,11 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ccU" = (
-/obj/machinery/door/airlock/maintenance,
 /obj/structure/cable{
 	icon_state = "1-2"
+	},
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -58455,6 +60214,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -58497,7 +60257,8 @@
 	areastring = "/area/crew_quarters/heads/cmo/private";
 	dir = 4;
 	name = "Chief Medical Officer's Quarters APC";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -58514,6 +60275,7 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -58526,6 +60288,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58536,6 +60299,7 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -58562,6 +60326,7 @@
 /obj/machinery/recharger,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -58677,6 +60442,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -58817,6 +60583,7 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
+	pixel_y = 0;
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
@@ -58827,6 +60594,7 @@
 "cdI" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/dormitory";
+	dir = 2;
 	name = "Dormitory Maintenance APC";
 	pixel_y = -28
 	},
@@ -58861,6 +60629,7 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -58874,6 +60643,7 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -58882,6 +60652,7 @@
 /obj/machinery/microwave,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -58923,6 +60694,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -58933,6 +60705,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -58994,6 +60767,7 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59031,6 +60805,7 @@
 /area/crew_quarters/toilet)
 "ceh" = (
 /obj/machinery/requests_console{
+	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC"
@@ -59197,6 +60972,7 @@
 /area/maintenance/aft)
 "ceH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/camera/autoname,
@@ -59213,6 +60989,7 @@
 	},
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59226,6 +61003,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "ceK" = (
 /obj/structure/sign/warning/radiation/rad_area{
+	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -59242,6 +61020,7 @@
 /area/engine/break_room)
 "ceM" = (
 /obj/machinery/door/window/southright{
+	dir = 2;
 	name = "Engineering Deliveries";
 	req_access_txt = "10"
 	},
@@ -59257,9 +61036,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -59269,13 +61050,15 @@
 /obj/item/bedsheet/cmo,
 /obj/structure/bed,
 /obj/machinery/status_display/ai{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo/private)
 "ceP" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59283,6 +61066,7 @@
 "ceQ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59290,6 +61074,7 @@
 "ceR" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59310,6 +61095,7 @@
 /area/hallway/primary/aft)
 "ceU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59322,6 +61108,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59430,6 +61217,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59439,6 +61227,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59481,6 +61270,7 @@
 /area/maintenance/aft)
 "cfq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59502,6 +61292,7 @@
 /area/crew_quarters/locker)
 "cfs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
+	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59511,6 +61302,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -59520,6 +61312,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59540,6 +61333,7 @@
 /area/engine/gravity_generator)
 "cfx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -59560,6 +61354,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -59646,6 +61441,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59659,6 +61455,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59687,6 +61484,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59697,6 +61495,7 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -59725,6 +61524,7 @@
 	areastring = "/area/chapel/main";
 	dir = 1;
 	name = "Chapel APC";
+	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -59828,6 +61628,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59840,6 +61641,7 @@
 "cgl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -59896,6 +61698,7 @@
 /area/engine/gravity_generator)
 "cgs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59956,6 +61759,7 @@
 	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60067,6 +61871,7 @@
 /area/chapel/main)
 "cgP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -60158,9 +61963,9 @@
 /area/crew_quarters/heads/chief)
 "chd" = (
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/engine/gravity_generator";
 	dir = 1;
 	name = "Gravity Generator APC";
+	areastring = "/area/engine/gravity_generator";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -60183,6 +61988,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60219,6 +62025,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -60291,6 +62098,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60339,6 +62147,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -60387,6 +62196,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60447,6 +62257,7 @@
 "chK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -60516,24 +62327,29 @@
 "chR" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "chS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "chT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light{
@@ -60621,15 +62437,23 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cic" = (
-/obj/structure/table,
-/obj/structure/disposalpipe/segment{
-	dir = 4
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced/spawner,
+/obj/machinery/door/window/eastright{
+	req_one_access_txt = "32;19"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
 	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
+/obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 "cid" = (
 /obj/structure/chair{
 	dir = 8
@@ -60654,15 +62478,18 @@
 /area/engine/break_room)
 "cif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "cig" = (
 /obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60672,9 +62499,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -60791,6 +62620,7 @@
 "cis" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
+	icon_state = "filter_on";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -60827,6 +62657,7 @@
 "civ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
+	icon_state = "filter_on";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -60920,6 +62751,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
+	icon_state = "filter_on";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60952,6 +62784,7 @@
 /area/maintenance/port)
 "ciE" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
+	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -60980,10 +62813,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway Stern";
+	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -61037,6 +62872,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -61073,6 +62909,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -61119,12 +62956,14 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ciZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61199,6 +63038,7 @@
 "cjg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61333,6 +63173,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61345,6 +63186,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61357,6 +63199,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61393,6 +63236,7 @@
 /area/maintenance/aft)
 "cjC" = (
 /obj/structure/mirror{
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/lipstick/black,
@@ -61437,6 +63281,7 @@
 "cjG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -61452,6 +63297,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -61642,6 +63488,7 @@
 /area/engine/atmos)
 "ckg" = (
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Pure to Fuel Pipe"
 	},
 /turf/open/floor/plasteel,
@@ -61652,13 +63499,13 @@
 /area/engine/atmos)
 "cki" = (
 /obj/machinery/power/apc{
-	areastring = "/area/security/checkpoint/customs";
-	name = "Customs APC";
-	pixel_x = 1;
-	pixel_y = -24
+	areastring = "/area/maintenance/port/aft";
+	dir = 4;
+	name = "Aft Port Maintenance APC";
+	pixel_x = 24
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
@@ -61693,6 +63540,7 @@
 /area/chapel/main)
 "cko" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -61726,7 +63574,8 @@
 "ckr" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
-	pixel_x = 30
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -61758,21 +63607,15 @@
 /turf/closed/wall/r_wall,
 /area/engine/engine_smes)
 "ckw" = (
-/obj/machinery/power/apc{
-	areastring = "/area/engine/engine_smes";
-	dir = 1;
-	name = "SMES room APC";
-	pixel_x = -26
+/obj/machinery/door/airlock/maintenance{
+	name = "Atmospherics Maintenance";
+	req_access_txt = "24"
 	},
 /obj/structure/cable{
-	icon_state = "0-2";
-	pixel_y = 1
+	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "2-4"
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
+/turf/open/floor/plating,
+/area/maintenance/starboard/aft)
 "ckx" = (
 /obj/machinery/camera{
 	c_tag = "Atmospherics Tank - N2O";
@@ -61781,15 +63624,19 @@
 /turf/open/floor/engine/n2o,
 /area/engine/atmos)
 "cky" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+/obj/structure/table,
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/engine/engine_smes)
+/obj/item/stack/cable_coil,
+/obj/item/stack/cable_coil,
+/obj/item/twohanded/rcl/pre_loaded,
+/obj/item/twohanded/rcl/pre_loaded,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
 "ckz" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -61915,6 +63762,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62023,7 +63871,8 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -62072,17 +63921,14 @@
 /turf/closed/wall,
 /area/security/vacantoffice/a)
 "clb" = (
-/obj/machinery/power/apc{
-	areastring = "/area/vacant_room/office";
-	dir = 8;
-	name = "Vacant Office APC";
-	pixel_x = -25
-	},
 /obj/structure/cable{
-	icon_state = "0-2"
+	icon_state = "4-8"
 	},
-/turf/open/floor/wood,
-/area/security/vacantoffice/a)
+/obj/machinery/door/airlock/maintenance{
+	req_one_access_txt = "12;5;39;6"
+	},
+/turf/open/floor/plating,
+/area/maintenance/aft)
 "clc" = (
 /turf/open/floor/wood,
 /area/security/vacantoffice/a)
@@ -62158,27 +64004,22 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "clm" = (
-/obj/machinery/power/terminal,
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
+/obj/machinery/power/apc{
+	areastring = "/area/engine/engine_smes";
+	dir = 1;
+	name = "SMES room APC";
+	pixel_x = -26;
+	pixel_y = 0
 	},
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
@@ -62300,6 +64141,7 @@
 /area/engine/atmos)
 "clA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
+	icon_state = "filter_on";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62309,9 +64151,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -62350,6 +64194,7 @@
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -62357,6 +64202,7 @@
 "clG" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/engine/break_room";
+	dir = 2;
 	name = "Engineering Foyer APC";
 	pixel_y = -24
 	},
@@ -62402,6 +64248,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62409,6 +64256,7 @@
 "clL" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62426,10 +64274,12 @@
 "clO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62450,9 +64300,11 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62489,6 +64341,7 @@
 	broadcasting = 1;
 	frequency = 1481;
 	name = "Confessional Intercom";
+	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light/small{
@@ -62509,6 +64362,7 @@
 	broadcasting = 1;
 	frequency = 1481;
 	name = "Confessional Intercom";
+	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light/small{
@@ -62568,6 +64422,7 @@
 /area/crew_quarters/heads/chief)
 "cmf" = (
 /obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -62601,12 +64456,14 @@
 "cmi" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -62645,6 +64502,7 @@
 "cmm" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
+	dir = 8;
 	icon_state = "right"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -62658,6 +64516,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62710,6 +64569,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62756,6 +64616,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62770,6 +64631,7 @@
 /obj/item/wrench,
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -62790,6 +64652,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62798,6 +64661,7 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Office";
+	opacity = 1;
 	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -62840,6 +64704,7 @@
 /area/security/vacantoffice/a)
 "cmJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -62858,12 +64723,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -62879,12 +64746,14 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -62950,11 +64819,24 @@
 /turf/open/floor/plating,
 /area/chapel/main)
 "cmT" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/structure/chair/comfy/black{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/crew_quarters/fitness/recreation)
+/obj/machinery/button{
+	id = "bridgespace";
+	name = "Bridge External Shutters";
+	pixel_x = 36;
+	pixel_y = 30
+	},
+/obj/machinery/button{
+	id = "bridgespace";
+	name = "Bridge Access Shutters";
+	pixel_x = 26;
+	pixel_y = 30;
+	req_access_txt = "19"
+	},
+/turf/open/floor/carpet,
+/area/bridge)
 "cmU" = (
 /obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
@@ -63007,9 +64889,11 @@
 	areastring = "/area/engine/atmos";
 	dir = 1;
 	name = "Atmospherics APC";
-	pixel_x = -27
+	pixel_x = -27;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63055,6 +64939,7 @@
 	pixel_x = -28
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63086,6 +64971,7 @@
 /area/engine/atmos)
 "cnj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
@@ -63158,6 +65044,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63192,6 +65079,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63220,6 +65108,7 @@
 /area/security/vacantoffice/a)
 "cnz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -63242,6 +65131,7 @@
 /area/chapel/office)
 "cnC" = (
 /obj/machinery/computer/arcade{
+	icon_state = "arcade";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -63249,12 +65139,14 @@
 "cnD" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
@@ -63309,9 +65201,11 @@
 "cnH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -63389,9 +65283,11 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -63404,12 +65300,15 @@
 /area/hydroponics/garden)
 "cnQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63424,6 +65323,7 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -63438,16 +65338,10 @@
 /area/maintenance/central)
 "cnU" = (
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
-/area/hallway/primary/starboard)
+/area/crew_quarters/fitness/recreation)
 "cnV" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -63459,6 +65353,7 @@
 	products = list(/obj/item/clothing/under/rank/engineer = 4, /obj/item/clothing/shoes/sneakers/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/storage/belt/utility = 4, /obj/item/clothing/glasses/meson/engine = 4, /obj/item/clothing/gloves/color/yellow = 2, /obj/item/screwdriver = 12, /obj/item/crowbar = 12, /obj/item/wirecutters = 12, /obj/item/multitool = 12, /obj/item/wrench = 12, /obj/item/t_scanner = 12, /obj/item/stock_parts/cell = 8, /obj/item/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/light/tube = 10, /obj/item/clothing/suit/fire = 4, /obj/item/stock_parts/scanning_module = 5, /obj/item/stock_parts/micro_laser = 5, /obj/item/stock_parts/matter_bin = 5, /obj/item/stock_parts/manipulator = 5)
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -63587,14 +65482,17 @@
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "coh" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "24"
+/obj/machinery/power/apc{
+	areastring = "/area/vacant_room/office/a";
+	dir = 8;
+	name = "Vacant Office APC";
+	pixel_x = -25
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "0-2"
 	},
-/turf/open/floor/plating,
-/area/maintenance/starboard/aft)
+/turf/open/floor/wood,
+/area/security/vacantoffice/a)
 "coi" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/dark/visible{
@@ -63607,6 +65505,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63616,12 +65515,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "col" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63629,6 +65530,7 @@
 "com" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -63670,10 +65572,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cos" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -63685,13 +65585,21 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 9
 	},
+/obj/machinery/button/crematorium{
+	id = "crematoriumChapel";
+	pixel_x = -26;
+	pixel_y = -58;
+	req_access_txt = "27"
+	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "cou" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63702,6 +65610,7 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -63758,9 +65667,11 @@
 /area/crew_quarters/dorms)
 "coE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -63783,9 +65694,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -63838,20 +65751,18 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "coK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/power/apc/highcap/fifteen_k{
-	areastring = "/area/engine/engineering";
-	dir = 1;
-	name = "Engine Room APC";
-	pixel_y = 27
+/obj/machinery/modular_computer/console/preset/engineering,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
 /obj/structure/cable/yellow{
 	icon_state = "0-2"
 	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "coL" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -63897,6 +65808,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -63909,6 +65821,7 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63953,6 +65866,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64204,6 +66118,7 @@
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -64282,8 +66197,10 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/chapel/office";
+	dir = 2;
+	lighting = 3;
 	name = "Chapel Office APC";
+	areastring = "/area/chapel/office";
 	pixel_y = -25
 	},
 /turf/open/floor/plasteel/grimy,
@@ -64305,8 +66222,8 @@
 /area/chapel/office)
 "cpB" = (
 /obj/structure/bodycontainer/crematorium{
-	dir = 1;
-	id = "crematoriumChapel"
+	id = "crematoriumChapel";
+	dir = 1
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -64342,15 +66259,12 @@
 /turf/open/floor/grass,
 /area/hydroponics/garden)
 "cpG" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
-/obj/item/twohanded/required/kirbyplants/photosynthetic,
-/obj/structure/disposalpipe/segment{
-	dir = 9
-	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+	icon_state = "trimline_fill";
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -64365,6 +66279,7 @@
 /obj/effect/landmark/start/depsec/engineering,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64375,6 +66290,7 @@
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64397,6 +66313,7 @@
 /area/maintenance/port/fore)
 "cpM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
@@ -64419,11 +66336,8 @@
 	dir = 4
 	},
 /obj/machinery/modular_computer/console/preset/engineering,
-/obj/structure/cable{
+/obj/structure/cable/yellow{
 	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
@@ -64438,6 +66352,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64480,6 +66395,7 @@
 "cpT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -64501,6 +66417,7 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64577,6 +66494,7 @@
 /area/hallway/secondary/entry)
 "cqh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64617,6 +66535,7 @@
 /area/hallway/secondary/entry)
 "cql" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -64624,6 +66543,7 @@
 "cqm" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -64673,7 +66593,7 @@
 	dir = 4
 	},
 /obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+	req_one_access_txt = "12;5;39;6"
 	},
 /turf/open/floor/plating,
 /area/maintenance/aft)
@@ -64756,6 +66676,7 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -64769,9 +66690,18 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engine_smes)
 "cqA" = (
-/obj/effect/turf_decal/stripes/corner,
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/apc/highcap/fifteen_k{
+	areastring = "/area/engine/engineering";
+	dir = 1;
+	name = "Engine Room APC";
+	pixel_y = 27
+	},
+/obj/structure/cable{
+	icon_state = "0-2";
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -64780,6 +66710,7 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /obj/machinery/light{
@@ -64788,9 +66719,26 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqC" = (
-/obj/effect/spawner/structure/window,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/power/terminal,
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/structure/cable/yellow,
+/turf/open/floor/plasteel/dark,
+/area/engine/engine_smes)
 "cqD" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -64816,6 +66764,7 @@
 "cqF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
@@ -64834,15 +66783,27 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqH" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
+/obj/item/radio/off,
+/obj/item/crowbar,
+/obj/item/screwdriver{
+	pixel_y = 10
 	},
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
+	dir = 9
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/customs";
+	dir = 1;
+	name = "Customs APC";
+	pixel_x = 1;
+	pixel_y = 24
+	},
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/security/checkpoint/customs)
 "cqI" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -65032,9 +66993,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65049,6 +67012,7 @@
 "crh" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
+	dir = 2;
 	name = "Fuel Pipe to Incinerator"
 	},
 /obj/structure/cable/yellow{
@@ -65082,15 +67046,18 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "crl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65128,18 +67095,21 @@
 /turf/closed/wall/r_wall,
 /area/engine/storage)
 "crt" = (
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/storage)
+/area/security/checkpoint/customs)
 "cru" = (
 /obj/effect/turf_decal/loading_area{
 	dir = 4
@@ -65331,6 +67301,7 @@
 /area/hallway/primary/fore)
 "crL" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/chair{
@@ -65346,6 +67317,7 @@
 /area/hallway/secondary/entry)
 "crM" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -65397,6 +67369,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -65558,6 +67531,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -65580,6 +67554,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -65595,6 +67570,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -65679,30 +67655,33 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "csu" = (
-/obj/machinery/airalarm/directional/west,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/effect/turf_decal/stripes/corner,
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
+/obj/structure/cable/yellow{
+	icon_state = "2-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "csw" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "2-4"
 	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "csx" = (
 /obj/machinery/suit_storage_unit/atmos,
 /obj/effect/turf_decal/delivery,
@@ -65720,6 +67699,7 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -65892,6 +67872,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/chair{
@@ -65914,6 +67895,7 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -65926,12 +67908,15 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65946,12 +67931,15 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65959,6 +67947,7 @@
 "ctc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -65969,6 +67958,7 @@
 "ctd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -65976,6 +67966,7 @@
 /area/hallway/secondary/entry)
 "cte" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -65991,6 +67982,7 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -66006,6 +67998,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -66094,6 +68087,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66109,6 +68103,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -66128,6 +68123,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -66143,6 +68139,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -66164,6 +68161,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -66201,12 +68199,14 @@
 /area/engine/engine_smes)
 "ctw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ctx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
@@ -66214,30 +68214,35 @@
 /area/engine/break_room)
 "cty" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+/obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
+	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "ctz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-8"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/item/twohanded/required/kirbyplants/photosynthetic,
+/obj/structure/disposalpipe/segment{
+	dir = 9
+	},
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
+	icon_state = "trimline_fill";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "ctA" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
@@ -66245,17 +68250,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ctB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "ctC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
@@ -66308,6 +68314,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -66344,6 +68351,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -66366,6 +68374,7 @@
 "ctP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve{
+	dir = 2;
 	name = "output gas to space"
 	},
 /turf/open/floor/plasteel,
@@ -66430,6 +68439,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -66514,6 +68524,7 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66540,7 +68551,9 @@
 "cuk" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hydroponics/garden";
+	dir = 2;
 	name = "Garden APC";
+	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable{
@@ -66568,6 +68581,7 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -66588,21 +68602,11 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cur" = (
-/obj/effect/turf_decal/loading_area{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/button/door{
-	id = "Singularity";
-	name = "Shutters Control";
-	pixel_x = 5;
-	pixel_y = 32;
-	req_access_txt = "11"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -66647,6 +68651,7 @@
 /area/engine/atmos)
 "cuA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -66680,6 +68685,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -66693,6 +68699,7 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -66710,6 +68717,7 @@
 /area/engine/atmos)
 "cuH" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -66732,15 +68740,11 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cuL" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 2
 	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/space,
-/area/space)
+/turf/closed/wall/r_wall,
+/area/maintenance/disposal/incinerator)
 "cuM" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -66781,6 +68785,7 @@
 "cuS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -66789,6 +68794,7 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -66800,6 +68806,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -66811,6 +68818,7 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66820,6 +68828,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -66898,6 +68907,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -66911,6 +68921,7 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -67005,6 +69016,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space,
@@ -67052,7 +69064,9 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on,
+/obj/machinery/atmospherics/components/binary/pump/on{
+	dir = 2
+	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -67077,6 +69091,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -67172,6 +69187,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -67198,6 +69214,7 @@
 "cvR" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -67241,11 +69258,13 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/camera/autoname{
@@ -67295,7 +69314,8 @@
 	areastring = "/area/construction/mining/aux_base";
 	dir = 4;
 	name = "Auxillary Base Construction APC";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -67308,6 +69328,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -67362,9 +69383,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/power/apc{
-	areastring = "/area/hallway/secondary/entry";
 	dir = 4;
 	name = "Entry Hall APC";
+	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -67532,6 +69553,7 @@
 /area/construction/mining/aux_base)
 "cwE" = (
 /obj/docking_port/stationary/public_mining_dock{
+	icon_state = "pinonfar";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -67630,6 +69652,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargobay Fore";
+	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plating,
@@ -67682,6 +69705,7 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/turnstile{
+	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67711,6 +69735,7 @@
 "cwZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -67718,6 +69743,7 @@
 /area/hallway/secondary/entry)
 "cxa" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -67788,9 +69814,11 @@
 /area/hallway/secondary/entry)
 "cxi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -67819,6 +69847,7 @@
 "cxl" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
@@ -67962,6 +69991,7 @@
 /area/space/nearstation)
 "cxC" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68060,7 +70090,9 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cxN" = (
-/obj/structure/disposaloutlet,
+/obj/structure/disposaloutlet{
+	dir = 2
+	},
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -68083,6 +70115,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68181,6 +70214,7 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68189,22 +70223,24 @@
 "cyc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cyd" = (
-/obj/effect/turf_decal/stripes/line{
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/break_room)
 "cye" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -68224,6 +70260,7 @@
 "cyh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68232,6 +70269,7 @@
 "cyi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68259,6 +70297,7 @@
 "cym" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -68282,7 +70321,8 @@
 	pixel_y = 26
 	},
 /obj/item/radio/intercom{
-	pixel_x = -26
+	pixel_x = -26;
+	pixel_y = 0
 	},
 /obj/item/stack/cable_coil/white{
 	pixel_x = 3;
@@ -68465,9 +70505,11 @@
 /area/engine/storage_shared)
 "cyF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -68495,6 +70537,7 @@
 "cyJ" = (
 /obj/machinery/rnd/production/protolathe/department/cargo,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -68656,12 +70699,12 @@
 /area/space)
 "cze" = (
 /obj/docking_port/stationary{
-	dir = 8;
-	dwidth = 1;
-	height = 4;
 	icon_state = "pinonalert";
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
+	dir = 8;
+	width = 3;
+	height = 4;
+	dwidth = 1;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -68799,16 +70842,17 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
+	},
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "czu" = (
-/obj/machinery/door/poddoor{
-	id = "SecJusticeChamber";
-	name = "Justice Vent"
+/obj/effect/turf_decal/stripes/line{
+	dir = 2
 	},
 /turf/open/floor/plating,
-/area/security/execution/education)
+/area/hallway/secondary/entry)
 "czv" = (
 /obj/item/storage/toolbox/artistic,
 /turf/open/floor/plating,
@@ -68868,12 +70912,15 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -68920,6 +70967,7 @@
 /area/gateway)
 "czF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/sign/departments/science{
@@ -69013,6 +71061,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69048,6 +71097,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -69071,9 +71121,11 @@
 /area/bridge)
 "czV" = (
 /obj/effect/turf_decal/box/white/corners{
+	icon_state = "box_corners_white";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -69111,6 +71163,7 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/camera/autoname{
@@ -69157,18 +71210,21 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "cAb" = (
 /obj/machinery/modular_computer/console/preset/engineering{
+	icon_state = "console";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -69187,6 +71243,7 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -69194,6 +71251,7 @@
 "cAd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -69204,6 +71262,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -69219,9 +71278,11 @@
 "cAh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -69273,6 +71334,7 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -69310,15 +71372,18 @@
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
 "cAr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/yellow,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 1
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line,
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "cAs" = (
 /obj/item/vending_refill/snack,
 /turf/open/floor/plating,
@@ -69353,9 +71418,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69368,6 +71435,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -69406,6 +71474,7 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -69430,9 +71499,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69457,6 +71528,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69480,9 +71552,11 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69490,9 +71564,11 @@
 "cAD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69507,6 +71583,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -69534,9 +71611,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69546,9 +71625,11 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -69573,9 +71654,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69599,9 +71682,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69627,9 +71712,11 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69652,9 +71739,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69679,9 +71768,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69706,9 +71797,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69719,6 +71812,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -69742,9 +71836,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69774,9 +71870,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69822,6 +71920,7 @@
 	pixel_y = 2
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -69871,6 +71970,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -69878,6 +71978,7 @@
 "cBb" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -69902,26 +72003,18 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "cBe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/structure/disposalpipe/segment{
+	dir = 5
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -69956,9 +72049,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -69971,6 +72066,7 @@
 "cBj" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -69981,6 +72077,7 @@
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -69990,7 +72087,8 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = 26
+	pixel_x = 26;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
@@ -70000,12 +72098,14 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70015,6 +72115,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -70023,6 +72124,7 @@
 "cBo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70032,15 +72134,18 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cBq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -70050,6 +72155,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -70066,6 +72172,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70075,6 +72182,7 @@
 	uses = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -70085,6 +72193,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70095,12 +72204,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -70110,6 +72221,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70119,7 +72231,8 @@
 	areastring = "/area/hallway/primary/starboard";
 	dir = 4;
 	name = "Starboard Hallway APC";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -70128,12 +72241,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70146,6 +72261,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70153,6 +72269,7 @@
 "cBC" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -70166,6 +72283,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70176,6 +72294,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -70186,6 +72305,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70199,6 +72319,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70208,15 +72329,16 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/hallway/primary/aft";
 	dir = 4;
 	name = "Aft Hallway APC";
+	areastring = "/area/hallway/primary/aft";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70233,9 +72355,11 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70301,6 +72425,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/navbeacon{
@@ -70314,6 +72439,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -70383,12 +72509,14 @@
 /area/hallway/primary/aft)
 "cBZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cCa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/navbeacon{
@@ -70403,9 +72531,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70414,9 +72544,11 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70427,6 +72559,7 @@
 	},
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -70445,18 +72578,21 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/dorms)
 "cCf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cCg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -70464,6 +72600,7 @@
 "cCh" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70472,6 +72609,7 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70481,6 +72619,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70489,6 +72628,7 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70501,6 +72641,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70543,7 +72684,8 @@
 	dir = 8;
 	name = "Auxillary Base Monitor";
 	network = list("auxbase");
-	pixel_x = 25
+	pixel_x = 25;
+	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -70554,6 +72696,7 @@
 "cCp" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70569,6 +72712,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/yjunction{
+	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -70589,6 +72733,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70599,6 +72744,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70622,6 +72768,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70646,15 +72793,18 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cCx" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -70668,6 +72818,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70712,9 +72863,11 @@
 /area/hallway/primary/aft)
 "cCD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70726,6 +72879,7 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70775,6 +72929,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70799,6 +72954,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70818,6 +72974,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -70854,6 +73011,7 @@
 /area/crew_quarters/fitness/recreation)
 "cCQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -70893,6 +73051,7 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -70903,6 +73062,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -70918,6 +73078,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -70927,6 +73088,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -70940,9 +73102,11 @@
 /area/aisat)
 "cCY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -70973,12 +73137,14 @@
 /area/ai_monitored/turret_protected/ai)
 "cDc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDd" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -70990,6 +73156,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -70999,6 +73166,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -71013,6 +73181,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71022,6 +73191,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71040,6 +73210,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71050,12 +73221,14 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cDl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71067,6 +73240,7 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71076,28 +73250,33 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 9
+/obj/machinery/disposal/bin,
+/obj/structure/disposalpipe/trunk{
+	dir = 8
 	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/storage)
+/area/engine/engineering)
 "cDq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71107,6 +73286,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71114,6 +73294,7 @@
 "cDs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -71206,6 +73387,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -71213,6 +73395,7 @@
 /area/hallway/secondary/command)
 "cDA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -71327,12 +73510,12 @@
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cDP" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
+	dir = 8
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/engine/break_room)
 "cDQ" = (
 /obj/effect/turf_decal/trimline/white/filled/line,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -71343,6 +73526,7 @@
 "cDR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71363,6 +73547,7 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/item/radio/intercom{
+	pixel_x = 0;
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
@@ -71484,6 +73669,7 @@
 /area/medical/morgue)
 "cEf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
+	icon_state = "vent_map_siphon_on-2";
 	dir = 1
 	},
 /turf/open/floor/engine/air,
@@ -71507,9 +73693,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
-	areastring = "/area/medical/morgue";
 	dir = 4;
 	name = "Morgue APC";
+	areastring = "/area/medical/morgue";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -71623,6 +73809,7 @@
 "cEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71783,6 +73970,7 @@
 /area/medical/morgue)
 "cEy" = (
 /obj/machinery/firealarm{
+	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/bot,
@@ -71790,9 +73978,11 @@
 /area/science/mixing)
 "cEz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -71800,15 +73990,18 @@
 	light_color = "#cee5d2"
 	},
 /obj/machinery/status_display/evac{
+	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cEA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/chemical,
@@ -71822,6 +74015,7 @@
 /obj/item/wrench/medical,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -71831,6 +74025,7 @@
 /area/medical/cryo)
 "cEC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/computer/pandemic,
@@ -71931,12 +74126,14 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71963,6 +74160,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71975,6 +74173,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72008,9 +74207,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72023,6 +74224,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -72033,6 +74235,7 @@
 /area/hallway/primary/starboard)
 "cER" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72045,12 +74248,14 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cET" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72081,6 +74286,7 @@
 /area/crew_quarters/locker)
 "cEW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72090,9 +74296,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -72166,6 +74374,7 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -72188,6 +74397,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72197,9 +74407,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72207,6 +74419,7 @@
 "cFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -72256,6 +74469,7 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -72271,6 +74485,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/monkey_recycler,
@@ -72344,9 +74559,11 @@
 "cFv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/fireaxecabinet{
-	pixel_x = -31
+	pixel_x = -31;
+	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72374,15 +74591,18 @@
 /area/engine/atmos)
 "cFA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72406,6 +74626,7 @@
 /area/crew_quarters/fitness/recreation)
 "cFD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/closet/crate,
@@ -72426,9 +74647,11 @@
 "cFG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72453,6 +74676,7 @@
 /area/crew_quarters/fitness/recreation)
 "cFK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -72718,12 +74942,14 @@
 "cFX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72801,6 +75027,7 @@
 "cGe" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72813,9 +75040,12 @@
 	c_tag = "Locker Room Aft";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /obj/machinery/vending/kink,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72833,6 +75063,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dorms - Port Fore";
+	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/structure/sign/poster/official/no_erp{
@@ -72858,6 +75089,7 @@
 /area/crew_quarters/fitness/recreation)
 "cGi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -72886,6 +75118,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72896,6 +75129,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72947,6 +75181,7 @@
 "cGp" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72969,6 +75204,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -72993,9 +75229,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -73066,6 +75304,7 @@
 "cGy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73085,6 +75324,7 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73094,9 +75334,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/light/small,
@@ -73117,6 +75359,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -73158,12 +75401,14 @@
 /area/medical/virology)
 "cGG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "cGH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73173,6 +75418,7 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = 24;
+	pixel_y = 0;
 	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/camera{
@@ -73194,6 +75440,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73216,6 +75463,7 @@
 /area/engine/atmos)
 "cGL" = (
 /obj/machinery/computer/camera_advanced/base_construction{
+	icon_state = "computer";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -73223,6 +75471,7 @@
 /area/construction/mining/aux_base)
 "cGM" = (
 /obj/machinery/computer/shuttle/mining{
+	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73259,6 +75508,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -73271,6 +75521,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -73294,6 +75545,7 @@
 "cGT" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -73316,6 +75568,7 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73324,18 +75577,21 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cGX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cGY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -73377,6 +75633,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73392,6 +75649,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73416,6 +75674,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73436,6 +75695,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -73459,6 +75719,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -73474,6 +75735,7 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -73490,15 +75752,14 @@
 /area/science/xenobiology)
 "cHl" = (
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
 /obj/machinery/door/airlock/maintenance{
-	name = "Research Maintenance";
-	req_access_txt = "47"
+	name = "Garden Maintenance";
+	req_one_access_txt = "12;5;39;6"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plating,
-/area/science/xenobiology)
+/area/maintenance/aft)
 "cHm" = (
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall,
@@ -73549,6 +75810,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/navbeacon{
@@ -73559,6 +75821,7 @@
 /area/hallway/primary/aft)
 "cHs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/navbeacon{
@@ -73572,6 +75835,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -73599,6 +75863,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73606,6 +75871,7 @@
 "cHv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -73616,6 +75882,7 @@
 /area/hallway/primary/aft)
 "cHw" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -73645,6 +75912,7 @@
 /area/hallway/secondary/entry)
 "cHy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -73697,6 +75965,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73721,9 +75990,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -73739,6 +76010,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73751,6 +76023,7 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73770,6 +76043,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73780,6 +76054,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73790,6 +76065,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -73801,6 +76077,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -73822,6 +76099,7 @@
 /area/engine/break_room)
 "cHM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73909,6 +76187,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -73918,6 +76197,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73929,6 +76209,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73939,6 +76220,7 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73948,6 +76230,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73978,6 +76261,7 @@
 	},
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/screwdriver,
@@ -74094,6 +76378,7 @@
 /area/maintenance/starboard/aft)
 "cIi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -74108,12 +76393,14 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cIk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -74123,6 +76410,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -74137,9 +76425,11 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar_control{
+	name = "Port Bow Solar Control";
+	icon_state = "computer";
 	dir = 4;
 	id = "foreport";
-	name = "Port Bow Solar Control"
+	track = 0
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
@@ -74165,6 +76455,7 @@
 /area/security/brig)
 "cIo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -74184,13 +76475,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/flasher{
 	id = "brigflashdoor";
-	pixel_x = -26
+	pixel_x = -26;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cIq" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/stripes/red/corner{
+	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -74203,9 +76496,11 @@
 /area/security/brig)
 "cIr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74248,6 +76543,7 @@
 "cIw" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -74256,6 +76552,7 @@
 "cIx" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -74303,36 +76600,42 @@
 /area/gateway)
 "cID" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cII" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -74343,6 +76646,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -74365,6 +76669,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -74374,9 +76679,11 @@
 /area/hallway/primary/starboard)
 "cIM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -74384,10 +76691,12 @@
 /area/hallway/primary/starboard)
 "cIN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -74406,6 +76715,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -74428,6 +76738,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -74440,9 +76751,11 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -74454,10 +76767,12 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74552,6 +76867,7 @@
 	},
 /obj/structure/chair/sofa/left,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -74564,6 +76880,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/status_display/evac{
@@ -74604,6 +76921,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -74621,6 +76939,7 @@
 "cJi" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -74630,6 +76949,7 @@
 /area/medical/medbay/central)
 "cJj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -74684,14 +77004,21 @@
 /turf/open/floor/circuit/green,
 /area/engine/engine_smes)
 "cJo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
+	dir = 8
+	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "cJp" = (
 /obj/structure/reagent_dispensers/watertank,
 /obj/item/storage/box/lights/mixed,
@@ -74712,7 +77039,8 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Office"
+	c_tag = "Security - Head of Security's Office";
+	dir = 2
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -74766,7 +77094,8 @@
 /obj/structure/closet/secure_closet/hos,
 /obj/effect/turf_decal/tile/red,
 /obj/item/storage/secure/safe/HoS{
-	pixel_x = 36
+	pixel_x = 36;
+	pixel_y = 0
 	},
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -74792,6 +77121,7 @@
 /obj/machinery/light,
 /obj/structure/closet/wardrobe/green,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -74808,6 +77138,7 @@
 /area/crew_quarters/locker)
 "cJC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/chair/stool,
@@ -74834,6 +77165,7 @@
 "cJG" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74888,6 +77220,7 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -74951,12 +77284,15 @@
 /area/maintenance/starboard/aft)
 "cJS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75042,19 +77378,16 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cJZ" = (
-/obj/item/twohanded/required/kirbyplants/random,
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/yellow{
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/engine/storage)
 "cKa" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -75065,37 +77398,40 @@
 /area/engine/break_room)
 "cKb" = (
 /obj/structure/cable{
-	icon_state = "2-4"
+	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 6
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "cKc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/cable{
-	icon_state = "4-8"
+	icon_state = "1-2"
 	},
-/obj/structure/disposalpipe/junction/flip{
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "cKd" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
+	dir = 4
+	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
+	icon_state = "trimline_fill";
+	dir = 8
 	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/storage)
 "cKe" = (
 /obj/structure/sink{
 	layer = 3;
@@ -75105,21 +77441,34 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "cKf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 6
+/obj/effect/turf_decal/loading_area{
+	dir = 4
 	},
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 1
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/button/door{
+	id = "Singularity";
+	name = "Shutters Control";
+	pixel_x = 26;
+	pixel_y = 32;
+	req_access_txt = "11"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
-/area/engine/break_room)
+/area/engine/engineering)
 "cKg" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-4"
@@ -75183,15 +77532,22 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "cKl" = (
-/obj/machinery/door/airlock/maintenance{
-	req_access_txt = "12"
+/obj/effect/turf_decal/delivery,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Singularity";
+	name = "radiation shutters"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
 	},
 /obj/structure/cable{
-	icon_state = "1-2"
+	icon_state = "4-8"
 	},
-/obj/machinery/atmospherics/pipe/layer_manifold,
-/turf/open/floor/plating,
-/area/maintenance/central)
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cKm" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -75304,9 +77660,11 @@
 "cKA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75317,6 +77675,7 @@
 /area/crew_quarters/fitness/recreation)
 "cKC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -75379,8 +77738,8 @@
 /area/construction)
 "cKI" = (
 /obj/machinery/power/apc{
-	areastring = "/area/construction";
 	name = "Construction Area APC";
+	areastring = "/area/construction";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -75650,6 +78009,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75658,24 +78018,29 @@
 "cLa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cLb" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cLc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75685,6 +78050,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75695,6 +78061,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75704,6 +78071,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75713,6 +78081,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75722,6 +78091,7 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75734,6 +78104,7 @@
 "cLj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75742,6 +78113,7 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75749,6 +78121,7 @@
 "cLl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75759,9 +78132,12 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cLn" = (
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 2
+	},
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -75778,16 +78154,18 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cLp" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 4
 	},
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
-/obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cLq" = (
@@ -75837,6 +78215,7 @@
 /area/engine/storage_shared)
 "cLv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -75845,6 +78224,7 @@
 "cLw" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -75861,6 +78241,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -75901,6 +78282,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -75912,6 +78294,7 @@
 /area/security/brig)
 "cLA" = (
 /obj/machinery/turnstile{
+	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76001,27 +78384,33 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
+	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
+	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76029,23 +78418,28 @@
 "cLM" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
+	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
+	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -76057,6 +78451,7 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -76104,6 +78499,7 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -76125,6 +78521,7 @@
 "cLW" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -76146,12 +78543,15 @@
 /area/maintenance/fore)
 "cLZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76168,12 +78568,15 @@
 "cMb" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76184,6 +78587,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -76209,13 +78613,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 4;
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
-	pixel_x = 30
+	pixel_x = 30;
+	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -76226,6 +78632,7 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -76283,6 +78690,7 @@
 /area/security/range)
 "cMi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -76300,6 +78708,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -76325,10 +78734,12 @@
 /area/crew_quarters/heads/captain/private)
 "cMl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Science Entrance";
+	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -76338,6 +78749,7 @@
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -76436,18 +78848,22 @@
 /area/crew_quarters/fitness/recreation)
 "cMy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cMz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -76556,6 +78972,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -76591,12 +79008,14 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cMM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -76639,6 +79058,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76665,6 +79085,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76695,6 +79116,7 @@
 /obj/machinery/plantgenes,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -76705,6 +79127,7 @@
 /area/hydroponics)
 "cMU" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -76722,13 +79145,15 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cMV" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge - Starboard Fore"
+	c_tag = "Departure Lounge - Starboard Fore";
+	dir = 2
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -76739,6 +79164,7 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/camera{
 	c_tag = "Escape Hallway";
+	dir = 2;
 	name = "departures camera"
 	},
 /turf/open/floor/plasteel,
@@ -76749,6 +79175,7 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library";
+	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/wood,
@@ -76777,6 +79204,7 @@
 "cNa" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76815,9 +79243,11 @@
 "cNd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76825,6 +79255,7 @@
 "cNe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -76848,6 +79279,7 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76858,6 +79290,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -76893,6 +79326,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -76910,6 +79344,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -76920,6 +79355,7 @@
 /area/engine/atmos)
 "cNm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -76938,6 +79374,7 @@
 /area/engine/atmos)
 "cNo" = (
 /obj/machinery/computer/arcade{
+	icon_state = "arcade";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -76954,6 +79391,7 @@
 /area/security/vacantoffice/a)
 "cNr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -76961,9 +79399,11 @@
 "cNs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -76973,6 +79413,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -76994,6 +79435,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77013,6 +79455,7 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -77022,6 +79465,7 @@
 /area/engine/storage)
 "cNz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -77031,6 +79475,7 @@
 	id = "ewradiation";
 	name = "Shutters Control";
 	pixel_x = 33;
+	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /turf/open/floor/plasteel,
@@ -77046,6 +79491,7 @@
 "cNB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -77062,6 +79508,7 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -77088,9 +79535,11 @@
 	},
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77098,8 +79547,9 @@
 "cNF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
-	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	dir = 2;
 	name = "Upload APC";
+	areastring = "/area/ai_monitored/turret_protected/ai_upload";
 	pixel_y = -24
 	},
 /obj/machinery/camera/motion{
@@ -77183,6 +79633,7 @@
 /area/teleporter)
 "cNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -77207,6 +79658,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77214,6 +79666,7 @@
 "cNO" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -77244,6 +79697,7 @@
 /area/medical/virology)
 "cNS" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
@@ -77262,6 +79716,7 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77282,12 +79737,14 @@
 /area/crew_quarters/toilet)
 "cNV" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "cNW" = (
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77300,6 +79757,7 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77322,6 +79780,7 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -77334,12 +79793,14 @@
 	pixel_x = 30
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
+	icon_state = "console";
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -77348,6 +79809,7 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77367,6 +79829,7 @@
 "cOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -77395,6 +79858,7 @@
 "cOg" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
+	icon_state = "outlet";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -77404,12 +79868,24 @@
 /turf/open/floor/plating/asteroid/airless,
 /area/asteroid/nearstation)
 "cOi" = (
-/obj/item/poster/random_contraband,
-/turf/open/floor/plating,
-/turf/open/floor/plating{
-	icon_state = "platingdmg2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
 	},
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "cOj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -77540,6 +80016,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -77578,6 +80055,7 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -77615,6 +80093,7 @@
 /area/engine/engineering)
 "cOJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -77777,6 +80256,7 @@
 "cPe" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -77842,6 +80322,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -77872,6 +80353,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -78038,9 +80520,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -78144,6 +80628,7 @@
 /area/maintenance/fore/secondary)
 "cPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -78270,8 +80755,9 @@
 "cQo" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	areastring = "/area/quartermaster/office";
+	dir = 2;
 	name = "Cargo Office APC";
+	areastring = "/area/quartermaster/office";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -78279,6 +80765,7 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet{
@@ -78340,6 +80827,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -78388,6 +80876,7 @@
 "cQE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -78443,6 +80932,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
+	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -78486,6 +80976,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -78496,12 +80987,14 @@
 /area/hallway/primary/central)
 "cQP" = (
 /obj/structure/chair/sofa/corp{
+	icon_state = "corp_sofamiddle";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cQQ" = (
 /obj/structure/chair/sofa/corp/left{
+	icon_state = "corp_sofaend_left";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -78559,6 +81052,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78615,13 +81109,16 @@
 "cRe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
+	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/food_cart,
@@ -78680,10 +81177,12 @@
 /area/engine/transit_tube)
 "cRl" = (
 /obj/structure/chair/sofa/right{
+	icon_state = "sofaend_right";
 	dir = 1
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/engine/transit_tube";
+	dir = 2;
 	name = "Transit Tube APC";
 	pixel_y = -26
 	},
@@ -78820,6 +81319,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78861,6 +81361,7 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78872,6 +81373,7 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/yjunction{
+	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -78888,6 +81390,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
+	icon_state = "trimline_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78910,6 +81413,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -78938,6 +81442,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -78997,6 +81502,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79029,6 +81535,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79061,6 +81568,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79090,6 +81598,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79123,6 +81632,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79149,6 +81659,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79172,6 +81683,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79199,6 +81711,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
+	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79221,14 +81734,23 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cSe" = (
-/obj/effect/mapping_helpers/airlock/cyclelink_helper{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/door/airlock/external{
-	req_access_txt = "13"
+/obj/machinery/atmospherics/pipe/manifold4w/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 8
 	},
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cSf" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/light{
@@ -79263,6 +81785,8 @@
 "cSi" = (
 /obj/structure/bed/dogbed/ian,
 /obj/item/radio/intercom{
+	dir = 2;
+	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/wood,
@@ -79321,39 +81845,46 @@
 /area/crew_quarters/fitness/recreation)
 "cSo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cSq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -79361,6 +81892,7 @@
 "cSs" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79368,6 +81900,7 @@
 "cSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -79379,6 +81912,7 @@
 "cSu" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79391,6 +81925,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -79401,12 +81936,20 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cSw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/machinery/door/airlock/maintenance,
-/turf/open/floor/plating,
-/area/maintenance/aft)
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "cSx" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/cable{
@@ -79414,6 +81957,7 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -79423,6 +81967,7 @@
 /area/engine/atmos)
 "cSy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -79433,9 +81978,11 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
+	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -79443,9 +81990,11 @@
 "cSA" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/mint,
@@ -79457,6 +82006,7 @@
 /area/crew_quarters/kitchen)
 "cSB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -79470,6 +82020,7 @@
 /area/maintenance/port/aft)
 "cSE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79479,16 +82030,19 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -79524,6 +82078,7 @@
 /area/hallway/primary/central)
 "cSK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -79541,6 +82096,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/engineering{
@@ -79553,6 +82109,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -79847,6 +82404,7 @@
 /area/engine/atmos)
 "cTA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79857,6 +82415,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79971,6 +82530,7 @@
 "cTP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/sign/departments/restroom{
@@ -79980,6 +82540,7 @@
 /area/crew_quarters/fitness/recreation)
 "cTQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/sign/departments/restroom{
@@ -80005,10 +82566,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
+	icon_state = "direction_evac";
 	pixel_x = 32
 	},
 /obj/structure/sign/directions/engineering{
@@ -80048,6 +82611,7 @@
 	},
 /obj/structure/sign/directions/medical{
 	dir = 1;
+	icon_state = "direction_med";
 	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
@@ -80057,13 +82621,16 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/structure/sign/directions/medical{
 	dir = 1;
+	icon_state = "direction_med";
 	pixel_x = 32;
 	pixel_y = 40
 	},
@@ -80074,6 +82641,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/departments/engineering{
@@ -80086,6 +82654,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/departments/engineering{
@@ -80101,6 +82670,7 @@
 /area/maintenance/department/cargo)
 "cUb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -80121,6 +82691,7 @@
 "cUc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/departments/holy{
@@ -80165,6 +82736,7 @@
 "cUi" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -80208,6 +82780,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80218,6 +82791,7 @@
 /area/medical/virology)
 "cUp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -80233,12 +82807,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/doorButtons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
-	idInterior = "virology_airlock_interior";
 	idSelf = "virology_airlock_control";
+	idInterior = "virology_airlock_interior";
 	name = "Virology Access Console";
 	pixel_x = 26;
 	pixel_y = 26;
@@ -80353,6 +82928,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80422,6 +82998,7 @@
 /area/maintenance/department/crew_quarters/dorms)
 "cUR" = (
 /obj/structure/chair/sofa/corp/right{
+	icon_state = "corp_sofaend_right";
 	dir = 8
 	},
 /obj/item/storage/daki,
@@ -80466,23 +83043,28 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cUZ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
 	},
-/obj/effect/turf_decal/trimline/red/filled/line{
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /turf/open/floor/plasteel,
-/area/security/checkpoint/customs)
+/area/engine/engineering)
 "cVa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/reagent_dispensers/peppertank{
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -80500,6 +83082,7 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -80552,6 +83135,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -80578,6 +83162,7 @@
 	},
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/trimline/red/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
@@ -80969,6 +83554,7 @@
 "cWo" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/crowbar,
@@ -80986,12 +83572,15 @@
 /area/crew_quarters/fitness/recreation)
 "cWr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/pool/Rboard,
@@ -81048,6 +83637,7 @@
 /area/maintenance/solars/starboard/aft)
 "cWx" = (
 /obj/machinery/power/terminal{
+	icon_state = "term";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -81073,6 +83663,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
@@ -81091,6 +83682,7 @@
 /area/engine/break_room)
 "cWB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/warning/enginesafety{
@@ -81172,6 +83764,7 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/securearea{
+	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -81187,7 +83780,9 @@
 "cWL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/storage";
+	dir = 2;
 	name = "Engineering Storage APC";
+	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable,
@@ -81282,6 +83877,7 @@
 /area/crew_quarters/locker)
 "cWV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -81309,6 +83905,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -81330,6 +83927,7 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -81348,6 +83946,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -81363,6 +83962,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -81568,7 +84168,8 @@
 	areastring = "/area/maintenance/department/electrical";
 	dir = 4;
 	name = "Electrical Maintenance APC";
-	pixel_x = 24
+	pixel_x = 24;
+	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -81668,6 +84269,7 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
+	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/vending/medical{
@@ -81684,12 +84286,14 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
@@ -81723,6 +84327,7 @@
 /area/medical/medbay/central)
 "cXL" = (
 /obj/effect/turf_decal/tile{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -81745,10 +84350,12 @@
 /area/crew_quarters/heads/chief/private)
 "cXO" = (
 /obj/machinery/status_display/ai{
-	pixel_x = -32
+	pixel_x = -32;
+	pixel_y = 0
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/chief/private";
+	dir = 2;
 	name = "Chief Engineer's Quarters APC";
 	pixel_y = -24
 	},
@@ -81833,6 +84440,7 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81847,19 +84455,23 @@
 /obj/machinery/camera/autoname,
 /obj/item/radio/intercom{
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/cafeteria)
 "cYa" = (
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
+	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Kitchen Starboard"
+	c_tag = "Kitchen Starboard";
+	dir = 2
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -81867,6 +84479,7 @@
 	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
+	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -81876,6 +84489,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -81890,6 +84504,7 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
+	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -81906,6 +84521,62 @@
 /turf/open/floor/plating,
 /area/engine/storage)
 "cYe" = (
+/obj/structure/chair/stool,
+/obj/effect/landmark/start/paramedic,
+/turf/open/floor/plasteel/white,
+/area/medical)
+"cYf" = (
+/obj/machinery/door/airlock/maintenance{
+	name = "Engineering Maintenance";
+	req_access_txt = "10"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/turf/open/floor/plating,
+/area/maintenance/aft)
+"cYg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	icon_state = "trimline_fill";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cYh" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 9
+	},
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	icon_state = "trimline_corner_fill";
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"cYi" = (
+/obj/item/poster/random_contraband,
+/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "platingdmg2"
+	},
+/area/maintenance/aft)
+"cYj" = (
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -81914,7 +84585,7 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/department/electrical)
-"cYf" = (
+"cYk" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -81923,8790 +84594,16 @@
 	icon_state = "platingdmg2"
 	},
 /area/maintenance/aft)
-"cYG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
+"cYl" = (
+/obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"cYW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/machinery/door/airlock/external{
+	req_access_txt = "13"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"dbI" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dbN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"dcb" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ddM" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ddU" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"deI" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"dfb" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dfP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"dgK" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"dhT" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dji" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"djk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"djl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dlH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"dlL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"doc" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"doE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dtJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"duy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dxj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dxn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dxR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dxT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dzN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dAn" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dDQ" = (
-/obj/structure/showcase/cyborg/old{
-	pixel_y = 20
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
-"dEN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dFk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"dFK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"dFM" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
-"dIh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dID" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dJm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"dJo" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dJp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dMg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dMR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dMX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"dPm" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dTJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dUE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"dZh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"eaj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"eas" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"eds" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"egx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"egW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ekd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ekq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ekT" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ela" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"emv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eom" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"eoG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"eqo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"euD" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"evn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"eyZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ezd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"ezq" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"eAr" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"eAO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eCr" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"eDK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"eFK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"eGo" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"eHh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eJb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"eJc" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"eJu" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"eKe" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"eLn" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"eNu" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"eNX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eSj" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"eUM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"eVw" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eXE" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fay" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"fcg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fcR" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"fdv" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fdP" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fel" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"fhw" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"fkc" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fkT" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"flu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"flN" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	backwards = 1;
-	forwards = 2;
-	id = "trashsort"
-	},
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
-/area/quartermaster/sorting)
-"fmE" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"fmQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"fnb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"fpA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"frQ" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ftq" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"fue" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fxw" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fxS" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fBV" = (
-/turf/open/floor/plasteel/cult,
-/area/library)
-"fDa" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"fEx" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"fFu" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"fHX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"fIj" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"fIn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"fIM" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fJc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"fJB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"fKt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fKN" = (
-/obj/structure/bed,
-/obj/machinery/flasher{
-	id = "insaneflash";
-	pixel_y = -26
-	},
-/turf/open/floor/plasteel/freezer,
-/area/security/prison)
-"fKY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
-"fNb" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"fPR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fQS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
-"fRz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fRZ" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"fTH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
-"fVm" = (
-/obj/effect/turf_decal/caution{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
-"fWa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"fWH" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
-"fXC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/light,
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gaN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"gcj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"gcv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gfs" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gfV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gin" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gjs" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gkf" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gkk" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"gox" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"gqw" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gtA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"gtD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"guI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gva" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"gzM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"gBD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gEp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gFd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gGZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gJc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"gJh" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gKr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gNp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gPS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"gSt" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gSu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"gTB" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gVQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"gWO" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gXF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"gZa" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gZN" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor";
-	name = "Supply Dock Loading Door"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"hba" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"hbP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"hcw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"hcP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"hdg" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hdo" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hgS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hjh" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hkb" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"hkc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hke" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"hkh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"hkl" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"hkI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hmz" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
-"hnv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"hnY" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"hof" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hpj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"hpR" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"hpY" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"hri" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hsf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hvC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"hxK" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"hyd" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hBp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hBT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"hCm" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hCK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"hEk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hEy" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hIv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hIz" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hJg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"hJE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"hJG" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hKb" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hKk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"hKC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hLe" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hNR" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"hNU" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"hOi" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"hOq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"hPF" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hRb" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hRg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"hRZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hSh" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hSl" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"hTl" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"hTn" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"hXa" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hYb" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hZb" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"ibw" = (
-/obj/machinery/deepfryer,
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"ifC" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ihL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ihQ" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iir" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"iiF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ijc" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
-"ijq" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ijS" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"ikh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ikD" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"imk" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"imo" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"inV" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"ion" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"iqU" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"isz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"ivv" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"ixo" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"iBq" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"iFL" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iGv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"iHh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"iHx" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"iJy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iJS" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"iMA" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iPK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iQe" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iRH" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"iSP" = (
-/turf/open/floor/plasteel/cult,
-/area/library)
-"iUr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"iWy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iXB" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"iZm" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"iZo" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iZx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jaf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"jaF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jdu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"jeo" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jiJ" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"jjz" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"jlb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jlf" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"jlO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"joi" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jpV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"jqQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jsb" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"jsA" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"jtv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"jtz" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"jux" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jvg" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jwB" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jyh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jyj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jBF" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"jCj" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"jCo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"jEx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jGS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jGT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jKw" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"jLs" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jLu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jMn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jRe" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jSw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jSQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"jTf" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"jTl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jTG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jUM" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"jVS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jWH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"jXg" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"jYK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"jYP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jZz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"jZR" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kaB" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"kbw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"kcR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"kdz" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kky" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"klt" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"klW" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kpN" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"krf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"krk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"krq" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"krM" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"kvO" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kwA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"kwC" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"kAs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"kDN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kGC" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"kGW" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"kKA" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"kNn" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kOb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"kOg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"kOs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kQF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"kUD" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kWh" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"kWi" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kWj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"kWL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"kWY" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"kYi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"lay" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"laA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"lea" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"lgr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"liE" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"liN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lkb" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"lkm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"lkQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"lnd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"lnz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lpm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"lpp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lpv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"lpO" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"lpU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ltT" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"luj" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"lzh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lDA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"lGQ" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"lGY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lHi" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"lHI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lIc" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lIF" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"lKd" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lLK" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lNf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lOV" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"lQl" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"lSo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"lUz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"lVV" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lWO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lYt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mae" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mex" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"meZ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"mfa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"mfq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mgC" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mgK" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"mhj" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mjc" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mjj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"mjR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"mjU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"mko" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"mnx" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mqW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"mrb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"msK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mvn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mvM" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"mAh" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"mAt" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mCd" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"mEI" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"mFj" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"mFl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mHy" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"mKL" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mLe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mNf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mPj" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"mRS" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mRW" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
-"mTN" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"mUo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nbf" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"nbz" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ncr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ndf" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ndn" = (
-/obj/machinery/turnstile{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"nfH" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ngs" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ngM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nik" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"niM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"nna" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"noo" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nop" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"noP" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nqb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nqv" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"nuj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nuy" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nvN" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"nyJ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"nzJ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nBJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"nCI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"nCM" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nEe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nED" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nEL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"nIk" = (
-/obj/structure/urinal{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"nIw" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nIP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"nJg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"nLA" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nLT" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"nPD" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nRG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nSy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nTh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"nTi" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"nTx" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nVQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"nYK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oav" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"obw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"obY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
-"oem" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ofK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ogz" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oiH" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"ojz" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"okh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"olD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ond" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"ooi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ooW" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"opU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oqN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"osV" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ouq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"owe" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oxw" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oyJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oAf" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oAP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"oBI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oBK" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"oCc" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oCy" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oCM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oDk" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oFd" = (
-/obj/structure/urinal{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"oFi" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oFt" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"oFv" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oIJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"oLT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"oMk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"oMp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oOy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oPb" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"oPn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"oPY" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oQL" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oRe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oRh" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"oTG" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oVK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"oYK" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oYL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oZQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oZT" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"pae" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"pal" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"paG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pbV" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"pcB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pcG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"pdu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pfL" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"pfM" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pge" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pji" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"pjD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"pjM" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"pkV" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"poB" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pru" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"prS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"psj" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"psL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ptj" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ptC" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"puf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"pyn" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"pyt" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"pzD" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pBI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"pCz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pCJ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"pGd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"pGK" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pIn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pKy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pLZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pMp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pOU" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"pQc" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"pRA" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"pRP" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"pSr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pSL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"pUa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pVA" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pVY" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"pWR" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pXD" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pXZ" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"pYW" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qaq" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qbf" = (
-/obj/machinery/door/poddoor{
-	id = "SecJusticeChamber";
-	name = "Justice Vent"
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
-"qcU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qdW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"qeR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qga" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qgY" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qhd" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"qhK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qhL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qhW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qid" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qkB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"qkH" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qld" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qmh" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"qnP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qoL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qpF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"qqn" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"qrM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"qrY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qsh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"qsj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qty" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"quK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"qwr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qxr" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qyB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qyN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qzM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qzS" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"qBl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qBA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
-"qEy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"qER" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qHo" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"qIA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qIR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qJZ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qKy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qMj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qMz" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"qNB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"qRf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"qTq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"qWC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rct" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"reB" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rkC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rmF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rqB" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rqZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rrF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"ruT" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"rvc" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rvU" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
-"rys" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rzH" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rzT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"rAT" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rBg" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"rBi" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rBM" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"rCO" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"rDY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rEJ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"rFD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rJn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rJC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rJH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rKh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rKU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rMG" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rNc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rNk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rNz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"rNU" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rPi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rQo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rQr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rQJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rQQ" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rRa" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rRq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rRI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"rVW" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"rZb" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"saw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"saV" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
-"scp" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"scP" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"sfx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sgi" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"sjm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"skd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"slz" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"som" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"soD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sqt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"srh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"svn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"syR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"sCn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"sCy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sCA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sCO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"sFi" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"sHG" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"sJt" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sMm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"sNK" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"sOO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sRj" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sUi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sUU" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
-"tad" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"taE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"tcs" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tcx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tcS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"tet" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"tfU" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"tgh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"thd" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"tif" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tiD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"tji" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"tkM" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tmC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"tmN" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
-"tmP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"tmQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"tnE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"tor" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"tpN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tqJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tqX" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tsg" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ttr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tBF" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"tEZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tFB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tFQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"tOa" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"tPy" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"tQT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tSS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tYa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tYM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"uae" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"uai" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"uaM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ubz" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"udc" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"udk" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"udl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"udt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"udJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ugz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ukc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ulA" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"umN" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"uoE" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"urz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"urW" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uvi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"uxM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"uxT" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uxX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uyQ" = (
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor2";
-	name = "Supply Dock Loading Door"
-	},
-/obj/machinery/conveyor{
-	id = "QMLoad2"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"uBF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uBU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uCj" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uCU" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uDO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"uFq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"uGa" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"uHa" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"uHw" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"uIB" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uLi" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"uMi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uMt" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uOb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"uOG" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uPw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"uPZ" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uQc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"uQG" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"uRx" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"uRR" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uSf" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uSk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"uTm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"uVU" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"uYx" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"uZv" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vcI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage)
-"vfi" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"vha" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
-"vhd" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vhp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"vhQ" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"vhY" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"vjf" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vju" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"vke" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"vls" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"vlz" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"vnA" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"vof" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"von" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"voB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vqp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vsg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"vtB" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vvl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vwg" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"vyn" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"vyC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"vyR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"vzC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vzE" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"vFl" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vGN" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"vHf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vIo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"vJl" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vNw" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vOp" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"vPe" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"vPB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"vQR" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"vTn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"vTQ" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vUT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"vVh" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vVt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"vXw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"waF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"wbJ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"wbT" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wcG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wdz" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"wgh" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"whS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wiA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wiL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wjk" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wma" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wpK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"wrm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wtY" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wwC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wxw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
-"wyb" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"wyh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wzf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wzk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wAA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wBC" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"wCd" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"wDD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wET" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wFK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"wHE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"wIT" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wLf" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wLm" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wLn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wNz" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wVY" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"wXh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wYn" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xaf" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xdo" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xdI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"xfj" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"xfK" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xio" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"xiq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
-"xjv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xkf" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"xkP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xmi" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"xmN" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"xmW" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xpN" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"xqb" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"xrE" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xrW" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"xsy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/security/brig)
-"xuk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xvf" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xxH" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xyQ" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xzt" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xzN" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xAN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xBm" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"xBI" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xCL" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"xDD" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xDF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"xGX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xJy" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xKT" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"xNi" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"xNo" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xOy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xOF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xPK" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xQM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"xRn" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xRH" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xRS" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"xSR" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xTF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xUc" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"xUe" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"xUO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"xVm" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xWn" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"xXJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xXO" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"xZI" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ycq" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ydS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"yeD" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"yhm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"yiZ" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"yjg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/area/maintenance/aft)
 
 (1,1,1) = {"
 aaa
@@ -100384,7 +94281,7 @@ aac
 aac
 aac
 bNe
-bUO
+cbb
 bPq
 aac
 aac
@@ -100641,7 +94538,7 @@ aaa
 aaa
 aac
 bNf
-bVo
+cic
 bPr
 aac
 aaa
@@ -100897,9 +94794,9 @@ bIY
 bIY
 bIY
 byU
-vqp
+bAS
 bVp
-noP
+bAa
 bKd
 bIY
 bIY
@@ -101147,23 +95044,23 @@ aaa
 aaa
 aaa
 bxN
-vqp
-jRe
-jRe
-jRe
-jRe
-jRe
-jRe
+bAS
+bLI
+bLI
+bLI
+bLI
+bLI
+bLI
 bPK
 bRU
 bYA
-jRe
-jRe
-jRe
-jRe
-jRe
-jRe
-noP
+bLI
+bLI
+bLI
+bLI
+bLI
+bLI
+bAa
 bzY
 aab
 aab
@@ -101403,25 +95300,25 @@ aab
 aab
 aab
 bzS
-vqp
-nik
-tcs
-tcs
-tcs
-guI
-gGZ
+bAS
+bEK
+bLL
+bLL
+bLL
+bMM
+bNg
 bOa
 bPL
 bVq
 caW
-guI
-gGZ
-guI
-tcs
-tcs
-tcs
+bMM
+bNg
+bMM
+bLL
+bLL
+bLL
 cAh
-xmW
+cAE
 bzY
 aab
 aav
@@ -101659,9 +95556,9 @@ aab
 aab
 aab
 bzS
-qty
-nik
-xfK
+bzU
+bEK
+bKZ
 bBW
 bJg
 bJg
@@ -101677,9 +95574,9 @@ bBX
 bSd
 bSS
 bAc
-uZv
-jGS
-xmW
+cAn
+cAG
+cAE
 bzY
 aav
 aab
@@ -101915,9 +95812,9 @@ aav
 aab
 aab
 bzS
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 bzV
 aav
 aaa
@@ -101935,9 +95832,9 @@ aab
 aav
 aab
 bAc
-nTx
-jGS
-xmW
+cAN
+cAG
+cAE
 bBY
 aab
 aab
@@ -102171,9 +96068,9 @@ aab
 aav
 aab
 bzS
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 bzV
 aab
 aav
@@ -102193,9 +96090,9 @@ aav
 aab
 aab
 bAc
-nTx
-jGS
-xmW
+cAN
+cAG
+cAE
 bzY
 aab
 aab
@@ -102427,9 +96324,9 @@ aab
 aab
 aav
 bzS
-qty
-nik
-xfK
+bzU
+bEK
+bKZ
 bzV
 aab
 aab
@@ -102451,9 +96348,9 @@ aab
 aab
 aab
 bAc
-uZv
-jGS
-xmW
+cAn
+cAG
+cAE
 bzY
 aab
 aab
@@ -102683,8 +96580,8 @@ aab
 aab
 aab
 bDC
-vqp
-nik
+bAS
+bEK
 bKY
 bzV
 aab
@@ -102709,9 +96606,9 @@ aab
 aab
 aab
 bAc
-nTx
-jGS
-xmW
+cAN
+cAG
+cAE
 bzY
 aab
 aaa
@@ -102939,8 +96836,8 @@ aab
 aab
 aab
 bzS
-vqp
-nik
+bAS
+bEK
 bJF
 bBW
 aab
@@ -102955,7 +96852,7 @@ bBX
 bBX
 bNC
 bOg
-hmz
+cuS
 bBX
 bBX
 bBX
@@ -102969,7 +96866,7 @@ aab
 bAc
 cBd
 cBh
-noP
+bAa
 bzY
 aaa
 aaa
@@ -103195,8 +97092,8 @@ aac
 aab
 aab
 bzS
-qty
-gSt
+bzU
+byW
 bKy
 bzV
 aav
@@ -103212,7 +97109,7 @@ aab
 bBX
 bNC
 bOg
-mRW
+cuT
 bBX
 aab
 aab
@@ -103226,8 +97123,8 @@ aab
 aab
 bAc
 clQ
-uxT
-noP
+cBq
+bAa
 bzY
 aaa
 aaa
@@ -103451,9 +97348,9 @@ aaa
 aac
 aab
 bzS
-vqp
-gSt
-pkV
+bAS
+byW
+bzZ
 bzV
 aab
 aav
@@ -103469,7 +97366,7 @@ aab
 bBX
 bNC
 bOg
-hmz
+cuS
 bBX
 aab
 aab
@@ -103483,9 +97380,9 @@ aab
 aab
 aab
 bYB
-nTx
-uxT
-noP
+cAN
+cBq
+bAa
 bJf
 aaa
 aac
@@ -103707,9 +97604,9 @@ aaa
 aaa
 aac
 bzS
-vqp
-gSt
-pkV
+bAS
+byW
+bzZ
 bBW
 aav
 aav
@@ -103741,9 +97638,9 @@ aav
 aav
 aav
 bYB
-nTx
-uxT
-noP
+cAN
+cBq
+bAa
 bJf
 aac
 aaa
@@ -103963,9 +97860,9 @@ aaa
 aab
 aaa
 byU
-qty
-gSt
-pkV
+bzU
+byW
+bzZ
 bBW
 aab
 aab
@@ -103999,9 +97896,9 @@ aab
 aav
 aab
 bAc
-uZv
-uxT
-noP
+cAn
+cBq
+bAa
 bKd
 aaa
 aab
@@ -104220,8 +98117,8 @@ aaa
 aab
 bxN
 byV
-gSt
-pkV
+byW
+bzZ
 bBW
 aav
 aav
@@ -104240,7 +98137,7 @@ aab
 bBX
 bNC
 bOh
-hmz
+cuS
 bBX
 aab
 aab
@@ -104257,9 +98154,9 @@ bST
 bST
 aav
 bYB
-nTx
-uxT
-noP
+cAN
+cBq
+bAa
 bJf
 aab
 aab
@@ -104476,8 +98373,8 @@ aaa
 aaa
 bwP
 bxO
-gSt
-pkV
+byW
+bzZ
 bzV
 aab
 aav
@@ -104497,7 +98394,7 @@ bBX
 bBX
 bNC
 bOg
-mRW
+cuT
 bBX
 aab
 aab
@@ -104515,9 +98412,9 @@ bBX
 bBX
 bST
 bAc
-nTx
-uxT
-noP
+cAN
+cBq
+bAa
 bzX
 aab
 aaa
@@ -104732,7 +98629,7 @@ aaa
 aaa
 aaa
 bwP
-oDk
+bxP
 byX
 bzV
 aab
@@ -104754,7 +98651,7 @@ bBX
 bME
 bNC
 bOg
-hmz
+cuS
 bBX
 aab
 bBX
@@ -104773,7 +98670,7 @@ bUP
 bST
 aab
 bAc
-lIc
+bxQ
 byX
 cdz
 aab
@@ -104989,7 +98886,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byX
 bzW
 aav
@@ -105030,7 +98927,7 @@ bUP
 bST
 aab
 cbC
-oDk
+bxP
 byX
 cdz
 aab
@@ -105246,7 +99143,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byX
 bzX
 aab
@@ -105270,7 +99167,7 @@ bOx
 bOj
 cuW
 can
-vzE
+bQL
 bLJ
 bSf
 bZG
@@ -105287,7 +99184,7 @@ bUP
 bST
 aab
 cbC
-lIc
+bxQ
 byX
 cdz
 aab
@@ -105503,7 +99400,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byX
 bzX
 aab
@@ -105544,7 +99441,7 @@ bUP
 bST
 aab
 cbC
-lIc
+bxQ
 byX
 cdz
 aab
@@ -105760,7 +99657,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byX
 bzX
 aab
@@ -105783,10 +99680,10 @@ bNj
 bNq
 bOk
 bPD
-hkh
+cDo
 ccT
 bLJ
-dDQ
+bSh
 bSY
 bTU
 bUR
@@ -105801,7 +99698,7 @@ bUP
 bST
 aab
 cbC
-lIc
+bxQ
 byX
 cdz
 aab
@@ -106017,7 +99914,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byX
 bzX
 aab
@@ -106058,7 +99955,7 @@ bUP
 bST
 aab
 cbC
-oDk
+bxP
 byX
 cdz
 aab
@@ -106531,7 +100428,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byZ
 bzX
 aab
@@ -106554,7 +100451,7 @@ bNp
 bNt
 bQm
 bOj
-lUz
+cDd
 cDs
 bLJ
 bSi
@@ -106572,7 +100469,7 @@ bUP
 bST
 aab
 cbC
-pGK
+cCU
 byX
 cdz
 aab
@@ -106788,7 +100685,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byZ
 bzX
 aab
@@ -106811,10 +100708,10 @@ bNj
 bNu
 bOn
 bPG
-hkh
+cDo
 cvc
 bLJ
-dDQ
+bSh
 bTb
 bSV
 bUP
@@ -106829,7 +100726,7 @@ bUP
 bST
 aab
 cbC
-pGK
+cCU
 byX
 cdz
 aab
@@ -107045,7 +100942,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byZ
 bzX
 aab
@@ -107067,7 +100964,7 @@ bNX
 bNw
 bPc
 bOj
-lUz
+cDd
 cDq
 cvd
 bLJ
@@ -107302,7 +101199,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byZ
 bzX
 aab
@@ -107326,7 +101223,7 @@ bPs
 bOj
 cDe
 cBc
-vzE
+bQL
 bLJ
 bSl
 bTc
@@ -107343,7 +101240,7 @@ bSU
 bST
 bSc
 bzS
-pGK
+cCU
 byX
 cdz
 aab
@@ -107559,7 +101456,7 @@ aaa
 aaa
 aaa
 bwP
-lIc
+bxQ
 byZ
 bzW
 aav
@@ -107598,8 +101495,8 @@ bUS
 bSV
 bZP
 bZO
-jRe
-jRe
+bLI
+bLI
 cCW
 byX
 cdz
@@ -107816,7 +101713,7 @@ aaa
 aaa
 aaa
 bwP
-oDk
+bxP
 byZ
 bzY
 aab
@@ -107838,7 +101735,7 @@ bBX
 bME
 bPv
 bOt
-ptC
+cDh
 bBX
 aab
 bBX
@@ -108075,7 +101972,7 @@ aaa
 bwP
 bxS
 bzb
-noP
+bAa
 bzY
 aab
 aav
@@ -108095,7 +101992,7 @@ bBX
 bBX
 bPv
 bOo
-xCL
+cDg
 bBX
 aab
 aab
@@ -108113,9 +102010,9 @@ bBX
 bBX
 bST
 caY
-lIc
+bxQ
 cCX
-pkV
+bzZ
 bzX
 aab
 aaa
@@ -108264,7 +102161,7 @@ apO
 atB
 ali
 avt
-cHl
+aMl
 axh
 axG
 axG
@@ -108332,8 +102229,8 @@ aaa
 aab
 bxT
 bzT
-lWO
-noP
+bAb
+bAa
 bBY
 aav
 aav
@@ -108352,7 +102249,7 @@ aab
 bBX
 bPv
 bOp
-ptC
+cDh
 bBX
 aab
 aab
@@ -108369,9 +102266,9 @@ bST
 bST
 aav
 cap
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 cbE
 aab
 aab
@@ -108589,9 +102486,9 @@ aaa
 aab
 aaa
 bxT
-uOG
-lWO
-noP
+bAR
+bAb
+bAa
 bBY
 aab
 aab
@@ -108625,9 +102522,9 @@ aab
 aav
 aab
 bzS
-qty
-nik
-xfK
+bzU
+bEK
+bKZ
 cbE
 aaa
 aab
@@ -108847,9 +102744,9 @@ aab
 aaa
 aaa
 bAc
-nLA
-lWO
-noP
+bDJ
+bAb
+bAa
 bBY
 aav
 aav
@@ -108881,9 +102778,9 @@ aav
 aav
 aav
 bDC
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 cbE
 aaa
 aaa
@@ -109105,9 +103002,9 @@ aaa
 aaa
 aab
 bAc
-nLA
-lWO
-noP
+bDJ
+bAb
+bAa
 bzY
 aab
 aav
@@ -109123,7 +103020,7 @@ aab
 bBX
 bPv
 bOo
-ptC
+cDh
 bBX
 aab
 aab
@@ -109137,9 +103034,9 @@ aab
 aab
 aab
 bDC
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 caZ
 aac
 aac
@@ -109363,8 +103260,8 @@ aaa
 aab
 aab
 bAc
-uOG
-lWO
+bAR
+bAb
 bKH
 bzY
 aav
@@ -109380,7 +103277,7 @@ aab
 bBX
 bPv
 bOo
-xCL
+cDg
 bBX
 aab
 aab
@@ -109394,8 +103291,8 @@ aab
 aab
 bzS
 cnO
-nik
-xfK
+bEK
+bKZ
 bzV
 aaa
 aaa
@@ -109537,7 +103434,7 @@ cMv
 cOq
 abY
 ahd
-ikD
+ahU
 aiN
 aiN
 alm
@@ -109621,7 +103518,7 @@ aab
 aab
 aab
 bAc
-nLA
+bDJ
 bFX
 bKa
 bBY
@@ -109637,7 +103534,7 @@ bBX
 bBX
 bPv
 bOo
-ptC
+cDh
 bBX
 bBX
 bBX
@@ -109651,7 +103548,7 @@ aaa
 bzS
 cCT
 cBn
-xfK
+bKZ
 bzV
 aab
 aaa
@@ -109879,9 +103776,9 @@ aab
 aab
 aab
 bAc
-nLA
-lWO
-noP
+bDJ
+bAb
+bAa
 bzY
 aab
 aab
@@ -109905,9 +103802,9 @@ aaa
 aaa
 aaa
 bxN
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 bzV
 aab
 aab
@@ -110137,9 +104034,9 @@ aab
 aab
 aab
 bAc
-uOG
-lWO
-noP
+bAR
+bAb
+bAa
 bzY
 aab
 aaa
@@ -110161,9 +104058,9 @@ aaa
 aaa
 aaa
 bxN
-qty
-nik
-xfK
+bzU
+bEK
+bKZ
 bzV
 aab
 aab
@@ -110395,9 +104292,9 @@ aab
 aab
 aab
 bAc
-nLA
-lWO
-noP
+bDJ
+bAb
+bAa
 bzY
 aaa
 aac
@@ -110417,9 +104314,9 @@ aac
 aaa
 aaa
 bxN
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 bzV
 aab
 aab
@@ -110565,7 +104462,7 @@ aeG
 acw
 abY
 ahd
-ikD
+ahU
 aiN
 aiN
 alp
@@ -110653,9 +104550,9 @@ aab
 aab
 aab
 bAc
-nLA
-lWO
-noP
+bDJ
+bAb
+bAa
 bJf
 aac
 aaa
@@ -110673,9 +104570,9 @@ aab
 aac
 aaa
 bxN
-vqp
-nik
-xfK
+bAS
+bEK
+bKZ
 bzV
 aab
 aaa
@@ -110911,9 +104808,9 @@ aab
 aab
 aab
 bAc
-uOG
-lWO
-noP
+bAR
+bAb
+bAa
 bKd
 bIY
 chv
@@ -110929,9 +104826,9 @@ bBX
 bSc
 bTe
 bzS
-qty
-nik
-xfK
+bzU
+bEK
+bKZ
 bBW
 aav
 aac
@@ -111169,25 +105066,25 @@ aaa
 aaa
 aaa
 bxT
-nLA
-lWO
-jRe
-jRe
+bDJ
+bAb
+bLI
+bLI
 bMG
-ezq
+bMQ
 bNY
 bRT
 bPQ
 bXM
 cuV
-ezq
+bMQ
 cve
-ezq
-jRe
-jRe
-jRe
-nik
-xfK
+bMQ
+bLI
+bLI
+bLI
+bEK
+bKZ
 bzV
 aav
 aab
@@ -111427,23 +105324,23 @@ aaa
 aaa
 aaa
 bxT
-nLA
-tcs
-tcs
+bDJ
+bLL
+bLL
 bML
-noo
-noo
+bMR
+bMR
 bPH
 bQT
 bOw
 caX
-noo
+bMR
 cvf
-tcs
-tcs
-tcs
-tcs
-xfK
+bLL
+bLL
+bLL
+bLL
+bKZ
 bzV
 aab
 aav
@@ -111593,7 +105490,7 @@ aeG
 acw
 abY
 ahd
-ikD
+ahU
 aiN
 aiN
 als
@@ -112621,7 +106518,7 @@ acw
 aeJ
 abY
 ahd
-ikD
+ahU
 aiN
 aiN
 alv
@@ -116712,7 +110609,7 @@ aaN
 aab
 aaa
 aaa
-cuL
+aaT
 aaX
 abb
 agk
@@ -116782,7 +110679,7 @@ aab
 aab
 bba
 bcg
-bdh
+cmT
 bcg
 bba
 aab
@@ -117004,7 +110901,7 @@ aqc
 aqc
 avE
 awv
-ukc
+aBs
 axl
 aaQ
 azx
@@ -117251,7 +111148,7 @@ aif
 aja
 akp
 anU
-wbJ
+aoQ
 apa
 arj
 atb
@@ -117261,7 +111158,7 @@ avO
 atW
 ayR
 aPu
-ukc
+aBs
 aCU
 aaV
 azy
@@ -117548,7 +111445,7 @@ acw
 acw
 aVM
 aWN
-aZR
+baf
 aZR
 bcj
 bfL
@@ -117776,7 +111673,7 @@ aqd
 azd
 awy
 axS
-wbJ
+aoQ
 aaV
 azA
 aAO
@@ -118032,7 +111929,7 @@ avU
 aqd
 azd
 aww
-ukc
+aBs
 abt
 aaV
 azB
@@ -118055,7 +111952,7 @@ acw
 acw
 afB
 acw
-aQC
+bUO
 aGz
 cSj
 cdW
@@ -118289,7 +112186,7 @@ avL
 aqd
 azd
 aww
-ukc
+aBs
 aUi
 aaQ
 aaQ
@@ -118546,7 +112443,7 @@ abJ
 abJ
 azf
 aww
-ukc
+aBs
 abt
 any
 azC
@@ -118803,7 +112700,7 @@ arn
 bJo
 azd
 awz
-ukc
+aBs
 aCU
 any
 azD
@@ -118835,8 +112732,8 @@ aYc
 aMh
 aaR
 aYQ
+bbs
 bey
-bgT
 aXT
 bdn
 bez
@@ -119193,12 +113090,12 @@ cvC
 cvC
 cwK
 cqk
-oav
+cFB
 cqk
 cqk
 cqk
 cyK
-ubz
+cGH
 cqk
 cza
 cvG
@@ -119317,7 +113214,7 @@ aro
 abJ
 azd
 aww
-ukc
+aBs
 aFN
 any
 azF
@@ -119574,7 +113471,7 @@ asV
 abJ
 aCi
 awB
-ukc
+aBs
 axl
 any
 azG
@@ -119831,7 +113728,7 @@ atM
 abJ
 bdT
 aww
-ukc
+aBs
 axL
 axL
 axL
@@ -120088,7 +113985,7 @@ arr
 abJ
 azd
 aww
-tet
+aBZ
 axM
 aIJ
 azH
@@ -120345,7 +114242,7 @@ atN
 auP
 azh
 awC
-ukc
+aBs
 axN
 ayE
 azI
@@ -120377,7 +114274,7 @@ aVS
 aWR
 aYS
 aYT
-cYW
+bad
 bbq
 bcu
 bcu
@@ -120602,7 +114499,7 @@ arr
 abJ
 azd
 awz
-ukc
+aBs
 axO
 ayF
 azJ
@@ -120859,7 +114756,7 @@ atO
 abJ
 azi
 awz
-ukc
+aBs
 axL
 ayG
 ayN
@@ -120984,7 +114881,7 @@ ceF
 cLR
 bSn
 cri
-bQx
+bQF
 ctJ
 cqk
 cwG
@@ -121373,7 +115270,7 @@ apY
 abJ
 azd
 awz
-ukc
+aBs
 axL
 ayI
 azK
@@ -121489,9 +115386,9 @@ aaA
 aaA
 bTf
 bUb
-cki
+bQW
 ckY
-bGf
+cqH
 ccF
 cVm
 cdg
@@ -121630,7 +115527,7 @@ abJ
 abJ
 azd
 awz
-ukc
+aBs
 axP
 ayJ
 azL
@@ -121748,12 +115645,12 @@ bTf
 ciF
 ckj
 ckZ
-cUZ
+crt
 clH
 clH
 cdL
 cpn
-tPy
+crM
 cqk
 cqk
 cth
@@ -121974,7 +115871,7 @@ boU
 cJk
 bOR
 cLJ
-bQx
+bQF
 bQX
 bRF
 bQW
@@ -122010,7 +115907,7 @@ cmB
 cnr
 cBo
 cpo
-tPy
+crM
 cqk
 cqk
 cti
@@ -122142,9 +116039,9 @@ arx
 akt
 atS
 auQ
-ptj
+azk
 awz
-tet
+aBZ
 axL
 ayL
 azM
@@ -122227,10 +116124,10 @@ aaA
 bFH
 cRh
 bMp
-bNa
+bQx
 cLB
 bOS
-fTH
+cLK
 boU
 bQY
 bRG
@@ -122247,7 +116144,7 @@ cKt
 cKE
 cKt
 boU
-cbb
+cki
 cbF
 cTw
 bQW
@@ -122267,7 +116164,7 @@ cVi
 cdd
 cdN
 cpp
-tPy
+crM
 cqk
 cqk
 cth
@@ -122401,7 +116298,7 @@ atT
 auR
 azQ
 awE
-ukc
+aBs
 axQ
 ayM
 azN
@@ -122433,7 +116330,7 @@ aVY
 aTF
 aTF
 aSt
-cYW
+bad
 cGw
 cGy
 cGA
@@ -122529,7 +116426,7 @@ cqk
 csh
 ctj
 cub
-pfL
+cwZ
 cvF
 cqg
 cqg
@@ -122658,7 +116555,7 @@ atS
 auS
 azS
 awz
-ukc
+aBs
 axN
 ayN
 azO
@@ -122690,8 +116587,8 @@ bYi
 bYi
 aYe
 aSt
-baf
-bbs
+bdh
+bgT
 bcr
 bcs
 bcs
@@ -122744,7 +116641,7 @@ bMq
 boU
 cLD
 bOU
-fTH
+cLK
 boU
 bRa
 bRI
@@ -122762,31 +116659,31 @@ cKF
 cKH
 boU
 cCz
-liN
-liN
-fdP
-vIo
-vIo
-vIo
-vIo
-vIo
+bNU
+bNU
+cCr
+bZn
+bZn
+bZn
+bZn
+bZn
 bkT
 bQg
-vIo
-vIo
-vIo
-vIo
+bZn
+bZn
+bZn
+bZn
 cCK
-vIo
+bZn
 cHc
-vIo
-fdP
+bZn
+cCr
 cEM
 cHw
 cER
 cth
 cub
-mEI
+cxa
 cvH
 cwj
 cqg
@@ -122915,7 +116812,7 @@ avA
 auQ
 azZ
 awF
-ukc
+aBs
 axR
 aTE
 azO
@@ -122948,7 +116845,7 @@ aTH
 aTH
 boB
 bam
-eom
+bvr
 bcs
 bdz
 beK
@@ -123001,7 +116898,7 @@ bMr
 boU
 cLE
 bOU
-fTH
+cLK
 boU
 bRb
 bRJ
@@ -123020,23 +116917,23 @@ cKE
 boU
 cCA
 cML
-wLn
-tkM
-eFK
-jaf
-eFK
-jaf
+cfS
+cHu
+cRJ
+cRL
+cRJ
+cRL
 cRP
-jaf
+cRL
 cRR
-jaf
+cRL
 cRT
-jaf
-eFK
+cRL
+cRJ
 cRV
 cRX
 cRY
-eFK
+cRJ
 cRZ
 cSa
 cHx
@@ -123172,7 +117069,7 @@ afU
 afU
 aAo
 awG
-ukc
+aBs
 axL
 axL
 azP
@@ -123276,25 +117173,25 @@ cKt
 cKI
 boU
 cBI
-uHw
-ddU
-hdo
-udJ
-kYi
-udJ
-udJ
+cMP
+cCg
+cCs
+cfj
+cfO
+cfj
+cfj
 crf
-udJ
+cfj
 cjw
-udJ
+cfj
 cnv
-udJ
-kYi
+cfj
+cfO
 cSN
 cHb
-udJ
-udJ
-hdo
+cfj
+cfj
+cCs
 cEO
 cHy
 cET
@@ -123427,15 +117324,15 @@ avo
 atf
 awJ
 auT
-ptj
+azk
 awH
 aCb
-luj
+aDq
 aDz
 aFW
 aHr
-luj
-luj
+aDq
+aDq
 aJQ
 aKK
 aNn
@@ -123462,7 +117359,7 @@ aTJ
 aTJ
 brk
 bao
-eom
+bvr
 bcs
 bdB
 beK
@@ -123515,7 +117412,7 @@ bJs
 boU
 cJk
 bOU
-fTH
+cLK
 boU
 bRd
 bRJ
@@ -123534,7 +117431,7 @@ cKJ
 boU
 cWR
 cMQ
-okh
+cCh
 boU
 cqg
 cqg
@@ -123695,7 +117592,7 @@ aBU
 axn
 aEs
 aEn
-ukc
+aBs
 aPf
 aaQ
 cMl
@@ -123790,8 +117687,8 @@ cKt
 cKK
 boU
 cgm
-uHw
-okh
+cMP
+cCh
 boU
 cPF
 chI
@@ -123803,7 +117700,7 @@ cjy
 cfQ
 cCG
 cqg
-clb
+coh
 clM
 cWn
 cnw
@@ -123814,7 +117711,7 @@ cqk
 cqk
 ctn
 cuf
-pfL
+cwZ
 cvG
 aab
 aab
@@ -123961,7 +117858,7 @@ aIO
 aKw
 aKF
 aUv
-aMl
+aUr
 aNm
 bis
 bxw
@@ -123976,7 +117873,7 @@ aTL
 aTJ
 brk
 bam
-eom
+bvr
 bct
 bdD
 beK
@@ -124029,7 +117926,7 @@ cVB
 boU
 cLG
 bOU
-sOO
+cLO
 boU
 bRf
 bSo
@@ -124048,7 +117945,7 @@ cKL
 boU
 cCC
 cQV
-okh
+cCh
 boU
 bYa
 ced
@@ -124071,7 +117968,7 @@ baC
 ctd
 cto
 cuf
-pfL
+cwZ
 cvG
 cvG
 cvG
@@ -124233,7 +118130,7 @@ aTL
 aTJ
 brk
 bam
-thd
+bJH
 bcl
 bcl
 bcl
@@ -124286,7 +118183,7 @@ bJs
 boU
 cLH
 bOU
-sOO
+cLO
 boU
 bRg
 bRK
@@ -124326,9 +118223,9 @@ cla
 cqq
 cqg
 cqg
-jsA
+ctM
 cuf
-pfL
+cwZ
 cvJ
 cwl
 cwO
@@ -124490,7 +118387,7 @@ aTL
 aTJ
 brl
 bbi
-ivv
+bxn
 bcl
 bdp
 bhl
@@ -124543,7 +118440,7 @@ bJs
 boU
 cLI
 bOV
-sOO
+cLO
 boU
 bDb
 boU
@@ -124585,7 +118482,7 @@ crm
 cqg
 cXa
 cuf
-pfL
+cwZ
 cvG
 cvG
 cvG
@@ -124729,9 +118626,9 @@ aGH
 aCL
 cXq
 aJF
-wzk
-rqB
-dlH
+aFH
+aKH
+aYW
 apg
 aab
 aab
@@ -124747,7 +118644,7 @@ aTK
 aTJ
 brr
 bam
-eom
+bvr
 bcl
 bdq
 beC
@@ -124800,26 +118697,26 @@ bJs
 boU
 cWN
 bOU
-rmF
-fdP
-liN
+cCf
+cCr
+bNU
 bSp
 bTl
 bUk
 bZm
 cCx
-liN
-liN
-lnz
-liN
-liN
+bNU
+bNU
+btX
+bNU
+bNU
 cMK
-mgC
-liN
-fdP
+cfP
+bNU
+cCr
 cHr
-uHw
-fkT
+cMP
+cCi
 boU
 cdB
 cRW
@@ -124842,7 +118739,7 @@ bYa
 cqg
 ctW
 cuf
-pfL
+cwZ
 cvG
 aab
 aab
@@ -124986,9 +118883,9 @@ aGI
 aBX
 cXq
 aJF
-wzk
-rqB
-dlH
+aFH
+aKH
+aYW
 bym
 aab
 aab
@@ -125004,7 +118901,7 @@ aSt
 aSt
 bdC
 bbj
-xdI
+bxo
 beN
 bdr
 bij
@@ -125055,26 +118952,26 @@ bDK
 bJr
 bLS
 boU
-cBK
+bVo
 cCm
-uFq
+cbI
 cfi
-uFq
-wLn
+cbI
+cfS
 cju
 czN
 cCL
-wLn
-uFq
-wLn
+cfS
+cbI
+cfS
 cEL
-wLn
-uFq
+cfS
+cbI
 cEN
-uFq
+cbI
 cHd
-tkM
-wLn
+cHu
+cfS
 cRI
 cCE
 boU
@@ -125097,9 +118994,9 @@ cla
 cqt
 crn
 cqg
-jsA
+ctM
 cuf
-pfL
+cwZ
 cvF
 cqg
 cwN
@@ -125243,7 +119140,7 @@ aPi
 aHt
 aHV
 aJF
-wzk
+aFH
 bwV
 aYX
 bBZ
@@ -125315,22 +119212,22 @@ boU
 cBI
 bOX
 cCa
-hdo
-tFB
-tFB
+cCs
+cBy
+cBy
 bWZ
-tFB
-tFB
-tFB
-tFB
-tFB
-tFB
-vhY
+cBy
+cBy
+cBy
+cBy
+cBy
+cBy
+cBG
 cUG
-tFB
+cBy
 cFf
-opU
-hdo
+bKW
+cCs
 cBR
 bOX
 cHv
@@ -125356,7 +119253,7 @@ cUl
 cqg
 cXb
 cuf
-mEI
+cxa
 cvH
 cwm
 cvH
@@ -125484,8 +119381,8 @@ ati
 auG
 auY
 aBc
-fQS
-fQS
+aBp
+aBp
 aDu
 ayS
 azY
@@ -125500,9 +119397,9 @@ aGK
 aBX
 aIb
 aJF
-wzk
-rqB
-dlH
+aFH
+aKH
+aYW
 cye
 aab
 aab
@@ -125571,7 +119468,7 @@ cRh
 boU
 cBI
 bOX
-qKy
+cqm
 bQz
 bQz
 bQz
@@ -125611,13 +119508,13 @@ ceG
 cqt
 cRy
 cqg
-jsA
+ctM
 cug
 cyh
 cvK
 cvK
 cue
-oav
+cFB
 cqk
 cqk
 cqk
@@ -125759,7 +119656,7 @@ aIc
 aJG
 aKx
 aKI
-wjk
+aYY
 apg
 aab
 aab
@@ -125828,16 +119725,16 @@ cTt
 boU
 cBN
 bOX
-fkT
+cCi
 bQz
 cUy
 bRh
 cFn
-qsh
+cIr
 cKA
-qsh
-qsh
-qsh
+cIr
+cIr
+cIr
 cLb
 cLL
 bQz
@@ -125847,7 +119744,7 @@ bZQ
 car
 cFF
 cFO
-dUE
+cFY
 bYJ
 cdB
 bYa
@@ -125878,11 +119775,11 @@ cxm
 cvK
 cvK
 cvK
-ubz
+cGH
 cqk
 cza
 czi
-cwl
+czu
 czw
 aab
 aab
@@ -125986,7 +119883,7 @@ abp
 bSy
 cDN
 cDO
-cDP
+aQC
 anB
 cDS
 akK
@@ -125994,28 +119891,28 @@ anR
 arG
 auk
 bXs
-nqv
-nqv
+avM
+avM
 axC
-lHi
-jUM
-jUM
+aBe
+aBq
+aBq
 aDv
 aEk
 aGJ
 aHA
 aXd
-nqv
-nqv
-nqv
-nqv
+avM
+avM
+avM
+avM
 aPg
 aPj
-lHi
-jUM
-jUM
+aBe
+aBq
+aBq
 aKy
-rqB
+aKH
 cNB
 apg
 aab
@@ -126032,7 +119929,7 @@ aXa
 aWY
 btl
 bam
-eom
+bvr
 bcw
 bdK
 beT
@@ -126041,8 +119938,8 @@ bgk
 bcw
 cIA
 cNM
-iHh
-iHh
+cIE
+cIE
 cIG
 bjC
 bmj
@@ -126085,7 +119982,7 @@ cRh
 boU
 cBI
 bOX
-okh
+cCh
 bQA
 cmx
 bRh
@@ -126096,7 +119993,7 @@ cWp
 cJx
 cJx
 cJx
-lpO
+cLZ
 bQz
 cWQ
 bZg
@@ -126104,7 +120001,7 @@ bZg
 bZg
 cJI
 cNb
-dUE
+cFY
 bYJ
 cdB
 bYa
@@ -126243,7 +120140,7 @@ abp
 abc
 cDL
 afU
-ajH
+bGf
 anC
 alY
 alX
@@ -126273,7 +120170,7 @@ aCM
 aJH
 aJM
 aPW
-dlH
+aYW
 apg
 aab
 aab
@@ -126289,7 +120186,7 @@ aXb
 aWY
 brk
 bpH
-xdI
+bxo
 bcx
 bdL
 beU
@@ -126300,7 +120197,7 @@ cIB
 bjz
 bkk
 bkL
-fay
+cIH
 biQ
 bmk
 bne
@@ -126316,17 +120213,17 @@ box
 cPo
 bsN
 bte
-vnA
-vnA
-hNR
+btT
+btT
+bwi
 bwR
 byh
 bAi
-qNB
+bAy
 bWT
-qNB
+bAy
 bDa
-hNR
+bwi
 bsN
 aaA
 aaA
@@ -126342,7 +120239,7 @@ cPB
 boU
 cBI
 bOX
-okh
+cCh
 bQA
 cUz
 bRh
@@ -126510,27 +120407,27 @@ aWv
 avG
 aYm
 axi
-rJH
-tSS
+axE
+aBm
 aJX
-tSS
-tSS
-tSS
-vTn
+aBm
+aBm
+aBm
+aPN
 aDQ
 aDF
 bku
-rJH
-vTn
-tSS
-tSS
-tSS
-tSS
-tSS
-tSS
+axE
+aPN
+aBm
+aBm
+aBm
+aBm
+aBm
+aBm
 aLw
-hBT
-dlH
+aOn
+aYW
 apg
 aab
 aab
@@ -126546,7 +120443,7 @@ aXc
 aYf
 btE
 cGt
-eom
+bvr
 bcw
 bdM
 beV
@@ -126557,7 +120454,7 @@ cIC
 bjA
 bkl
 bkM
-fay
+cIH
 blP
 bml
 bnf
@@ -126583,7 +120480,7 @@ bAz
 bBx
 bCr
 bFS
-uai
+bwr
 bsN
 aaA
 aaA
@@ -126599,7 +120496,7 @@ bFI
 boU
 cIy
 bOX
-okh
+cCh
 bQA
 cmx
 bRh
@@ -126786,8 +120683,8 @@ apk
 aHX
 apk
 bPB
-hBT
-dlH
+aOn
+aYW
 apg
 aab
 aab
@@ -126814,7 +120711,7 @@ cIB
 bjB
 bkm
 bkN
-fay
+cIH
 biQ
 bmm
 bre
@@ -126856,7 +120753,7 @@ boU
 cFZ
 cBI
 bOX
-okh
+cCh
 bQA
 bRh
 bRh
@@ -126867,7 +120764,7 @@ cJx
 cJx
 cJx
 cWs
-lpO
+cLZ
 bQz
 bZj
 cJB
@@ -127043,8 +120940,8 @@ aEv
 aHY
 aFl
 aJD
-hBT
-dlH
+aOn
+aYW
 apg
 aab
 aab
@@ -127060,7 +120957,7 @@ aWY
 aWY
 brk
 bam
-thd
+bJH
 bcw
 bdO
 biG
@@ -127068,9 +120965,9 @@ bfa
 bhs
 bcw
 cID
-vyR
-vyR
-vyR
+cIF
+cIF
+cIF
 cII
 bjC
 bmn
@@ -127093,13 +120990,13 @@ bwT
 bwR
 byk
 bAp
-vnA
+btT
 bBz
 bFc
 bwR
 bDP
 bEX
-vnA
+btT
 bGr
 bsN
 bsN
@@ -127124,7 +121021,7 @@ cJx
 cWq
 cJx
 cJx
-lpO
+cLZ
 bQz
 cjU
 cJA
@@ -127300,8 +121197,8 @@ aHu
 aHY
 aFl
 aJD
-hBT
-dlH
+aOn
+aYW
 apg
 aab
 aab
@@ -127317,7 +121214,7 @@ aWY
 aWY
 buq
 bam
-eom
+bvr
 bcw
 bdQ
 cJK
@@ -127370,21 +121267,21 @@ boU
 cGb
 cBI
 bOX
-okh
+cCh
 bQz
 cUB
 bRh
 cFG
-xUe
-xUe
-xUe
+cJS
+cJS
+cJS
 cWr
-xUe
-xUe
+cJS
+cJS
 cMy
 cFI
-pru
-pru
+cfq
+cfq
 cJC
 cJG
 cFK
@@ -127557,8 +121454,8 @@ aHv
 aHY
 aFl
 aJD
-hBT
-dlH
+aOn
+aYW
 apg
 aab
 aab
@@ -127574,7 +121471,7 @@ cEU
 aWY
 buu
 ban
-eom
+bvr
 bcw
 bht
 beY
@@ -127627,7 +121524,7 @@ bMs
 boU
 cIz
 bOX
-okh
+cCh
 bQA
 cUC
 bRh
@@ -127814,8 +121711,8 @@ aGO
 aGO
 aGO
 aKv
-hBT
-wjk
+aOn
+aYY
 apg
 aab
 aab
@@ -127831,7 +121728,7 @@ aOW
 aSt
 brk
 bam
-eom
+bvr
 bcw
 bdR
 bfa
@@ -127884,26 +121781,26 @@ cVD
 boU
 cgm
 bOX
-okh
+cCh
 bQA
 cUC
 bRh
 bXb
 bSw
 bVM
-dFk
-kGW
-kGW
+bRW
+cbk
+cbk
 chS
 ccm
 cFI
 cfs
-dji
+cFA
 cnQ
-dji
+cFA
 cFM
 cFV
-kWh
+cLW
 bYJ
 cVK
 chI
@@ -128072,7 +121969,7 @@ aHZ
 aIR
 aLt
 aPc
-dlH
+aYW
 apg
 aOl
 aPa
@@ -128088,7 +121985,7 @@ aPV
 aSt
 brl
 bbi
-ivv
+bxn
 bcw
 bdS
 bfb
@@ -128123,7 +122020,7 @@ byo
 cUo
 cUp
 cUq
-uai
+bwr
 bsN
 bEa
 bEY
@@ -128141,7 +122038,7 @@ bFI
 boU
 cBI
 bOX
-okh
+cCh
 bQA
 cUC
 bRh
@@ -128160,7 +122057,7 @@ cEV
 cEV
 cEV
 cFW
-kWh
+cLW
 bYJ
 cdB
 chI
@@ -128330,34 +122227,34 @@ aIS
 aTf
 aTY
 aKJ
-kbw
-kbw
+aZa
+aZa
 aZd
-eAO
+aZv
 aQm
 bvQ
-djk
-eAO
-eAO
+boX
+aZv
+aZv
 bEb
-eAO
+aZv
 biP
-eAO
+aZv
 brX
 bbm
 bvB
 bNH
-uxM
-uxM
-rPi
-eAO
-eAO
+bvS
+bvS
+bwg
+aZv
+aZv
 cQx
-uxM
-uxM
-rPi
-djk
-eAO
+bvS
+bvS
+bwg
+boX
+aZv
 bqS
 bMu
 bNJ
@@ -128398,7 +122295,7 @@ bKj
 bNb
 cBO
 bOZ
-okh
+cCh
 bQz
 cUC
 bRN
@@ -128412,10 +122309,10 @@ cbP
 cMz
 cFI
 cEW
-oAP
+cGi
 cQH
 cSp
-oAP
+cGi
 cQH
 cMm
 bYJ
@@ -128586,9 +122483,9 @@ aIQ
 aIR
 aJD
 aXg
-tqJ
-tqJ
-tqJ
+aXi
+aXi
+aXi
 aZT
 aZU
 bkc
@@ -128617,7 +122514,7 @@ blq
 aQO
 bmr
 bAr
-msK
+bNK
 bTr
 aRZ
 cRb
@@ -128655,7 +122552,7 @@ bIt
 boU
 cBI
 bOX
-fkT
+cCi
 bQB
 bQB
 bQB
@@ -128671,10 +122568,10 @@ bQB
 cIv
 cJI
 cQH
-dUE
+cFY
 cJI
 cQH
-kWh
+cLW
 bYJ
 cVL
 bYN
@@ -128850,31 +122747,31 @@ brh
 aZY
 aRY
 bkA
-owe
+bpf
 aVO
 biO
-ofK
-ofK
-ofK
-ofK
+bpF
+bpF
+bpF
+bpF
 bsp
 blr
-ofK
-ofK
-ofK
-ofK
+bpF
+bpF
+bpF
+bpF
 bmv
 cQE
-ofK
-ofK
-ofK
-ofK
+bpF
+bpF
+bpF
+bpF
 bSv
-owe
-ofK
+bpf
+bpF
 bDV
 bnn
-msK
+bNK
 bON
 aRZ
 boR
@@ -128912,7 +122809,7 @@ bFI
 boU
 cBI
 bOX
-okh
+cCh
 bQB
 bRl
 bWv
@@ -129106,7 +123003,7 @@ axa
 axa
 bap
 aPY
-gWO
+blg
 aRH
 aRH
 aRH
@@ -129131,7 +123028,7 @@ bgp
 bgp
 bRS
 aPY
-msK
+bNK
 aOz
 aRZ
 boR
@@ -129169,7 +123066,7 @@ bFI
 boU
 cWO
 bOX
-okh
+cCh
 bQB
 coD
 bRP
@@ -129331,12 +123228,12 @@ adx
 adx
 ama
 aNh
-qHo
+aqx
 asO
 aFn
-qHo
-qHo
-qHo
+aqx
+aqx
+aqx
 axI
 awa
 awS
@@ -129344,16 +123241,16 @@ axw
 aye
 aIw
 aWt
-jGT
+aHC
 aMq
-uBU
-uBU
-wVY
-uBU
+auu
+auu
+axq
+auu
 aZj
-jGT
-jGT
-jGT
+aHC
+aHC
+aHC
 aQX
 aqG
 aKL
@@ -129363,7 +123260,7 @@ aMn
 axa
 bap
 aPY
-fWa
+bwS
 aRH
 bBv
 cck
@@ -129388,7 +123285,7 @@ bPX
 bgp
 cJa
 aPY
-msK
+bNK
 aOy
 aRZ
 boR
@@ -129426,10 +123323,10 @@ bFH
 boU
 cBM
 bPa
-okh
+cCh
 bQB
 bRn
-ijc
+bWx
 bQB
 bUw
 bWW
@@ -129611,7 +123508,7 @@ aBl
 aGT
 aBl
 aWQ
-iBq
+aHE
 aqG
 aKM
 aKO
@@ -129620,7 +123517,7 @@ aKO
 axa
 cHZ
 aPY
-oFv
+bms
 aRI
 aSF
 aTT
@@ -129645,7 +123542,7 @@ bgr
 bii
 bgn
 aPY
-iWy
+bnl
 aRZ
 aRZ
 bpt
@@ -129683,7 +123580,7 @@ aaA
 boU
 cBK
 bOX
-okh
+cCh
 bQB
 bQB
 bQB
@@ -129846,10 +123743,10 @@ afi
 abA
 aWS
 aob
-wpK
-wpK
-wpK
-wpK
+asQ
+asQ
+asQ
+asQ
 axj
 axK
 awc
@@ -129861,14 +123758,14 @@ aAe
 aHD
 aEi
 bpE
-jEx
-jEx
-jEx
+auO
+auO
+auO
 bZZ
-jEx
-hKk
+auO
+aFM
 aIe
-xWn
+aHG
 aJT
 aKN
 aKN
@@ -129877,7 +123774,7 @@ cND
 axa
 bap
 aPY
-oFv
+bms
 aRJ
 aSG
 aSG
@@ -129902,7 +123799,7 @@ bko
 blT
 bDW
 bno
-iWy
+bnl
 aRZ
 cAs
 bpr
@@ -129940,7 +123837,7 @@ aaA
 boU
 cBI
 bOX
-qKy
+cqm
 bQB
 cph
 cCe
@@ -130125,7 +124022,7 @@ aqG
 aqG
 aPp
 aIe
-jaF
+aIT
 aqG
 aKO
 aLy
@@ -130159,7 +124056,7 @@ bls
 blU
 bFm
 bnp
-fXC
+cGD
 aRZ
 boR
 bpr
@@ -130197,7 +124094,7 @@ aaA
 boU
 cBL
 bOX
-okh
+cCh
 bQB
 cpR
 cEZ
@@ -130372,7 +124269,7 @@ axz
 aqG
 aEu
 aAe
-iBq
+aHE
 aqG
 aCV
 aDI
@@ -130416,7 +124313,7 @@ blt
 blV
 bFJ
 bnq
-paG
+bSF
 aRZ
 boR
 bps
@@ -130454,7 +124351,7 @@ aaA
 boU
 cBI
 bOX
-okh
+cCh
 bQB
 cpX
 cFc
@@ -130496,7 +124393,7 @@ bYa
 bYa
 bYa
 bYa
-cOi
+cYi
 bYa
 bYa
 ceG
@@ -130625,11 +124522,11 @@ aul
 aul
 aul
 awW
-fKN
+axA
 aqG
 cDE
 aAe
-xWn
+aHG
 aCl
 aqJ
 aDJ
@@ -130642,13 +124539,13 @@ aIf
 aKX
 aqG
 aNv
-wxw
-wxw
-wxw
+cIo
+cIo
+cIo
 axa
 btt
 aPY
-oFv
+bms
 aRI
 aSG
 aTW
@@ -130673,7 +124570,7 @@ bjH
 bii
 bgn
 aPY
-iWy
+bnl
 aRZ
 boU
 boU
@@ -130702,7 +124599,7 @@ boU
 boU
 boU
 boU
-bJu
+bNa
 boU
 boU
 boU
@@ -130711,7 +124608,7 @@ boU
 boU
 cBP
 bPb
-rqZ
+cCk
 bQB
 bQB
 bQB
@@ -130724,14 +124621,14 @@ bQB
 bQB
 bQB
 cGm
-svn
+bRr
 bXu
 cQH
 cco
 cor
 cQH
 bXu
-svn
+bRr
 cSq
 bQz
 cdB
@@ -130896,7 +124793,7 @@ aGb
 aGV
 aPr
 aIg
-ouq
+aMy
 aJU
 aQY
 aXQ
@@ -130930,45 +124827,45 @@ bqt
 bgp
 bnu
 bAs
-ncr
-djk
-liN
+bNL
+boX
+bNU
 bTt
-liN
-liN
+bNU
+bNU
 cec
-mgC
+cfP
 cPl
-liN
-liN
-liN
-liN
+bNU
+bNU
+bNU
+bNU
 bVI
-gin
+bUN
 cBm
-hdg
+cCb
 cEv
 bNv
 bBr
 byf
-hdg
-gin
-gin
-gin
-liN
+cCb
+bUN
+bUN
+bUN
+bNU
 bZR
-mgC
-liN
+cfP
+bNU
 cjv
-liN
-lnz
+bNU
+btX
 cBF
-liN
-liN
-liN
+bNU
+bNU
+bNU
 cBQ
 bOX
-okh
+cCh
 bQB
 bRl
 bWN
@@ -131139,11 +125036,11 @@ aum
 ayn
 awe
 awW
-fKN
+axA
 aqG
 aFf
 aAg
-iBq
+aHE
 aqG
 aCX
 aDL
@@ -131162,7 +125059,7 @@ aZN
 axa
 bbt
 aPY
-som
+bmq
 aRH
 aSK
 aTX
@@ -131189,20 +125086,20 @@ bgn
 bqv
 bqx
 bqz
-ddM
+brz
 bsB
-ddM
-pCz
-ddM
-pCz
+brz
+bPk
+brz
+bPk
 cPm
-pCz
-ddM
+bPk
+brz
 cAB
-ddM
-pCz
-ddM
-pCz
+brz
+bPk
+brz
+bPk
 bQQ
 cAm
 cuX
@@ -131410,7 +125307,7 @@ aCV
 aqG
 aQn
 aIh
-jaF
+aIT
 aqG
 aXP
 aXQ
@@ -131419,7 +125316,7 @@ aYP
 axa
 cCB
 aPY
-som
+bmq
 aRM
 aSL
 aZV
@@ -131445,47 +125342,47 @@ bii
 cGC
 bns
 bNM
-owe
-dMR
-dMR
-qld
-dMR
-dMR
+bpf
+bNV
+bNV
+bSu
+bNV
+bNV
 bUo
 clK
-dMR
-qld
+bNV
+bSu
 bAQ
-dMR
-uaM
+bNV
+bXh
 cSG
-uaM
-eXE
+bXh
+cCc
 cEw
 byf
 bBC
 cGd
-eXE
-uaM
-uaM
+cCc
+bXh
+bXh
 cIR
-opU
-tFB
-tFB
-tFB
+bKW
+cBy
+cBy
+cBy
 cBB
-tFB
-tFB
-vhY
+cBy
+cBy
+cBG
 clB
 cBH
-tFB
+cBy
 bVV
 bOY
 bVk
 bQB
 bRn
-ijc
+bWx
 bQB
 bSw
 bXX
@@ -131496,12 +125393,12 @@ bWV
 bQB
 cWP
 bSw
-jsb
+cNa
 cbS
 ckT
 cTK
 cMx
-fmE
+cSy
 bSw
 cSu
 bQz
@@ -131667,7 +125564,7 @@ aqG
 aqG
 cDV
 aIe
-xsy
+aKP
 aqG
 aqG
 aLA
@@ -131676,7 +125573,7 @@ aLA
 axa
 bap
 aPY
-som
+bmq
 aRN
 aSM
 aTZ
@@ -131701,7 +125598,7 @@ blx
 bii
 bgn
 bns
-iWy
+bnl
 aRZ
 boU
 boU
@@ -131739,7 +125636,7 @@ boU
 boU
 cTW
 bOX
-okh
+cCh
 bQB
 bQB
 bQB
@@ -131753,16 +125650,16 @@ bQB
 bQB
 bTw
 bSw
-jsb
+cNa
 cSn
 cSn
 cSn
 cSn
-fmE
+cSy
 bSw
 cSE
 bQz
-cSw
+clb
 cfo
 cgi
 cgi
@@ -131780,7 +125677,7 @@ cfo
 ceG
 ceG
 ceG
-bYc
+cHl
 ceG
 ceG
 ceG
@@ -131914,7 +125811,7 @@ axB
 ayh
 aFi
 aAj
-xsy
+aKP
 aCn
 aCY
 aDM
@@ -131924,7 +125821,7 @@ aGc
 aGW
 aEq
 aIe
-ouq
+aMy
 aJV
 aKR
 aKR
@@ -131933,7 +125830,7 @@ aNo
 axa
 bap
 aPY
-som
+bmq
 aRN
 aSN
 aUa
@@ -131958,7 +125855,7 @@ blv
 bii
 bgn
 bns
-iWy
+bnl
 aRZ
 czI
 bpw
@@ -131976,11 +125873,11 @@ bws
 bxt
 bzf
 bsV
-pCJ
+bAE
 bBE
 bCU
-hNU
-hNU
+bDg
+bDg
 bEZ
 bFK
 bHC
@@ -131996,32 +125893,32 @@ bMv
 boU
 cBS
 bOX
-rmF
+cCf
 bQC
-svn
-rVW
+bRr
+bSC
 bZT
 bSw
 bWQ
-uQc
-svn
-rVW
+cav
+bRr
+bSC
 cbQ
 bZU
 ccV
 cGh
 cPH
-hba
+cSo
 cSr
-hba
-hba
+cSo
+cSo
 cSz
 cGh
 cSF
 cUb
 cSK
 cUc
-svn
+bRr
 chT
 czC
 bSw
@@ -132181,7 +126078,7 @@ aGd
 aGX
 cDE
 aIe
-jaF
+aIT
 aqG
 aKS
 aLB
@@ -132190,7 +126087,7 @@ aKR
 axa
 bap
 aPY
-gKr
+bRM
 aRN
 aSO
 aUb
@@ -132215,7 +126112,7 @@ bkX
 bii
 bGO
 bnt
-iWy
+bnl
 aRZ
 boZ
 cAg
@@ -132233,7 +126130,7 @@ btG
 btG
 bzg
 bzq
-pCJ
+bAE
 bBw
 bCm
 bCm
@@ -132282,9 +126179,9 @@ bSw
 csZ
 czC
 bSw
-uQc
-svn
-svn
+cav
+bRr
+bRr
 cmb
 cmW
 brT
@@ -132428,7 +126325,7 @@ aqG
 aqG
 cXc
 aAl
-jaF
+aIT
 aqG
 aDa
 aEJ
@@ -132438,7 +126335,7 @@ aGe
 aGY
 cDF
 aIi
-iBq
+aHE
 aqG
 aqG
 aqG
@@ -132447,7 +126344,7 @@ aqG
 axa
 bap
 aPY
-gWO
+blg
 aRN
 aSP
 aUc
@@ -132472,7 +126369,7 @@ blx
 bii
 bgn
 bns
-paG
+bSF
 aRZ
 boZ
 cOS
@@ -132492,8 +126389,8 @@ bzh
 bzr
 bAF
 bBF
-pae
-pae
+bCV
+bCV
 bGu
 bFN
 bFK
@@ -132512,7 +126409,7 @@ cBT
 bPe
 bYs
 bQC
-dFk
+bRW
 bSD
 bUq
 bVc
@@ -132695,7 +126592,7 @@ aGf
 aqG
 aPp
 aIj
-kWL
+aRa
 aJW
 bRj
 aLC
@@ -132729,7 +126626,7 @@ blv
 bii
 bgn
 bns
-fXC
+cGD
 aRZ
 boZ
 bDx
@@ -132747,7 +126644,7 @@ bwk
 btG
 bzl
 bsV
-pCJ
+bAE
 bBH
 bCo
 bDm
@@ -132774,30 +126671,30 @@ bSw
 bYo
 bVc
 bYO
-ijS
-ijS
-ijS
-ijS
-ijS
+cbh
+cbh
+cbh
+cbh
+cbh
 cFg
 ccv
 cEY
 bZS
 cTP
 cSt
-ijS
+cbh
 cGk
-ijS
+cbh
 cGl
-ijS
+cbh
 bUy
 cay
 cft
-uDO
+ccn
 cGp
-uDO
-uDO
-uDO
+ccn
+ccn
+ccn
 cyF
 cmb
 cmX
@@ -132813,11 +126710,11 @@ cmd
 aaA
 cSc
 cVT
-cYe
+cYj
 cXu
 cXz
 ceG
-cYf
+cYk
 cTU
 cyo
 aab
@@ -132942,7 +126839,7 @@ aqG
 aqG
 aFh
 aAl
-jaF
+aIT
 aqG
 aqG
 aDH
@@ -132969,11 +126866,11 @@ aRO
 cJN
 aSY
 aWq
-inV
+aVs
 aYw
 cMT
 cAV
-inV
+aVs
 bcK
 bgp
 bhM
@@ -132986,7 +126883,7 @@ bly
 bii
 bgn
 bns
-iWy
+bnl
 aRZ
 boZ
 bDx
@@ -133004,7 +126901,7 @@ bwl
 bxa
 bzp
 bsQ
-pCJ
+bAE
 bBH
 bCW
 bDo
@@ -133024,7 +126921,7 @@ bCD
 boU
 cBS
 bOU
-ddU
+cCg
 bQC
 bSx
 bSE
@@ -133049,7 +126946,7 @@ bWB
 bWB
 bTw
 bVc
-meZ
+cfu
 cNW
 bRh
 bRh
@@ -133189,23 +127086,23 @@ apj
 aoC
 asS
 aNf
-rvc
-uBU
-uBU
-wVY
-uBU
-uBU
+avH
+auu
+auu
+axq
+auu
+auu
 aCk
-rvc
+avH
 aFk
 aAl
 aIU
 aYZ
-uBU
-uBU
-uBU
-uBU
-uBU
+auu
+auu
+auu
+auu
+auu
 cLx
 aQQ
 aIl
@@ -133213,7 +127110,7 @@ aKu
 aqJ
 aBk
 aLE
-tsg
+aMw
 aNq
 aOr
 bap
@@ -133243,7 +127140,7 @@ blx
 bii
 bgn
 bns
-iWy
+bnl
 aRZ
 czK
 bpx
@@ -133281,7 +127178,7 @@ bCD
 boU
 cBS
 bOU
-okh
+cCh
 boU
 bQB
 bQB
@@ -133306,9 +127203,9 @@ cdE
 bWB
 bTw
 bVc
-meZ
+cfu
 bQz
-cmT
+cnU
 bQz
 ciR
 cjL
@@ -133431,7 +127328,7 @@ aab
 aab
 aab
 acS
-qbf
+adm
 adF
 ael
 afk
@@ -133466,7 +127363,7 @@ ayi
 cLy
 cdt
 cEt
-kWL
+aRa
 aqJ
 cDx
 aqG
@@ -133518,14 +127415,14 @@ bwn
 bxc
 bzF
 bsQ
-xio
+bwC
 bCc
 bCX
 bDE
 bEk
 bGk
 bCq
-xio
+bwC
 bGU
 bJe
 bIy
@@ -133538,15 +127435,15 @@ bMx
 boU
 cBV
 bOU
-okh
+cCh
 boU
-fFu
-fFu
-fFu
+bRt
+bRt
+bRt
 bSH
-fFu
-fFu
-fFu
+bRt
+bRt
+bRt
 bWB
 bWY
 bWY
@@ -133688,7 +127585,7 @@ aab
 aab
 aab
 acS
-qbf
+adm
 adG
 aem
 afl
@@ -133703,27 +127600,27 @@ apj
 aoe
 aqe
 bdo
-jEx
-jEx
-jEx
-jEx
-jEx
-jEx
+auO
+auO
+auO
+auO
+auO
+auO
 aCF
-jEx
-hKk
+auO
+aFM
 aAn
 aIV
 aJf
-jyj
+aJO
 aKa
 aGo
-jyj
-jyj
+aJO
+aJO
 cLz
 aQR
 aIn
-kWL
+aRa
 aqJ
 aBk
 aLF
@@ -133732,7 +127629,7 @@ aNr
 aOs
 bbv
 aPY
-hYb
+bmz
 aRQ
 cnj
 aUj
@@ -133757,7 +127654,7 @@ bjH
 bgp
 bFQ
 bns
-iWy
+bnl
 aRZ
 boZ
 bpx
@@ -133782,8 +127679,8 @@ bDh
 bEE
 bDh
 bCq
-xio
-bGV
+bwC
+cOi
 bJy
 bJC
 bJK
@@ -133795,7 +127692,7 @@ cPC
 boU
 cBW
 bOV
-fkT
+cCi
 boU
 bRu
 bRX
@@ -133945,7 +127842,7 @@ aab
 aab
 aab
 acS
-qbf
+adm
 cif
 aen
 afm
@@ -133991,7 +127888,7 @@ bbv
 aQb
 aSA
 aRR
-xUc
+aUf
 cAw
 aVm
 aWk
@@ -134014,13 +127911,13 @@ blz
 bgw
 bGg
 bHj
-iWy
+bnl
 aRZ
 boZ
 bpx
 bfs
 bqP
-fJc
+bru
 bqT
 bpx
 bsV
@@ -134045,14 +127942,14 @@ bJe
 bIy
 bJL
 bKp
-qBA
+bRO
 bLB
 bIx
 bCD
 boU
 cBX
 bPf
-rqZ
+cCk
 boU
 bRv
 bRY
@@ -134215,7 +128112,7 @@ akV
 abA
 apl
 aEI
-mTN
+atI
 aqK
 arY
 atq
@@ -134237,21 +128134,21 @@ aGg
 aqG
 cDW
 aIp
-kWL
+aRa
 azm
 aKV
 aLE
-tsg
+aMw
 aNs
 aOr
 bbw
 aPY
-hYb
+bmz
 aRR
-xUc
+aUf
 czO
 aVm
-xUc
+aUf
 aXl
 aYq
 aYq
@@ -134271,13 +128168,13 @@ blA
 blW
 bJT
 bnv
-iWy
+bnl
 aRZ
 boZ
 bpx
 cNO
 buC
-fJc
+bru
 brs
 bsu
 brP
@@ -134309,7 +128206,7 @@ bCD
 boU
 cBS
 bPg
-qKy
+cqm
 boU
 bRw
 bRw
@@ -134472,7 +128369,7 @@ akW
 amd
 apn
 aof
-mTN
+atI
 aqK
 arZ
 atr
@@ -134505,10 +128402,10 @@ btR
 aQd
 bmI
 aRT
-lay
+aUh
 cAy
 aUA
-lay
+aUh
 aXm
 aYs
 aYs
@@ -134518,11 +128415,11 @@ aYs
 aZo
 bfn
 aVo
-mFj
-mFj
-mFj
-mFj
-rrF
+bhG
+bhG
+bhG
+bhG
+bkr
 bki
 bgw
 bgw
@@ -134566,7 +128463,7 @@ bCD
 boU
 cBS
 bPg
-okh
+cCh
 boU
 bRx
 bRx
@@ -134581,9 +128478,9 @@ bXz
 bXz
 bWB
 bZw
-nIk
-nIk
-nIk
+caB
+caB
+caB
 bWB
 cXf
 bWB
@@ -134760,12 +128657,12 @@ aNt
 aOt
 bby
 aQe
-hYb
+bmz
 aRU
-xUc
+aUf
 cAw
 aVn
-xUc
+aUf
 aXn
 aSX
 aSX
@@ -134776,16 +128673,16 @@ cNJ
 aRO
 bgw
 bhH
-mFj
-mFj
-mFj
-rrF
-lea
+bhG
+bhG
+bhG
+bkr
+bkU
 blB
 aPb
 bmB
 bnw
-emv
+bog
 aRZ
 bpa
 bpy
@@ -134810,7 +128707,7 @@ bDl
 bEg
 bFd
 bCs
-xio
+bwC
 bGZ
 bJe
 bIy
@@ -134823,12 +128720,12 @@ cVC
 boU
 cBU
 bPg
-okh
+cCh
 boU
 bQB
 bQB
 bQB
-bTE
+bYc
 bQB
 bQB
 bQB
@@ -134837,7 +128734,7 @@ bWB
 bWB
 bWB
 bWB
-bZx
+bZM
 bWB
 bWB
 bWB
@@ -134972,18 +128869,18 @@ aaa
 aaS
 abW
 ayv
-acT
+aby
 bsn
 adI
 acT
-xBm
-xBm
-xBm
+akL
+akL
+akL
 aqM
-xBm
-xBm
+akL
+akL
 aqt
-xBm
+akL
 apz
 aoh
 att
@@ -135010,19 +128907,19 @@ bdE
 bwH
 aJZ
 cAo
-ndn
+cLA
 aLI
 aEG
 aNu
-ndn
+cLA
 bbz
 aQf
-hYb
+bmz
 aRR
-xUc
+aUf
 cAx
 aVm
-xUc
+aUf
 aXn
 aYq
 aYq
@@ -135032,23 +128929,23 @@ aYq
 bfo
 aRR
 bgB
-mFj
-mFj
+bhG
+bhG
 biX
-mFj
-rrF
-gaN
+bhG
+bkr
+cGB
 blB
 aPb
 bmC
 bnx
-iWy
+bnl
 aRZ
 boZ
 bpx
 bqc
-tOa
-tOa
+bqe
+bqe
 brL
 bsu
 bsU
@@ -135073,14 +128970,14 @@ bJe
 bIy
 bJO
 bKp
-qBA
+bRO
 bLE
 bIx
 bCD
 boU
 cBY
 bPg
-okh
+cCh
 boU
 bRy
 bRy
@@ -135114,7 +129011,7 @@ cks
 cjM
 czV
 cfv
-tor
+ceU
 cCp
 cpH
 cku
@@ -135226,7 +129123,7 @@ abr
 aaa
 aaa
 aaa
-cuL
+aaT
 abX
 acq
 acU
@@ -135274,12 +129171,12 @@ cIq
 aOu
 bbW
 aQg
-hYb
+bmz
 aRR
-xUc
+aUf
 cAw
 aVm
-xUc
+aUf
 aXo
 aYt
 aZk
@@ -135288,13 +129185,13 @@ aSX
 aSX
 cAw
 bft
-iir
-mFj
+bhI
+bhG
 blF
-ibw
-ibw
-rrF
-lea
+biY
+biY
+bkr
+bkU
 blC
 aTh
 bmD
@@ -135316,7 +129213,7 @@ btb
 bwy
 bxi
 byw
-bxg
+bGV
 bxg
 bCn
 bCY
@@ -135324,7 +129221,7 @@ bDF
 bET
 bGl
 bGp
-nEL
+bwG
 bHa
 bJA
 bJD
@@ -135338,7 +129235,7 @@ boU
 ceT
 bPh
 bVl
-bQF
+bTE
 bRz
 bSa
 cTM
@@ -135374,22 +129271,22 @@ cfv
 ctx
 cKa
 cfE
-cku
-crt
-cDp
+cDP
+cJZ
+cKd
 cBp
-vcI
+cCj
 cHg
 cNy
-vcI
-xiq
+cCj
+cHC
 cHE
-xiq
+cHC
 cHF
 cHG
 cHH
 cHI
-bZM
+cYf
 czl
 bYa
 cAX
@@ -135491,14 +129388,14 @@ ado
 ayv
 acT
 akM
-pYW
+alB
 aSU
-eNu
-eNu
+alC
+alC
 amO
-pYW
+alB
 anZ
-eNu
+alC
 aqA
 atV
 aqL
@@ -135531,7 +129428,7 @@ aNw
 axa
 cIs
 aPY
-hYb
+bmz
 aSQ
 cNE
 cAz
@@ -135546,17 +129443,17 @@ aSX
 cAw
 bfu
 bhJ
-mFj
+bhG
 biq
 biZ
 bjS
-rrF
+bkr
 bkV
 blD
 aTh
 bmE
 bnz
-fWa
+bwS
 aRZ
 boZ
 bpx
@@ -135581,7 +129478,7 @@ bDn
 bEj
 bCl
 bFM
-xio
+bwC
 bHb
 bJe
 bIy
@@ -135594,7 +129491,7 @@ bMx
 boU
 cBS
 bPg
-fkT
+cCi
 boU
 bRA
 bRA
@@ -135629,11 +129526,11 @@ cli
 ciV
 cfv
 cNs
+csw
+ctB
+ctB
 cKb
-cJo
-cAr
-cBe
-cty
+cSe
 cso
 cvh
 cvh
@@ -135651,7 +129548,7 @@ bYa
 cAW
 cSd
 cAW
-cSe
+cYl
 acv
 acv
 aav
@@ -135749,11 +129646,11 @@ adK
 aep
 afp
 aep
-aep
-aep
-aep
+adK
+adK
+adK
 ajY
-aep
+adK
 adK
 amg
 aok
@@ -135779,7 +129676,7 @@ aGm
 arX
 aFh
 aIv
-iBq
+aHE
 aKc
 aLa
 aLL
@@ -135802,18 +129699,18 @@ aYq
 aYq
 cAw
 bgy
-iir
-mFj
-mFj
+bhI
+bhG
+bhG
 bjh
 bjT
-rrF
-lea
+bkr
+bkU
 blD
 aTh
 bmF
 bnA
-gKr
+bRM
 aRZ
 boZ
 bpx
@@ -135851,7 +129748,7 @@ bCD
 boU
 cBS
 bPg
-okh
+cCh
 boU
 aaA
 aaA
@@ -135885,23 +129782,23 @@ cjO
 cjN
 ciV
 cfv
-tor
-cKc
-cKd
-cKf
-cJZ
-qqn
+ceU
+coJ
+cyd
+cyd
+cAr
+cUZ
 cnR
-kWY
-kWY
+col
+col
 cNz
-kWY
-kWY
-kWY
-kWY
-kWY
-kWY
-kWY
+col
+col
+col
+col
+col
+col
+col
 cLv
 cmZ
 cVW
@@ -136045,7 +129942,7 @@ aNy
 axa
 bcy
 aPY
-iWy
+bnl
 aRO
 aSS
 cAS
@@ -136060,17 +129957,17 @@ aSX
 cAw
 aRR
 bhK
-mFj
-mFj
+bhG
+bhG
 bjb
 bjU
-rrF
-gaN
+bkr
+cGB
 blB
 aPo
 bmG
 bnB
-som
+bmq
 aRZ
 boZ
 bpx
@@ -136084,7 +129981,7 @@ cEu
 btS
 bvh
 bvM
-xio
+bwC
 bxk
 byy
 bzw
@@ -136095,7 +129992,7 @@ bDI
 bBI
 bBI
 bBI
-xio
+bwC
 bHb
 bCl
 bIx
@@ -136108,7 +130005,7 @@ bCD
 boU
 cBS
 bPg
-okh
+cCh
 boU
 bRB
 bRB
@@ -136142,12 +130039,12 @@ ciV
 ciV
 bJn
 cfv
-tor
+cpG
 coJ
-cjS
-cjS
-cjS
-qqn
+cAr
+cAr
+cAr
+cUZ
 cxt
 cmZ
 cmZ
@@ -136302,7 +130199,7 @@ aHL
 aHM
 cWH
 aQh
-iWy
+bnl
 aRO
 aSW
 aUk
@@ -136317,7 +130214,7 @@ bbR
 bfp
 aRO
 bhL
-mFj
+bhG
 bir
 bjV
 bks
@@ -136327,7 +130224,7 @@ blB
 aPo
 bmH
 bnC
-som
+bmq
 aRZ
 boZ
 bpx
@@ -136341,7 +130238,7 @@ btS
 buG
 bvi
 bwe
-nEL
+bwG
 bxl
 byz
 bzx
@@ -136365,7 +130262,7 @@ bCD
 boU
 cBU
 bPg
-okh
+cCh
 boU
 bRB
 aaA
@@ -136399,12 +130296,12 @@ cfv
 cfv
 cfv
 cfv
-tor
+ceU
 coJ
-cqC
-csu
-csw
-cLp
+cAr
+cAr
+cAr
+cYg
 cxu
 cmZ
 cwT
@@ -136622,7 +130519,7 @@ bCD
 boU
 cBS
 bPg
-okh
+cCh
 boU
 bRB
 aaA
@@ -136649,19 +130546,19 @@ ceM
 cfz
 che
 cig
-hpR
-hpR
-hpR
+ciZ
+ciZ
+ciZ
 cmJ
 cNm
-hpR
-hpR
-jSQ
-coJ
-cqC
-csv
-clr
-cqL
+ciZ
+ciZ
+cgs
+cty
+cBe
+cJo
+cKc
+cYh
 cxt
 cmZ
 cwU
@@ -136816,7 +130713,7 @@ aNA
 aOx
 bgn
 aPY
-emv
+bog
 aRO
 aSV
 aUe
@@ -136841,7 +130738,7 @@ aTa
 aRZ
 bgn
 bns
-som
+bmq
 aRZ
 cOQ
 bpx
@@ -136879,7 +130776,7 @@ bMy
 boU
 cBV
 bPg
-okh
+cCh
 boU
 bRB
 bRB
@@ -136903,7 +130800,7 @@ cWm
 cXO
 bXe
 cdO
-jSQ
+cgs
 cgt
 chf
 chY
@@ -136912,11 +130809,11 @@ cNk
 cmA
 ciX
 cjb
-pBI
-pBI
-cpG
-cmZ
-cur
+cmn
+cmn
+ctz
+cDp
+cKf
 cru
 cnR
 cyc
@@ -137129,14 +131026,14 @@ bHO
 bFP
 bKq
 bKx
-bLd
+cYe
 bMf
 bKA
 bCD
 boU
 cBW
 bPi
-fkT
+cCi
 boU
 ccG
 bRB
@@ -137173,7 +131070,7 @@ cmZ
 cmZ
 cmZ
 cmZ
-cqJ
+cKl
 crv
 cmZ
 cmZ
@@ -137355,7 +131252,7 @@ aTa
 aRZ
 bgn
 bns
-som
+bmq
 aRZ
 czP
 bpA
@@ -137393,7 +131290,7 @@ bCD
 boU
 cod
 bPg
-okh
+cCh
 bDb
 ccK
 bRB
@@ -137430,7 +131327,7 @@ ckv
 cqE
 cpK
 cqG
-cyd
+cLp
 crw
 cLq
 ctA
@@ -137587,7 +131484,7 @@ aHM
 aHM
 bih
 aPY
-iWy
+bnl
 aRV
 aRZ
 aUp
@@ -137609,10 +131506,10 @@ bkZ
 bqw
 bLn
 cKk
-cKl
+blY
 cKm
 cKn
-som
+bmq
 aRZ
 bpc
 bpA
@@ -137650,7 +131547,7 @@ cVC
 boU
 cBS
 bPg
-okh
+cCh
 bDb
 cdj
 bRB
@@ -137680,14 +131577,14 @@ chh
 cia
 cku
 cjR
-ckw
+clm
 coI
 cqz
 ckv
-coK
 cqA
-coO
-ctB
+csu
+cur
+cSw
 cLr
 cOJ
 cON
@@ -137844,7 +131741,7 @@ aND
 aOy
 bgn
 aPY
-iWy
+bnl
 aRW
 aRZ
 aUq
@@ -137869,7 +131766,7 @@ bit
 cXT
 bvp
 bns
-som
+bmq
 aRZ
 bpc
 bpA
@@ -137907,7 +131804,7 @@ bCD
 boU
 cBU
 bPg
-okh
+cCh
 bDb
 cep
 bRB
@@ -137930,7 +131827,7 @@ bDR
 bFE
 bGb
 cei
-jjz
+ceQ
 bYV
 cgw
 cJY
@@ -137942,7 +131839,7 @@ ctv
 cJl
 cjR
 cnV
-cqH
+csv
 csz
 czb
 cNu
@@ -138101,10 +131998,10 @@ aND
 aOz
 bgn
 aPY
-iWy
+bnl
 cla
 cla
-aUr
+aZu
 cla
 cla
 cla
@@ -138126,7 +132023,7 @@ blH
 bit
 cWM
 bnt
-som
+bmq
 aRZ
 bpc
 bpA
@@ -138164,7 +132061,7 @@ bCD
 boU
 cGq
 bPg
-okh
+cCh
 bDb
 ceX
 bRB
@@ -138187,15 +132084,15 @@ bDS
 cpI
 bGc
 cej
-jjz
+ceQ
 cfE
 bYq
 chj
 cHX
 cku
 cjR
-cpO
-clm
+coK
+cqC
 cJm
 cjR
 cnV
@@ -138358,7 +132255,7 @@ aND
 aOy
 bgn
 aPY
-emv
+bog
 cla
 aTc
 aUt
@@ -138383,7 +132280,7 @@ bka
 bit
 cIt
 bns
-som
+bmq
 aRZ
 bpc
 bpA
@@ -138421,7 +132318,7 @@ bCE
 boU
 cBS
 bPg
-okh
+cCh
 bDb
 cBs
 bRB
@@ -138451,7 +132348,7 @@ chk
 cKi
 cku
 cjR
-cky
+cpO
 cna
 cJm
 cjR
@@ -138615,7 +132512,7 @@ aND
 aND
 cMA
 aPY
-iWy
+bnl
 cla
 aTd
 aUu
@@ -138640,7 +132537,7 @@ blI
 bit
 bgn
 bns
-gWO
+blg
 aRZ
 bpd
 bpB
@@ -138678,7 +132575,7 @@ bpc
 boU
 cBS
 bPg
-okh
+cCh
 bDb
 ccK
 bRB
@@ -138695,7 +132592,7 @@ cEG
 cEH
 cbv
 caJ
-mjU
+ccP
 cbY
 bES
 bFG
@@ -138705,7 +132602,7 @@ cNh
 bYV
 cgw
 chl
-cic
+cky
 clj
 cjR
 ckz
@@ -138872,7 +132769,7 @@ cGW
 aND
 bgn
 aPY
-iWy
+bnl
 cla
 aTe
 aVu
@@ -138897,7 +132794,7 @@ blJ
 bit
 bgn
 bns
-som
+bmq
 aRZ
 czR
 bpA
@@ -139192,7 +133089,7 @@ cED
 bpe
 cBX
 bPf
-rqZ
+cCk
 boU
 bpe
 bSb
@@ -139209,13 +133106,13 @@ cAT
 cAT
 cbv
 caL
-mjU
+ccP
 bYn
 cNf
 cdi
 cdP
 cel
-tor
+ceU
 cqh
 bYq
 chg
@@ -139387,92 +133284,92 @@ aOA
 biu
 aQl
 boF
-fIj
-ngs
-ngs
-ngs
-kwC
-kwC
+bph
+bpD
+bpD
+bpD
+bpZ
+bpZ
 bBK
 bsr
-ngs
+bpD
 bvC
-ngs
-ngs
-fIj
-tcS
-tcS
-ngs
+bpD
+bpD
+bph
+cSB
+cSB
+bpD
 bya
 byJ
 bsA
 bCb
-fIj
-ngs
+bph
+bpD
 bLo
 bns
-ncr
-eAO
-dbN
-dbN
-dbN
-dbN
-dbN
-dbN
+bNL
+aZv
+bPl
+bPl
+bPl
+bPl
+bPl
+bPl
 cmE
 bUt
 cWz
-vPB
-mCd
-vPB
+bQM
+bQP
+bQM
 cAD
 abN
 bVw
 bxv
 cIL
-mCd
-vPB
+bQP
+bQM
 cIN
-vPB
+bQM
 cBt
-hcw
+cBv
 cBa
-dbN
-dbN
-rRq
-rRq
-dbN
+bPl
+bPl
+cBA
+cBA
+bPl
 ceN
-dbN
-dbN
-dbN
+bPl
+bPl
+bPl
 cOC
 cBZ
 bPj
 cHs
-hcw
+cBv
 cTY
-dbN
-dbN
+bPl
+bPl
 cCw
-dbN
-dbN
-dbN
+bPl
+bPl
+bPl
 cHt
 bXe
-jtv
+bfq
 bYW
-hnY
-hnY
+cah
+cah
 ccI
 caL
 cdT
 coE
-jtv
+bfq
 cCN
 cdP
 cem
-tor
+ceU
 bYq
 bYq
 cii
@@ -139481,10 +133378,10 @@ clI
 cjT
 ckD
 cns
-qzS
+coj
 coP
 cNt
-qzS
+coj
 cpP
 cqK
 crC
@@ -139674,48 +133571,48 @@ bsq
 bNn
 bvR
 bNl
-mjj
-mjj
+bTQ
+bTQ
 cAu
 cAA
-mjj
-mjj
-mjj
-mjj
+bTQ
+bTQ
+bTQ
+bTQ
 cAC
 bPA
 cAF
 bPz
-mjj
-mjj
-mjj
-mjj
-mjj
+bTQ
+bTQ
+bTQ
+bTQ
+bTQ
 cAH
 cAI
-mjj
+bTQ
 cAJ
-ooi
-ooi
+cAK
+cAK
 cAL
-ooi
-ooi
-ooi
-ooi
-ooi
-ooi
+cAK
+cAK
+cAK
+cAK
+cAK
+cAK
 cAM
 cEP
-ooi
+cAK
 cAO
-ooi
-ooi
+cAK
+cAK
 coF
 cAP
 cHD
-ooi
-ooi
-ooi
+cAK
+cAK
+cAK
 cIc
 bXJ
 bYr
@@ -139900,42 +133797,42 @@ bLO
 aND
 bjm
 aZc
-xxH
-xxH
+boV
+boV
 aTn
-voB
+bzH
 bFf
 brb
 brd
 bcp
-voB
-voB
+bzH
+bzH
 cGQ
-xxH
+boV
 bRk
-xxH
-xxH
+boV
+boV
 cQO
-dAn
-xxH
-xxH
+bxY
+boV
+boV
 bBg
-xxH
-xxH
-xxH
-xxH
-xxH
-dAn
+boV
+boV
+boV
+boV
+boV
+bxY
 bTs
 bVb
 bsf
 byi
 bTp
 cSM
-reB
-syR
+chC
+bPV
 byR
-syR
+bPV
 bQN
 bwJ
 bwJ
@@ -139943,45 +133840,45 @@ cUi
 cBJ
 bDc
 bVK
-wbT
-wbT
-wbT
-wbT
+cIM
+cIM
+cIM
+cIM
 cIQ
-mko
-iHx
-syR
+cEX
+cBw
+bPV
 cBz
-syR
-reB
+bPV
+chC
 bMo
 cBD
-syR
-syR
-syR
-syR
+bPV
+bPV
+bPV
+bPV
 cTT
 cTX
 cEQ
-reB
-iHx
+chC
+cBw
 cTZ
-syR
+bPV
 bYG
-mko
+cEX
 cvO
 cCy
-syR
-syR
+bPV
+bPV
 bXe
-uQG
+bZJ
 clO
 cak
 cbu
 cHJ
 cHN
 cHS
-uQG
+bZJ
 cdq
 cdS
 cdR
@@ -139995,12 +133892,12 @@ cSv
 cjT
 cTF
 cnR
-ftq
-kWY
+cok
+col
 cWB
-kWY
+col
 cKZ
-ftq
+cok
 ctw
 cjS
 ctF
@@ -140197,7 +134094,7 @@ brA
 brD
 brD
 brA
-bxx
+bJu
 bpe
 bpe
 bpe
@@ -140226,13 +134123,13 @@ bpe
 bpe
 bpe
 bpe
-cnU
-bpe
-bpe
-bpe
-bXe
-bXe
 bYt
+bpe
+bpe
+bpe
+bXe
+bXe
+bZx
 bXe
 caN
 cHK
@@ -140447,9 +134344,9 @@ bzJ
 bUl
 brA
 brY
-dFM
-dFM
-dFM
+bsC
+bsC
+bsC
 buL
 bsg
 bsg
@@ -140958,7 +134855,7 @@ cAf
 bpi
 bQc
 bHi
-oIJ
+bVn
 brB
 bsa
 bsE
@@ -141027,7 +134924,7 @@ cTH
 coS
 cnd
 cKO
-ikh
+cLc
 cqO
 crF
 csG
@@ -141215,7 +135112,7 @@ aRj
 bpi
 bQb
 bFn
-oIJ
+bVn
 brB
 bsa
 bsF
@@ -141275,12 +135172,12 @@ cdx
 ceZ
 cgA
 chr
-rCO
+cjg
 cTB
-rCO
+cjg
 cmt
 ckI
-rCO
+cjg
 coT
 cpT
 cKP
@@ -141442,8 +135339,8 @@ aOc
 aOP
 aPD
 cym
-rvU
-rvU
+aSc
+aSc
 aUx
 aUB
 aWz
@@ -141454,8 +135351,8 @@ baR
 baX
 bcb
 bel
-flN
-flN
+ber
+ber
 bgH
 bda
 cce
@@ -141541,7 +135438,7 @@ cng
 coY
 cpU
 cKQ
-pjM
+cLe
 cqP
 crI
 csG
@@ -141743,7 +135640,7 @@ bxC
 bsE
 bzK
 brA
-iSP
+bvZ
 bCG
 brA
 bEt
@@ -141798,7 +135695,7 @@ cdy
 cnf
 cdy
 cKQ
-hkl
+cLf
 coU
 crO
 csI
@@ -141986,7 +135883,7 @@ aRj
 bpi
 cMW
 bHi
-oIJ
+bVn
 brA
 bsc
 bsE
@@ -142000,7 +135897,7 @@ bxD
 bDt
 bzL
 brA
-iSP
+bvZ
 bCH
 brA
 bEq
@@ -142055,7 +135952,7 @@ cni
 cnf
 cpV
 cKQ
-frQ
+cLg
 chu
 crJ
 csJ
@@ -142312,7 +136209,7 @@ cNp
 cnf
 cpV
 cKQ
-pjM
+cLe
 coW
 ciw
 csH
@@ -142461,9 +136358,9 @@ aaa
 aaa
 aab
 aab
-gZN
+aJu
 aKl
-gZN
+aJu
 aLW
 aMT
 aNR
@@ -142500,7 +136397,7 @@ bix
 bpi
 bQb
 bHi
-oIJ
+bVn
 brB
 bsa
 bsH
@@ -142569,7 +136466,7 @@ cnY
 cnf
 cqx
 cKQ
-pjM
+cLe
 coW
 cix
 csG
@@ -142733,8 +136630,8 @@ aUG
 cyJ
 aWL
 aYF
-fVm
-fVm
+aWD
+aWD
 baS
 cQo
 bce
@@ -142757,7 +136654,7 @@ aRj
 bpi
 bQb
 bFn
-oIJ
+bVn
 brB
 bsa
 bsH
@@ -142826,7 +136723,7 @@ cmu
 cnf
 csx
 cKQ
-pjM
+cLe
 coX
 crG
 csI
@@ -143014,7 +136911,7 @@ aQz
 bpi
 bQf
 bJS
-oIJ
+bVn
 brB
 bsa
 bsH
@@ -143083,7 +136980,7 @@ cmu
 cnf
 csx
 cKQ
-frQ
+cLg
 cpS
 crN
 csJ
@@ -143247,8 +137144,8 @@ aVz
 aUH
 aXz
 aYL
-fWH
-fWH
+aWF
+aWF
 baT
 bpG
 aUH
@@ -143271,7 +137168,7 @@ ccA
 bpi
 bQb
 bFn
-oIJ
+bVn
 brA
 bse
 bsH
@@ -143340,7 +137237,7 @@ cdy
 cnf
 cdy
 cNY
-hkl
+cLf
 cqQ
 cta
 csK
@@ -143489,9 +137386,9 @@ aab
 aab
 aab
 aab
-uyQ
+aJx
 aKn
-uyQ
+aJx
 aLZ
 aMT
 aNR
@@ -143597,7 +137494,7 @@ cnZ
 cpa
 cuo
 cKQ
-hkl
+cLf
 cqP
 ctb
 csG
@@ -143777,7 +137674,7 @@ aaA
 aQz
 blj
 blK
-blY
+bxx
 bmM
 bmM
 boo
@@ -144368,7 +138265,7 @@ cdx
 cdx
 cvj
 cKQ
-ikh
+cLc
 cgB
 crR
 ctH
@@ -144559,12 +138456,12 @@ bqB
 bnL
 brE
 bsh
-mAh
-mAh
+bpS
+bpS
 bua
 blZ
 bvv
-iSP
+bvZ
 brA
 aaA
 aaA
@@ -144625,7 +138522,7 @@ cdy
 cdy
 cdy
 cKQ
-ikh
+cLc
 cqV
 crS
 csN
@@ -145139,7 +139036,7 @@ cXh
 cpc
 cpc
 cKQ
-ikh
+cLc
 cqV
 crU
 cdy
@@ -145396,7 +139293,7 @@ cMg
 cpd
 cpc
 cKT
-ikh
+cLc
 cqV
 crV
 cdy
@@ -145584,9 +139481,9 @@ boI
 bpk
 bpN
 bqF
-mHy
-iJS
-xRS
+bqK
+bpo
+bnM
 bsL
 bnL
 bue
@@ -145653,7 +139550,7 @@ coe
 cpc
 cpc
 cKT
-ikh
+cLc
 cqV
 cOf
 cdy
@@ -145910,7 +139807,7 @@ cXi
 cpc
 cpc
 cKQ
-ikh
+cLc
 cqV
 crU
 ccS
@@ -146091,19 +139988,19 @@ aac
 aaa
 aab
 bma
-hkb
+bmU
 bnL
 bot
-eAr
+boK
 bpl
 bpP
 bqH
 brn
 brG
-hZb
+bsj
 bsL
 bnL
-eAr
+boK
 bma
 aaa
 aaa
@@ -146167,7 +140064,7 @@ coH
 cpQ
 cdy
 cKU
-ikh
+cLc
 cqV
 crV
 cgF
@@ -146348,19 +140245,19 @@ aac
 aaa
 aab
 bma
-hkb
+bmU
 bnL
 bot
-eAr
+boK
 bpm
 bpQ
 bnL
 bro
 bpm
-hZb
+bsj
 bsL
 bnL
-eAr
+boK
 bma
 aaa
 aaa
@@ -146424,7 +140321,7 @@ cdy
 cdy
 cdy
 cKQ
-ikh
+cLc
 cqX
 crU
 cgF
@@ -146577,7 +140474,7 @@ aJy
 aKo
 aNa
 aMf
-fKY
+aMZ
 aPy
 aNa
 aQq
@@ -146617,7 +140514,7 @@ blZ
 bsk
 bsL
 bnL
-eAr
+boK
 bma
 aaa
 aaa
@@ -146834,7 +140731,7 @@ aJz
 aKp
 aLm
 aMe
-fKY
+aMZ
 aOb
 aNa
 aQq
@@ -146866,11 +140763,11 @@ bmW
 bnL
 bot
 boL
-dgK
-mAh
-mAh
-mAh
-dgK
+bpn
+bpS
+bpS
+bpS
+bpn
 bsl
 bsL
 bnL
@@ -147120,7 +141017,7 @@ aac
 aav
 bma
 bmX
-xRS
+bnM
 btm
 bnL
 bnL
@@ -147195,7 +141092,7 @@ cdx
 cdx
 cvj
 cKX
-ikh
+cLc
 cra
 crX
 csP
@@ -147380,12 +141277,12 @@ bmY
 cMV
 bnL
 boM
-iJS
+bpo
 bnL
-mHy
+bqK
 bnL
-iJS
-xRS
+bpo
+bnM
 bnL
 btu
 bui
@@ -147441,7 +141338,7 @@ cAU
 bQi
 bQi
 ccg
-coh
+ckw
 cjt
 cjt
 clE
@@ -147634,17 +141531,17 @@ aaa
 aab
 aab
 bma
-jTf
+bnO
 bov
-mgK
+boN
 cHm
 bpT
 bqL
 brq
 cHm
-jTf
+bnO
 bov
-mgK
+boN
 bma
 aab
 aaa
@@ -148742,9 +142639,9 @@ cre
 csb
 csT
 ctR
-cuN
+cuL
 cvv
-cuN
+cuL
 cwz
 cnp
 cnp

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -61843,7 +61843,7 @@
 "csa" = (
 /obj/structure/table,
 /obj/item/restraints/handcuffs/cable/white,
-/obj/item/gun/syringe,
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "csb" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -54133,7 +54133,6 @@
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/gun/syringe,
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -54146,6 +54145,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cds" = (
@@ -59207,13 +59207,13 @@
 	},
 /obj/item/clothing/suit/straight_jacket,
 /obj/item/clothing/mask/muzzle,
-/obj/item/gun/syringe,
 /obj/item/clothing/glasses/eyepatch,
 /obj/item/clothing/glasses/sunglasses/blindfold,
 /obj/item/clothing/ears/earmuffs,
 /obj/item/storage/belt/medical{
 	pixel_y = 2
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white/side,
 /area/medical/surgery)
 "cnu" = (

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -27696,12 +27696,12 @@
 	pixel_y = 3
 	},
 /obj/item/storage/box/syringes,
-/obj/item/gun/syringe,
 /obj/item/reagent_containers/hypospray/CMO,
 /obj/item/storage/belt/medical,
 /obj/item/storage/belt/medical,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/neck/stethoscope,
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXR" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -39520,7 +39520,6 @@
 "bMK" = (
 /obj/item/soap/nanotrasen,
 /obj/item/clothing/neck/stethoscope,
-/obj/item/gun/syringe,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -39529,6 +39528,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bMM" = (


### PR DESCRIPTION

## About The Pull Request

Takes the one or two syringe guns on every map in the code and replaces them with medidart guns.

## Why It's Good For The Game

Chem warfare is not fun or interesting to use or fight, and these syringe guns at best make the dart gun nearly useless and at worst enable validhunters to one shot nuke ops and wizards. Syringe guns have no reason to be given out to medical roundstart when we're trying to get rid of golden-bolt style one click wins. Medidart guns mean that the only reason to have or use a syringe gun is validhunting or antagging.

## Changelog
:cl:
balance: Medical no longer spawns with syringe guns, Medical now spawns with medidart guns.
/:cl:
