### PR TITLE
Clockie Vanguard Spell - rebalance for stamcombat

### DIFF
--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -82,6 +82,7 @@
 
 /datum/status_effect/vanguard_shield/tick()
 	progbar.update(duration - world.time)
+	owner.adjustStaminaLoss(-2)
 
 /datum/status_effect/vanguard_shield/on_remove()
 	var/vanguard = owner.stun_absorption["vanguard"]

--- a/code/datums/status_effects/buffs.dm
+++ b/code/datums/status_effects/buffs.dm
@@ -48,20 +48,24 @@
 	status_type = STATUS_EFFECT_REPLACE
 	alert_type = /obj/screen/alert/status_effect/vanguard
 	var/datum/progressbar/progbar
+	var/stamhealed = 0 //How much stamina did we regenerate?
 
 /obj/screen/alert/status_effect/vanguard
 	name = "Vanguard"
-	desc = "You're absorbing stuns! Your stamina is greatly increased, but not infinite. 25% of all stuns taken will affect you after this effect ends."
+	desc = "You're absorbing stuns aswell as quickly regenerating stamina, but be careful: 50% of stamina restored and 25% of stuns absorbed will affect you after this effect ends."
 	icon_state = "vanguard"
 	alerttooltipstyle = "clockcult"
 
 /obj/screen/alert/status_effect/vanguard/MouseEntered(location,control,params)
 	var/mob/living/L = usr
+	var/datum/status_effect/vanguard_shield/E = attached_effect
 	if(istype(L)) //this is probably more safety than actually needed
 		var/vanguard = L.stun_absorption["vanguard"]
 		desc = initial(desc)
 		desc += "<br><b>[FLOOR(vanguard["stuns_absorbed"] * 0.1, 1)]</b> seconds of stuns held back.\
-		[GLOB.ratvar_awakens ? "":"<br><b>[FLOOR(min(vanguard["stuns_absorbed"] * 0.025, 20), 1)]</b> seconds of stun will affect you."]"
+		<br><b>[E.stamhealed]</b> stamina regenerated.\
+		[GLOB.ratvar_awakens ? "":"<br><b>[FLOOR(min(vanguard["stuns_absorbed"] * 0.025, 20), 1)]</b> seconds of stun will affect you.\
+		<br>You will incur <b>[E.stamhealed * 0.5]</b> staminaloss."]"
 	..()
 
 /datum/status_effect/vanguard_shield/Destroy()
@@ -72,9 +76,8 @@
 /datum/status_effect/vanguard_shield/on_apply()
 	owner.log_message("gained Vanguard stun immunity", LOG_ATTACK)
 	owner.add_stun_absorption("vanguard", INFINITY, 1, "'s yellow aura momentarily intensifies!", "Your ward absorbs the stun!", " radiating with a soft yellow light!")
-	owner.visible_message("<span class='warning'>[owner] begins to faintly glow!</span>", "<span class='brass'>You will absorb all stuns for the next twenty seconds.</span>")
+	owner.visible_message("<span class='warning'>[owner] begins to faintly glow!</span>", "<span class='brass'>You will absorb all stuns aswell as quickly regenerate stamina for the next twenty seconds .</span>")
 	owner.SetAllImmobility(0, FALSE)
-	owner.setStaminaLoss(0, FALSE)
 	progbar = new(owner, duration, owner)
 	progbar.bar.color = list("#FAE48C", "#FAE48C", "#FAE48C", rgb(0,0,0))
 	progbar.update(duration - world.time)
@@ -82,7 +85,9 @@
 
 /datum/status_effect/vanguard_shield/tick()
 	progbar.update(duration - world.time)
-	owner.adjustStaminaLoss(-2)
+	var/oldstamloss = owner.getStaminaLoss()
+	owner.adjustStaminaLoss(-6) //up to 30 stam / second for now, lets see...
+	stamhealed += oldstamloss - owner.getStaminaLoss()
 
 /datum/status_effect/vanguard_shield/on_remove()
 	var/vanguard = owner.stun_absorption["vanguard"]
@@ -96,8 +101,9 @@
 		for(var/i in owner.stun_absorption)
 			if(owner.stun_absorption[i]["end_time"] > world.time && owner.stun_absorption[i]["priority"] > vanguard["priority"])
 				otheractiveabsorptions = TRUE
-		if(!GLOB.ratvar_awakens && stuns_blocked && !otheractiveabsorptions)
+		if(!GLOB.ratvar_awakens && (stuns_blocked && !otheractiveabsorptions || stamhealed))
 			owner.DefaultCombatKnockdown(stuns_blocked)
+			owner.adjustStaminaLoss(stamhealed * 0.5)
 			message_to_owner = "<span class='boldwarning'>The weight of the Vanguard's protection crashes down upon you!</span>"
 			if(stuns_blocked >= 300)
 				message_to_owner += "\n<span class='userdanger'>You faint from the exertion!</span>"
@@ -106,7 +112,7 @@
 		else
 			stuns_blocked = 0 //so logging is correct in cases where there were stuns blocked but we didn't stun for other reasons
 		owner.visible_message("<span class='warning'>[owner]'s glowing aura fades!</span>", message_to_owner)
-		owner.log_message("lost Vanguard stun immunity[stuns_blocked ? "and was stunned for [stuns_blocked]":""]", LOG_ATTACK)
+		owner.log_message("lost Vanguard stun immunity[stuns_blocked ? "and was stunned for [stuns_blocked]":""] [stamhealed ? ", incurring [stamhealed * 0.25] staminaloss" : ""]", LOG_ATTACK)
 
 
 /datum/status_effect/inathneqs_endowment

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_drivers.dm
@@ -138,11 +138,11 @@
 	quickbind_desc = "Applies handcuffs to a struck target."
 
 
-//Vanguard: Provides twenty seconds of greatly increased stamina and stun immunity. At the end of the twenty seconds, 25% of all stuns absorbed are applied to the invoker.
+//Vanguard: Provides twenty seconds of greatly increased stamina regeneration and stun immunity. At the end of the twenty seconds, 25% of all stuns absorbed aswell as 50% of healed stamloss are applied to the invoker.
 /datum/clockwork_scripture/vanguard
 	descname = "Self Stun Immunity"
 	name = "Vanguard"
-	desc = "Provides twenty seconds of greatly increased stamina and stun immunity. At the end of the twenty seconds, the invoker is knocked down for the equivalent of 25% of all stuns they absorbed. \
+	desc = "Provides twenty seconds of greatly increased stamina regeneration and stun immunity. At the end of the twenty seconds, the invoker is knocked down for the equivalent of 25% of all stuns they absorbed aswell as incurring 50% of the stamina regenerated as stamina loss \
 	Excessive absorption will cause unconsciousness."
 	invocations = list("Shield me...", "...from darkness!")
 	channel_time = 30
@@ -152,7 +152,7 @@
 	primary_component = VANGUARD_COGWHEEL
 	sort_priority = 7
 	quickbind = TRUE
-	quickbind_desc = "Allows you to temporarily have quickly regenerating stamina and absorb stuns. All stuns absorbed will affect you when disabled."
+	quickbind_desc = "Allows you to temporarily have quickly regenerating stamina and absorb stuns. Part of the stuns absorbed and staminaloss healed will affect you when disabled."
 
 /datum/clockwork_scripture/vanguard/check_special_requirements()
 	if(!GLOB.ratvar_awakens && islist(invoker.stun_absorption) && invoker.stun_absorption["vanguard"] && invoker.stun_absorption["vanguard"]["end_time"] > world.time)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->
This modifies the vanguard spell for clock cultists. Before, it only sucked up stuns which we have nearly completely removed and set stamloss to 0 once at the very beginning of it. Now, it doesn't set stamloss to 0 immediately, but instead regenerates 6(!, inform me if you think this is too much but its supposed to make stamina / stun weaponry pretty much ineffective for its duration and just fuck them over when it ends) stamina per tick (30 per second), but causes 50% of staminaloss it healed to hit the affected person when it runs out. Fun fact, the description of vanguard told people it sped up stamina regen, yet it only did the aforementioned 'set to 0' at the beginning. This should make it a viable tool in our stamcombat system.

## Why It's Good For The Game
Currently, vanguard, a spell supposedly quite important for combat, is very ineffective due to it only setting stamloss to 0 when its casted, and the stunsucc effect being quite useless with our combat system. Therefore, this aims to expand vanguards 'fight now, ignore stuns for now, backfire later if you did get hit and still fight at that time' from just stuns to stamcombat aswell, with its constant stamregen making it a effective tool in a clock cultists arsenal, but having the same disadvantage as for stuns (partial backfire on spellend).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: clockie vanguard now quickly regenerates stam while active (as its description always told you,)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
