### PR TITLE
Medical Mechs syringe gun now innately know more healing chems

### DIFF
--- a/code/game/mecha/equipment/tools/medical_tools.dm
+++ b/code/game/mecha/equipment/tools/medical_tools.dm
@@ -259,7 +259,8 @@
 	. = ..()
 	create_reagents(max_volume, NO_REACT)
 	syringes = new
-	known_reagents = list(/datum/reagent/medicine/epinephrine = "Epinephrine", /datum/reagent/medicine/charcoal = "Charcoal")
+	known_reagents = list(/datum/reagent/medicine/epinephrine = "Epinephrine", /datum/reagent/medicine/charcoal = "Charcoal", /datum/reagent/medicine/prussian_blue = "Prussian Blue", \
+	/datum/reagent/medicine/dexalin = "Dexalin", /datum/reagent/medicine/insulin = "Insulin", /datum/reagent/medicine/kelotane = "Kelotane", /datum/reagent/medicine/bicaridine = "Bicaridine")
 	processed_reagents = new
 
 /obj/item/mecha_parts/mecha_equipment/medical/syringe_gun/detach()


### PR DESCRIPTION
## About The Pull Request

Medical Mechs syringe gun now knows many more life saving chems, like Insulin, Dexalin, Prussian Blue, Kelotane and Bicaridine

## Why It's Good For The Game

Medical Mechs are rarely used and for a reason! You have to first of all to use any chems in the sleeper that are knew, get a combat syringe gun of dread and doom, then play the game of eather hoping out making the chems and then anazlyering them, just to make them so you can heal people using a whats ment to be portable sleeper that cant be upgraded.

Besides slow and weak these also mainly get used for that slow medibeam, cuz its amazingly good and worth it do to healing just everything. Well the sleeper is never added on if so as an after thought do to being cheap.

## Changelog
:cl:
add: Medical Mechs syringe gun now knows many more life saving chems, like Insulin, Dexalin, Prussian Blue, Kelotane and Bicaridine
/:cl: