### PR TITLE
Corrects missing slash in a bullet

### DIFF
--- a/modular_citadel/code/modules/projectiles/guns/ballistic/handguns.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/handguns.dm
@@ -58,12 +58,9 @@
 
 //////10mm soporific bullets//////
 
-obj/item/projectile/bullet/c10mm/soporific
+/obj/item/projectile/bullet/c10mm/soporific
 	name ="10mm soporific bullet"
-	armour_penetration = 0
 	nodamage = TRUE
-	dismemberment = 0
-	knockdown = 0
 
 /obj/item/projectile/bullet/c10mm/soporific/on_hit(atom/target, blocked = FALSE)
 	. = ..()


### PR DESCRIPTION

## About The Pull Request

Were the bullets even working?

## Why It's Good For The Game

Fixes a missing slash

## Changelog
:cl:
code: Corrects the missing slash in 10mm sleeping bullets, also removes double vars that are not needed
/:cl:
