### PR TITLE
[s] Makes lockers not crash my client

### DIFF
--- a/code/game/objects/structures/crates_lockers/closets.dm
+++ b/code/game/objects/structures/crates_lockers/closets.dm
@@ -37,6 +37,7 @@
 	var/lock_in_use = FALSE //Someone is doing some stuff with the lock here, better not proceed further
 	var/eigen_teleport = FALSE //If the closet leads to Mr Tumnus.
 	var/obj/structure/closet/eigen_target //Where you go to.
+	var/breaking_out = FALSE // whether someone is breaking out
 
 
 /obj/structure/closet/Initialize(mapload)
@@ -503,7 +504,7 @@
 	return 1
 
 /obj/structure/closet/container_resist(mob/living/user)
-	if(opened)
+	if(opened || breaking_out)
 		return
 	if(ismovableatom(loc))
 		user.changeNext_move(CLICK_CD_BREAKOUT)
@@ -521,6 +522,7 @@
 	user.visible_message("<span class='warning'>[src] begins to shake violently!</span>", \
 		"<span class='notice'>You lean on the back of [src] and start pushing the door open... (this will take about [DisplayTimeText(breakout_time)].)</span>", \
 		"<span class='italics'>You hear banging from [src].</span>")
+	breaking_out = TRUE
 	if(do_after(user,(breakout_time), target = src, required_mobility_flags = MOBILITY_RESIST))
 		if(!user || user.stat != CONSCIOUS || user.loc != src || opened || (!locked && !welded) )
 			return
@@ -531,6 +533,7 @@
 	else
 		if(user.loc == src) //so we don't get the message if we resisted multiple times and succeeded.
 			to_chat(user, "<span class='warning'>You fail to break out of [src]!</span>")
+	breaking_out = FALSE
 
 /obj/structure/closet/AltClick(mob/user)
 	. = ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. If you used a movement key, it would spam "The [x] begins to shake violently"... for every input event?? Very bad.

## Why It's Good For The Game

Crashes are bad.

## Changelog
Not this time.

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
