### PR TITLE
Removes Weapon/Gear bloat from cargo

### DIFF
--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -164,17 +164,6 @@
 					/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
-/datum/supply_pack/security/armory/riotshotguns
-	name = "Riot Shotgun Crate"
-	desc = "For when the greytide gets really uppity. Contains three riot shotguns, seven rubber shot and beanbag shells. Requires Armory access to open."
-	cost = 6500
-	contains = list(/obj/item/gun/ballistic/shotgun/riot,
-					/obj/item/gun/ballistic/shotgun/riot,
-					/obj/item/gun/ballistic/shotgun/riot,
-					/obj/item/storage/box/rubbershot,
-					/obj/item/storage/box/beanbag)
-	crate_name = "riot shotgun crate"
-
 /datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
@@ -216,23 +205,6 @@
 					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
 
-/datum/supply_pack/security/armory/swattasers //Lesser AEG tbh
-	name = "SWAT tactical tasers Crate"
-	desc = "Contains two tactical energy gun, these guns are able to tase, disable and lethal as well as hold a seclight. Requires Armory access to open."
-	cost = 7000
-	contains = list(/obj/item/gun/energy/e_gun/stun,
-					/obj/item/gun/energy/e_gun/stun)
-	crate_name = "swat taser crate"
-
-/datum/supply_pack/security/armory/woodstock
-	name = "WoodStock Classic Shotguns Crate"
-	desc = "Contains three rustic, pumpaction shotguns. Requires Armory access to open."
-	cost = 3000
-	contains = list(/obj/item/gun/ballistic/shotgun,
-					/obj/item/gun/ballistic/shotgun,
-					/obj/item/gun/ballistic/shotgun)
-	crate_name = "woodstock shotguns crate"
-
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Semi-Auto Rifle Crate"
 	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
@@ -259,14 +231,4 @@
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber)
-	crate_name = "auto rifle ammo crate"
-
-/datum/supply_pack/security/armory/wt550ammo_special
-	name = "WT-550 Semi-Auto SMG Special Ammo Crate"
-	desc = "Contains 2 20-round Armour Piercing and Incendiary magazines for the WT-550 Semi-Auto SMG. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
-	cost = 3000
-	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtap,
-					/obj/item/ammo_box/magazine/wt550m9/wtap,
-					/obj/item/ammo_box/magazine/wt550m9/wtic,
-					/obj/item/ammo_box/magazine/wt550m9/wtic)
 	crate_name = "auto rifle ammo crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -108,17 +108,6 @@
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "nitrile gloves crate"
 
-/datum/supply_pack/science/nuke_b_gone
-	name = "Nuke Defusal Kit"
-	desc = "Contains set of tools to defuse a nuke."
-	cost = 7500 //Useful for traitors/nukies that fucked up
-	dangerous = TRUE
-	hidden = TRUE
-	contains = list(/obj/item/nuke_core_container/nt,
-					/obj/item/screwdriver/nuke/nt,
-					/obj/item/paper/guides/nt/nuke_instructions)
-	crate_name = "safe defusal kit storage"
-
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, and timer! Warranty void if exposed to high temperatures. Requires Toxins access to open."
@@ -191,17 +180,6 @@
 	crate_name = "slime core crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
-/datum/supply_pack/science/supermater
-	name = "Supermatter Extraction Tools Crate"
-	desc = "Contains a set of tools to extract a sliver of supermatter. Consult your CE today!"
-	cost = 7500 //Useful for traitors that fucked up
-	hidden = TRUE
-	contains = list(/obj/item/nuke_core_container/supermatter,
-					/obj/item/scalpel/supermatter,
-					/obj/item/hemostat/supermatter,
-					/obj/item/paper/guides/antag/supermatter_sliver)
-	crate_name = "supermatter extraction kit crate"
-
 /datum/supply_pack/science/tablets
 	name = "Tablet Crate"
 	desc = "What's a computer? Contains five cargo tablets."
@@ -224,10 +202,3 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
-/datum/supply_pack/science/tech_slugs
-	name = "Tech Slug Ammo Shells"
-	desc = "A new type of shell that is able to be made into a few different dangerous types. Contains two boxes of tech slugs, 14 shells in all."
-	cost = 1700
-	contains = list(/obj/item/storage/box/techsslug,
-					/obj/item/storage/box/techsslug)
-	crate_name = "tech slug crate"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

**_Riot Shotgun/Shotgun Crate:_** Riot shotguns are meant to be reasonably exclusive weapons for the crew, and cargo is meant to order the more bulky though still formidable combat shotguns if they need to replace them or upgrade. Being able to purchase more is not exactly a smart idea given they fit in suit slots and are generally accepted to be among the strongest weapons in the game.

**_Double-Barreled Shotgun:_** See above, because this isn't used to replace the shotgun, it's to get more shotguns, and the double-barreled shotgun is a good fucking gun. Especially when I made it usable with a shield again. It SHOULD be exclusive.

**_Techshell Crate:_** Speeding past techwebs is not good, especially since most of the techshell ammo types are stupidly powerful for what they do.

**_Swat Tasers:_** These were the HoS' special gun but mass purchasable. Yeah, no fucking way. They are not lesser AEG's, they are literally better than the HoS' exclusive weapon and AEG's got nerfed to shit on top of this fairly recently.

**_WT550 ammo types:_** I've left rubber as purchasable but the special types now are once again techweb exclusive.

**_Traitor Objective Theft Kit:_** These should never have been added. This is absurd. If you as a traitor lose your kit, eat goddamn shit and don't lose the fucking kit next time. All these crates enable is absolute horseshit like defusing nukes under nukies and removing traitor objectives before they can get to them.

## Why It's Good For The Game

The extraction kits enabled the crew to invalidate the need for the nuke disk to even disarm the nuke. Like come the fuck on. This wasn't ever utilized by it's intended user, traitors. 

## Changelog
:cl:
del: Removed an number of cargo crate packs: Riot shotguns/standard shotguns, double barreled shotguns, techshell crate, swat tasers, WT550 types (not rubber or standard), traitor theft objective kits.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
