### PR TITLE
cook now gets to choose their ingredient box + sushi ingredient box

### DIFF
--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -55,7 +55,21 @@
 		if(istype(H.ears, /obj/item/radio/headset))
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""
 	to_chat(M, msg)
+	
+/obj/item/choice_beacon/ingredients
+	name = "ingredient box delivery beacon"
+	desc = "Summon a box of ingredients from a wide selection!"
+	icon_state = "gangtool-red"
 
+/obj/item/choice_beacon/ingredients/generate_display_names()
+	var/static/list/ingredientboxes
+	if(!ingredientboxes)
+		instruments = list()
+		var/list/templist = typesof(/obj/item/storage/box/ingredients)
+		for(var/V in templist)
+			var/atom/A = V
+			ingredientboxes[initial(A.name)] = A
+	return ingredientboxes
 	new /obj/effect/abstract/DPtarget(get_turf(src), pod)
 
 /obj/item/choice_beacon/hero

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -55,7 +55,7 @@
 		if(istype(H.ears, /obj/item/radio/headset))
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""
 	to_chat(M, msg)
-	
+
 /obj/item/choice_beacon/ingredients
 	name = "ingredient box delivery beacon"
 	desc = "Summon a box of ingredients from a wide selection!"
@@ -64,13 +64,12 @@
 /obj/item/choice_beacon/ingredients/generate_display_names()
 	var/static/list/ingredientboxes
 	if(!ingredientboxes)
-		instruments = list()
+		ingredientboxes = list()
 		var/list/templist = typesof(/obj/item/storage/box/ingredients)
 		for(var/V in templist)
 			var/atom/A = V
 			ingredientboxes[initial(A.name)] = A
 	return ingredientboxes
-	new /obj/effect/abstract/DPtarget(get_turf(src), pod)
 
 /obj/item/choice_beacon/hero
 	name = "heroic beacon"

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -130,3 +130,4 @@
 	icon_state = "supermatterspray"
 	w_class = WEIGHT_CLASS_SMALL
 	var/usesleft = 2
+

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -56,6 +56,8 @@
 			msg = "You hear something crackle in your ears for a moment before a voice speaks.  \"Please stand by for a message from Central Command.  Message as follows: <span class='bold'>Item request received. Your package is inbound, please stand back from the landing site.</span> Message ends.\""
 	to_chat(M, msg)
 
+	new /obj/effect/abstract/DPtarget(get_turf(src), pod)
+
 /obj/item/choice_beacon/ingredients
 	name = "ingredient box delivery beacon"
 	desc = "Summon a box of ingredients from a wide selection!"

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -87,7 +87,6 @@
 			hero_item_list[initial(A.name)] = A
 	return hero_item_list
 
-
 /obj/item/storage/box/hero
 	name = "Courageous Tomb Raider - 1940's."
 

--- a/code/game/objects/items/miscellaneous.dm
+++ b/code/game/objects/items/miscellaneous.dm
@@ -69,8 +69,8 @@
 		ingredientboxes = list()
 		var/list/templist = typesof(/obj/item/storage/box/ingredients)
 		for(var/V in templist)
-			var/atom/A = V
-			ingredientboxes[initial(A.name)] = A
+			var/obj/item/storage/box/ingredients/A = V
+			ingredientboxes[initial(A.theme_name)] = A
 	return ingredientboxes
 
 /obj/item/choice_beacon/hero

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -960,6 +960,9 @@
 							  /obj/item/reagent_containers/food/snacks/grown/bluecherries,
 							  /obj/item/reagent_containers/food/snacks/grown/cocoapod,
 							  /obj/item/reagent_containers/food/snacks/grown/vanillapod,
+							  /obj/item/reagent_containers/food/snacks/grown/grapes,
+							  /obj/item/reagent_containers/food/snacks/grown/strawberry,
+							  /obj/item/reagent_containers/food/snacks/grown/whitebeet,
 							  /obj/item/reagent_containers/food/snacks/meat/slab/bear,
 							  /obj/item/reagent_containers/food/snacks/meat/slab/spider,
 							  /obj/item/reagent_containers/food/snacks/spidereggs,
@@ -976,6 +979,14 @@
 							  /obj/item/reagent_containers/food/snacks/grown/pineapple,
 							  /obj/item/reagent_containers/food/snacks/grown/pumpkin,
 							  /obj/item/reagent_containers/food/snacks/meat/rawcrab,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/goliath,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/chicken,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/slime,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/golem,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
+							  /obj/item/reagent_containers/food/snacks/egg,
+
 							  /obj/item/reagent_containers/food/snacks/grown/eggplant)
 		new randomFood(src)
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -986,7 +986,6 @@
 							  /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/lizard,
 							  /obj/item/reagent_containers/food/snacks/meat/slab/human/mutant/skeleton,
 							  /obj/item/reagent_containers/food/snacks/egg,
-
 							  /obj/item/reagent_containers/food/snacks/grown/eggplant)
 		new randomFood(src)
 

--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -946,12 +946,37 @@
 							  /obj/item/reagent_containers/food/snacks/grown/apple,
 							  /obj/item/reagent_containers/food/snacks/chocolatebar,
 							  /obj/item/reagent_containers/food/snacks/grown/cherries,
+							  /obj/item/reagent_containers/food/snacks/grown/berries,
 							  /obj/item/reagent_containers/food/snacks/grown/banana,
 							  /obj/item/reagent_containers/food/snacks/grown/cabbage,
 							  /obj/item/reagent_containers/food/snacks/grown/soybeans,
 							  /obj/item/reagent_containers/food/snacks/grown/corn,
 							  /obj/item/reagent_containers/food/snacks/grown/mushroom/plumphelmet,
-							  /obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle)
+							  /obj/item/reagent_containers/food/snacks/grown/mushroom/chanterelle,
+							  /obj/item/reagent_containers/food/snacks/faggot,
+							  /obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+							  /obj/item/reagent_containers/food/snacks/grown/citrus/lemon,
+							  /obj/item/reagent_containers/food/snacks/grown/citrus/lime,
+							  /obj/item/reagent_containers/food/snacks/grown/bluecherries,
+							  /obj/item/reagent_containers/food/snacks/grown/cocoapod,
+							  /obj/item/reagent_containers/food/snacks/grown/vanillapod,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/bear,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/spider,
+							  /obj/item/reagent_containers/food/snacks/spidereggs,
+							  /obj/item/reagent_containers/food/snacks/carpmeat,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/xeno,
+							  /obj/item/reagent_containers/food/snacks/meat/slab/corgi,
+							  /obj/item/reagent_containers/food/snacks/grown/oat,
+							  /obj/item/reagent_containers/food/snacks/grown/wheat,
+							  /obj/item/reagent_containers/honeycomb,
+							  /obj/item/reagent_containers/food/snacks/grown/watermelon,
+							  /obj/item/reagent_containers/food/snacks/grown/onion,
+							  /obj/item/reagent_containers/food/snacks/grown/peach,
+							  /obj/item/reagent_containers/food/snacks/grown/peanut,
+							  /obj/item/reagent_containers/food/snacks/grown/pineapple,
+							  /obj/item/reagent_containers/food/snacks/grown/pumpkin,
+							  /obj/item/reagent_containers/food/snacks/meat/rawcrab,
+							  /obj/item/reagent_containers/food/snacks/grown/eggplant)
 		new randomFood(src)
 
 /obj/item/storage/box/ingredients/fiesta
@@ -1060,6 +1085,15 @@
 		new /obj/item/reagent_containers/food/snacks/grown/soybeans(src)
 		new /obj/item/reagent_containers/food/snacks/grown/cabbage(src)
 	new /obj/item/reagent_containers/food/snacks/grown/chili(src)
+
+/obj/item/storage/box/ingredients/sushi
+	theme_name = "sushi"
+
+/obj/item/storage/box/ingredients/sushi/PopulateContents()
+	for(var/i in 1 to 3)
+		new /obj/item/reagent_containers/food/snacks/sea_weed(src)
+		new /obj/item/reagent_containers/food/snacks/carpmeat(src)
+	new /obj/item/reagent_containers/food/snacks/meat/rawcrab(src)
 
 /obj/item/storage/box/emptysandbags
 	name = "box of empty sandbags"

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -27,7 +27,7 @@
 	suit = /obj/item/clothing/suit/toggle/chef
 	head = /obj/item/clothing/head/chefhat
 	mask = /obj/item/clothing/mask/fakemoustache/italian
-	backpack_contents = list(/obj/item/sharpener = 1, /object/item/choice_beacon/ingredients = 1)
+	backpack_contents = list(/obj/item/sharpener = 1, /obj/item/choice_beacon/ingredients = 1)
 
 /datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
 	..()

--- a/code/modules/jobs/job_types/cook.dm
+++ b/code/modules/jobs/job_types/cook.dm
@@ -27,7 +27,7 @@
 	suit = /obj/item/clothing/suit/toggle/chef
 	head = /obj/item/clothing/head/chefhat
 	mask = /obj/item/clothing/mask/fakemoustache/italian
-	backpack_contents = list(/obj/item/sharpener = 1)
+	backpack_contents = list(/obj/item/sharpener = 1, /object/item/choice_beacon/ingredients = 1)
 
 /datum/outfit/job/cook/pre_equip(mob/living/carbon/human/H, visualsOnly = FALSE, client/preference_source)
 	..()
@@ -43,10 +43,6 @@
 	..()
 	if(visualsOnly)
 		return
-	var/list/possible_boxes = subtypesof(/obj/item/storage/box/ingredients)
-	var/chosen_box = pick(possible_boxes)
-	var/obj/item/storage/box/I = new chosen_box(src)
-	H.equip_to_slot_or_del(I,SLOT_IN_BACKPACK)
 	var/datum/martial_art/cqc/under_siege/justacook = new
 	justacook.teach(H)
 


### PR DESCRIPTION
## About The Pull Request
cook now gets a choice beacon to choose a box of ingredients to spawn, instead of getting a random one

new sushi ingredient box containing 3 carp meat, 3 seaweed sheets, 1 crab meat

wildcard box now contains far more possible items, including things such as skeleton meat

## Why It's Good For The Game
being able to pick the ingredient box you start with gives you far more freedom, which is cool and stops cooks getting a box they don't want

## Changelog
:cl:
add: added beacon for cooks to choose an ingredient box, which replaces the random box they used to receive
add: added a new sushi ingredients box
add: added more items to the wildcard box's possible contents
/:cl:
