### PR TITLE
Sabotage objective tweaks

### DIFF
--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -77,14 +77,14 @@
 
 /datum/sabotage_objective/processing/supermatter/can_run()
 	return (locate(/obj/machinery/power/supermatter_crystal) in GLOB.machines)
-
+/*
 /datum/sabotage_objective/station_integrity
 	name = "Make sure the station is at less than 80% integrity by the end. Smash walls, windows etc. to reach this goal."
 	sabotage_type = "integrity"
 
 /datum/sabotage_objective/station_integrity/check_conditions()
 	return 5-(max(SSticker.station_integrity*4,320)/80)
-
+*/
 /datum/sabotage_objective/cloner
 	name = "Destroy all Nanotrasen cloning machines."
 	sabotage_type = "cloner"

--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -98,6 +98,9 @@
 	special_equipment = list(/obj/item/aiModule/syndicate)
 	excludefromjob = list("Chief Engineer","Research Director","Head of Personnel","Captain","Chief Medical Officer","Head Of Security")
 
+/datum/sabotage_objective/ai_law/can_run()
+	return length(active_ais())
+
 /datum/sabotage_objective/ai_law/check_conditions()
 	for (var/i in GLOB.ai_list)
 		var/mob/living/silicon/ai/aiPlayer = i


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Removes station integrity objective (for now), makes hacked AI law only work if there's an AI

## Why It's Good For The Game

One of these objectives is terribly unfair 100% of the time, the other way too often. Best to make them... not that.

## Changelog
:cl:
del: No more station integrity goal
tweak: Upload-hacked-law goal only picksif there's an AI to upload to
/:cl: