### PR TITLE
Stops one of the many monkey tricks with mob holders.

### DIFF
--- a/code/datums/elements/mob_holder.dm
+++ b/code/datums/elements/mob_holder.dm
@@ -162,6 +162,11 @@
 		L.visible_message("<span class='warning'>[held_mob] escapes from [L]!</span>", "<span class='warning'>[held_mob] escapes your grip!</span>")
 	release()
 
+/obj/item/clothing/head/mob_holder/mob_can_equip(mob/living/M, mob/living/equipper, slot, disable_warning = FALSE, bypass_equip_delay_self = FALSE)
+	if(!ishuman(M)) //monkeys holding monkeys holding monkeys...
+		return FALSE
+	return ..()
+
 /obj/item/clothing/head/mob_holder/assume_air(datum/gas_mixture/env)
 	var/atom/location = loc
 	if(!loc)

--- a/code/datums/elements/mob_holder.dm
+++ b/code/datums/elements/mob_holder.dm
@@ -76,6 +76,7 @@
 	lefthand_file = 'icons/mob/animals_held_lh.dmi'
 	icon_state = ""
 	w_class = WEIGHT_CLASS_BULKY
+	dynamic_hair_suffix = ""
 	var/mob/living/held_mob
 
 /obj/item/clothing/head/mob_holder/Initialize(mapload, mob/living/target, worn_state, alt_worn, right_hand, left_hand, slots = NONE)


### PR DESCRIPTION
## About The Pull Request
I really should refactor mob holder some times later to allow using monkeys and other critters are blunt weapons and shield, as well as a typecache of mobs allowed to hold the critter, as opposed to the human check, but bespoke elements don't support list arguments yet.

## Why It's Good For The Game
Because monkeys aren't supposed to hold other monkeys.

## Changelog
:cl:
fix: Stopped one of the many monkey tricks with mob holders.
/:cl:

