### PR TITLE
Punches land with the same consistency across races, punches cheaper, king hits are nastier

### DIFF
--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1477,6 +1477,8 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		user.adjustStaminaLossBuffered(5) //CITADEL CHANGE - makes punching cause staminaloss
 
 		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
+		var/puncherstam = user.getStaminaLoss()
+		var/puncherbrute = user.getBruteLoss()
 
 		//CITADEL CHANGES - makes resting and disabled combat mode reduce punch damage, makes being out of combat mode result in you taking more damage
 		if(!(target.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE) && damage < user.dna.species.punchstunthreshold)
@@ -1494,7 +1496,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			if(atk_verb == ATTACK_EFFECT_KICK) //kicks never miss (provided your species deals more than 0 damage)
 				miss_chance = 0
 			else
-				miss_chance = min((user.dna.species.punchdamagehigh/user.dna.species.punchdamagelow) + user.getStaminaLoss() + (user.getBruteLoss()*0.5), 100) //old base chance for a miss + various damage. capped at 100 to prevent weirdness in prob()
+				miss_chance = min(puncherstam + (puncherbrute*0.5), 100) //probability of miss based on stamina + half of brute. capped at 100 to prevent weirdness in prob()
 
 		if(!damage || !affecting || prob(miss_chance))//future-proofing for species that have 0 damage/weird cases where no zone is targeted
 			playsound(target.loc, user.dna.species.miss_sound, 25, TRUE, -1)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1474,7 +1474,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			else
 				user.do_attack_animation(target, ATTACK_EFFECT_PUNCH)
 
-		user.adjustStaminaLossBuffered(5) //CITADEL CHANGE - makes punching cause staminaloss
+		user.adjustStaminaLossBuffered(3.5) //CITADEL CHANGE - makes punching cause staminaloss
 
 		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 		var/puncherstam = user.getStaminaLoss()
@@ -1483,8 +1483,8 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		var/punchedbrute = target.getBruteLoss()
 
 		//CITADEL CHANGES - makes resting and disabled combat mode reduce punch damage, makes being out of combat mode result in you taking more damage
-		if(!(target.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE) && damage < user.dna.species.punchstunthreshold)
-			damage = user.dna.species.punchstunthreshold - 1
+		if(!(target.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE))
+			damage *= 1.5
 		if(!CHECK_MOBILITY(user, MOBILITY_STAND))
 			damage *= 0.5
 		if(!(user.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE))
@@ -1498,7 +1498,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			if(atk_verb == ATTACK_EFFECT_KICK) //kicks never miss (provided your species deals more than 0 damage)
 				miss_chance = 0
 			else
-				miss_chance = min(clamp(((puncherstam + puncherbrute)*0.5) - ((punchedstam + punchedbrute)*0.5), 0, 100)) //probability of miss based on half your stamina and brute total against half their stamina and brute total. Capped at max 100 and min 0 to prevent weirdness in prob()
+				miss_chance = min(10 + ((puncherstam + puncherbrute)*0.5), 100) //probability of miss has a base of 10, and modified based on half your stamina and brute total. Capped at max 100 and min 0 to prevent weirdness in prob()
 
 		if(!damage || !affecting || prob(miss_chance))//future-proofing for species that have 0 damage/weird cases where no zone is targeted
 			playsound(target.loc, user.dna.species.miss_sound, 25, TRUE, -1)
@@ -1536,7 +1536,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
 							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 			to_chat(user, "<span class='danger'>You knock [target] down!</span>")
-			var/knockdown_duration = 40 + (target.getStaminaLoss() + (target.getBruteLoss()*0.5))*0.8 - armor_block
+			var/knockdown_duration = 40 + (punchedstam + (punchedbrute*0.5))*0.8 - armor_block
 			target.DefaultCombatKnockdown(knockdown_duration)
 			target.forcesay(GLOB.hit_appends)
 			log_combat(user, target, "got a stun punch with their previous punch")

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1533,13 +1533,14 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			log_combat(user, target, "punched")
 
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
-							"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
-			to_chat(user, "<span class='danger'>You knock [target] down!</span>")
-			var/knockdown_duration = 40 + (punchedstam + (punchedbrute*0.5))*0.8 - armor_block
-			target.DefaultCombatKnockdown(knockdown_duration)
-			target.forcesay(GLOB.hit_appends)
-			log_combat(user, target, "got a stun punch with their previous punch")
+			if((punchedstam > 50) && prob(punchedstam*0.5)) \\If our punch victim has been hit above the threshold, and they have more than 50 stamina damage, roll for stun, probability of 1% per 2 stamina damage
+				target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
+								"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
+				to_chat(user, "<span class='danger'>You knock [target] down!</span>")
+				var/knockdown_duration = 40 + (punchedstam + (punchedbrute*0.5))*0.8 - armor_block
+				target.DefaultCombatKnockdown(knockdown_duration)
+				target.forcesay(GLOB.hit_appends)
+				log_combat(user, target, "got a stun punch with their previous punch")
 		else if(!(target.mobility_flags & MOBILITY_STAND))
 			target.forcesay(GLOB.hit_appends)
 

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1479,6 +1479,8 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		var/damage = rand(user.dna.species.punchdamagelow, user.dna.species.punchdamagehigh)
 		var/puncherstam = user.getStaminaLoss()
 		var/puncherbrute = user.getBruteLoss()
+		var/punchedstam = target.getStaminaLoss()
+		var/punchedbrute = target.getBruteLoss()
 
 		//CITADEL CHANGES - makes resting and disabled combat mode reduce punch damage, makes being out of combat mode result in you taking more damage
 		if(!(target.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE) && damage < user.dna.species.punchstunthreshold)
@@ -1496,7 +1498,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			if(atk_verb == ATTACK_EFFECT_KICK) //kicks never miss (provided your species deals more than 0 damage)
 				miss_chance = 0
 			else
-				miss_chance = min(puncherstam + (puncherbrute*0.5), 100) //probability of miss based on stamina + half of brute. capped at 100 to prevent weirdness in prob()
+				miss_chance = min(clamp(((puncherstam + puncherbrute)*0.5) - ((punchedstam + punchedbrute)*0.5), 0, 100)) //probability of miss based on half your stamina and brute total against half their stamina and brute total. Capped at max 100 and min 0 to prevent weirdness in prob()
 
 		if(!damage || !affecting || prob(miss_chance))//future-proofing for species that have 0 damage/weird cases where no zone is targeted
 			playsound(target.loc, user.dna.species.miss_sound, 25, TRUE, -1)

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1533,7 +1533,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			log_combat(user, target, "punched")
 
 		if((target.stat != DEAD) && damage >= user.dna.species.punchstunthreshold)
-			if((punchedstam > 50) && prob(punchedstam*0.5)) \\If our punch victim has been hit above the threshold, and they have more than 50 stamina damage, roll for stun, probability of 1% per 2 stamina damage
+			if((punchedstam > 50) && prob(punchedstam*0.5)) //If our punch victim has been hit above the threshold, and they have more than 50 stamina damage, roll for stun, probability of 1% per 2 stamina damage
 				target.visible_message("<span class='danger'>[user] knocks [target] down!</span>", \
 								"<span class='userdanger'>You're knocked down by [user]!</span>", "<span class='hear'>You hear aggressive shuffling followed by a loud thud!</span>", COMBAT_MESSAGE_RANGE, user)
 				to_chat(user, "<span class='danger'>You knock [target] down!</span>")


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

~~This probably was because of combat mode code fucking this over. I have no idea why it was affecting xenos of all things because this was exclusively human species shit but I guess it's fine now.~~

This has gone from a fix to a rebalance because god it was really just punching being dumb on citadel due to stamina combat.

Now your miss chance is a calculation of 10+half your stamina and brute combined. You only roll for a miss if you roll your punchdamagelow. This is a really dumb way to get miss chance because it has to fucking roll twice basically but whatever.

The reason this is now consistent is because you literally have an obscenely large variance on punch values on most species. This should now be fixed by using 10 as the base, so now everyone is equal to a human on base punch chance.

In addition, punches cost 3.5 stamina per punch. This is the same value used for Gloves of the North Star's stamina heal. Which means they can punch infinitely. I don't think martial artists are using standard punch stamina costs anyway so this is almost certainly not going to affect glove scarpies, who may actually be right now capable of regenerating stamina through punching. Iunno. That's silly. 

But this really only affects everyone who isn't a martial artist basically.

In addition to all this, punching someone outside of combat mode is a 1.5x multiplier to your damage. Why? Because having a higher punch stun threshold is usually only something that humans have and they benefit from, but races with low stun thresholds will end up only getting marginal benefit from this. Now everyone benefits, but it ends up being a lot swingier on damage. 1.5 times 1 is still only 1.5. (Also meant you couldn't miss before)

**Edit:** And because of this modifier, a stun punch is now impossible before your target has already taken 50 stamina damage and is rolled based on a percentage of your stamina. Or else king hitting someone while they're out of combat mode is an almost certain knockdown and that's dumb as fuck. But this means you are more likely to be floored at higher stamina loss. Sprinting while in a boxing match is probably a bad idea.

## Why It's Good For The Game

~~I wanna punch shit.~~

I not only want to punch shit, I want to fucking redo all this fucking punching balance, starting with skooma and it's power to oneshot you because boy I was super fucking kind to it when I did the port and now I've gotta come back and end it once and for all.

Also why was a welder using less stamina than a punch but three times the damage and printed from an autolathe?

## Changelog
:cl:
balance: Punching should now be considerably more consistent across species.
balance: Punching is cheaper on stamina use.
balance: Punching someone out of combat mode now multiplies the damage by x1.5, just like hitting them with a blunt object!
balance: Stun punches are only possible if your target has suffered more than 50 stamina damage, with a higher probability at higher stamina damage.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
