### PR TITLE
Buffs Stimpacks

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_devices.dm
+++ b/code/modules/uplink/uplink_items/uplink_devices.dm
@@ -185,7 +185,8 @@
 /datum/uplink_item/device_tools/stimpack
 	name = "Stimpack"
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
-			5 minutes after injection fully injecting yourself. Can inject yourself, or others, 5 times and through hardsuits."
+			5 minutes after fully injecting yourself. Can inject yourself, or others, 5 times and through hardsuits. \
+			Each injection will gives around a minute of stimulants."
 	item = /obj/item/reagent_containers/hypospray/medipen/stimulants
 	cost = 5
 	surplus = 90

--- a/code/modules/uplink/uplink_items/uplink_devices.dm
+++ b/code/modules/uplink/uplink_items/uplink_devices.dm
@@ -185,8 +185,8 @@
 /datum/uplink_item/device_tools/stimpack
 	name = "Stimpack"
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \
-			5 minutes after injection."
-	item = /obj/item/reagent_containers/syringe/stimulants
+			5 minutes after injection fully injecting yourself. Can inject yourself, or others, 5 times and through hardsuits."
+	item = /obj/item/reagent_containers/hypospray/medipen/stimulants
 	cost = 5
 	surplus = 90
 


### PR DESCRIPTION
## About The Pull Request
```
Wow 5 tc for 5 mins of SPEED, so amazing so useless so wast of credits.
Just buy stim implant its flat out better!
```
Well kiddos not anymore! You can now inject yourself through hardsuits - yay, as well as it now has a controlled injection of 10u per click! Meaning it gives 1 min per injection of stim action, and can share! - Legally dont share needles IRL just a bad idea 
## Why It's Good For The Game

Makes stimpacks not trash that is outclassed by a chemi with a micro or a implant that costs about the same, ecomic wise its still fucken better to buy the emp proof implant >:L but hey baby steps.

This also means chemis or traitors with smarts cant refill the needle with a cocktail of bad chems to inject all at one 50u.
## Changelog
:cl:
balance: Stimpacks now use a hypo meaning they can inject through hardsuits. Only inject 10u per injection (meaning you can inject someone or yourself upto 5 times). Sadly no longer just a 50u injection of chems, that can be refilled.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
