### PR TITLE
Makes Envy knife amongst other dna disguise shenanigeans actually update the gender.

### DIFF
--- a/code/datums/dna.dm
+++ b/code/datums/dna.dm
@@ -412,13 +412,13 @@
 
 	switch(deconstruct_block(getblock(dna.uni_identity, DNA_GENDER_BLOCK), 4))
 		if(G_MALE)
-			set_gender(MALE, TRUE)
+			set_gender(MALE, TRUE, forced = TRUE)
 		if(G_FEMALE)
-			set_gender(FEMALE, TRUE)
+			set_gender(FEMALE, TRUE, forced = TRUE)
 		if(G_PLURAL)
-			set_gender(PLURAL, TRUE)
+			set_gender(PLURAL, TRUE, forced = TRUE)
 		else
-			set_gender(NEUTER, TRUE)
+			set_gender(NEUTER, TRUE, forced = TRUE)
 
 /mob/living/carbon/human/updateappearance(icon_update=1, mutcolor_update=0, mutations_overlay_update=0)
 	..()


### PR DESCRIPTION
## About The Pull Request
A little issue with my latest gender code related PR, `dna/updateappearance` is used in several places, and there are more issues with having preference checks for the gender swap than not, and I'm not in the mood of sorting out which call instances should run those checks and which not atm.

## Why It's Good For The Game
This will close #11637.

## Changelog
None.