### PR TITLE
Made votes obfuscation settings more robust, including them in custom votes.

### DIFF
--- a/code/__DEFINES/vote.dm
+++ b/code/__DEFINES/vote.dm
@@ -5,6 +5,11 @@
 #define MAJORITY_JUDGEMENT_VOTING 4
 #define INSTANT_RUNOFF_VOTING 5
 
+#define SHOW_RESULTS (1<<0)
+#define SHOW_VOTES (1<<1)
+#define SHOW_WINNER (1<<2)
+#define SHOW_ABSTENTION (1<<3)
+
 GLOBAL_LIST_INIT(vote_score_options,list("Bad","Poor","Acceptable","Good","Great"))
 
 GLOBAL_LIST_INIT(vote_type_names,list(\
@@ -14,4 +19,11 @@ GLOBAL_LIST_INIT(vote_type_names,list(\
 "Schulze (ranked choice, higher result=better)" = SCHULZE_VOTING,\
 "Raw Score (returns results from 0 to 1, winner is 1)" = SCORE_VOTING,\
 "Majority Judgement (single-winner score voting)" = MAJORITY_JUDGEMENT_VOTING,\
+))
+
+GLOBAL_LIST_INIT(display_vote_settings, list(\
+"Results" = SHOW_RESULTS,
+"Ongoing Votes" = SHOW_VOTES,
+"Winner" =  SHOW_WINNER,
+"Abstainers" = SHOW_ABSTENTION
 ))

--- a/code/controllers/subsystem/ticker.dm
+++ b/code/controllers/subsystem/ticker.dm
@@ -479,15 +479,15 @@ SUBSYSTEM_DEF(ticker)
 		var/vote_type = CONFIG_GET(string/map_vote_type)
 		switch(vote_type)
 			if("PLURALITY")
-				SSvote.initiate_vote("map","server",hideresults=TRUE)
+				SSvote.initiate_vote("map","server", display = SHOW_RESULTS)
 			if("APPROVAL")
-				SSvote.initiate_vote("map","server",hideresults=TRUE,votesystem = APPROVAL_VOTING)
+				SSvote.initiate_vote("map","server", display = SHOW_RESULTS, votesystem = APPROVAL_VOTING)
 			if("IRV")
-				SSvote.initiate_vote("map","server",hideresults=TRUE,votesystem = INSTANT_RUNOFF_VOTING)
+				SSvote.initiate_vote("map","server", display = SHOW_RESULTS, votesystem = INSTANT_RUNOFF_VOTING)
 			if("SCORE")
-				SSvote.initiate_vote("map","server",hideresults=TRUE,votesystem = MAJORITY_JUDGEMENT_VOTING)
+				SSvote.initiate_vote("map","server", display = SHOW_RESULTS, votesystem = MAJORITY_JUDGEMENT_VOTING)
 			else
-				SSvote.initiate_vote("map","server",hideresults=TRUE)
+				SSvote.initiate_vote("map","server", display = SHOW_RESULTS)
 		// fallback
 
 /datum/controller/subsystem/ticker/proc/HasRoundStarted()
@@ -503,9 +503,9 @@ SUBSYSTEM_DEF(ticker)
 		SSticker.modevoted = TRUE
 		var/dynamic = CONFIG_GET(flag/dynamic_voting)
 		if(dynamic)
-			SSvote.initiate_vote("dynamic","server",hideresults=TRUE,votesystem=SCORE_VOTING,forced=TRUE,vote_time = 20 MINUTES)
+			SSvote.initiate_vote("dynamic", "server", display = NONE, votesystem = SCORE_VOTING, forced = TRUE,vote_time = 20 MINUTES)
 		else
-			SSvote.initiate_vote("roundtype","server",hideresults=TRUE,votesystem=PLURALITY_VOTING,forced=TRUE, \
+			SSvote.initiate_vote("roundtype", "server", display = NONE, votesystem = PLURALITY_VOTING, forced=TRUE, \
 			vote_time = (CONFIG_GET(flag/modetier_voting) ? 1 MINUTES : 20 MINUTES))
 
 /datum/controller/subsystem/ticker/Recover()

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(vote)
 	var/list/generated_actions = list()
 	var/next_pop = 0
 
-	var/obfuscated = FALSE//CIT CHANGE - adds obfuscated/admin-only votes
+	var/display_votes = SHOW_RESULTS|SHOW_VOTES|SHOW_WINNER|SHOW_ABSTENTION //CIT CHANGE - adds obfuscated/admin-only votes
 
 	var/list/stored_gamemode_votes = list() //Basically the last voted gamemode is stored here for end-of-round use.
 
@@ -59,7 +59,7 @@ SUBSYSTEM_DEF(vote)
 	voted.Cut()
 	voting.Cut()
 	scores.Cut()
-	obfuscated = FALSE //CIT CHANGE - obfuscated votes
+	display_votes = initial(display_votes) //CIT CHANGE - obfuscated votes
 	remove_action_buttons()
 
 /datum/controller/subsystem/vote/proc/get_result()
@@ -250,7 +250,7 @@ SUBSYSTEM_DEF(vote)
 	if(winners.len > 0)
 		if(was_roundtype_vote)
 			stored_gamemode_votes = list()
-		if(!obfuscated)
+		if(display_votes & SHOW_RESULTS)
 			if(vote_system == SCHULZE_VOTING)
 				text += "\nIt should be noted that this is not a raw tally of votes (impossible in ranked choice) but the score determined by the schulze method of voting, so the numbers will look weird!"
 			if(vote_system == MAJORITY_JUDGEMENT_VOTING)
@@ -261,15 +261,15 @@ SUBSYSTEM_DEF(vote)
 				votes = 0
 			if(was_roundtype_vote)
 				stored_gamemode_votes[choices[i]] = votes
-			text += "\n<b>[choices[i]]:</b> [obfuscated ? "???" : votes]" //CIT CHANGE - adds obfuscated votes
+			text += "\n<b>[choices[i]]:</b> [display_votes & SHOW_RESULTS ? votes : "???"]" //CIT CHANGE - adds obfuscated votes
 		if(mode != "custom")
-			if(winners.len > 1 && !obfuscated) //CIT CHANGE - adds obfuscated votes
+			if(winners.len > 1 && display_votes & SHOW_WINNER) //CIT CHANGE - adds obfuscated votes
 				text = "\n<b>Vote Tied Between:</b>"
 				for(var/option in winners)
 					text += "\n\t[option]"
 			. = pick(winners)
-			text += "\n<b>Vote Result: [obfuscated ? "???" : .]</b>" //CIT CHANGE - adds obfuscated votes
-		else
+			text += "\n<b>Vote Result: [display_votes & SHOW_WINNER ? . : "???"]</b>" //CIT CHANGE - adds obfuscated votes
+		if(display_votes & SHOW_ABSTENTION)
 			text += "\n<b>Did not vote:</b> [GLOB.clients.len-voted.len]"
 	else if(vote_system == SCORE_VOTING)
 		for(var/score_name in scores)
@@ -278,7 +278,7 @@ SUBSYSTEM_DEF(vote)
 				score = 0
 			if(was_roundtype_vote)
 				stored_gamemode_votes[score_name] = score
-			text = "\n<b>[score_name]:</b> [obfuscated ? "???" : score]"
+			text = "\n<b>[score_name]:</b> [display_votes & SHOW_RESULTS ? score : "???"]"
 			. = 1
 	else
 		text += "<b>Vote Result: Inconclusive - No Votes!</b>"
@@ -295,7 +295,7 @@ SUBSYSTEM_DEF(vote)
 				if(islist(myvote))
 					for(var/j=1,j<=myvote.len,j++)
 						SSblackbox.record_feedback("nested tally","voting",1,list(vote_title_text,"[j]\th",choices[myvote[j]]))
-	if(obfuscated) //CIT CHANGE - adds obfuscated votes. this messages admins with the vote's true results
+	if(!(display_votes & SHOW_RESULTS)) //CIT CHANGE - adds obfuscated votes. this messages admins with the vote's true results
 		var/admintext = "Obfuscated results"
 		if(vote_system != SCORE_VOTING)
 			if(vote_system == SCHULZE_VOTING)
@@ -327,7 +327,7 @@ SUBSYSTEM_DEF(vote)
 				if(CONFIG_GET(flag/modetier_voting))
 					reset()
 					started_time = 0
-					initiate_vote("mode tiers","server",hideresults=FALSE,votesystem=SCORE_VOTING,forced=TRUE, vote_time = 30 MINUTES)
+					initiate_vote("mode tiers","server", votesystem=SCORE_VOTING, forced=TRUE, vote_time = 30 MINUTES)
 					to_chat(world,"<b>The vote will end right as the round starts.</b>")
 					return .
 			if("restart")
@@ -432,7 +432,7 @@ SUBSYSTEM_DEF(vote)
 					saved -= usr.ckey
 	return 0
 
-/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, hideresults, votesystem = PLURALITY_VOTING, forced = FALSE,vote_time = -1)//CIT CHANGE - adds hideresults argument to votes to allow for obfuscated votes
+/datum/controller/subsystem/vote/proc/initiate_vote(vote_type, initiator_key, display = display_votes, votesystem = PLURALITY_VOTING, forced = FALSE,vote_time = -1)//CIT CHANGE - adds display argument to votes to allow for obfuscated votes
 	vote_system = votesystem
 	if(!mode)
 		if(started_time)
@@ -452,7 +452,7 @@ SUBSYSTEM_DEF(vote)
 
 		SEND_SOUND(world, sound('sound/misc/notice2.ogg'))
 		reset()
-		obfuscated = hideresults //CIT CHANGE - adds obfuscated votes
+		display_votes = display //CIT CHANGE - adds obfuscated votes
 		switch(vote_type)
 			if("restart")
 				choices.Add("Restart Round","Continue Playing")
@@ -503,6 +503,21 @@ SUBSYSTEM_DEF(vote)
 					if(!option || mode || !usr.client)
 						break
 					choices.Add(option)
+				var/keep_going = TRUE
+				var/toggles = SHOW_RESULTS|SHOW_VOTES|SHOW_WINNER
+				while(keep_going)
+					var/list/choices = list()
+					for(var/A in GLOB.display_vote_settings)
+						var/toggletext
+						var/bitflag = GLOB.display_vote_settings[A]
+						toggletext = "[toggles & bitflag ? "Show" : "Hide"] [A]"
+						choices[toggletext] = bitflag
+					var/chosen = input(usr, "Toggle vote display settings. Cancel to finalize.", toggles) as null|anything in choices
+					if(!chosen)
+						keep_going = FALSE
+					else
+						toggles ^= choices[chosen]
+				display_votes = toggles
 			else
 				return 0
 		mode = vote_type
@@ -573,7 +588,7 @@ SUBSYSTEM_DEF(vote)
 							ivotedforthis = ((C.ckey in voted) && (i in voted[C.ckey]))
 					if(!votes)
 						votes = 0
-					. += "<li>[ivotedforthis ? "<b>" : ""]<a href='?src=[REF(src)];vote=[i]'>[choices[i]]</a> ([obfuscated ? (admin ? "??? ([votes])" : "???") : votes] votes)[ivotedforthis ? "</b>" : ""]</li>" // CIT CHANGE - adds obfuscated votes
+					. += "<li>[ivotedforthis ? "<b>" : ""]<a href='?src=[REF(src)];vote=[i]'>[choices[i]]</a> ([display_votes & SHOW_VOTES ? votes : (admin ? "??? ([votes])" : "???")] votes)[ivotedforthis ? "</b>" : ""]</li>" // CIT CHANGE - adds obfuscated votes
 					if(choice_descs.len >= i)
 						. += "<li>[choice_descs[i]]</li>"
 				. += "</ul><hr>"


### PR DESCRIPTION
## About The Pull Request
Title. Also made the map rotation votes only hide ongoing votes since the mapping subsystem already warns players about the results winner anyway.

## Why It's Good For The Game
More flexible and customizable vote types.

## Changelog
:cl:
refactor: Made votes obfuscation settings more robust.
admin: Also included them in custom votes.
tweak: The map rotation vote will only hide ongoing votes now, not the results.
/:cl:

