### PR TITLE
Fixing an inconsistency with nuclear bombs exploding on station level space.

### DIFF
--- a/code/__DEFINES/misc.dm
+++ b/code/__DEFINES/misc.dm
@@ -345,11 +345,10 @@ GLOBAL_LIST_INIT(pda_reskins, list(PDA_SKIN_CLASSIC = 'icons/obj/pda.dmi', PDA_S
 #define COLOUR_PRIORITY_AMOUNT 4 //how many priority levels there are.
 
 //Endgame Results
-#define NUKE_NEAR_MISS 1
-#define NUKE_MISS_STATION 2
-#define NUKE_SYNDICATE_BASE 3
-#define STATION_DESTROYED_NUKE 4
-#define STATION_EVACUATED 5
+#define NUKE_MISS_STATION 1
+#define NUKE_SYNDICATE_BASE 2
+#define STATION_DESTROYED_NUKE 3
+#define STATION_EVACUATED 4
 #define BLOB_WIN 8
 #define BLOB_NUKE 9
 #define BLOB_DESTROYED 10

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -323,7 +323,7 @@
 	var/free_tickets = CONFIG_GET(number/default_antag_tickets)
 	//Max extra tickets you can use
 	var/additional_tickets = CONFIG_GET(number/max_tickets_per_roll)
-	
+
 	var/list/ckey_to_mind = list()		//this is admittedly shitcode but I'm webediting
 	var/list/prev_tickets = SSpersistence.antag_rep		//cache for hyper-speed in theory. how many tickets someone has stored
 	var/list/curr_tickets = list()				//how many tickets someone has for *this* antag roll, so with the free tickets
@@ -337,7 +337,7 @@
 			continue
 		curr_tickets[mind_ckey] = amount
 		ckey_to_mind[mind_ckey] = M			//make sure we can look them up after picking
-	
+
 	if(!return_list)		//return a single guy
 		var/ckey
 		if(length(curr_tickets))
@@ -584,7 +584,7 @@
 //By default nuke just ends the round
 /datum/game_mode/proc/OnNukeExplosion(off_station)
 	nuke_off_station = off_station
-	if(off_station < 2)
+	if(!off_station)
 		station_was_nuked = TRUE //Will end the round on next check.
 
 //Additional report section in roundend report


### PR DESCRIPTION
## About The Pull Request
See #11197.

## Why It's Good For The Game
This will close #11197.

## Changelog
:cl:
fix: Near-station nuclear explosions now display the on-station nuke explosion cinematic, consistently with its clearance of the station level and its nuclear victory / total annihilation ending status.
balance: Nuclear bombs can't be anchored in space areas (not just turfs) anymore, as a quick effortless way to discourage players from anchoring the device on the edge of the map.
/:cl: