### PR TITLE
Stunslugs rework, Mech Scattershot nerf

### DIFF
--- a/code/modules/projectiles/projectile/bullets/shotgun.dm
+++ b/code/modules/projectiles/projectile/bullets/shotgun.dm
@@ -18,13 +18,28 @@
 /obj/item/projectile/bullet/shotgun_stunslug
 	name = "stunslug"
 	damage = 5
-	stamina = 20
-	knockdown = 100
+	stamina = 30
 	stutter = 5
 	jitter = 20
 	range = 7
 	icon_state = "spark"
 	color = "#FFFF00"
+	var/tase_duration = 50
+
+/obj/item/projectile/bullet/shotgun_stunslug/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if(!ismob(target) || blocked >= 100) //Fully blocked by mob or collided with dense object - burst into sparks!
+		do_sparks(1, TRUE, src)
+	if(iscarbon(target))
+		var/mob/living/carbon/C = target
+		SEND_SIGNAL(C, COMSIG_ADD_MOOD_EVENT, "tased", /datum/mood_event/tased)
+		SEND_SIGNAL(C, COMSIG_LIVING_MINOR_SHOCK)
+		C.IgniteMob()
+		if(C.dna && C.dna.check_mutation(HULK))
+			C.say(pick(";RAAAAAAAARGH!", ";HNNNNNNNNNGGGGGGH!", ";GWAAAAAAAARRRHHH!", "NNNNNNNNGGGGGGGGHH!", ";AAAAAAARRRGH!" ), forced = "hulk")
+		else if(tase_duration && (C.status_flags & CANKNOCKDOWN) && !HAS_TRAIT(C, TRAIT_STUNIMMUNE) && !HAS_TRAIT(C, TRAIT_TASED_RESISTANCE))
+			C.electrocute_act(15, src, 1, SHOCK_NOSTUN)
+			C.apply_status_effect(STATUS_EFFECT_TASED_WEAK, tase_duration)
 
 /obj/item/projectile/bullet/shotgun_meteorslug
 	name = "meteorslug"
@@ -93,7 +108,6 @@
 
 /obj/item/projectile/bullet/scattershot
 	damage = 20
-	stamina = 65
 
 /obj/item/projectile/bullet/seed
 	damage = 4


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Stunslugs are now functionally similar to tasers, causing the victim to suffer from the tased status effect, electrocuting them for a little bit of damage and the slugs themselves have 5 brute and 30 stamina on hit. They no longer knock down and if you're a hulk or have stun immunity/taser resistance you won't suffer the ill effects of the slug besides the impact damage. This basically allows you to mix your damage up a lot while using this ammo type, doing a mixture of burn, brute, stamina and a stamina drain and slowdown. It's not quite the instant victory it was before, but it is still very nasty to be shot with.

Mech scattershot now just does 20 brute per pellet. It was very silly that it did 65 stamina damage per pellet as well as the brute damage.

## Why It's Good For The Game

I don't like oneshotting people with shotguns.

## Changelog
:cl:
tweak: Stunslugs are now a mixed damage taser-like slug that will allow you to apply a variety of damage while still being countered by tasers usual counters.
balance: Mech scattershot guns are no longer oneshotting people into stamina crit.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
