### PR TITLE
Bots can no longer be candidates for sentience events

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -31,7 +31,7 @@
 	var/list/potential = list()
 	for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
 		var/turf/T = get_turf(L)
-		if(!T || !is_station_level(T.z))
+		if(!T || !is_station_level(T.z) || isbot(L))
 			continue
 		if(!(L in GLOB.player_list) && !L.mind)
 			potential += L


### PR DESCRIPTION
## About The Pull Request

see title

## Why It's Good For The Game

sentient ed-209s are horrifying and i hate how much it upsets balance

## Changelog
:cl:Kraso
balance: Bots can no longer be sentience event targets. Sorry, Beepsky mains.
/:cl:
