### PR TITLE
Bump up rust-g version to 0.4.3

### DIFF
--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@ export BYOND_MINOR=${LIST[1]}
 unset LIST
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.2
+export RUST_G_VERSION=0.4.4
 
 #bsql git tag
 export BSQL_VERSION=v1.4.0.0

--- a/dependencies.sh
+++ b/dependencies.sh
@@ -11,7 +11,7 @@ export BYOND_MINOR=${LIST[1]}
 unset LIST
 
 #rust_g git tag
-export RUST_G_VERSION=0.4.4
+export RUST_G_VERSION=0.4.3
 
 #bsql git tag
 export BSQL_VERSION=v1.4.0.0


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Keeping the libraries fresh. (well, 0.4.4 is probably not actually bugged, I was overreacting, tg isn't using it yet)

## Changelog
None.