### PR TITLE
Makes pacifists able to vore properly

### DIFF
--- a/code/modules/mob/living/living_defense.dm
+++ b/code/modules/mob/living/living_defense.dm
@@ -193,17 +193,6 @@
 	if(user == anchored || !isturf(user.loc))
 		return FALSE
 
-	//pacifist vore check.
-	if(user.pulling && HAS_TRAIT(user, TRAIT_PACIFISM) && user.voremode) //they can only do heals, noisy guts, absorbing (technically not harm)
-		if(ismob(user.pulling))
-			var/mob/P = user.pulling
-			if(src != user)
-				to_chat(user, "<span class='notice'>You can't risk digestion!</span>")
-				return FALSE
-			else
-				user.vore_attack(user, P, user)
-				return
-
 	//normal vore check.
 	if(user.pulling && user.grab_state == GRAB_AGGRESSIVE && user.voremode)
 		if(ismob(user.pulling))

--- a/code/modules/vore/eating/bellymodes.dm
+++ b/code/modules/vore/eating/bellymodes.dm
@@ -60,204 +60,198 @@
 	var/sound/pred_digest = sound(get_sfx("digest_pred"))
 	var/sound/pred_death = sound(get_sfx("death_pred"))
 
-///////////////////////////// DM_HOLD /////////////////////////////
-	if(digest_mode == DM_HOLD)
-		return SSBELLIES_PROCESSED
+	switch(digest_mode)
+		if(DM_HOLD)
+			return SSBELLIES_PROCESSED
 
-//////////////////////////// DM_DIGEST ////////////////////////////
-	else if(digest_mode == DM_DIGEST)
-		if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //obvious.
-			digest_mode = DM_NOISY
-			return
+		if(DM_DIGEST)
+			if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //obvious.
+				digest_mode = DM_NOISY
+				return
 
-		for (var/mob/living/M in contents)
-			if(prob(25))
-				if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
-					SEND_SOUND(M,prey_digest)
-				play_sound = pick(pred_digest)
+			for (var/mob/living/M in contents)
+				if(prob(25))
+					if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
+						SEND_SOUND(M,prey_digest)
+					play_sound = pick(pred_digest)
 
-			//Pref protection!
-			if (!M.digestable || M.absorbed)
-				continue
+				//Pref protection!
+				if (!M.digestable || M.absorbed)
+					continue
+
+				//Person just died in guts!
+				if(M.stat == DEAD)
+					var/digest_alert_owner = pick(digest_messages_owner)
+					var/digest_alert_prey = pick(digest_messages_prey)
+
+					//Replace placeholder vars
+					digest_alert_owner = replacetext(digest_alert_owner,"%pred",owner)
+					digest_alert_owner = replacetext(digest_alert_owner,"%prey",M)
+					digest_alert_owner = replacetext(digest_alert_owner,"%belly",lowertext(name))
+
+					digest_alert_prey = replacetext(digest_alert_prey,"%pred",owner)
+					digest_alert_prey = replacetext(digest_alert_prey,"%prey",M)
+					digest_alert_prey = replacetext(digest_alert_prey,"%belly",lowertext(name))
+
+					//Send messages
+					to_chat(owner, "<span class='warning'>[digest_alert_owner]</span>")
+					to_chat(M, "<span class='warning'>[digest_alert_prey]</span>")
+					M.visible_message("<span class='notice'>You watch as [owner]'s form loses its additions.</span>")
+
+					owner.nutrition += 400 // so eating dead mobs gives you *something*.
+					play_sound = pick(pred_death)
+					if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
+						SEND_SOUND(M,prey_death)
+					M.stop_sound_channel(CHANNEL_PREYLOOP)
+					digestion_death(M)
+					owner.update_icons()
+					to_update = TRUE
+					continue
+
+
+				// Deal digestion damage (and feed the pred)
+				if(!(M.status_flags & GODMODE))
+					M.adjustFireLoss(digest_burn)
+					owner.nutrition += 1
+
+			//Contaminate or gurgle items
+			var/obj/item/T = pick(touchable_items)
+			if(istype(T))
+				if(istype(T,/obj/item/reagent_containers/food) || istype(T,/obj/item/organ))
+					digest_item(T)
+
+		if(DM_HEAL)
+			for (var/mob/living/M in contents)
+				if(prob(25))
+					if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
+						SEND_SOUND(M,prey_digest)
+					play_sound = pick(pred_digest)
+				if(M.stat != DEAD)
+					if(owner.nutrition >= NUTRITION_LEVEL_STARVING && (M.health < M.maxHealth))
+						M.adjustBruteLoss(-3)
+						M.adjustFireLoss(-3)
+						owner.nutrition -= 5
+
+	//for when you just want people to squelch around
+		if(DM_NOISY)
+			if(prob(35))
+				for(var/mob/M in contents)
+					if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
+						SEND_SOUND(M,prey_digest)
+					play_sound = pick(pred_digest)
+
+
+		if(DM_ABSORB)
+
+			for (var/mob/living/M in contents)
+
+				if(prob(10))//Less often than gurgles. People might leave this on forever.
+					if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
+						SEND_SOUND(M,prey_digest)
+					play_sound = pick(pred_digest)
+
+				if(M.absorbed)
+					continue
+
+				if(M.nutrition >= 100) //Drain them until there's no nutrients left. Slowly "absorb" them.
+					var/oldnutrition = (M.nutrition * 0.05)
+					M.nutrition = (M.nutrition * 0.95)
+					owner.nutrition += oldnutrition
+				else if(M.nutrition < 100) //When they're finally drained.
+					absorb_living(M)
+					to_update = TRUE
+
+		if(DM_UNABSORB)
+
+			for (var/mob/living/M in contents)
+				if(M.absorbed && owner.nutrition >= 100)
+					M.absorbed = FALSE
+					to_chat(M,"<span class='notice'>You suddenly feel solid again </span>")
+					to_chat(owner,"<span class='notice'>You feel like a part of you is missing.</span>")
+					owner.nutrition -= 100
+					to_update = TRUE
+
+	//because dragons need snowflake guts
+		if(digest_mode == DM_DRAGON)
+			if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //imagine var editing this when you're a pacifist. smh
+				digest_mode = DM_NOISY
+				return
+
+			for (var/mob/living/M in contents)
+				if(prob(55)) //if you're hearing this, you're a vore ho anyway.
+					if((world.time + NORMIE_HEARCHECK) > last_hearcheck)
+						LAZYCLEARLIST(hearing_mobs)
+						for(var/mob/living/H in get_hearers_in_view(3, owner))
+							if(!H.client || !(H.client.prefs.cit_toggles & DIGESTION_NOISES))
+								continue
+							LAZYADD(hearing_mobs, H)
+						last_hearcheck = world.time
+					for(var/mob/living/H in hearing_mobs)
+						if(H && H.client && (isturf(H.loc) || (H.loc != src.contents)))
+							SEND_SOUND(H,pred_digest)
+						else if(H?.client && (H in contents))
+							SEND_SOUND(H,prey_digest)
+
+			//No digestion protection for megafauna.
 
 			//Person just died in guts!
-			if(M.stat == DEAD)
-				var/digest_alert_owner = pick(digest_messages_owner)
-				var/digest_alert_prey = pick(digest_messages_prey)
+				if(M.stat == DEAD)
+					var/digest_alert_owner = pick(digest_messages_owner)
+					var/digest_alert_prey = pick(digest_messages_prey)
 
-				//Replace placeholder vars
-				digest_alert_owner = replacetext(digest_alert_owner,"%pred",owner)
-				digest_alert_owner = replacetext(digest_alert_owner,"%prey",M)
-				digest_alert_owner = replacetext(digest_alert_owner,"%belly",lowertext(name))
+					//Replace placeholder vars
+					digest_alert_owner = replacetext(digest_alert_owner,"%pred",owner)
+					digest_alert_owner = replacetext(digest_alert_owner,"%prey",M)
+					digest_alert_owner = replacetext(digest_alert_owner,"%belly",lowertext(name))
 
-				digest_alert_prey = replacetext(digest_alert_prey,"%pred",owner)
-				digest_alert_prey = replacetext(digest_alert_prey,"%prey",M)
-				digest_alert_prey = replacetext(digest_alert_prey,"%belly",lowertext(name))
+					digest_alert_prey = replacetext(digest_alert_prey,"%pred",owner)
+					digest_alert_prey = replacetext(digest_alert_prey,"%prey",M)
+					digest_alert_prey = replacetext(digest_alert_prey,"%belly",lowertext(name))
 
-				//Send messages
-				to_chat(owner, "<span class='warning'>[digest_alert_owner]</span>")
-				to_chat(M, "<span class='warning'>[digest_alert_prey]</span>")
-				M.visible_message("<span class='notice'>You watch as [owner]'s form loses its additions.</span>")
-
-				owner.nutrition += 400 // so eating dead mobs gives you *something*.
-				play_sound = pick(pred_death)
-				if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
-					SEND_SOUND(M,prey_death)
-				M.stop_sound_channel(CHANNEL_PREYLOOP)
-				digestion_death(M)
-				owner.update_icons()
-				to_update = TRUE
-				continue
-
-
-			// Deal digestion damage (and feed the pred)
-			if(!(M.status_flags & GODMODE))
-				M.adjustFireLoss(digest_burn)
-				owner.nutrition += 1
-
-		//Contaminate or gurgle items
-		var/obj/item/T = pick(touchable_items)
-		if(istype(T))
-			if(istype(T,/obj/item/reagent_containers/food) || istype(T,/obj/item/organ))
-				digest_item(T)
-
-///////////////////////////// DM_HEAL /////////////////////////////
-	if(digest_mode == DM_HEAL)
-		for (var/mob/living/M in contents)
-			if(prob(25))
-				if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
-					SEND_SOUND(M,prey_digest)
-				play_sound = pick(pred_digest)
-			if(M.stat != DEAD)
-				if(owner.nutrition >= NUTRITION_LEVEL_STARVING && (M.health < M.maxHealth))
-					M.adjustBruteLoss(-3)
-					M.adjustFireLoss(-3)
-					owner.nutrition -= 5
-
-////////////////////////// DM_NOISY /////////////////////////////////
-//for when you just want people to squelch around
-	if(digest_mode == DM_NOISY)
-		if(prob(35))
-			for(var/mob/M in contents)
-				if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
-					SEND_SOUND(M,prey_digest)
-				play_sound = pick(pred_digest)
-
-
-//////////////////////////// DM_ABSORB ////////////////////////////
-	else if(digest_mode == DM_ABSORB)
-
-		for (var/mob/living/M in contents)
-
-			if(prob(10))//Less often than gurgles. People might leave this on forever.
-				if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
-					SEND_SOUND(M,prey_digest)
-				play_sound = pick(pred_digest)
-
-			if(M.absorbed)
-				continue
-
-			if(M.nutrition >= 100) //Drain them until there's no nutrients left. Slowly "absorb" them.
-				var/oldnutrition = (M.nutrition * 0.05)
-				M.nutrition = (M.nutrition * 0.95)
-				owner.nutrition += oldnutrition
-			else if(M.nutrition < 100) //When they're finally drained.
-				absorb_living(M)
-				to_update = TRUE
-
-//////////////////////////// DM_UNABSORB ////////////////////////////
-	else if(digest_mode == DM_UNABSORB)
-
-		for (var/mob/living/M in contents)
-			if(M.absorbed && owner.nutrition >= 100)
-				M.absorbed = FALSE
-				to_chat(M,"<span class='notice'>You suddenly feel solid again </span>")
-				to_chat(owner,"<span class='notice'>You feel like a part of you is missing.</span>")
-				owner.nutrition -= 100
-				to_update = TRUE
-
-//////////////////////////DM_DRAGON /////////////////////////////////////
-//because dragons need snowflake guts
-	if(digest_mode == DM_DRAGON)
-		if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //imagine var editing this when you're a pacifist. smh
-			digest_mode = DM_NOISY
-			return
-
-		for (var/mob/living/M in contents)
-			if(prob(55)) //if you're hearing this, you're a vore ho anyway.
-				if((world.time + NORMIE_HEARCHECK) > last_hearcheck)
-					LAZYCLEARLIST(hearing_mobs)
-					for(var/mob/living/H in get_hearers_in_view(3, owner))
-						if(!H.client || !(H.client.prefs.cit_toggles & DIGESTION_NOISES))
-							continue
-						LAZYADD(hearing_mobs, H)
-					last_hearcheck = world.time
-				for(var/mob/living/H in hearing_mobs)
-					if(H && H.client && (isturf(H.loc) || (H.loc != src.contents)))
-						SEND_SOUND(H,pred_digest)
-					else if(H?.client && (H in contents))
-						SEND_SOUND(H,prey_digest)
-
-		//No digestion protection for megafauna.
-
-		//Person just died in guts!
-			if(M.stat == DEAD)
-				var/digest_alert_owner = pick(digest_messages_owner)
-				var/digest_alert_prey = pick(digest_messages_prey)
-
-				//Replace placeholder vars
-				digest_alert_owner = replacetext(digest_alert_owner,"%pred",owner)
-				digest_alert_owner = replacetext(digest_alert_owner,"%prey",M)
-				digest_alert_owner = replacetext(digest_alert_owner,"%belly",lowertext(name))
-
-				digest_alert_prey = replacetext(digest_alert_prey,"%pred",owner)
-				digest_alert_prey = replacetext(digest_alert_prey,"%prey",M)
-				digest_alert_prey = replacetext(digest_alert_prey,"%belly",lowertext(name))
-
-				//Send messages
-				to_chat(owner, "<span class='warning'>[digest_alert_owner]</span>")
-				to_chat(M, "<span class='warning'>[digest_alert_prey]</span>")
-				M.visible_message("<span class='notice'>You watch as [owner]'s guts loudly rumble as it finishes off a meal.</span>")
-				play_sound = pick(pred_death)
-				if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
-					SEND_SOUND(M,prey_death)
-				M.spill_organs(FALSE,TRUE,TRUE)
-				M.stop_sound_channel(CHANNEL_PREYLOOP)
-				digestion_death(M)
-				owner.update_icons()
-				to_update = TRUE
-				continue
-
-
-			// Deal digestion damage (and feed the pred)
-			if(!(M.status_flags & GODMODE))
-				M.adjustFireLoss(digest_burn)
-				M.adjustToxLoss(2) // something something plasma based acids
-				M.adjustCloneLoss(1) // eventually this'll kill you if you're healing everything else, you nerds.
-			//Contaminate or gurgle items
-		var/obj/item/T = pick(touchable_items)
-		if(istype(T))
-			if(istype(T,/obj/item/reagent_containers/food) || istype(T,/obj/item/organ))
-				digest_item(T)
-
-/////////////////////////// Make any noise ///////////////////////////
-	if(play_sound)
-		if((world.time + NORMIE_HEARCHECK) > last_hearcheck)
-			LAZYCLEARLIST(hearing_mobs)
-			for(var/mob/M in hearers(VORE_SOUND_RANGE, owner))
-				if(!M.client || !(M.client.prefs.cit_toggles & DIGESTION_NOISES))
+					//Send messages
+					to_chat(owner, "<span class='warning'>[digest_alert_owner]</span>")
+					to_chat(M, "<span class='warning'>[digest_alert_prey]</span>")
+					M.visible_message("<span class='notice'>You watch as [owner]'s guts loudly rumble as it finishes off a meal.</span>")
+					play_sound = pick(pred_death)
+					if(M && M.client && M.client.prefs.cit_toggles & DIGESTION_NOISES)
+						SEND_SOUND(M,prey_death)
+					M.spill_organs(FALSE,TRUE,TRUE)
+					M.stop_sound_channel(CHANNEL_PREYLOOP)
+					digestion_death(M)
+					owner.update_icons()
+					to_update = TRUE
 					continue
-				LAZYADD(hearing_mobs, M)
-				last_hearcheck = world.time
-			for(var/mob/M in hearing_mobs) //so we don't fill the whole room with the sound effect
-				if(M && M.client && (isturf(M.loc) || (M.loc != src.contents))) //to avoid people on the inside getting the outside sounds and their direct sounds + built in sound pref check
-					M.playsound_local(owner.loc, play_sound, vol = 75, vary = 1, falloff = VORE_SOUND_FALLOFF)
-					 //these are all external sound triggers now, so it's ok.
-	if(to_update)
-		for(var/mob/living/M in contents)
-			if(M.client)
-				M.updateVRPanel()
-		if(owner.client)
-			owner.updateVRPanel()
+
+
+				// Deal digestion damage (and feed the pred)
+				if(!(M.status_flags & GODMODE))
+					M.adjustFireLoss(digest_burn)
+					M.adjustToxLoss(2) // something something plasma based acids
+					M.adjustCloneLoss(1) // eventually this'll kill you if you're healing everything else, you nerds.
+				//Contaminate or gurgle items
+			var/obj/item/T = pick(touchable_items)
+			if(istype(T))
+				if(istype(T,/obj/item/reagent_containers/food) || istype(T,/obj/item/organ))
+					digest_item(T)
+
+	/////////////////////////// Make any noise ///////////////////////////
+		if(play_sound)
+			if((world.time + NORMIE_HEARCHECK) > last_hearcheck)
+				LAZYCLEARLIST(hearing_mobs)
+				for(var/mob/M in hearers(VORE_SOUND_RANGE, owner))
+					if(!M.client || !(M.client.prefs.cit_toggles & DIGESTION_NOISES))
+						continue
+					LAZYADD(hearing_mobs, M)
+					last_hearcheck = world.time
+				for(var/mob/M in hearing_mobs) //so we don't fill the whole room with the sound effect
+					if(M && M.client && (isturf(M.loc) || (M.loc != src.contents))) //to avoid people on the inside getting the outside sounds and their direct sounds + built in sound pref check
+						M.playsound_local(owner.loc, play_sound, vol = 75, vary = 1, falloff = VORE_SOUND_FALLOFF)
+						//these are all external sound triggers now, so it's ok.
+		if(to_update)
+			for(var/mob/living/M in contents)
+				if(M.client)
+					M.updateVRPanel()
+			if(owner.client)
+				owner.updateVRPanel()
 
 	return SSBELLIES_PROCESSED

--- a/code/modules/vore/eating/bellymodes.dm
+++ b/code/modules/vore/eating/bellymodes.dm
@@ -172,7 +172,7 @@
 					to_update = TRUE
 
 	//because dragons need snowflake guts
-		if(digest_mode == DM_DRAGON)
+		if(DM_DRAGON)
 			if(HAS_TRAIT(owner, TRAIT_PACIFISM)) //imagine var editing this when you're a pacifist. smh
 				digest_mode = DM_NOISY
 				return
@@ -235,23 +235,23 @@
 					digest_item(T)
 
 	/////////////////////////// Make any noise ///////////////////////////
-		if(play_sound)
-			if((world.time + NORMIE_HEARCHECK) > last_hearcheck)
-				LAZYCLEARLIST(hearing_mobs)
-				for(var/mob/M in hearers(VORE_SOUND_RANGE, owner))
-					if(!M.client || !(M.client.prefs.cit_toggles & DIGESTION_NOISES))
-						continue
-					LAZYADD(hearing_mobs, M)
-					last_hearcheck = world.time
-				for(var/mob/M in hearing_mobs) //so we don't fill the whole room with the sound effect
-					if(M && M.client && (isturf(M.loc) || (M.loc != src.contents))) //to avoid people on the inside getting the outside sounds and their direct sounds + built in sound pref check
-						M.playsound_local(owner.loc, play_sound, vol = 75, vary = 1, falloff = VORE_SOUND_FALLOFF)
-						//these are all external sound triggers now, so it's ok.
-		if(to_update)
-			for(var/mob/living/M in contents)
-				if(M.client)
-					M.updateVRPanel()
-			if(owner.client)
-				owner.updateVRPanel()
+	if(play_sound)
+		if((world.time + NORMIE_HEARCHECK) > last_hearcheck)
+			LAZYCLEARLIST(hearing_mobs)
+			for(var/mob/M in hearers(VORE_SOUND_RANGE, owner))
+				if(!M.client || !(M.client.prefs.cit_toggles & DIGESTION_NOISES))
+					continue
+				LAZYADD(hearing_mobs, M)
+				last_hearcheck = world.time
+			for(var/mob/M in hearing_mobs) //so we don't fill the whole room with the sound effect
+				if(M && M.client && (isturf(M.loc) || (M.loc != src.contents))) //to avoid people on the inside getting the outside sounds and their direct sounds + built in sound pref check
+					M.playsound_local(owner.loc, play_sound, vol = 75, vary = 1, falloff = VORE_SOUND_FALLOFF)
+					//these are all external sound triggers now, so it's ok.
+	if(to_update)
+		for(var/mob/living/M in contents)
+			if(M.client)
+				M.updateVRPanel()
+		if(owner.client)
+			owner.updateVRPanel()
 
 	return SSBELLIES_PROCESSED


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Pacifists can't vore at all. The code comment suggests it's only supposed to proc on certain digestion types, but that code is elsewhere. The code being removed here is totally redundant.

## Why It's Good For The Game

It's kinda cleaning up vore code!

## Changelog
:cl:
fix: Pacifists can now vore, but not digest (as intended)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
