### PR TITLE
does the quirky thing where a beam with origin/target in a container doesn't cut the map in half because byond is quirky and things inside things are x/y/z=0

### DIFF
--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -92,7 +92,7 @@
 	return ..()
 
 /datum/beam/proc/Draw()
-	if(!get_turf && (!isturf(target.loc) || !isturf(source.loc)))		//byond is quirky! if we aren't getting turf tell it to just Not(tm)
+	if(!get_turf && (!isturf(src.target.loc) || !isturf(src.source.loc)))		//byond is quirky! if we aren't getting turf tell it to just Not(tm)
 		return
 	var/atom/origin = get_turf? get_turf(src.origin) : src.origin
 	var/atom/target = get_turf? get_turf(src.target) : src.target

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -15,8 +15,6 @@
 	var/beam_type = /obj/effect/ebeam //must be subtype
 	var/timing_id = null
 	var/recalculating = FALSE
-	/// If either origin or target is in a container, do get_turf instead of just not beaming.
-	var/get_turf = FALSE
 
 /datum/beam/New(beam_origin,beam_target,beam_icon='icons/effects/beam.dmi',beam_icon_state="b_beam",time=50,maxdistance=10,btype = /obj/effect/ebeam,beam_sleep_time=3)
 	origin = beam_origin
@@ -92,10 +90,8 @@
 	return ..()
 
 /datum/beam/proc/Draw()
-	if(!get_turf && (!isturf(src.target.loc) || !isturf(src.origin.loc)))		//byond is quirky! if we aren't getting turf tell it to just Not(tm)
+	if(!isturf(origin.loc) || !isturf(target.loc))
 		return
-	var/atom/origin = get_turf? get_turf(src.origin) : src.origin
-	var/atom/target = get_turf? get_turf(src.target) : src.target
 	var/Angle = round(Get_Angle(origin,target))
 	var/matrix/rot_matrix = matrix()
 	rot_matrix.Turn(Angle)

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -9,8 +9,8 @@
 	var/max_distance = 0
 	var/sleep_time = 3
 	var/finished = 0
-	var/target_oldloc = null
-	var/origin_oldloc = null
+	var/turf/target_oldloc
+	var/turf/origin_oldloc
 	var/static_beam = 0
 	var/beam_type = /obj/effect/ebeam //must be subtype
 	var/timing_id = null
@@ -42,9 +42,13 @@
 		return
 	recalculating = TRUE
 	timing_id = null
-	if(origin && target && (get_dist(origin,target) < max_distance) && (origin.z == target.z))
-		var/origin_turf = get_turf(origin)
-		var/target_turf = get_turf(target)
+	var/turf/origin_turf
+	if(origin)
+		origin_turf = get_turf(origin)
+	var/turf/target_turf
+	if(target)
+		target_turf = get_turf(target)
+	if(origin_turf && target_turf && (get_dist(origin_turf, target_turf) < max_distance) && (origin_turf.z == target_turf.z))
 		if(!static_beam && ((origin_turf != origin_oldloc) || (target_turf != target_oldloc)))
 			origin_oldloc = origin_turf //so we don't keep checking against their initial positions, leading to endless Reset()+Draw() calls
 			target_oldloc = target_turf
@@ -90,15 +94,15 @@
 	return ..()
 
 /datum/beam/proc/Draw()
-	if(!isturf(origin.loc) || !isturf(target.loc))
+	if(!origin_oldloc || !target_oldloc)
 		return
-	var/Angle = round(Get_Angle(origin,target))
+	var/Angle = round(Get_Angle(origin_oldloc,target_oldloc))
 	var/matrix/rot_matrix = matrix()
 	rot_matrix.Turn(Angle)
 
 	//Translation vector for origin and target
-	var/DX = (32*target.x+target.pixel_x)-(32*origin.x+origin.pixel_x)
-	var/DY = (32*target.y+target.pixel_y)-(32*origin.y+origin.pixel_y)
+	var/DX = (32*target_oldloc.x+target_oldloc.pixel_x)-(32*origin_oldloc.x+origin_oldloc.pixel_x)
+	var/DY = (32*target_oldloc.y+target_oldloc.pixel_y)-(32*origin_oldloc.y+origin_oldloc.pixel_y)
 	var/N = 0
 	var/length = round(sqrt((DX)**2+(DY)**2)) //hypotenuse of the triangle formed by target and origin's displacement
 

--- a/code/datums/beam.dm
+++ b/code/datums/beam.dm
@@ -92,7 +92,7 @@
 	return ..()
 
 /datum/beam/proc/Draw()
-	if(!get_turf && (!isturf(src.target.loc) || !isturf(src.source.loc)))		//byond is quirky! if we aren't getting turf tell it to just Not(tm)
+	if(!get_turf && (!isturf(src.target.loc) || !isturf(src.origin.loc)))		//byond is quirky! if we aren't getting turf tell it to just Not(tm)
 		return
 	var/atom/origin = get_turf? get_turf(src.origin) : src.origin
 	var/atom/target = get_turf? get_turf(src.target) : src.target


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

this is why you have beams going across the map
that's Bad(tm)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: beams should no longer go across the map and mess everything up if their source or target isn't on a turf.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
