### PR TITLE
Shotgun-flavoured Balance Pass: Antag-roller kills NULL crates edition!

### DIFF
--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -164,17 +164,6 @@
 					/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
-/datum/supply_pack/security/armory/riotshotguns
-	name = "Riot Shotgun Crate"
-	desc = "For when the greytide gets really uppity. Contains three riot shotguns, seven rubber shot and beanbag shells. Requires Armory access to open."
-	cost = 6500
-	contains = list(/obj/item/gun/ballistic/shotgun/riot,
-					/obj/item/gun/ballistic/shotgun/riot,
-					/obj/item/gun/ballistic/shotgun/riot,
-					/obj/item/storage/box/rubbershot,
-					/obj/item/storage/box/beanbag)
-	crate_name = "riot shotgun crate"
-
 /datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
@@ -216,23 +205,6 @@
 					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
 
-/datum/supply_pack/security/armory/swattasers //Lesser AEG tbh
-	name = "SWAT tactical tasers Crate"
-	desc = "Contains two tactical energy gun, these guns are able to tase, disable and lethal as well as hold a seclight. Requires Armory access to open."
-	cost = 7000
-	contains = list(/obj/item/gun/energy/e_gun/stun,
-					/obj/item/gun/energy/e_gun/stun)
-	crate_name = "swat taser crate"
-
-/datum/supply_pack/security/armory/woodstock
-	name = "WoodStock Classic Shotguns Crate"
-	desc = "Contains three rustic, pumpaction shotguns. Requires Armory access to open."
-	cost = 3000
-	contains = list(/obj/item/gun/ballistic/shotgun,
-					/obj/item/gun/ballistic/shotgun,
-					/obj/item/gun/ballistic/shotgun)
-	crate_name = "woodstock shotguns crate"
-
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Semi-Auto Rifle Crate"
 	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
@@ -259,14 +231,4 @@
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber)
-	crate_name = "auto rifle ammo crate"
-
-/datum/supply_pack/security/armory/wt550ammo_special
-	name = "WT-550 Semi-Auto SMG Special Ammo Crate"
-	desc = "Contains 2 20-round Armour Piercing and Incendiary magazines for the WT-550 Semi-Auto SMG. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
-	cost = 3000
-	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtap,
-					/obj/item/ammo_box/magazine/wt550m9/wtap,
-					/obj/item/ammo_box/magazine/wt550m9/wtic,
-					/obj/item/ammo_box/magazine/wt550m9/wtic)
 	crate_name = "auto rifle ammo crate"

--- a/code/modules/cargo/packs/emergency.dm
+++ b/code/modules/cargo/packs/emergency.dm
@@ -206,30 +206,6 @@
 					/obj/item/storage/box/mre/menu4/safe)
 	crate_name = "MRE crate (emergency rations)"
 
-/datum/supply_pack/emergency/syndicate
-	name = "NULL_ENTRY"
-	desc = "(#@&^$THIS PACKAGE CONTAINS 30TC WORTH OF SOME RANDOM SYNDICATE GEAR WE HAD LYING AROUND THE WAREHOUSE. GIVE EM HELL, OPERATIVE@&!*() "
-	hidden = TRUE
-	cost = 20000
-	contains = list()
-	crate_name = "emergency crate"
-	crate_type = /obj/structure/closet/crate/internals
-	dangerous = TRUE
-
-/datum/supply_pack/emergency/syndicate/fill(obj/structure/closet/crate/C)
-	var/crate_value = 30
-	var/list/uplink_items = get_uplink_items(SSticker.mode)
-	while(crate_value)
-		var/category = pick(uplink_items)
-		var/item = pick(uplink_items[category])
-		var/datum/uplink_item/I = uplink_items[category][item]
-		if(!I.surplus_nullcrates || prob(100 - I.surplus_nullcrates))
-			continue
-		if(crate_value < I.cost)
-			continue
-		crate_value -= I.cost
-		new I.item(C)
-
 /datum/supply_pack/emergency/plasma_spacesuit
 	name = "Plasmaman Space Envirosuits"
 	desc = "Contains two space-worthy envirosuits for Plasmamen. Order now and we'll throw in two free helmets! Requires EVA access to open."

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -108,17 +108,6 @@
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "nitrile gloves crate"
 
-/datum/supply_pack/science/nuke_b_gone
-	name = "Nuke Defusal Kit"
-	desc = "Contains set of tools to defuse a nuke."
-	cost = 7500 //Useful for traitors/nukies that fucked up
-	dangerous = TRUE
-	hidden = TRUE
-	contains = list(/obj/item/nuke_core_container/nt,
-					/obj/item/screwdriver/nuke/nt,
-					/obj/item/paper/guides/nt/nuke_instructions)
-	crate_name = "safe defusal kit storage"
-
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, and timer! Warranty void if exposed to high temperatures. Requires Toxins access to open."
@@ -191,17 +180,6 @@
 	crate_name = "slime core crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
-/datum/supply_pack/science/supermater
-	name = "Supermatter Extraction Tools Crate"
-	desc = "Contains a set of tools to extract a sliver of supermatter. Consult your CE today!"
-	cost = 7500 //Useful for traitors that fucked up
-	hidden = TRUE
-	contains = list(/obj/item/nuke_core_container/supermatter,
-					/obj/item/scalpel/supermatter,
-					/obj/item/hemostat/supermatter,
-					/obj/item/paper/guides/antag/supermatter_sliver)
-	crate_name = "supermatter extraction kit crate"
-
 /datum/supply_pack/science/tablets
 	name = "Tablet Crate"
 	desc = "What's a computer? Contains five cargo tablets."
@@ -224,10 +202,3 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
-/datum/supply_pack/science/tech_slugs
-	name = "Tech Slug Ammo Shells"
-	desc = "A new type of shell that is able to be made into a few different dangerous types. Contains two boxes of tech slugs, 14 shells in all."
-	cost = 1700
-	contains = list(/obj/item/storage/box/techsslug,
-					/obj/item/storage/box/techsslug)
-	crate_name = "tech slug crate"

--- a/code/modules/cargo/packs/service.dm
+++ b/code/modules/cargo/packs/service.dm
@@ -159,16 +159,6 @@
 					/obj/item/reagent_containers/food/drinks/drinkingglass/shotglass)
 	crate_name = "kitchen cutlery deluxe set"
 
-/datum/supply_pack/service/replacementdb
-	name = "Replacement Defensive Bar Shotgun"
-	desc = "Someone stole the Bartender's twin-barreled possession? Give them another one at a significant markup. Comes with one unused double-barrel shotgun, shells not included. Requires bartender access to open."
-	cost = 2200
-	access = ACCESS_BAR
-	contraband = TRUE
-	contains = list(/obj/item/gun/ballistic/revolver/doublebarrel)
-	crate_name = "replacement double-barrel crate"
-	crate_type = /obj/structure/closet/crate/secure
-
 //////////////////////////////////////////////////////////////////////////////
 /////////////////////////////// Janitor //////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////

--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -95,7 +95,7 @@
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/weak
+	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 6
 	variance = 35
 
@@ -130,12 +130,17 @@
 	ENABLE_BITFIELD(reagents.reagents_holder_flags, NO_REACT)
 
 /obj/item/ammo_casing/shotgun/dart/bioterror
-	desc = "A shotgun dart filled with deadly toxins."
+	desc = "A shotgun dart filled with an obscene amount of lethal reagents. God help whoever is shot with this."
+	projectile_type = /obj/item/projectile/bullet/dart/piercing
+	reagent_amount = 50
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/toxin/fentanyl, 6)
-	reagents.add_reagent(/datum/reagent/toxin/spore, 6)
-	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6) //;HELP OPS IN MAINT
-	reagents.add_reagent(/datum/reagent/toxin/coniine, 6)
-	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 6)
+	reagents.add_reagent(/datum/reagent/toxin/amanitin, 12) //for a nasty surprise after you get shot and somehow escape and don't think to quickly purge, and even shock those who are loaded up on purging agents
+	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 6)
+	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6) //;HELPIES OPS IN MAINT
+	reagents.add_reagent(/datum/reagent/impedrezene, 6)
+	reagents.add_reagent(/datum/reagent/toxin/acid/fluacid, 5) //this and the acid equal about 25ish burn, not counting the minute toxin damage dealt by their metabolism, this makes each dart about as lethal as a stechkin shot in upfront damage
+	reagents.add_reagent(/datum/reagent/toxin/acid, 5)
+	reagents.add_reagent(/datum/reagent/consumable/frostoil, 10) //tempgun slowdown goes both ways and adds to the burn
+

--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -273,7 +273,7 @@
 	icon_state = "dshotgun"
 	item_state = "shotgun"
 	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	force = 10
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -50,7 +50,7 @@
 /obj/item/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	damage = 12.5
 
 /obj/item/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -29,6 +29,9 @@
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
 
+/obj/item/projectile/bullet/dart/piercing
+	piercing = TRUE
+
 /obj/item/projectile/bullet/dart/metalfoam/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/aluminium, 15)

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -16,15 +16,29 @@
 	damage = 5
 
 /obj/item/projectile/bullet/shotgun_stunslug
-	name = "stunslug"
+	name = "electroslug"
 	damage = 5
-	stamina = 20
-	knockdown = 100
 	stutter = 5
 	jitter = 20
 	range = 7
 	icon_state = "spark"
 	color = "#FFFF00"
+	var/tase_duration = 50
+
+/obj/item/projectile/bullet/shotgun_stunslug/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
+		do_sparks(1, TRUE, src)
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
+		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
+		C.IgniteMob()
+		if(C.dna && C.dna.check_mutation(HULK))
+			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
+		else if(tase_duration && (C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE) && !HAS_TRAIT(C, TRAIT_TASED_RESISTANCE))
+			C.electrocute_act(15, src, 1, SHOCK_NOSTUN)
+			C.apply_status_effect(STATUS_EFFECT_TASED_WEAK, tase_duration)
 
 /obj/item/projectile/bullet/shotgun_meteorslug
 	name = "meteorslug"
@@ -93,7 +107,6 @@
 
 /obj/item/projectile/bullet/scattershot
 	damage = 20
-	stamina = 65
 
 /obj/item/projectile/bullet/seed
 	damage = 4

--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -18,6 +18,7 @@
 /obj/item/projectile/bullet/shotgun_stunslug
 	name = "electroslug"
 	damage = 5
+	stamina = 30
 	stutter = 5
 	jitter = 20
 	range = 7

--- a/code/modules/uplink/uplink_items.dm
+++ b/code/modules/uplink/uplink_items.dm
@@ -65,7 +65,6 @@
 	var/refund_amount = 0 // specified refund amount in case there needs to be a TC penalty for refunds.
 	var/refundable = FALSE
 	var/surplus = 100 // Chance of being included in the surplus crate.
-	var/surplus_nullcrates //Chance of being included in null crates. null = pull from surplus
 	var/cant_discount = FALSE
 	var/limited_stock = -1 //Setting this above zero limits how many times this item can be bought by the same traitor in a round, -1 is unlimited
 	var/list/include_modes = list() // Game modes to allow this item in.
@@ -75,11 +74,6 @@
 	var/purchase_log_vis = TRUE // Visible in the purchase log?
 	var/restricted = FALSE // Adds restrictions for VR/Events
 	var/illegal_tech = TRUE // Can this item be deconstructed to unlock certain techweb research nodes?
-
-/datum/uplink_item/New()
-	. = ..()
-	if(isnull(surplus_nullcrates))
-		surplus_nullcrates = surplus
 
 /datum/uplink_item/proc/get_discount()
 	return pick(4;0.75,2;0.5,1;0.25)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Lot of stuff in a variety of areas all in one. Let's go one by one. They're all together mostly because it's related by a reasonably common factor: imbalanced bullshit or just shit that is lagging behind.

**Cargo Packs:**
**_Riot Shotgun/Shotgun Crate:_** Riot shotguns are meant to be reasonably exclusive weapons for the crew, and cargo is meant to order the more bulky though still formidable combat shotguns if they need to replace them or upgrade. Being able to purchase more is not exactly a smart idea given they fit in suit slots and are generally accepted to be among the strongest weapons in the game.

**_Double-Barreled Shotgun:_** See above, because this isn't used to replace the shotgun, it's to get more shotguns, and the double-barreled shotgun is a good fucking gun. Especially when I made it usable with a shield again. It SHOULD be exclusive.

**_Techshell Crate:_** Speeding past techwebs is not good, especially since most of the techshell ammo types are stupidly powerful for what they do.

**_Swat Tasers:_** These were the HoS' special gun but mass purchasable. Yeah, no fucking way. They are not lesser AEG's, they are literally better than the HoS' exclusive weapon and AEG's got nerfed to shit on top of this fairly recently.

**_WT550 ammo types:_** I've left rubber as purchasable but the special types now are once again techweb exclusive.

**_Traitor Objective theft Kit:_** These should never have been added. This is absurd. If you as a traitor lose your kit, eat goddamn shit and don't lose the fucking kit next time. All these crates enable is absolute horseshit like defusing nukes under nukies and removing traitor objectives before they can get to them.

**_NULL Crates:_** At worst, exponential TC for whatever antag happened to take control over cargo and also able to put into the vault 14TC worth of money and acquire all the gamer gear they'd ever want. That's assuming they don't use one of the many infinite money options cargo has as of the moment. At the very least, a walking rules violation. It's best these get axed for being the unbalanced pieces of shit they are. 

**Weapon Balance**
**_Double-Barreled/Improvised/anything that's a child of the double-barreled:_**
Has been made WEIGHT_MEDIUM to allow them once again to be used with shields and other weapons in the off-hand. This is matching with /tg/. These are fairly rare, or they are very limited in ability. I'd love to add the inaccuracy spread from sawning these weapons down as well but I think I'm going to do some backend ports in the future that will include that.

_**Bioterror Darts:**_ Now contains some actually fucking scary chems including amanitin toxin, the various acids, chloral hydrate, impedrezene, and frost oil. It also pierces now. If you get shot with this, you will probably die a horrible and painful death. Exactly as it should be. All hail chem warfare.

_**Stunslugs:**_ Rather than being old /tg/ tasers, these now cause the tase effect, no knockdown and electrocute the shit out of you. Probably better as an opener to beanbags than a complete replacement for any nonlethal ammo you'd want, or as a way to do a mixture of damage. As a reminder, stamina and lethal damage no longer stacks for any purpose.

**_Laser Scattershot:_** Good news everyone. These are literally now identical to buckshot in damage. And in addition to this, now use the scatter laser beam rather than beam/weak, which was what some laser guns were using. This means scatterlaser guns are stronger. Hooray for those I guess.

**_Mech Scattershot:_** It only does 20 brute damage, no stamina damage. Did you know these could stamcrit you at point blank? Well now they can't. They will probably nearly oneshot you still at point blank however so don't just stand near mechs, like, ever. I abused this to high hell on /tg/ until oranges caught wind of it and had someone nerf it. I felt bad about that one. It only seems fitting I be the one to axe it here.

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: A lot of unnecessary or powercreep cargo crates.
del: Removed NULL crates.
balance: Rebalanced stunslugs into electrocution slugs with mixed damage.
balance: Rebalanced scatterlaser to be equal to their buckshot counterparts. As a consequence, scatterlaser guns are cooler.
balance: Bioterror darts are now not only piercing but also contain very, very nasty reagents.
balance: Mech scattershot pellets no longer have stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
