### PR TITLE
Makes a few space ruins hard spawn

### DIFF
--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -18,7 +18,6 @@
 	name = "Asteroid 1"
 	description = "I-spy with my little eye, something beginning with R."
 
-
 /datum/map_template/ruin/space/asteroid2
 	id = "asteroid2"
 	suffix = "asteroid2.dmm"
@@ -143,6 +142,7 @@
 	name = "DK Excavator 453"
 	description = "Based on the trace elements we've detected on the gutted asteroids, we suspect that a mining ship using a restricted engine is somewhere in the area. \
 	We'd like to request a patrol vessel to investigate."
+	always_place = TRUE
 
 /datum/map_template/ruin/space/spacehotel
 	id = "spacehotel"
@@ -187,6 +187,7 @@
 	name = "Abandoned Teleporter"
 	description = "In space construction the teleporter is often the first system brought online. \
 	This lonely half built teleporter is a sign of a proposed structure that for one reason or another just never got built."
+	always_place = TRUE
 
 /datum/map_template/ruin/space/crashedclownship
 	id = "crashedclownship"
@@ -268,6 +269,7 @@
 	suffix = "whiteshipdock.dmm"
 	name = "Whiteship Dock"
 	description = "An abandoned but functional vessel parked in deep space, ripe for the taking."
+	always_place = TRUE
 
 /datum/map_template/ruin/space/cat_experiments
 	id = "meow"
@@ -287,6 +289,7 @@
 	suffix = "hilbertshoteltestingsite.dmm"
 	name = "Hilbert Research Facility"
 	description = "A research facility of great bluespace discoveries. Long since abandoned, willingly or not..."
+
 /datum/map_template/ruin/space/augmentation
 	id = "augmentationfacility"
 	suffix = "augmentationfacility.dmm"
@@ -376,13 +379,13 @@
 	id = "roid8"
 	suffix = "roid8.dmm"
 	name = "Dead wizard Roid"
-	description = "Mineral asteroid. Ft. Dead wizard and toilet paradox bag."
+	description = "Mineral asteroid. Ft. Dead wizard and toilet wand."
 
 /datum/map_template/ruin/spacenearstation/roid9
 	id = "roid9"
 	suffix = "roid9.dmm"
 	name = "Monitoring Roid"
-	description = "Mineral asteroid. Ft. Station monitoring, syndie toolbox and erp."
+	description = "Mineral asteroid. Ft. Station monitoring, toolbox and erp."
 
 /datum/map_template/ruin/spacenearstation/roid10
 	id = "roid10"

--- a/code/datums/ruins/space.dm
+++ b/code/datums/ruins/space.dm
@@ -142,7 +142,6 @@
 	name = "DK Excavator 453"
 	description = "Based on the trace elements we've detected on the gutted asteroids, we suspect that a mining ship using a restricted engine is somewhere in the area. \
 	We'd like to request a patrol vessel to investigate."
-	always_place = TRUE
 
 /datum/map_template/ruin/space/spacehotel
 	id = "spacehotel"


### PR DESCRIPTION
## About The Pull Request

Lost ship, Syndie mining base in space and broken old tele relay are now all hard spawns
Corrects a few words on BM's space ruins

## Why It's Good For The Game

Lost ship is rare and rare and its rather nice to get.
Syndie mining base is one of the few ruins needed for cargo thus it should be prob spawning in.
Old Tele Relay is just a really good space ruin to teleport to and make a new ~~ERP~~ room for people to hangout in

## Changelog
:cl:
balance: White Ships, Telerelays and a defunk mining post are now always going to spawn.
spellcheck: Corrects a few desc on station side ruins
/:cl:
