### PR TITLE
Revert "Scattershot Nerf, Bioterror Revival; Changes to nukies well"

### DIFF
--- a/code/modules/projectiles/ammunition/ballistic/shotgun.dm
+++ b/code/modules/projectiles/ammunition/ballistic/shotgun.dm
@@ -95,7 +95,7 @@
 	name = "scatter laser shell"
 	desc = "An advanced shotgun shell that uses a micro laser to replicate the effects of a scatter laser weapon in a ballistic package."
 	icon_state = "lshell"
-	projectile_type = /obj/item/projectile/beam/scatter
+	projectile_type = /obj/item/projectile/beam/weak
 	pellets = 6
 	variance = 35
 
@@ -130,16 +130,12 @@
 	ENABLE_BITFIELD(reagents.reagents_holder_flags, NO_REACT)
 
 /obj/item/ammo_casing/shotgun/dart/bioterror
-	desc = "A shotgun dart filled with an obscene amount of lethal reagents. God help whoever is shot with this."
-	projectile_type = /obj/item/projectile/bullet/dart/piercing
-	reagent_amount = 50
+	desc = "A shotgun dart filled with deadly toxins."
 
 /obj/item/ammo_casing/shotgun/dart/bioterror/Initialize()
 	. = ..()
-	reagents.add_reagent(/datum/reagent/toxin/amanitin, 12) //for a nasty surprise after you get shot and somehow escape and don't think to quickly purge, and even shock those who are loaded up on purging agents
-	reagents.add_reagent(/datum/reagent/toxin/chloralhydrate, 6)
-	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6) //;HELPIES OPS IN MAINT
-	reagents.add_reagent(/datum/reagent/impedrezene, 6)
-	reagents.add_reagent(/datum/reagent/toxin/acid/fluacid, 5) //this and the acid equal about 25ish burn, not counting the minute toxin damage dealt by their metabolism, this makes each dart about as lethal as a stechkin shot in upfront damage
-	reagents.add_reagent(/datum/reagent/toxin/acid, 5)
-	reagents.add_reagent(/datum/reagent/consumable/frostoil, 10) //tempgun slowdown goes both ways and adds to the burn
+	reagents.add_reagent(/datum/reagent/toxin/fentanyl, 6)
+	reagents.add_reagent(/datum/reagent/toxin/spore, 6)
+	reagents.add_reagent(/datum/reagent/toxin/mutetoxin, 6) //;HELP OPS IN MAINT
+	reagents.add_reagent(/datum/reagent/toxin/coniine, 6)
+	reagents.add_reagent(/datum/reagent/toxin/sodium_thiopental, 6)

--- a/code/modules/projectiles/projectile/beams.dm
+++ b/code/modules/projectiles/projectile/beams.dm
@@ -50,7 +50,7 @@
 /obj/item/projectile/beam/scatter
 	name = "laser pellet"
 	icon_state = "scatterlaser"
-	damage = 12.5
+	damage = 5
 
 /obj/item/projectile/beam/xray
 	name = "\improper X-ray beam"

--- a/code/modules/projectiles/projectile/bullets/dart_syringe.dm
+++ b/code/modules/projectiles/projectile/bullets/dart_syringe.dm
@@ -29,9 +29,6 @@
 	reagents.handle_reactions()
 	return BULLET_ACT_HIT
 
-/obj/item/projectile/bullet/dart/piercing
-	piercing = TRUE
-
 /obj/item/projectile/bullet/dart/metalfoam/Initialize()
 	. = ..()
 	reagents.add_reagent(/datum/reagent/aluminium, 15)

--- a/code/modules/uplink/uplink_items/uplink_ammo.dm
+++ b/code/modules/uplink/uplink_items/uplink_ammo.dm
@@ -66,14 +66,12 @@
 	desc = "An alternative 8-round dragon's breath magazine for use in the Bulldog shotgun. \
 			'I'm a fire starter, twisted fire starter!'"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/shotgun/meteor
 	name = "12g Meteorslug Shells"
 	desc = "An alternative 8-round meteorslug magazine for use in the Bulldog shotgun. \
 			Great for blasting airlocks off their frames and knocking down enemies."
 	item = /obj/item/ammo_box/magazine/m12g/meteor
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/shotgun/scatter
 	name = "12g Scatter Laser shot Slugs"
@@ -93,7 +91,6 @@
 	desc = "An alternative 8-round stun slug magazine for use with the Bulldog shotgun. \
 			Saying that they're completely non-lethal would be lying."
 	item = /obj/item/ammo_box/magazine/m12g/stun
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"
@@ -122,7 +119,6 @@
 	desc = "A duffel bag filled with enough .45 ammo to supply an entire team, at a discounted price."
 	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/smg
 	cost = 20 //instead of 27 TC
-	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/smg
 	name = ".45 SMG Magazine"

--- a/code/modules/uplink/uplink_items/uplink_ammo.dm
+++ b/code/modules/uplink/uplink_items/uplink_ammo.dm
@@ -56,13 +56,6 @@
 	item = /obj/item/storage/backpack/duffelbag/syndie/ammo/shotgun
 	cost = 12
 
-/datum/uplink_item/ammo/shotgun/bioterror
-	name = "12g Bioterror Dart Drum"
-	desc = "An additional 8-round bioterror dart magazine for use with the Bulldog shotgun. \
-			Pierces armor and injects are horrid cocktail of death into your target. Be careful about friendly fire."
-	cost = 6 //legacy price
-	item = /obj/item/ammo_box/magazine/m12g/bioterror
-
 /datum/uplink_item/ammo/shotgun/buck
 	name = "12g Buckshot Drum"
 	desc = "An additional 8-round buckshot magazine for use with the Bulldog shotgun. Front towards enemy."
@@ -73,12 +66,20 @@
 	desc = "An alternative 8-round dragon's breath magazine for use in the Bulldog shotgun. \
 			'I'm a fire starter, twisted fire starter!'"
 	item = /obj/item/ammo_box/magazine/m12g/dragon
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/shotgun/meteor
 	name = "12g Meteorslug Shells"
 	desc = "An alternative 8-round meteorslug magazine for use in the Bulldog shotgun. \
 			Great for blasting airlocks off their frames and knocking down enemies."
 	item = /obj/item/ammo_box/magazine/m12g/meteor
+	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/shotgun/scatter
+	name = "12g Scatter Laser shot Slugs"
+	desc = "An alternative 8-round Scatter Laser Shot magazine for use in the Bulldog shotgun."
+	item = /obj/item/ammo_box/magazine/m12g/scatter
+	cost = 4 // most armor has less laser protection then bullet
 
 /datum/uplink_item/ammo/shotgun/slug
 	name = "12g Slug Drum"
@@ -92,6 +93,7 @@
 	desc = "An alternative 8-round stun slug magazine for use with the Bulldog shotgun. \
 			Saying that they're completely non-lethal would be lying."
 	item = /obj/item/ammo_box/magazine/m12g/stun
+	include_modes = list(/datum/game_mode/nuclear)
 
 /datum/uplink_item/ammo/revolver
 	name = ".357 Speed Loader"


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#11675

## About this Pull Request 

Removes the chem warfar from nukies, as kev stated

> bioterror - i hate chemical warfare how expensive is this because one hit is uh, a really really powerful thing, especially if it's to the point where anti toxins can't fix you. you are certain this will not be an issue?
> laser scattershells - subtype the scatter pellets if only because we still have missions and stuff that use this and i wouldn't want people to suddenly get it. even though adminspawn stuff has always been unbalanced i'd rather the scatterlaser gun thing be usable from the get-go instead of being one-hits due to your changes

## Why is this good for the game

Removes chem based warfair and buffs to scatter shot

Changelog
:cl: Reverts
balance: Rebalanced scatterlaser to be equal to their buckshot counterparts. As a consequence, scatterlaser guns are cooler.
balance: Bioterror darts are now not only piercing but also contain very, very nasty reagents.
/:cl: