### PR TITLE
Massive optimization for sink objective.

### DIFF
--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -41,16 +41,9 @@
 	var/count = 0
 
 /datum/sabotage_objective/processing/power_sink/check_condition_processing()
-	count += 1
-	if(count==10 || sink_found) // doesn't need to fire that often unless a sink exists
-		var/sink_found_this_time = FALSE
-		for(var/datum/powernet/PN in GLOB.powernets)
-			for(var/obj/item/powersink/sink in PN.nodes)
-				sink_found_this_time = TRUE
-				won = max(won,sink.power_drained/1e8)
-		sink_found = sink_found_this_time
-		count = 0
-	return FALSE
+	for(var/s in GLOB.power_sinks)
+		var/obj/item/powersink/sink = s
+		won = max(won,sink.power_drained/1e8)
 
 /obj/item/paper/guides/antag/supermatter_sabotage
 	info = "Ways to sabotage a supermatter:<br>\

--- a/code/game/objects/items/devices/powersink.dm
+++ b/code/game/objects/items/devices/powersink.dm
@@ -1,5 +1,7 @@
 // Powersink - used to drain station power
 
+GLOBAL_LIST_EMPTY(power_sinks)
+
 /obj/item/powersink
 	desc = "A nulling power sink which drains energy from electrical systems."
 	name = "power sink"
@@ -25,6 +27,14 @@
 	var/const/OPERATING = 2
 
 	var/obj/structure/cable/attached		// the attached cable
+
+/obj/item/powersink/Initialize()
+	. = ..()
+	GLOB.power_sinks += src
+
+/obj/item/powersink/Destroy()
+	GLOB.power_sinks -= src
+	. = ..()
 
 /obj/item/powersink/update_icon_state()
 	icon_state = "powersink[mode == OPERATING]"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. I've just made powersinks add theirselves to a global list upon creation and had the power sink objective check *that*.

## Why It's Good For The Game

The way I did it before was peanut-brained.

## Changelog
:cl:
code: Power sink objective processing now makes sense.
/:cl: