### PR TITLE
stops hijackers from being able to remotely blow up borgs (probably)

### DIFF
--- a/code/game/machinery/computer/robot.dm
+++ b/code/game/machinery/computer/robot.dm
@@ -11,16 +11,19 @@
 
 /obj/machinery/computer/robotics/proc/can_control(mob/user, mob/living/silicon/robot/R)
 	if(!istype(R))
-		return 0
+		return FALSE
 	if(isAI(user))
 		if (R.connected_ai != user)
-			return 0
+			return FALSE
 	if(iscyborg(user))
 		if (R != user)
-			return 0
+			return FALSE
 	if(R.scrambledcodes)
-		return 0
-	return 1
+		return FALSE
+	if (hasSiliconAccessInArea(user) && !issilicon(user))
+		if (!Adjacent(user))
+			return FALSE
+	return TRUE
 
 /obj/machinery/computer/robotics/ui_interact(mob/user)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request

title

not sure if it actually works since I can't really locally test it

## Why It's Good For The Game

because blowing borgs from far away at any time is really shit.

## Changelog
:cl:
balance: stops hijackers from being able to remotely blow up borgs
/:cl: