### PR TITLE
Minesweeper armageddon improvements

### DIFF
--- a/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/code/game/machinery/computer/arcade/minesweeper.dm
@@ -382,7 +382,10 @@
 	for(var/y69 in y-row_limit to y+row_limit)	//Create a shitton of explosions in irl turfs if we lose, it will probably kill us
 		for(var/x69 in x-column_limit to x+column_limit)
 			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
-				addtimer(CALLBACK(GLOBAL_PROC, /proc/explosion, locate(y69,x69,z), 0, rand(1,2),rand(1,5),rand(3,10), FALSE), 10 * ++num_explosions)
+				var/turf/target = locate(y69,x69,z)
+				if(!target)
+					continue
+				addtimer(CALLBACK(GLOBAL_PROC, /proc/explosion, target, 0, rand(1,2),rand(1,5),rand(3,10), FALSE), 10 * ++num_explosions)
 				if(num_explosions == mine_limit_v2)
 					return
 

--- a/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/code/game/machinery/computer/arcade/minesweeper.dm
@@ -159,6 +159,8 @@
 										if(CHECK_BITFIELD(obj_flags, EMAGGED) && !exploding_hell)
 											exploding_hell  = TRUE
 											explode_EVERYTHING()
+											if(QDELETED(src))
+												return
 										if(mine_sound)
 											switch(rand(1,3))	//Play every time a mine is hit
 												if(1)
@@ -367,10 +369,10 @@
 	var/row_limit = rows-1
 	var/column_limit = columns-1
 	var/mine_limit_v2 = mine_limit
-	if(rows > 11)
-		row_limit = 10
-	if(columns > 11)
-		column_limit = 10
+	if(rows > 21)
+		row_limit = 20
+	if(columns > 21)
+		column_limit = 20
 	if(mine_limit > (rows*columns) * 0.25)
 		mine_limit_v2 = 24
 	message_admins("[key_name_admin(user)] failed an emagged Minesweeper arcade and has unleashed an explosion armageddon of size [row_limit],[column_limit] around [ADMIN_LOOKUPFLW(user.loc)]!")
@@ -378,16 +380,27 @@
 		explosion(loc, 2, 5, 10, 15)	//Thought you could survive by putting as few mines as possible, huh??
 	else
 		explosion(loc, 1, 3, rand(1,5), rand(1,10))
-	var/num_explosions = 0
-	for(var/y69 in y-row_limit to y+row_limit)	//Create a shitton of explosions in irl turfs if we lose, it will probably kill us
-		for(var/x69 in x-column_limit to x+column_limit)
-			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
-				var/turf/target = locate(y69,x69,z)
+	var/list/targets = list()
+	var/cur_y = y - round(row_limit * 0.5, 1)
+	var/start_x = x - round(column_limit * 0.5, 1)
+	for(var/row in table) //translate the mines locations into actual turf coordinates.
+		if(!locate(cur_y, start_x, z))
+			continue
+		var/cur_x = start_x
+		for(var/column in row)
+			var/coord_value = table[row][column]
+			if(coord_value == 10 || coord_value == 0) //there is a mine in here.
+				var/turf/target = locate(cur_y, cur_x, z)
 				if(!target)
 					continue
-				addtimer(CALLBACK(GLOBAL_PROC, /proc/explosion, target, 0, rand(1,2),rand(1,5),rand(3,10), FALSE), 10 * ++num_explosions)
-				if(num_explosions == mine_limit_v2)
-					return
+				targets += target
+			cur_x++
+		cur_y++
+	var/num_explosions = 0
+	for(var/T in shuffle(targets)) //Create a shitton of explosions in irl turfs if we lose, it will probably kill us
+		addtimer(CALLBACK(GLOBAL_PROC, /proc/explosion, T, 0, rand(1,2),rand(1,5),rand(3,10), FALSE), 15 * ++num_explosions)
+		if(num_explosions == mine_limit_v2)
+			return
 
 #undef MINESWEEPERIMG
 #undef MINESWEEPER_GAME_MAIN_MENU

--- a/code/game/machinery/computer/arcade/minesweeper.dm
+++ b/code/game/machinery/computer/arcade/minesweeper.dm
@@ -378,12 +378,13 @@
 		explosion(loc, 2, 5, 10, 15)	//Thought you could survive by putting as few mines as possible, huh??
 	else
 		explosion(loc, 1, 3, rand(1,5), rand(1,10))
-	for(var/y69=y-row_limit;y69<y+row_limit;y69++)	//Create a shitton of explosions in irl turfs if we lose, it will probably kill us
-		for(var/x69=x-column_limit;x69<x+column_limit;x69++)
+	var/num_explosions = 0
+	for(var/y69 in y-row_limit to y+row_limit)	//Create a shitton of explosions in irl turfs if we lose, it will probably kill us
+		for(var/x69 in x-column_limit to x+column_limit)
 			if(prob(mine_limit_v2))	//Probability of explosion happening, according to how many mines were on the board... up to a limit
-				var/explosionloc
-				explosionloc = locate(y69,x69,z)
-				explosion(explosionloc, 0, rand(1,2),rand(1,5),rand(3,10), adminlog = FALSE)
+				addtimer(CALLBACK(GLOBAL_PROC, /proc/explosion, locate(y69,x69,z), 0, rand(1,2),rand(1,5),rand(3,10), FALSE), 10 * ++num_explosions)
+				if(num_explosions == mine_limit_v2)
+					return
 
 #undef MINESWEEPERIMG
 #undef MINESWEEPER_GAME_MAIN_MENU

--- a/code/modules/research/designs/machine_desings/machine_designs_all_misc.dm
+++ b/code/modules/research/designs/machine_desings/machine_designs_all_misc.dm
@@ -45,7 +45,7 @@
 
 /datum/design/board/vendor
 	name = "Machine Design (Vendor Board)"
-	desc = "The circuit board for a Vendor."
+	desc = "The circuit board for a Vendor. Use a screwdriver to turn the \"brand selection\" dial."
 	id = "vendor"
 	build_path = /obj/item/circuitboard/machine/vendor
 	category = list ("Misc. Machinery")

--- a/code/modules/research/techweb/all_nodes.dm
+++ b/code/modules/research/techweb/all_nodes.dm
@@ -237,7 +237,7 @@
 	display_name = "Games and Toys"
 	description = "For the slackers on the station."
 	prereq_ids = list("comptech")
-	design_ids = list("arcade_battle", "arcade_orion", "slotmachine", "autoylathe")
+	design_ids = list("arcade_battle", "arcade_orion", "arcade_minesweeper", "slotmachine", "autoylathe")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 1000)
 
 /////////////////////////Bluespace tech/////////////////////////


### PR DESCRIPTION
## About The Pull Request
The (obviously emagged) minesweeper armageddon shouldn't set off dozens explosions all at once anymore, and also actually translates the mines locations on the board into actual turf coordinates to bomb, instead of using cheap probabilities.

Extras: Including the board design in the arcade tech node and adding some extra infos to the generic vendor board design.


## Why It's Good For The Game
See above.

## Changelog
:cl:
add: Minesweeper armageddon improvements.
fix: Actually added the minesweeper design to the arcade tech node.
/:cl:
