### PR TITLE
Quick and dirty PR to make contractor targets actually show up in the traitor panel

### DIFF
--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -98,7 +98,7 @@
 
 /datum/antagonist/traitor/antag_panel_objectives()
 	. = ..()
-	if(contractor_hub?.assigned_targets)
+	if(contractor_hub?.assigned_targets && length(contractor_hub.assigned_targets))
 		. += "<i><b>Contract Targets</b></i>:<br>"
 		for(var/datum/mind/M in contractor_hub.assigned_targets)
 			. += "<b> - </b>[key_name(M, FALSE, TRUE)]<br>"

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -96,6 +96,13 @@
 			equip(silent)
 		owner.current.playsound_local(get_turf(owner.current), 'sound/ambience/antag/tatoralert.ogg', 100, FALSE, pressure_affected = FALSE)
 
+/datum/antagonist/traitor/antag_panel_objectives()
+	. = ..()
+	if(contractor_hub?.assigned_targets)
+		. += "<i><b>Contract Targets</b></i>:<br>"
+		for(var/datum/mind/M in contractor_hub.assigned_targets)
+			. += "<b> - </b>[key_name(M, FALSE, TRUE)]<br>"
+
 /datum/antagonist/traitor/apply_innate_effects(mob/living/mob_override)
 	. = ..()
 	update_traitor_icons_added()


### PR DESCRIPTION
## About The Pull Request
This does exactly as it says on the tin. Makes contractor targets actually appear in the traitor panel

## Why It's Good For The Game
Because hey maybe it's kind of a terrible fucking idea to have things like this not be conveniently logged or tracked.

## Changelog
:cl: Bhijn
admin: The traitor panel now actually shows a list of contractor targets.
/:cl:
