### PR TITLE
frying changes with bad chems

### DIFF
--- a/code/modules/food_and_drinks/food/snacks_bread.dm
+++ b/code/modules/food_and_drinks/food/snacks_bread.dm
@@ -189,12 +189,11 @@
 GLOBAL_VAR_INIT(frying_hardmode, TRUE)
 GLOBAL_VAR_INIT(frying_bad_chem_add_volume, TRUE)
 GLOBAL_LIST_INIT(frying_bad_chems, list(
-/datum/reagent/toxin/bad_food = 10,
-/datum/reagent/clf3 = 2,
+/datum/reagent/toxin/bad_food = 3,
 /datum/reagent/drug/aranesp = 2,
-/datum/reagent/blackpowder = 10,
-/datum/reagent/phlogiston = 3,
-/datum/reagent/toxin/cyanide = 3,
+/datum/reagent/toxin = 2,
+/datum/reagent/lithium = 2,
+/datum/reagent/mercury = 2,
 ))
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/Initialize(mapload, obj/item/fried)
@@ -227,8 +226,10 @@ GLOBAL_LIST_INIT(frying_bad_chems, list(
 			var/bad_chem = GLOB.frying_bad_chems[R]
 			var/bad_chem_amount = GLOB.frying_bad_chems[bad_chem]
 			if(GLOB.frying_bad_chem_add_volume)
-				reagents.maximum_volume += bad_chem_amount
+				reagents.maximum_volume += bad_chem_amount + 2 //Added room for condensed cooking oil
 			reagents.add_reagent(bad_chem, bad_chem_amount)
+			//All fried inedible items also get condensed cooking oil added, which induces minor vomiting and heart damage
+			reagents.add_reagent(/datum/reagent/toxin/condensed_cooking_oil, 2)
 
 /obj/item/reagent_containers/food/snacks/deepfryholder/Destroy()
 	if(trash)

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -494,10 +494,6 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	toxpwr = 0.5
 	taste_description = "bad cooking"
-	
-	
-
-
 
 /datum/reagent/toxin/condensed_cooking_oil
 	name = "Condensed Cooking Oil"

--- a/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/toxin_reagents.dm
@@ -494,6 +494,28 @@
 	metabolization_rate = 0.25 * REAGENTS_METABOLISM
 	toxpwr = 0.5
 	taste_description = "bad cooking"
+	
+	
+
+
+
+/datum/reagent/toxin/condensed_cooking_oil
+	name = "Condensed Cooking Oil"
+	description = "Taste the consequences of your mistakes."
+	reagent_state = LIQUID
+	color = "#d6d6d8"
+	metabolization_rate = 0.25 * REAGENTS_METABOLISM
+	toxpwr = 0
+	taste_mult = -2
+	taste_description = "awful cooking"
+
+/datum/reagent/toxin/condensed_cooking_oil/on_mob_life(mob/living/carbon/M)
+	if(prob(15))
+		M.vomit()
+	else
+		if(prob(40))
+			M.adjustOrganLoss(ORGAN_SLOT_HEART, 0.5) //For reference, bungotoxin does 3
+	..()
 
 /datum/reagent/toxin/itching_powder
 	name = "Itching Powder"


### PR DESCRIPTION
## About The Pull Request
quick note: remade this pull request after closing my last one because I fucked up my fork as i'm still learning how to use git

adds a new toxin called 'Condensed Cooking Oil' which induces vomiting and very minor heart damage (bungotoxin does 3 damage, this does a 40% chance at 0.5 damage), this is contained in small amounts in all fried non-food items alongside the regular random 'bad' chemical

changes the reagents in fried non-food items to be less memey, (no more phlogiston, clf3, black powder)

also fried non-food items now have a toxic taste and a negative taste multiplier, meaning they don't taste good (unless your species for some reason likes both fried, and toxic foods)

## Why It's Good For The Game
cooks being able to get large quantities of black powder, clf3 and phlogiston was probably a bad idea, also people blowing up from eating fried food was too memey

## Changelog
:cl:
add: new reagent 'Condensed Cooking Oil'
tweak: list of chems that can go into fried non-food items was changed
/:cl: