### PR TITLE
Glitter-B-Gone. Removes Glitter from Arcades.

### DIFF
--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -56,11 +56,11 @@
 		/obj/item/stack/tile/fakepit/loaded = ARCADE_WEIGHT_TRICK,
 		/obj/item/restraints/handcuffs/fake = ARCADE_WEIGHT_TRICK,
 		/obj/item/clothing/gloves/rapid/hug = ARCADE_WEIGHT_TRICK,
-
+/*
 		/obj/item/grenade/chem_grenade/glitter/pink = ARCADE_WEIGHT_TRICK,
 		/obj/item/grenade/chem_grenade/glitter/blue = ARCADE_WEIGHT_TRICK,
 		/obj/item/grenade/chem_grenade/glitter/white = ARCADE_WEIGHT_TRICK,
-
+*/
 		/obj/item/extendohand/acme = ARCADE_WEIGHT_TRICK,
 		/obj/item/card/emagfake	= ARCADE_WEIGHT_TRICK,
 		/obj/item/clothing/shoes/wheelys = ARCADE_WEIGHT_RARE,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Comments out Glitter from Arcade Machines
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

If you want to carpet bomb a place with glitter, you can grind up plastic and crayons. Giving people who know how to exploit minesweeper access to endless glitterbombs with no effort is stupid.

Also, what is the point of a glitterbomb other than an easy way to be a dick to bartenders.

## Changelog
:cl:
tweak: Glitter removed from Arcades.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
