### PR TITLE
Six new Sci based bounties!

### DIFF
--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -116,3 +116,50 @@
 	exclude_types = list(/obj/item/stack/ore/bluespace_crystal,
 						 /obj/item/stack/sheet/bluespace_crystal,
 						 /obj/item/stack/ore/bluespace_crystal/refined)
+
+/datum/bounty/item/science/noneactive_reactivearmor
+	name = "Reactive Armor Shells"
+	description = "Do to the brake throughs in anomalies, we can not keep up in making reactive armor shells, can you send us a few?"
+	reward = 2000
+	required_count = 5
+	wanted_types = list(/obj/item/reactive_armour_shell, /obj/item/clothing/suit/armor/reactive)
+	exclude_types = list(/obj/item/clothing/suit/armor/reactive/repulse,
+						 /obj/item/clothing/suit/armor/reactive/tesla,
+						 /obj/item/clothing/suit/armor/reactive/teleport,
+						 /obj/item/clothing/suit/armor/reactive/stealth,
+						 /obj/item/clothing/suit/armor/reactive/fire)
+
+/datum/bounty/item/science/anomaly_core
+	name = "Anomaly Core"
+	description = "A new theory has begone that each sector of space has different anomalies, this all started when a local station tried to make a fire based reactive suit and failed making a stealth version, please send us a core so we may study it more."
+	reward = 2000
+	required_count = 1
+	wanted_types = list(/obj/item/assembly/signaler/anomaly)
+
+/datum/bounty/item/science/anomaly_neutralizer
+	name = "Anomaly Neutralizers"
+	description = "An idea for a long time was to use an unstable Suppermatter Shard to help crate the breeding grounds for an unstable part of space to harvest any anomalies we want. It worked a little to well and now were out of anomaly neutralizers please send us a baker's dozen."
+	reward = 2500
+	required_count = 13
+	wanted_types = list(/obj/item/anomaly_neutralizer)
+
+/datum/bounty/item/science/integrated_circuit_printer
+	name = "Integrated Circuit Printer"
+	description = "Do to a paperwork error, a newly made integrated circuit manufacturer line is missing three of its printers needed to operate. Until the paper work is corrected were outsourcing this problem, so please send us three integrated circuit printers."
+	reward = 2000
+	required_count = 3
+	wanted_types = list(/obj/item/integrated_circuit_printer)
+
+/datum/bounty/item/science/integrated_circuit_disks
+	name = "Integrated Circuit Printer Upgrade Disks"
+	description = "HR has requested ten more integrated circuit printer upgrade disks, please send them to CC as soon as possable."
+	reward = 2000
+	required_count = 10 //Its just metal
+	wanted_types = list(/obj/item/disk/integrated_circuit/upgrade)
+
+/datum/bounty/item/science/nanite_trash
+	name = "Nanite Based Gear"
+	description = "CC wants to make nanite based gear available to a new wing of devolvement but lacks the hand held tools to get it full up and running. Please send us any you have."
+	reward = 2500
+	required_count = 20 //Its just metal
+	wanted_types = list( /obj/item/nanite_remote, /obj/item/nanite_remote/comm, /obj/item/nanite_scanner)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -119,7 +119,7 @@
 
 /datum/bounty/item/science/noneactive_reactivearmor
 	name = "Reactive Armor Shells"
-	description = "Do to the brake throughs in anomalies, we can not keep up in making reactive armor shells, can you send us a few?"
+	description = "Do to the breakthroughs in anomalies, we can not keep up in making reactive armor shells, can you send us a few?"
 	reward = 2000
 	required_count = 5
 	wanted_types = list(/obj/item/reactive_armour_shell, /obj/item/clothing/suit/armor/reactive)
@@ -131,28 +131,28 @@
 
 /datum/bounty/item/science/anomaly_core
 	name = "Anomaly Core"
-	description = "A new theory has begone that each sector of space has different anomalies, this all started when a local station tried to make a fire based reactive suit and failed making a stealth version, please send us a core so we may study it more."
+	description = "A new theory has begun that each sector of space has different anomalies, this all started when a local station tried to make a fire based reactive suit and failed making a stealth version, please send us a core so we may study it more."
 	reward = 2500
 	required_count = 1
 	wanted_types = list(/obj/item/assembly/signaler/anomaly)
 
 /datum/bounty/item/science/anomaly_neutralizer
 	name = "Anomaly Neutralizers"
-	description = "An idea for a long time was to use an unstable Suppermatter Shard to help crate the breeding grounds for an unstable part of space to harvest any anomalies we want. It worked a little to well and now were out of anomaly neutralizers please send us a baker's dozen."
+	description = "An idea for a long time was to use an unstable Supermatter Shard to help create  the breeding grounds for an unstable part of space to harvest any anomalies we want. It worked a little too well and now were out of anomaly neutralizers please send us a baker's dozen."
 	reward = 2500
 	required_count = 13
 	wanted_types = list(/obj/item/anomaly_neutralizer)
 
 /datum/bounty/item/science/integrated_circuit_printer
 	name = "Integrated Circuit Printer"
-	description = "Do to a paperwork error, a newly made integrated circuit manufacturer line is missing three of its printers needed to operate. Until the paper work is corrected were outsourcing this problem, so please send us three integrated circuit printers."
+	description = "due to a paperwork error, a newly made integrated circuit manufacturer line is missing three of its printers needed to operate. Until the paper work is corrected we are outsourcing this problem, so please send us three integrated circuit printers."
 	reward = 2000
 	required_count = 3
 	wanted_types = list(/obj/item/integrated_circuit_printer)
 
 /datum/bounty/item/science/integrated_circuit_disks
 	name = "Integrated Circuit Printer Upgrade Disks"
-	description = "HR has requested ten more integrated circuit printer upgrade disks, please send them to CC as soon as possable."
+	description = "HR has requested ten more integrated circuit printer upgrade disks, please send them to CC as soon as possible."
 	reward = 2000
 	required_count = 10 //Its just metal
 	wanted_types = list(/obj/item/disk/integrated_circuit/upgrade)

--- a/code/modules/cargo/bounties/science.dm
+++ b/code/modules/cargo/bounties/science.dm
@@ -132,7 +132,7 @@
 /datum/bounty/item/science/anomaly_core
 	name = "Anomaly Core"
 	description = "A new theory has begone that each sector of space has different anomalies, this all started when a local station tried to make a fire based reactive suit and failed making a stealth version, please send us a core so we may study it more."
-	reward = 2000
+	reward = 2500
 	required_count = 1
 	wanted_types = list(/obj/item/assembly/signaler/anomaly)
 


### PR DESCRIPTION
## About The Pull Request

Adds SIX count them SIX new bounties for sci based gear
Reactive Armor  - 5 none active suits for 2k
Anomaly Core - 1 core for 2.5k
Anomaly Neutralizers - 13 for 2.5k
Nanite Gear - 10 nanite based hand held gear for 2.5k
Integrated Circuit Gear - 3 printers for 2k
Integrated Circuit Upgrades - 10 disks for 2k


## Why It's Good For The Game

Gives cargo more a reason to heckle sci over the nodes that sometimes never get gotton, as well as gives more uses to the one trick anomaly core that should really be sellable for 1k each but then you would get SM cash farms and that just bothers me.

## Changelog
:cl:
add: Six more Sci based bounties have been posted at your local Cargo Bounty Request console
/:cl:
