### PR TITLE
PUNCHING: YOU SHOULD BE SCREAMING EDITION

### DIFF
--- a/code/datums/martial/boxing.dm
+++ b/code/datums/martial/boxing.dm
@@ -37,7 +37,7 @@
 
 	D.apply_damage(damage, STAMINA, affecting, armor_block)
 	log_combat(A, D, "punched (boxing) ")
-	if(D.getStaminaLoss() > 100)
+	if(D.getStaminaLoss() > 100 && istype(D.mind?.martial_art, /datum/martial_art/boxing))
 		var/knockout_prob = (D.getStaminaLoss() + rand(-15,15))*0.75
 		if((D.stat != DEAD) && prob(knockout_prob))
 			D.visible_message("<span class='danger'>[A] has knocked [D] out with a haymaker!</span>", \

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -580,7 +580,7 @@
 /mob/living/carbon/update_stamina()
 	var/stam = getStaminaLoss()
 	if(stam > DAMAGE_PRECISION)
-		var/total_health = (health - stam)
+		var/total_health = (maxHealth - stam)
 		if(total_health <= crit_threshold && !stat)
 			if(CHECK_MOBILITY(src, MOBILITY_STAND))
 				to_chat(src, "<span class='notice'>You're too exhausted to keep going...</span>")

--- a/code/modules/mob/living/carbon/human/human.dm
+++ b/code/modules/mob/living/carbon/human/human.dm
@@ -769,7 +769,7 @@
 		return
 	else
 		if(hud_used.healths)
-			var/health_amount = health - CLAMP(getStaminaLoss()-50, 0, 80)//CIT CHANGE - makes staminaloss have less of an impact on the health hud
+			var/health_amount = min(health, maxHealth - CLAMP(getStaminaLoss()-50, 0, 80))//CIT CHANGE - makes staminaloss have less of an impact on the health hud
 			if(..(health_amount)) //not dead
 				switch(hal_screwyhud)
 					if(SCREWYHUD_CRIT)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -63,9 +63,9 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	var/coldmod = 1		// multiplier for cold damage
 	var/heatmod = 1		// multiplier for heat damage
 	var/stunmod = 1		// multiplier for stun duration
-	var/punchdamagelow = 0       //lowest possible punch damage
-	var/punchdamagehigh = 9      //highest possible punch damage
-	var/punchstunthreshold = 9//damage at which punches from this race will stun //yes it should be to the attacked race but it's not useful that way even if it's logical
+	var/punchdamagelow = 1       //lowest possible punch damage. if this is set to 0, punches will always miss
+	var/punchdamagehigh = 10      //highest possible punch damage
+	var/punchstunthreshold = 10//damage at which punches from this race will stun //yes it should be to the attacked race but it's not useful that way even if it's logical
 	var/siemens_coeff = 1 //base electrocution coefficient
 	var/damage_overlay_type = "human" //what kind of damage overlays (if any) appear on our species when wounded?
 	var/fixed_mut_color = "" //to use MUTCOLOR with a fixed color that's independent of dna.feature["mcolor"]
@@ -1465,15 +1465,15 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	else
 
 		var/atk_verb = user.dna.species.attack_verb
-		if(target.lying)
-			atk_verb = "kick"
+		if(!(target.mobility_flags & MOBILITY_STAND))
+			atk_verb = ATTACK_EFFECT_KICK
 
 		switch(atk_verb)
-			if("kick")
+			if(ATTACK_EFFECT_KICK)
 				user.do_attack_animation(target, ATTACK_EFFECT_KICK)
-			if("slash")
+			if(ATTACK_EFFECT_CLAW)
 				user.do_attack_animation(target, ATTACK_EFFECT_CLAW)
-			if("smash")
+			if(ATTACK_EFFECT_SMASH)
 				user.do_attack_animation(target, ATTACK_EFFECT_SMASH)
 			else
 				user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)
@@ -1493,10 +1493,19 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 		var/obj/item/bodypart/affecting = target.get_bodypart(ran_zone(user.zone_selected))
 
-		if(!damage || !affecting)
-			playsound(target.loc, user.dna.species.miss_sound, 25, 1, -1)
-			target.visible_message("<span class='danger'>[user] has attempted to [atk_verb] [target]!</span>",\
-			"<span class='userdanger'>[user] has attempted to [atk_verb] [target]!</span>", null, COMBAT_MESSAGE_RANGE)
+		var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases
+		if(user.dna.species.punchdamagelow)
+			if(atk_verb == ATTACK_EFFECT_KICK) //kicks never miss (provided your species deals more than 0 damage)
+				miss_chance = 0
+			else
+				miss_chance = min((user.dna.species.punchdamagehigh/user.dna.species.punchdamagelow) + user.getStaminaLoss() + (user.getBruteLoss()*0.5), 100) //old base chance for a miss + various damage. capped at 100 to prevent weirdness in prob()
+
+		if(!damage || !affecting || prob(miss_chance))//future-proofing for species that have 0 damage/weird cases where no zone is targeted
+			playsound(target.loc, user.dna.species.miss_sound, 25, TRUE, -1)
+			target.visible_message("<span class='danger'>[user]'s [atk_verb] misses [target]!</span>", \
+							"<span class='danger'>You avoid [user]'s [atk_verb]!</span>", "<span class='hear'>You hear a swoosh!</span>", COMBAT_MESSAGE_RANGE, user)
+			to_chat(user, "<span class='warning'>Your [atk_verb] misses [target]!</span>")
+			log_combat(user, target, "attempted to punch")
 			return FALSE
 
 
@@ -1513,14 +1522,25 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 		if(user.limb_destroyer)
 			target.dismembering_strike(user, affecting.body_zone)
-		target.apply_damage(damage, BRUTE, affecting, armor_block)
-		log_combat(user, target, "punched")
+		
+		if(atk_verb == ATTACK_EFFECT_KICK)//kicks deal 1.5x raw damage + 0.5x stamina damage
+			target.apply_damage(damage*1.5, BRUTE, affecting, armor_block)
+			target.apply_damage(damage*0.5, STAMINA, affecting, armor_block)
+			log_combat(user, target, "kicked")
+		else//other attacks deal full raw damage + 2x in stamina damage
+			target.apply_damage(damage, BRUTE, affecting, armor_block)
+			target.apply_damage(damage*2, STAMINA, affecting, armor_block)
+			log_combat(user, target, "punched")
+
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			target.visible_message("<span class='danger'>[user] has knocked  [target] down!</span>", \
-							"<span class='userdanger'>[user] has knocked [target] down!</span>", null, COMBAT_MESSAGE_RANGE)
-			target.apply_effect(80, EFFECT_KNOCKDOWN, armor_block)
+			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
+							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
+			to_chat(user, "<span class='danger'>You knock [target] down!</span>")
+			var/knockdown_duration = 40 + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 - armor_block
+			target.DefaultCombatKnockdown(knockdown_duration)
 			target.forcesay(GLOB.hit_appends)
-		else if(target.lying)
+			log_combat(user, target, "got a stun punch with their previous punch")
+		else if(!(target.mobility_flags & MOBILITY_STAND))
 			target.forcesay(GLOB.hit_appends)
 
 /datum/species/proc/spec_unarmedattacked(mob/living/carbon/human/user, mob/living/carbon/human/target)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -467,7 +467,9 @@
 		if(H.physiology)
 			H.physiology.stamina_mod *= 0.5
 		if(H.dna && H.dna.species)
-			H.dna.species.punchdamagehigh *= 5
+			H.dna.species.punchdamagehigh *= 4
+			H.dna.species.punchdamagelow  *= 10
+			H.dna.species.punchstunthreshold *= 2
 
 /datum/reagent/drug/skooma/on_mob_end_metabolize(mob/living/L)
 	. = ..()
@@ -478,7 +480,9 @@
 		if(H.physiology)
 			H.physiology.stamina_mod *= 2
 		if(H.dna && H.dna.species)
-			H.dna.species.punchdamagehigh *= 0.2
+			H.dna.species.punchdamagehigh *= 0.25
+			H.dna.species.punchdamagelow *= 0.1
+			H.dna.species.punchstunthreshold *= 0.5
 
 /datum/reagent/drug/skooma/on_mob_life(mob/living/carbon/M)
 	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, 1*REM)

--- a/code/modules/reagents/chemistry/reagents/drug_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/drug_reagents.dm
@@ -468,7 +468,7 @@
 			H.physiology.stamina_mod *= 0.5
 		if(H.dna && H.dna.species)
 			H.dna.species.punchdamagehigh *= 4
-			H.dna.species.punchdamagelow  *= 10
+			H.dna.species.punchdamagelow  *= 4
 			H.dna.species.punchstunthreshold *= 2
 
 /datum/reagent/drug/skooma/on_mob_end_metabolize(mob/living/L)
@@ -481,7 +481,7 @@
 			H.physiology.stamina_mod *= 2
 		if(H.dna && H.dna.species)
 			H.dna.species.punchdamagehigh *= 0.25
-			H.dna.species.punchdamagelow *= 0.1
+			H.dna.species.punchdamagelow *= 0.25
 			H.dna.species.punchstunthreshold *= 0.5
 
 /datum/reagent/drug/skooma/on_mob_life(mob/living/carbon/M)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -23,7 +23,7 @@
 
 	var/disabled = BODYPART_NOT_DISABLED //If disabled, limb is as good as missing
 	var/body_damage_coeff = 1 //Multiplier of the limb's damage that gets applied to the mob
-	var/stam_damage_coeff = 0.5
+	var/stam_damage_coeff = 0.75
 	var/brutestate = 0
 	var/burnstate = 0
 	var/brute_dam = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

PICKS OUT TWO THINGS FROM THESE THREE PRS

**STAMINA AND HEALTH NO LONGER STACK FOR THE PURPOSE OF CRIT FROM THIS ONE:**
https://github.com/tgstation/tgstation/pull/43966

**PUNCHING IS DUMBY THICC FROM THIS ONE:**
https://github.com/tgstation/tgstation/pull/43291

**BOXERS CAN ONLY KNOCK OUT OTHER BOXERS FROM HERE**
https://github.com/tgstation/tgstation/pull/46212

AND IN ADDITION TO ALL THIS: 

LIMBS TAKE 75% DAMAGE INSTEAD OF 50%. OH FUCK.

SKOOMA HAS BEEN REBALANCED A LITTLE. JUST A BIT. IT IS STILL FUCKING OBSCENELY BROKEN.

I HEAR YOU LIMP DICK MOTHERFUCKERS SAYING 'ANNE, WHILE SMOKING THE FELINIDS SIN ROCKS, DOESN'T THIS MEAN THAT MY FISTS ON SKOOMA DOES 80 STAMINA DAMAGE ON A HIGH ROLL AGAINST SOMEONE WHO IS OUT OF COMBAT MODE, LET ALONE DOING ABOUT AS MUCH BRUTE DAMAGE AS A HYPEREUTATIC BLADE AND EXCEEDING A HYPEREUTATIC IF THEY'RE ON THE FLOOR, WHICH THEY DEFINITELY WILL BE WHEN YOU KNOCK THEM DOWN DUE TO THE MASSIVE KNOCKDOWN THRESHOLD?'

AND TO THE BITCH WHO JUST UTTERED THOSE WORDS TO MY FACE, I SAY

**SKOOMA IS A HELL OF A FUCKING DRUG.**

**NYA NYA NYA**

## Why It's Good For The Game

ONLY TRUST YOUR FISTS.

SECURITY WILL NEVER HELP YOU.

## Changelog
:cl:
balance: HEALTH AND STAMINA DON'T STACK FOR PUTTING YOU INTO STAMINA CRIT.
balance: YOUR FISTS ARE HELLA GODDAMN STRONG.
balance: ACCEPT THE FELINIDS WARES, FOR SKOOMA HAS INCREDIBLE LETHAL PROPERTIES: YOUR HANDS BECOME LIKE SWORDS.
balance: BOXERS CAN ONLY KNOCK OUT OTHER BOXERS BECAUSE THEY HAVE HONOR OR SOME SHIT
balance: INCREASED STAMINA DAMAGE TO LIMBS FROM 50% TO 75%.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
