### PR TITLE
Massive megafauna buff.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
+++ b/code/modules/mob/living/simple_animal/hostile/megafauna/megafauna.dm
@@ -26,7 +26,6 @@
 	pull_force = MOVE_FORCE_OVERPOWERING
 	mob_size = MOB_SIZE_LARGE
 	layer = LARGE_MOB_LAYER //Looks weird with them slipping under mineral walls and cameras and shit otherwise
-	mouse_opacity = MOUSE_OPACITY_OPAQUE // Easier to click on in melee, they're giant targets anyway
 	flags_1 = PREVENT_CONTENTS_EXPLOSION_1 | HEAR_1
 	var/list/crusher_loot
 	var/medal_type


### PR DESCRIPTION
## About The Pull Request
How the heck do you even miss if their hitbox is many times bigger than your generic spessman's? They have density, projectiles won't skip them.

## Why It's Good For The Game
For the rare ocasion you may actually have to click something underneath the megafauna's dang big sprite box.

## Changelog
:cl:
tweak: The megafauna's hitbox doesn't include 0 alpha sections anymore.
/:cl:
