### PR TITLE
Refactors mesmerize and tweaks it a bit, alternative title "whoever coded this is bad and should feel bad do not ever use notransform ever"

### DIFF
--- a/code/modules/antagonists/bloodsucker/powers/mesmerize.dm
+++ b/code/modules/antagonists/bloodsucker/powers/mesmerize.dm
@@ -120,20 +120,20 @@
 		cleanup_target(user, target, success)
 
 /datum/action/bloodsucker/targeted/mesmerize/proc/do_mesmerize_cycle(mob/living/user, mob/living/carbon/target)
-		var/power_time = 138 + level_current * 12
-		sleep(windup_time)
-		if(success)
-			PowerActivatedSuccessfully() // blood & cooldown only altered if power activated successfully - less "fuck you"-y
-			target.face_atom(user)
-			target.apply_status_effect(STATUS_EFFECT_MESMERIZE, power_time) // pretty much purely cosmetic
-			ADD_TRAIT(target, TRAIT_MOBILITY_NOPICKUP, src)
-			ADD_TRAIT(target, TRAIT_MOBILITY_NOUSE, src)
-			ADD_TRAIT(target, TRAIT_MOBILITY_NOMOVE, src)
-			to_chat(user, "<span class='notice'>[target] is fixed in place by your hypnotic gaze.</span>")
-			addtimer(CALLBACK(src, .proc/reset_victim), power_time)
-			reset_victim()		//make sure old one is cleared if it isn't already 
-			current_victim = target
-			RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/reset_victim)
+	var/power_time = 138 + level_current * 12
+	sleep(windup_time)
+	if(success)
+		PowerActivatedSuccessfully() // blood & cooldown only altered if power activated successfully - less "fuck you"-y
+		target.face_atom(user)
+		target.apply_status_effect(STATUS_EFFECT_MESMERIZE, power_time) // pretty much purely cosmetic
+		ADD_TRAIT(target, TRAIT_MOBILITY_NOPICKUP, src)
+		ADD_TRAIT(target, TRAIT_MOBILITY_NOUSE, src)
+		ADD_TRAIT(target, TRAIT_MOBILITY_NOMOVE, src)
+		to_chat(user, "<span class='notice'>[target] is fixed in place by your hypnotic gaze.</span>")
+		addtimer(CALLBACK(src, .proc/reset_victim), power_time)
+		reset_victim()		//make sure old one is cleared if it isn't already 
+		current_victim = target
+		RegisterSignal(target, COMSIG_PARENT_QDELETING, .proc/reset_victim)
 
 /datum/action/bloodsucker/targeted/mesmerize/proc/reset_victim()
 	if(!current_victim)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Things that actually matter for gameplay: 
Mesmerize can now only hit one person at a time. If you successfully mesmerize another guy before the first guy wears off, it'll wear off the first guy.
Mesmerize no longer gives the vampire the debuff while mesmerizing. It makes no sense.

Things that you will notice if this works right:
No more infinite combat mode lock and stun from mesmerize being a buggy piece of shit.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Debuffing the vampire with the mesmerize effect was silly.
being able to hit more than one person at a time was tossed in the name of more stable code because I don't want to add another 30 lines just to handle unexpected deletions if multitargets were to be allowed. Single target only allows me to just store it in a variable and clear it whenever needed without having to add complicated handling for cleaning up every potentially mesmerized target separately if someone mesmerized more than one person.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Bloodsucker mesmerize can only affect one person at a time now, but no longer debuffs the vampire while casting. It also shouldn't bug out.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
