### PR TITLE
Bringing Our shotguns up to (TG)snuff

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -264,7 +264,7 @@
 	icon_state = "dshotgun"
 	item_state = "shotgun"
 	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 	force = 10
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -87,6 +87,7 @@
 	name = "riot shotgun"
 	desc = "A sturdy shotgun with a longer magazine and a fixed tactical stock designed for non-lethal riot control."
 	icon_state = "riotshotgun"
+	fire_delay = 7
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
 	unique_reskin = list("Tatical" = "riotshotgun",
@@ -207,7 +208,7 @@
 	name = "combat shotgun"
 	desc = "A semi automatic shotgun with tactical furniture and a six-shell capacity underneath."
 	icon_state = "cshotgun"
-	fire_delay = 3
+	fire_delay = 5
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
 	unique_reskin = list("Tatical" = "cshotgun",

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -10,7 +10,7 @@
 	mag_type = /obj/item/ammo_box/magazine/internal/shot
 	casing_ejector = FALSE
 	var/recentpump = 0 // to prevent spammage
-	weapon_weight = WEAPON_MEDIUM
+	weapon_weight = WEAPON_HEAVY
 
 /obj/item/gun/ballistic/shotgun/attackby(obj/item/A, mob/user, params)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Ports PRs #47472 and #47039 from TG
Makes Riot shotguns and combat shotguns have fire delay values (one had none, the other was tweaked upwards) 
Also makes shotguns a heavy weapon( think L6 saw) meaning they require two hands to fire, this does _not_ apply to nuke op bulldog shotguns. 

## Why It's Good For The Game

Shotguns are currently the indisputable "meta" weapon, causing security to reach for lethals before any other solution. This means that you can no longer use a shotgun whilst carrying a 50% block chance shield in your other hand, as well as meaning it's generally more difficult to use weapons that are meant to be strong and unwieldy.

Also means you can't instakill/lagswitch people using shotguns with little to no firing delay.

## Changelog
:cl:
balance: Shotguns are now slower and require two hands to fire.
/:cl: