### PR TITLE
Fixes crafting hud icon overlapping the second pocket on 1:1 screen mode.

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -2,18 +2,6 @@
 //Be sure to update the min/max of these if you do change them.
 //Measurements are in imperial units. Inches, feet, yards, miles. Tsp, tbsp, cups, quarts, gallons, etc
 
-//HUD stuff
-#define  ui_arousal "EAST-1:28,CENTER-4:8"//Below the health doll
-#define ui_stamina "EAST-1:28,CENTER:17" // replacing internals button
-#define ui_overridden_resist "EAST-3:24,SOUTH+1:7"
-#define ui_combat_toggle "EAST-4:22,SOUTH:5"
-
-//1:1 HUD layout stuff
-#define ui_boxcraft "EAST-4:22,SOUTH+1:6"
-#define ui_boxarea "EAST-4:6,SOUTH+1:6"
-#define ui_boxlang "EAST-5:22,SOUTH+1:6"
-#define ui_boxvore	"EAST-5:22,SOUTH+1:6"
-
 //Filters
 #define CIT_FILTER_STAMINACRIT filter(type="drop_shadow", x=0, y=0, size=-3, color="#04080F")
 

--- a/code/_onclick/hud/_defines.dm
+++ b/code/_onclick/hud/_defines.dm
@@ -163,3 +163,14 @@
 #define ui_ghost_reenter_corpse "SOUTH:6,CENTER:24"
 #define ui_ghost_teleport "SOUTH:6,CENTER+1:24"
 #define ui_ghost_pai "SOUTH: 6, CENTER+2:24"
+
+
+//UI position overrides for 1:1 screen layout. (default is 7:5)
+#define ui_stamina "EAST-1:28,CENTER:17" // replacing internals button
+#define ui_overridden_resist "EAST-3:24,SOUTH+1:7"
+#define ui_combat_toggle "EAST-4:22,SOUTH:5"
+
+#define ui_boxcraft "EAST-4:22,SOUTH+1:6"
+#define ui_boxarea "EAST-4:6,SOUTH+1:6"
+#define ui_boxlang "EAST-5:22,SOUTH+1:6"
+#define ui_boxvore	"EAST-5:22,SOUTH+1:6"

--- a/code/datums/components/crafting/craft.dm
+++ b/code/datums/components/crafting/craft.dm
@@ -8,6 +8,8 @@
 	var/obj/screen/craft/C = new()
 	C.icon = H.ui_style
 	H.static_inventory += C
+	if(!CL.prefs.widescreenpref)
+		C.screen_loc = ui_boxcraft
 	CL.screen += C
 	RegisterSignal(C, COMSIG_CLICK, .proc/component_ui_interact)
 


### PR DESCRIPTION
## About The Pull Request
Title. Also moving some hud-related defines to hud/_defines.dm.

## Why It's Good For The Game
Two lines fix. This will close #10878.

## Changelog
:cl:
fix: Fixed crafting hud icon overlapping the second pocket on 1:1 screen mode.
/:cl: