### PR TITLE
Fixing permanent slapstick comedy creamed overlay.

### DIFF
--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -707,7 +707,7 @@
 
 /mob/living/carbon/human/wash_cream()
 	if(creamed) //clean both to prevent a rare bug
-		cut_overlay(mutable_appearance('icons/effects/creampie.dmi', "creampie_lizard"))
+		cut_overlay(mutable_appearance('icons/effects/creampie.dmi', "creampie_snout"))
 		cut_overlay(mutable_appearance('icons/effects/creampie.dmi', "creampie_human"))
 		creamed = FALSE
 


### PR DESCRIPTION
## About The Pull Request
Title. The component should be ported someday.

## Why It's Good For The Game
This will close #11558.

## Changelog
:cl:
fix: Fixed permanent slapstick comedy pie'd overlay for snouted humanoids.
/:cl:
