### PR TITLE
probably stops borgs from clicking fast enough to circumvent low health module failures

### DIFF
--- a/code/modules/mob/living/silicon/robot/inventory.dm
+++ b/code/modules/mob/living/silicon/robot/inventory.dm
@@ -70,15 +70,15 @@
 	if(activated(O))
 		to_chat(src, "<span class='warning'>That module is already activated.</span>")
 		return
-	if(!held_items[1])
+	if(!held_items[1] && health >= -maxHealth*0.5)
 		held_items[1] = O
 		O.screen_loc = inv1.screen_loc
 		. = TRUE
-	else if(!held_items[2])
+	else if(!held_items[2] && health >= 0)
 		held_items[2] = O
 		O.screen_loc = inv2.screen_loc
 		. = TRUE
-	else if(!held_items[3])
+	else if(!held_items[3] && health >= maxHealth*0.5)
 		held_items[3] = O
 		O.screen_loc = inv3.screen_loc
 		. = TRUE


### PR DESCRIPTION
## About The Pull Request

title

also this is a webedit so someone should look over this since I spent very little time on it

## Why It's Good For The Game

borgs being able to click fast and launch syndie grenades when they're damaged is bad

## Changelog
:cl:
fix: borgs being able to select and use a module when it's too damaged
/:cl: