### PR TITLE
Scattershot Nerf, Bioterror Revival; Changes to nukies well

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -95,7 +95,7 @@
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/weak
+	projectile_type = /obj/item/projectile/beam/scatter
 	pellets = 6
 	variance = 35
 
@@ -130,12 +130,16 @@
 	ENABLE_BITFIELD(reagents.reagents_holder_flags, NO_REACT)
 
 /obj/item/ammo_casing/shotgun/dart/bioterror
-	desc = "A shotgun dart filled with deadly toxins."
+	desc = "A shotgun dart filled with an obscene amount of lethal reagents. God help whoever is shot with this."
+	projectile_type = /obj/item/projectile/bullet/dart/piercing
+	reagent_amount = 50
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/toxin/fentanyl, 6)
-	reagents.add_reagent(/datum/reagent/toxin/spore, 6)
-	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6) //;HELP OPS IN MAINT
-	reagents.add_reagent(/datum/reagent/toxin/coniine, 6)
-	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 6)
+	reagents.add_reagent(/datum/reagent/toxin/amanitin, 12) //for a nasty surprise after you get shot and somehow escape and don't think to quickly purge, and even shock those who are loaded up on purging agents
+	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 6)
+	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6) //;HELPIES OPS IN MAINT
+	reagents.add_reagent(/datum/reagent/impedrezene, 6)
+	reagents.add_reagent(/datum/reagent/toxin/acid/fluacid, 5) //this and the acid equal about 25ish burn, not counting the minute toxin damage dealt by their metabolism, this makes each dart about as lethal as a stechkin shot in upfront damage
+	reagents.add_reagent(/datum/reagent/toxin/acid, 5)
+	reagents.add_reagent(/datum/reagent/consumable/frostoil, 10) //tempgun slowdown goes both ways and adds to the burn

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -50,7 +50,7 @@
 /obj/item/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 5
+	damage = 12.5
 
 /obj/item/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -29,6 +29,9 @@
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
 
+/obj/item/projectile/bullet/dart/piercing
+	piercing = TRUE
+
 /obj/item/projectile/bullet/dart/metalfoam/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/aluminium, 15)

--- a/code/modules/uplink/uplink_items/uplink_ammo.dm
+++ b/code/modules/uplink/uplink_items/uplink_ammo.dm
@@ -56,6 +56,13 @@
 	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun
 	cost = 12
 
+/datum/uplink_item/ammo/shotgun/bioterror
+	name = "12g Bioterror Dart Drum"
+	desc = "An additional 8-round bioterror dart magazine for use with the Bulldog shotgun. \
+			Pierces armor and injects are horrid cocktail of death into your target. Be careful about friendly fire."
+	cost = 6 //legacy price
+	item = /obj/item/ammo_box/magazine/m12g/bioterror
+
 /datum/uplink_item/ammo/shotgun/buck
 	name = "12g Buckshot Drum"
 	desc = "An additional 8-round buckshot magazine for use with the Bulldog shotgun. Front towards enemy."
@@ -66,20 +73,12 @@
 	desc = "An alternative 8-round dragon's breath magazine for use in the Bulldog shotgun. \
 			'I'm a fire starter, twisted fire starter!'"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/shotgun/meteor
 	name = "12g Meteorslug Shells"
 	desc = "An alternative 8-round meteorslug magazine for use in the Bulldog shotgun. \
 			Great for blasting airlocks off their frames and knocking down enemies."
 	item = /obj/item/ammo_box/magazine/m12g/meteor
-	include_modes = list(/datum/game_mode/nuclear)
-
-/datum/uplink_item/ammo/shotgun/scatter
-	name = "12g Scatter Laser shot Slugs"
-	desc = "An alternative 8-round Scatter Laser Shot magazine for use in the Bulldog shotgun."
-	item = /obj/item/ammo_box/magazine/m12g/scatter
-	cost = 4 // most armor has less laser protection then bullet
 
 /datum/uplink_item/ammo/shotgun/slug
 	name = "12g Slug Drum"
@@ -93,7 +92,6 @@
 	desc = "An alternative 8-round stun slug magazine for use with the Bulldog shotgun. \
 			Saying that they're completely non-lethal would be lying."
 	item = /obj/item/ammo_box/magazine/m12g/stun
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Scatterlaser Shells have been nerfed from the obscene 15 shot damage it was doing per pellet to 12.5 per pellet. This is now equal to buckshot. That basically isn't much of a nerf but you know. As such, buffs scatterlaser guns as a consequence. It's better not having scatterlaser shells be at the mercy of balance for any gun using the weak laser beam. (Whatever weapons even use that variant of the laser beam anyway), and makes both the scatterlaser gun and shells functionally identical.

Don't panic, scatterlaser guns are only admin spawnable or obtainable during wizard and do only about 60 burn per shot, more or less equal to a revolver (understatement but you get my point, you have more shots than a revolver so realistically it's probably better still).

Bioterror dart syringes have had their contents massively buffed and now the syringes pierce armor. They are very, very nasty to get shot by.

Finally, I've removed scatterlaser shells from nuclear operatives and readded bioterror darts almost 5 years later! By golly. The game has changed so much overt that time that these have gone from apparently onetapping folks tp barely being able to kill you through an epipen.

Why remove scatterlaser? While ballistic/laser dichotomy is dead and buried for NT I would want to keep it for Syndicate at the very least.

Why add bioterror? Because nuclear operatives got creeped so hard over this period of time that a delayed kill is frankly a lot fairer than anything else nukies can get. At the very least, these should now be a slow, insidious killer rather than an upfront rocket tag kill shot.

## Why It's Good For The Game

Scatterlaser being buckshot+ was dumb as fuck. And nukies getting it was equally as bad.

Bioterror darts sound wacky.

## Changelog
:cl:
add: Readds bioterror darts to the nuclear operative uplink for the legacy price of 6tc! Has all new horrid reagents!
balance: Scatterlaser is now in-line with buckshot. Nukies can't purchase scatterlaser shot.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
