### PR TITLE
Double-Barreled Shotguns and their children can be used with off-hand equipment again

### DIFF
--- a/code/modules/projectiles/guns/ballistic/revolver.dm
+++ b/code/modules/projectiles/guns/ballistic/revolver.dm
@@ -273,7 +273,7 @@
 	icon_state = "dshotgun"
 	item_state = "shotgun"
 	w_class = WEIGHT_CLASS_BULKY
-	weapon_weight = WEAPON_HEAVY
+	weapon_weight = WEAPON_MEDIUM
 	force = 10
 	flags_1 = CONDUCT_1
 	slot_flags = ITEM_SLOT_BACK


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

The double-barreled shotgun and any child of the double-barreled shotgun (like improvs) have been made WEIGHT_MEDIUM to allow them once again to be used with shields and other weapons in the off-hand. This is matching with /tg/. These are fairly rare (if the pr to remove them from cargo goes through), or they are very limited in functionality to a fully fledged shotgun. I'd love to add the inaccuracy spread from sawing these weapons down as well but I think I'm going to do some backend ports in the future that will include that.

## Why It's Good For The Game

This was kind of overzealous on Google's part but with good reason. I wasn't aware until recently that you could just buy more double-barreled shotguns. That's fucking absurd so frankly don't merge this if https://github.com/Citadel-Station-13/Citadel-Station-13/pull/11673 gets closed.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Double-barreled shotguns and any child of such now can be used with off-hand equipment.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
