### PR TITLE
Quick webedit fixing an issue with the split personality.

### DIFF
--- a/code/datums/brain_damage/split_personality.dm
+++ b/code/datums/brain_damage/split_personality.dm
@@ -20,6 +20,7 @@
 	..()
 	make_backseats()
 	get_ghost()
+	RegisterSignal(M, COMSIG_MOB_DEATH, .proc/revert_to_normal)
 
 /datum/brain_trauma/severe/split_personality/proc/make_backseats()
 	stranger_backseat = new(owner, src)
@@ -37,23 +38,23 @@
 		qdel(src)
 
 /datum/brain_trauma/severe/split_personality/on_life()
-	if(owner.stat == DEAD)
-		if(current_controller != OWNER)
-			switch_personalities()
-		qdel(src)
-	else if(prob(3))
+	if(prob(3))
 		switch_personalities()
 	..()
 
 /datum/brain_trauma/severe/split_personality/on_lose()
 	if(current_controller != OWNER) //it would be funny to cure a guy only to be left with the other personality, but it seems too cruel
-		switch_personalities()
+		switch_personalities(TRUE)
 	QDEL_NULL(stranger_backseat)
 	QDEL_NULL(owner_backseat)
+	UnregisterSignal(M, COMSIG_MOB_DEATH)
 	..()
 
-/datum/brain_trauma/severe/split_personality/proc/switch_personalities()
-	if(QDELETED(owner) || owner.stat == DEAD || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
+/datum/brain_trauma/severe/split_personality/proc/revert_to_normal()
+	qdel(src)
+
+/datum/brain_trauma/severe/split_personality/proc/switch_personalities(forced = FALSE)
+	if(QDELETED(owner) || (owner.stat == DEAD && !forced) || QDELETED(stranger_backseat) || QDELETED(owner_backseat))
 		return
 
 	var/mob/living/split_personality/current_backseat
@@ -125,10 +126,6 @@
 /mob/living/split_personality/Life()
 	if(QDELETED(body))
 		qdel(src) //in case trauma deletion doesn't already do it
-
-	if((body.stat == DEAD && trauma.owner_backseat == src))
-		trauma.switch_personalities()
-		qdel(trauma)
 
 	//if one of the two ghosts, the other one stays permanently
 	if(!body.client && trauma.initialized)


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Because `switch_personalities` early returns if the owner is dead, potentially leaving the owner in a soon to be deleted backseat. This will close #11613.

## Changelog
:cl:
fix: Fixing an issue with the split personality removing the original owner from the round if the body died while the stranger was in control.
/:cl:
