### PR TITLE
Lowers o2 harm and cell use of screaming

### DIFF
--- a/modular_citadel/code/modules/mob/cit_emotes.dm
+++ b/modular_citadel/code/modules/mob/cit_emotes.dm
@@ -36,13 +36,13 @@
 				if(S.cell?.charge < 20)
 					to_chat(S, "<span class='warning'>Scream module deactivated. Please recharge.</span>")
 					return
-				S.cell.use(200)
+				S.cell.use(50)
 		if(ismonkey(user))
 			sound = 'modular_citadel/sound/voice/scream_monkey.ogg'
 		if(istype(user, /mob/living/simple_animal/hostile/gorilla))
 			sound = 'sound/creatures/gorilla.ogg'
 		if(ishuman(user))
-			user.adjustOxyLoss(5)
+			user.adjustOxyLoss(1)
 			sound = pick('modular_citadel/sound/voice/scream_m1.ogg', 'modular_citadel/sound/voice/scream_m2.ogg')
 			if(user.gender == FEMALE)
 				sound = pick('modular_citadel/sound/voice/scream_f1.ogg', 'modular_citadel/sound/voice/scream_f2.ogg')


### PR DESCRIPTION

## About The Pull Request

screaming now only takes 1 o2 damage to use, and for borgs only 50wats

## Why It's Good For The Game

Screaming is a really quick way to get more harmed then healed when getting medical help. It somehow is better then getting injected with chems whom are idea in making your die from a lack of air.

## Changelog
:cl:
tweak: Screaming is less lethal and takes less power 
/:cl:
