### PR TITLE
Revert Removal of riot shotguns in the PR of "Removes Weapon/Gear bloat from cargo"

### DIFF
--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -216,23 +216,6 @@
 					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
 
-/datum/supply_pack/security/armory/swattasers //Lesser AEG tbh
-	name = "SWAT tactical tasers Crate"
-	desc = "Contains two tactical energy gun, these guns are able to tase, disable and lethal as well as hold a seclight. Requires Armory access to open."
-	cost = 7000
-	contains = list(/obj/item/gun/energy/e_gun/stun,
-					/obj/item/gun/energy/e_gun/stun)
-	crate_name = "swat taser crate"
-
-/datum/supply_pack/security/armory/woodstock
-	name = "WoodStock Classic Shotguns Crate"
-	desc = "Contains three rustic, pumpaction shotguns. Requires Armory access to open."
-	cost = 3000
-	contains = list(/obj/item/gun/ballistic/shotgun,
-					/obj/item/gun/ballistic/shotgun,
-					/obj/item/gun/ballistic/shotgun)
-	crate_name = "woodstock shotguns crate"
-
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Semi-Auto Rifle Crate"
 	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
@@ -259,14 +242,4 @@
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber)
-	crate_name = "auto rifle ammo crate"
-
-/datum/supply_pack/security/armory/wt550ammo_special
-	name = "WT-550 Semi-Auto SMG Special Ammo Crate"
-	desc = "Contains 2 20-round Armour Piercing and Incendiary magazines for the WT-550 Semi-Auto SMG. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
-	cost = 3000
-	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtap,
-					/obj/item/ammo_box/magazine/wt550m9/wtap,
-					/obj/item/ammo_box/magazine/wt550m9/wtic,
-					/obj/item/ammo_box/magazine/wt550m9/wtic)
 	crate_name = "auto rifle ammo crate"

--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -167,7 +167,7 @@
 /datum/supply_pack/security/armory/riotshotguns
 	name = "Riot Shotgun Crate"
 	desc = "For when the greytide gets really uppity. Contains three riot shotguns, seven rubber shot and beanbag shells. Requires Armory access to open."
-	cost = 6500
+	cost = 8000
 	contains = list(/obj/item/gun/ballistic/shotgun/riot,
 					/obj/item/gun/ballistic/shotgun/riot,
 					/obj/item/gun/ballistic/shotgun/riot,

--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -164,6 +164,17 @@
 					/obj/item/shield/riot)
 	crate_name = "riot shields crate"
 
+/datum/supply_pack/security/armory/riotshotguns
+	name = "Riot Shotgun Crate"
+	desc = "For when the greytide gets really uppity. Contains three riot shotguns, seven rubber shot and beanbag shells. Requires Armory access to open."
+	cost = 6500
+	contains = list(/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/gun/ballistic/shotgun/riot,
+					/obj/item/storage/box/rubbershot,
+					/obj/item/storage/box/beanbag)
+	crate_name = "riot shotgun crate"
+
 /datum/supply_pack/security/armory/russian
 	name = "Russian Surplus Crate"
 	desc = "Hello Comrade, we have the most modern russian military equipment the black market can offer, for the right price of course. Sadly we couldnt remove the lock so it requires Armory access to open."
@@ -205,6 +216,23 @@
 					/obj/item/clothing/gloves/combat)
 	crate_name = "swat crate"
 
+/datum/supply_pack/security/armory/swattasers //Lesser AEG tbh
+	name = "SWAT tactical tasers Crate"
+	desc = "Contains two tactical energy gun, these guns are able to tase, disable and lethal as well as hold a seclight. Requires Armory access to open."
+	cost = 7000
+	contains = list(/obj/item/gun/energy/e_gun/stun,
+					/obj/item/gun/energy/e_gun/stun)
+	crate_name = "swat taser crate"
+
+/datum/supply_pack/security/armory/woodstock
+	name = "WoodStock Classic Shotguns Crate"
+	desc = "Contains three rustic, pumpaction shotguns. Requires Armory access to open."
+	cost = 3000
+	contains = list(/obj/item/gun/ballistic/shotgun,
+					/obj/item/gun/ballistic/shotgun,
+					/obj/item/gun/ballistic/shotgun)
+	crate_name = "woodstock shotguns crate"
+
 /datum/supply_pack/security/armory/wt550
 	name = "WT-550 Semi-Auto Rifle Crate"
 	desc = "Contains two high-powered, semiautomatic rifles chambered in 4.6x30mm. Requires Armory access to open."
@@ -231,4 +259,14 @@
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber,
 					/obj/item/ammo_box/magazine/wt550m9/wtrubber)
+	crate_name = "auto rifle ammo crate"
+
+/datum/supply_pack/security/armory/wt550ammo_special
+	name = "WT-550 Semi-Auto SMG Special Ammo Crate"
+	desc = "Contains 2 20-round Armour Piercing and Incendiary magazines for the WT-550 Semi-Auto SMG. Each magazine is designed to facilitate rapid tactical reloads. Requires Armory access to open."
+	cost = 3000
+	contains = list(/obj/item/ammo_box/magazine/wt550m9/wtap,
+					/obj/item/ammo_box/magazine/wt550m9/wtap,
+					/obj/item/ammo_box/magazine/wt550m9/wtic,
+					/obj/item/ammo_box/magazine/wt550m9/wtic)
 	crate_name = "auto rifle ammo crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -201,11 +201,3 @@
 	crate_name = "tank transfer valves crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
-
-/datum/supply_pack/science/tech_slugs
-	name = "Tech Slug Ammo Shells"
-	desc = "A new type of shell that is able to be made into a few different dangerous types. Contains two boxes of tech slugs, 14 shells in all."
-	cost = 1700
-	contains = list(/obj/item/storage/box/techsslug,
-					/obj/item/storage/box/techsslug)
-	crate_name = "tech slug crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -108,6 +108,17 @@
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "nitrile gloves crate"
 
+/datum/supply_pack/science/nuke_b_gone
+	name = "Nuke Defusal Kit"
+	desc = "Contains set of tools to defuse a nuke."
+	cost = 7500 //Useful for traitors/nukies that fucked up
+	dangerous = TRUE
+	hidden = TRUE
+	contains = list(/obj/item/nuke_core_container/nt,
+					/obj/item/screwdriver/nuke/nt,
+					/obj/item/paper/guides/nt/nuke_instructions)
+	crate_name = "safe defusal kit storage"
+
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, and timer! Warranty void if exposed to high temperatures. Requires Toxins access to open."
@@ -180,6 +191,17 @@
 	crate_name = "slime core crate"
 	crate_type = /obj/structure/closet/crate/secure/science
 
+/datum/supply_pack/science/supermater
+	name = "Supermatter Extraction Tools Crate"
+	desc = "Contains a set of tools to extract a sliver of supermatter. Consult your CE today!"
+	cost = 7500 //Useful for traitors that fucked up
+	hidden = TRUE
+	contains = list(/obj/item/nuke_core_container/supermatter,
+					/obj/item/scalpel/supermatter,
+					/obj/item/hemostat/supermatter,
+					/obj/item/paper/guides/antag/supermatter_sliver)
+	crate_name = "supermatter extraction kit crate"
+
 /datum/supply_pack/science/tablets
 	name = "Tablet Crate"
 	desc = "What's a computer? Contains five cargo tablets."
@@ -202,3 +224,10 @@
 	crate_type = /obj/structure/closet/crate/secure/science
 	dangerous = TRUE
 
+/datum/supply_pack/science/tech_slugs
+	name = "Tech Slug Ammo Shells"
+	desc = "A new type of shell that is able to be made into a few different dangerous types. Contains two boxes of tech slugs, 14 shells in all."
+	cost = 1700
+	contains = list(/obj/item/storage/box/techsslug,
+					/obj/item/storage/box/techsslug)
+	crate_name = "tech slug crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -108,17 +108,6 @@
 					/obj/item/clothing/gloves/color/latex/nitrile)
 	crate_name = "nitrile gloves crate"
 
-/datum/supply_pack/science/nuke_b_gone
-	name = "Nuke Defusal Kit"
-	desc = "Contains set of tools to defuse a nuke."
-	cost = 7500 //Useful for traitors/nukies that fucked up
-	dangerous = TRUE
-	hidden = TRUE
-	contains = list(/obj/item/nuke_core_container/nt,
-					/obj/item/screwdriver/nuke/nt,
-					/obj/item/paper/guides/nt/nuke_instructions)
-	crate_name = "safe defusal kit storage"
-
 /datum/supply_pack/science/plasma
 	name = "Plasma Assembly Crate"
 	desc = "Everything you need to burn something to the ground, this contains three plasma assembly sets. Each set contains a plasma tank, igniter, proximity sensor, and timer! Warranty void if exposed to high temperatures. Requires Toxins access to open."
@@ -190,17 +179,6 @@
 	contains = list(/obj/item/slime_extract/grey)
 	crate_name = "slime core crate"
 	crate_type = /obj/structure/closet/crate/secure/science
-
-/datum/supply_pack/science/supermater
-	name = "Supermatter Extraction Tools Crate"
-	desc = "Contains a set of tools to extract a sliver of supermatter. Consult your CE today!"
-	cost = 7500 //Useful for traitors that fucked up
-	hidden = TRUE
-	contains = list(/obj/item/nuke_core_container/supermatter,
-					/obj/item/scalpel/supermatter,
-					/obj/item/hemostat/supermatter,
-					/obj/item/paper/guides/antag/supermatter_sliver)
-	crate_name = "supermatter extraction kit crate"
 
 /datum/supply_pack/science/tablets
 	name = "Tablet Crate"


### PR DESCRIPTION
Reverts Citadel-Station-13/Citadel-Station-13#11673
## About this pull request 
As kev stated with the shotgun cargo packet,
> riot shotguns - i feel like a staple of the station's armory should be purchasable, maybe it should be a bit costlier for the fact that it can be carried it guess instead of strictly more economical than combat shotguns in 90% of situations.

## Why is this good for the game

As stated by Kev its a stable of the station's armory, as well as being costly, almost half of what combat shotguns cost*
This was really not a good reason for this one to be removed other then `Shotgun is meta remove meta`

Changelog
🆑 Reverts
del: Removed the cargo crate packs Riot shotguns
/🆑