### PR TITLE
Makes Anti-Tank Pistol and Rocket Launchers more costly

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -23,6 +23,17 @@
 	surplus = 50
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/dangerous/antitank
+	name = "Anti Tank Pistol"
+	desc = "Essentially amounting to a sniper rifle with no stock and barrel (or indeed, any rifling at all), \
+			this extremely dubious pistol is guaranteed to dislocate your wrists and hit the broad side of a barn! \
+	 		Uses sniper ammo. \
+	 		Bullets tend to veer off-course. We are not responsible for any unintentional damage or injury resulting from inaacuracy."
+	item = /obj/item/gun/ballistic/automatic/pistol/antitank/syndicate
+	cost = 20
+	surplus = 0
+	include_modes = list(/datum/game_mode/nuclear)
+
 /datum/uplink_item/dangerous/rawketlawnchair
 	name = "84mm Rocket Propelled Grenade Launcher"
 	desc = "A reusable rocket propelled grenade launcher preloaded with a low-yield 84mm HE round. \

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -28,19 +28,8 @@
 	desc = "A reusable rocket propelled grenade launcher preloaded with a low-yield 84mm HE round. \
 		Guaranteed to send your target out with a bang or your money back!"
 	item = /obj/item/gun/ballistic/rocketlauncher
-	cost = 8
+	cost = 18
 	surplus = 30
-	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/dangerous/antitank
-	name = "Anti Tank Pistol"
-	desc = "Essentially amounting to a sniper rifle with no stock and barrel (or indeed, any rifling at all), \
-			this extremely dubious pistol is guaranteed to dislocate your wrists and hit the broad side of a barn! \
-	 		Uses sniper ammo. \
-	 		Bullets tend to veer off-course. We are not responsible for any unintentional damage or injury resulting from inaacuracy."
-	item = /obj/item/gun/ballistic/automatic/pistol/antitank/syndicate
-	cost = 14
-	surplus = 25
 	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/dangerous/pie_cannon


### PR DESCRIPTION
## About The Pull Request

Rocket launchers cost 18 now and not 8
Anti-tank Pistol cost 20 from 18

## Why It's Good For The Game

Rocket Launchers are a 1 hit kill, cant be blocked and has no really counter other then `Dont get hit` and always waring a bomb proof hardsuit. They are not to to bad to flat out remove but should now have a bit more of a thought put in rather then just `Ill use this to down 12 people in sec suits`
I remember when cargo had a rocket launcher and no one liked that...

Anti-Tank Pistol has and always will be just to meme, it fits in boots for stealth ops, cheaper then a normal 50. cal, did a huge stun, uses 50. cal ammo meaning its 100% ap + 70~ damage in one shot that cant be blocked 

```
/obj/item/projectile/bullet/p50
	name =".50 bullet"
	speed = 0.4
	damage = 70
	knockdown = 100
	dismemberment = 50
	armour_penetration = 50
	zone_accuracy_factor = 100		//guarunteed 100%
	var/breakthings = TRUE

/obj/item/projectile/bullet/p50/on_hit(atom/target, blocked = 0)
	if(isobj(target) && (blocked != 100) && breakthings)
		var/obj/O = target
		O.take_damage(80, BRUTE, "bullet", FALSE)
	return ..()
```
On top of all that you can load in the sniper's other ammo to make a AP, multy hit sniper round that is just to much for any normal person to handle in a boot.

## Changelog
:cl:
balance: Rocket Launchers are now 18 tc form 8, Anti Tank Pistol is now 20 tc form 6
/:cl:
