### PR TITLE
Infested plasmamen now are miner type

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
+++ b/code/modules/mob/living/simple_animal/hostile/mining_mobs/hivelord.dm
@@ -285,9 +285,10 @@
 		if("Miner")
 			mob_species = pickweight(list(/datum/species/human = 70, /datum/species/lizard = 26, /datum/species/fly = 2, /datum/species/plasmaman = 2))
 			if(mob_species == /datum/species/plasmaman)
-				uniform = /obj/item/clothing/under/plasmaman
-				head = /obj/item/clothing/head/helmet/space/plasmaman
+				uniform = /obj/item/clothing/under/plasmaman/mining
+				head = /obj/item/clothing/head/helmet/space/plasmaman/mining
 				belt = /obj/item/tank/internals/plasmaman/belt
+				mask = /obj/item/clothing/mask/gas/explorer
 			else
 				uniform = /obj/item/clothing/under/rank/cargo/miner/lavaland
 				if (prob(4))


### PR DESCRIPTION
## About The Pull Request

Changes the once normal plasma men outfit to a miner subtype for cosmetics.
Also added in the miner gas mask. 

## Why It's Good For The Game

Makes a bit more logic why a plasma men would be down their with rather then just a normal suit and maskless

## Changelog
:cl:
tweak: Infested plasmamen - the ones that drop from legions - now has the miner type suit with addition of a mask
/:cl:
