### PR TITLE
infiltrator sneaky boots fix.

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -236,6 +236,7 @@
 #define APHRO_TRAIT "aphro"
 #define BLOODSUCKER_TRAIT "bloodsucker"
 #define CLOTHING_TRAIT "clothing" //used for quirky carrygloves
+#define SHOES_TRAIT "shoes" //inherited from your sweet kicks
 
 // unique trait sources, still defines
 #define STATUE_MUTE "statue"

--- a/code/modules/clothing/shoes/miscellaneous.dm
+++ b/code/modules/clothing/shoes/miscellaneous.dm
@@ -25,7 +25,15 @@
 	icon_state = "sneakboots"
 	item_state = "sneakboots"
 	resistance_flags = FIRE_PROOF |  ACID_PROOF
-	clothing_flags = TRAIT_SILENT_STEP
+
+/obj/item/clothing/shoes/combat/sneakboots/equipped(mob/user, slot)
+	. = ..()
+	if(slot == SLOT_SHOES)
+		ADD_TRAIT(user, TRAIT_SILENT_STEP, SHOES_TRAIT)
+
+/obj/item/clothing/shoes/combat/sneakboots/dropped(mob/user)
+	. = ..()
+	REMOVE_TRAIT(user, TRAIT_SILENT_STEP, SHOES_TRAIT)
 
 /obj/item/clothing/shoes/combat/swat //overpowered boots for death squads
 	name = "\improper SWAT boots"

--- a/code/modules/ninja/suit/shoes.dm
+++ b/code/modules/ninja/suit/shoes.dm
@@ -15,8 +15,8 @@
 /obj/item/clothing/shoes/space_ninja/equipped(mob/user, slot)
 	. = ..()
 	if(slot == SLOT_SHOES)
-		ADD_TRAIT(user, TRAIT_SILENT_STEP, "ninja_shoes_[REF(src)]")
+		ADD_TRAIT(user, TRAIT_SILENT_STEP, SHOES_TRAIT)
 
 /obj/item/clothing/shoes/space_ninja/dropped(mob/user)
 	. = ..()
-	REMOVE_TRAIT(user, TRAIT_SILENT_STEP, "ninja_shoes_[REF(src)]")
+	REMOVE_TRAIT(user, TRAIT_SILENT_STEP, SHOES_TRAIT)


### PR DESCRIPTION
## About The Pull Request
Now they properly slip and experience pressure change, and of course, silence footsteps.

## Why It's Good For The Game
See above.

## Changelog
:cl:
fix: Infiltrator's boots don't stop slips and "space wind" through the power of runtime errors anymore, and properly silence the user's footsteps now.
/:cl:
