### PR TITLE
Atomic PR 1 or 2 - Toilet Loot!

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -488,7 +488,7 @@
 		/obj/effect/spawner/lootdrop/druggie_pill = 5,
 		/obj/item/kitchen/knife = 5,
 		/obj/item/screwdriver = 5,
-		/obj/item/crowbar/red = 0.5, //Dont your need a crowbar to open this?
+		/obj/item/crowbar/red = 0.5, //Dont you need a crowbar to open this?
 		/obj/item/stack/medical/bruise_pack = 3,
 		/obj/item/reagent_containers/food/drinks/bottle/vodka = 2,
 		/obj/item/radio = 5,

--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -45,7 +45,6 @@
 /obj/effect/spawner/lootdrop/armory_contraband
 	name = "armory contraband gun spawner"
 	lootdoubles = FALSE
-
 	loot = list(
 				/obj/item/gun/ballistic/automatic/pistol = 8,
 				/obj/item/gun/ballistic/shotgun/automatic/combat = 5,
@@ -129,7 +128,6 @@
 	loot = typesof(/obj/item/flashlight/glowstick)
 	. = ..()
 
-
 /obj/effect/spawner/lootdrop/gloves
 	name = "random gloves"
 	desc = "These gloves are supposed to be a random color..."
@@ -150,7 +148,6 @@
 /obj/effect/spawner/lootdrop/crate_spawner
 	name = "lootcrate spawner" //USE PROMO CODE "SELLOUT" FOR 20% OFF!
 	lootdoubles = FALSE
-
 	loot = list(
 				/obj/structure/closet/crate/secure/loot = 20,
 				"" = 80
@@ -386,3 +383,141 @@
 		/obj/structure/reagent_dispensers/keg/aphro = 2,
 		/obj/structure/reagent_dispensers/keg/aphro/strong = 2,
 		/obj/structure/reagent_dispensers/keg/gargle = 1)
+
+/obj/effect/spawner/lootdrop/coin
+	lootcount = 1
+	loot = list(
+				/obj/item/coin/silver = 30,
+				/obj/item/coin/iron = 30,
+				/obj/item/coin/gold = 10,
+				/obj/item/coin/diamond = 10,
+				/obj/item/coin/plasma = 10,
+				/obj/item/coin/uranium = 10,
+				)
+
+/obj/effect/spawner/lootdrop/cig_packs
+	lootcount = 1
+	loot = list(
+				/obj/item/storage/fancy/cigarettes = 20,
+				/obj/item/storage/fancy/cigarettes/dromedaryco = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_robust = 5,
+				/obj/item/storage/fancy/cigarettes/cigpack_robustgold = 5,
+				/obj/item/storage/fancy/cigarettes/cigpack_carp = 15,
+				/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 2,
+				/obj/item/storage/fancy/cigarettes/cigpack_midori = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_shadyjims = 5,
+				/obj/item/storage/fancy/cigarettes/cigpack_xeno = 3,
+				/obj/item/storage/fancy/cigarettes/cigpack_cannabis = 10,
+				/obj/item/storage/fancy/cigarettes/cigpack_mindbreaker = 10,
+				/obj/item/storage/fancy/rollingpapers = 10
+				)
+
+/obj/effect/spawner/lootdrop/cigars_cases
+	lootcount = 1
+	loot = list(
+				/obj/item/storage/fancy/cigarettes/cigars = 50,
+				/obj/item/storage/fancy/cigarettes/cigars/cohiba = 25,
+				/obj/item/storage/fancy/cigarettes/cigars/havana = 25,
+				)
+
+/obj/effect/spawner/lootdrop/space_cash
+	lootcount = 1
+	loot = list(
+				/obj/item/stack/spacecash/c1    = 1,
+				/obj/item/stack/spacecash/c10   = 9,
+				/obj/item/stack/spacecash/c20   = 10,
+				/obj/item/stack/spacecash/c50   = 15,
+				/obj/item/stack/spacecash/c100  = 25,
+				/obj/item/stack/spacecash/c200  = 20,
+				/obj/item/stack/spacecash/c500  = 19,
+				/obj/item/stack/spacecash/c1000 = 1,
+				)
+
+/obj/effect/spawner/lootdrop/druggie_pill
+	lootcount = 1
+	loot = list(
+				/obj/item/reagent_containers/pill/stimulant    = 1,
+				/obj/item/reagent_containers/pill/zoom   = 9,
+				/obj/item/reagent_containers/pill/happy   = 10,
+				/obj/item/reagent_containers/pill/lsd   = 15,
+				/obj/item/reagent_containers/pill/aranesp  = 25,
+				/obj/item/reagent_containers/pill/psicodine  = 20,
+				/obj/item/reagent_containers/pill/mannitol  = 19,
+				/obj/item/reagent_containers/pill/happiness = 1,
+				)
+
+/obj/effect/spawner/lootdrop/low_loot_toilet
+	name = "random low toilet spawner"
+	lootcount = 1
+//Note this is out of a 100 - Meaning the number you see is also the percent its going to pick that
+//This is ment for "low" loot that anyone could fine in a toilet, for better gear use high loot toilet
+	loot = list("" = 30,
+		/obj/item/lighter = 2,
+		/obj/item/tape/random = 1,
+		/obj/item/poster/random_contraband = 1,
+		/obj/item/clothing/glasses/sunglasses/blindfold = 4,
+		/obj/item/clothing/glasses/sunglasses = 1,
+		/obj/item/toy/plush/random = 5,
+		/obj/effect/spawner/lootdrop/gloves = 5,
+		/obj/effect/spawner/lootdrop/glowstick = 5,
+		/obj/effect/spawner/lootdrop/coin = 3,
+		/obj/effect/spawner/lootdrop/cig_packs = 10,
+		/obj/effect/spawner/lootdrop/cigars_cases = 2,
+		/obj/effect/spawner/lootdrop/space_cash = 5,
+		/obj/item/reagent_containers/food/snacks/grown/cannabis = 5,
+		/obj/item/storage/pill_bottle/dice = 5,
+		/obj/item/toy/cards/deck = 5,
+		/obj/effect/spawner/lootdrop/druggie_pill = 5
+		)
+
+/obj/effect/spawner/lootdrop/prison_loot_toilet
+	name = "random prison toilet spawner"
+	lootcount = 1
+//Note this is out of a 100 - Meaning the number you see is also the percent its going to pick that
+//This is ment for "prison" loot that is rather rare and ment for "prisoners if they get a crowbar to fine, or sec.
+	loot = list("" = 10,
+		/obj/item/lighter = 5,
+		/obj/item/poster/random_contraband = 5,
+		/obj/item/clothing/glasses/sunglasses = 5,
+		/obj/effect/spawner/lootdrop/coin = 5,
+		/obj/effect/spawner/lootdrop/cig_packs = 10,
+		/obj/effect/spawner/lootdrop/cigars_cases = 5,
+		/obj/item/reagent_containers/food/snacks/grown/cannabis = 5,
+		/obj/item/storage/pill_bottle/dice = 5,
+		/obj/item/toy/cards/deck = 5,
+		/obj/effect/spawner/lootdrop/druggie_pill = 5,
+		/obj/item/kitchen/knife = 5,
+		/obj/item/screwdriver = 5,
+		/obj/item/crowbar/red = 0.5, //Dont your need a crowbar to open this?
+		/obj/item/stack/medical/bruise_pack = 3,
+		/obj/item/reagent_containers/food/drinks/bottle/vodka = 2,
+		/obj/item/radio = 5,
+		/obj/item/flashlight = 4.5,
+		/obj/item/clothing/mask/breath = 2,
+		/obj/item/tank/internals/emergency_oxygen = 3,
+		/obj/item/storage/box/mre/menu4/safe = 3,
+		/obj/item/grenade/smokebomb = 2
+		)
+
+/obj/effect/spawner/lootdrop/high_loot_toilet
+	name = "random high toilet spawner"
+	lootcount = 1
+//Note this is out of a 100 - Meaning the number you see is also the percent its going to pick that
+//The items inside are always going to be something usefull, illegal and likely traitorous.
+	loot = list(
+		/obj/item/clothing/glasses/sunglasses = 5,
+		/obj/effect/spawner/lootdrop/coin = 5,
+		/obj/effect/spawner/lootdrop/space_cash = 5,
+		/obj/effect/spawner/lootdrop/druggie_pill = 5,
+		/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 5,
+		/obj/item/suppressor = 5,
+		/obj/item/toy/cards/deck/syndicate = 5,
+		/obj/item/clothing/under/syndicate = 5,
+		/obj/item/clothing/mask/gas/syndicate = 5,
+		/obj/item/grenade/smokebomb = 10,
+		/obj/item/gun/ballistic/automatic/toy/pistol = 5,
+		/obj/item/firing_pin = 5,
+		/obj/item/grenade/empgrenade = 15,
+		/obj/item/clothing/gloves/combat = 10,
+		/obj/item/clothing/shoes/sneakers/noslip = 10
+		)

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -12,12 +12,10 @@
 	var/w_items = 0			//the combined w_class of all the items in the cistern
 	var/mob/living/swirlie = null	//the mob being given a swirlie
 
-
 /obj/structure/toilet/Initialize()
 	. = ..()
 	open = round(rand(0, 1))
 	update_icon()
-
 
 /obj/structure/toilet/attack_hand(mob/living/user)
 	. = ..()
@@ -71,10 +69,8 @@
 		open = !open
 		update_icon()
 
-
 /obj/structure/toilet/update_icon_state()
 	icon_state = "toilet[open][cistern]"
-
 
 /obj/structure/toilet/attackby(obj/item/I, mob/living/user, params)
 	if(istype(I, /obj/item/crowbar))
@@ -120,8 +116,14 @@
 		w_items += secret.w_class
 		contents += secret
 
+/obj/structure/toilet/secret/prison //We care about you Skyrats!
+	secret_type = /obj/effect/spawner/lootdrop/prison_loot_toilet
 
+/obj/structure/toilet/secret/low_loot
+	secret_type = /obj/effect/spawner/lootdrop/low_loot_toilet
 
+/obj/structure/toilet/secret/high_loot
+	secret_type = /obj/effect/spawner/lootdrop/high_loot_toilet
 
 /obj/structure/urinal
 	name = "urinal"
@@ -193,7 +195,6 @@
 			"<span class='italics'>You hear metal and squishing noises.</span>")
 		exposed = !exposed
 	return TRUE
-
 
 /obj/item/reagent_containers/food/urinalcake
 	name = "urinal cake"
@@ -278,7 +279,6 @@
 		add_hiddenprint(user)
 	return TRUE
 
-
 /obj/machinery/shower/update_overlays()
 	. = ..()
 	if(on)
@@ -315,7 +315,6 @@
 		else if(isobj(AM))
 			wash_obj(AM)
 
-
 /obj/machinery/shower/proc/wash_obj(obj/O)
 	. = SEND_SIGNAL(O, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
 	. = O.clean_blood()
@@ -324,7 +323,6 @@
 		var/obj/item/I = O
 		I.acid_level = 0
 		I.extinguish()
-
 
 /obj/machinery/shower/proc/wash_turf()
 	if(isturf(loc))
@@ -335,7 +333,6 @@
 		for(var/obj/effect/E in tile)
 			if(is_cleanable(E))
 				qdel(E)
-
 
 /obj/machinery/shower/proc/wash_mob(mob/living/L)
 	SEND_SIGNAL(L, COMSIG_COMPONENT_CLEAN_ACT, CLEAN_WEAK)
@@ -667,10 +664,8 @@
 /obj/structure/sink/puddle/deconstruct(disassembled = TRUE)
 	qdel(src)
 
-
 //Shower Curtains//
 //Defines used are pre-existing in layers.dm//
-
 
 /obj/structure/curtain
 	name = "curtain"
@@ -726,7 +721,6 @@
 		deconstruct()
 
 	return TRUE
-
 
 /obj/structure/curtain/attack_hand(mob/user)
 	. = ..()

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -116,7 +116,7 @@
 		w_items += secret.w_class
 		contents += secret
 
-/obj/structure/toilet/secret/prison //We care about you Skyrats!
+/obj/structure/toilet/secret/prison
 	secret_type = /obj/effect/spawner/lootdrop/prison_loot_toilet
 
 /obj/structure/toilet/secret/low_loot


### PR DESCRIPTION

## About The Pull Request

That gray tide and clown are at it again and stashing loot in the most odd of places again... The toilet, this pr simply makes the loot tables and toilet subtypes ready to be used by mappers.

## Why It's Good For The Game

This allows some more Rng and loot in the game as well as helps add to the story of the rounds left over. Kinda like the Black Box, Hidden bags, and Photo book. Without all the nasty powergaming and player added op magic bullshit loot that got Black Box and hidden bags storage from round to round removed.

## Changelog
:cl:
add: Map wise you now can have loot tables of, Cigs, Coins, Cigar Cases, Space Cash, Illegal Pills.
add: Mappers can now use toilets that have loot inside them to add a bit more Rng to their station/ruin ect!
/:cl: