### PR TITLE
Removed nymphomania, plus code cleanup

### DIFF
--- a/code/controllers/subsystem/processing/quirks.dm
+++ b/code/controllers/subsystem/processing/quirks.dm
@@ -37,11 +37,11 @@ PROCESSING_SUBSYSTEM_DEF(quirks)
 	if(job?.blacklisted_quirks)
 		cut = filter_quirks(my_quirks, job.blacklisted_quirks)
 	for(var/V in my_quirks)
-		var/datum/quirk/Q = quirks[V]
-		if(Q)
+		if(V in quirks)
+			var/datum/quirk/Q = quirks[V]
 			user.add_quirk(Q, spawn_effects)
 		else
-			stack_trace("Invalid quirk \"[V]\" in client [cli.ckey] preferences")
+			log_admin("Invalid quirk \"[V]\" in client [cli.ckey] preferences")
 			cli.prefs.all_quirks -= V
 			badquirk = TRUE
 	if(badquirk)

--- a/code/datums/traits/neutral.dm
+++ b/code/datums/traits/neutral.dm
@@ -88,14 +88,6 @@
 	if(quirk_holder)
 		quirk_holder.remove_client_colour(/datum/client_colour/monochrome)
 
-/datum/quirk/libido
-	name = "Nymphomania"
-	desc = "You're always feeling a bit in heat. Also, you get aroused faster than usual."
-	value = 0
-	mob_trait = TRAIT_PERMABONER
-	gain_text = "<span class='notice'>You are feeling extra wild.</span>"
-	lose_text = "<span class='notice'>You don't feel that burning sensation anymore.</span>"
-
 /datum/quirk/maso
 	name = "Masochism"
 	desc = "You are aroused by pain."

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -396,7 +396,6 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 
 	//Citadel code
 	S["feature_genitals_use_skintone"]	>> features["genitals_use_skintone"]
-	S["feature_exhibitionist"]			>> features["exhibitionist"]
 	S["feature_mcolor2"]				>> features["mcolor2"]
 	S["feature_mcolor3"]				>> features["mcolor3"]
 	S["feature_mam_body_markings"]		>> features["mam_body_markings"]


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Removes the nymphomania quirk--it doesn't even do what it says it does anymore--and cleaned up some code related to quirk cleanup.

## Why It's Good For The Game

Nymphomania in its current form is so fucking janky that I thought it was broken the first time I noticed it and it was working as intended the way *I wrote it*.

## Changelog
:cl:
del: Nymphomania removed
code: Exhibitionism ignored by preferences now, since it was also removed
code: Quirk migration now does an admin log instead of a stack trace
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
