### PR TITLE
Makes miasma actually properly incorporate with air instead of using hacky spec heat stuff

### DIFF
--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -172,7 +172,7 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 
 /datum/gas/pluoxium
 	id = "pluox"
-	specific_heat = 80
+	specific_heat = 160
 	name = "Pluoxium"
 	fusion_power = 10
 	rarity = 200

--- a/code/modules/atmospherics/gasmixtures/gas_types.dm
+++ b/code/modules/atmospherics/gasmixtures/gas_types.dm
@@ -172,14 +172,14 @@ GLOBAL_LIST_INIT(nonreactive_gases, typecacheof(list(/datum/gas/oxygen, /datum/g
 
 /datum/gas/pluoxium
 	id = "pluox"
-	specific_heat = 160
+	specific_heat = 80
 	name = "Pluoxium"
 	fusion_power = 10
 	rarity = 200
 
 /datum/gas/miasma
 	id = "miasma"
-	specific_heat = 0.00001
+	specific_heat = 20
 	fusion_power = 50
 	name = "Miasma"
 	gas_overlay = "miasma"

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -377,9 +377,15 @@
 
 	var/turf/open/miasma_turf = deceasedturf
 
-	var/list/cached_gases = miasma_turf.air.gases
+	var/datum/gas_mixture/stank = new
 
-	cached_gases[/datum/gas/miasma] += 0.1
+	stank.gases[/datum/gas/miasma] = 0.1
+
+	stank.temperature = BODYTEMP_NORMAL
+
+	miasma_turf.assume_air(stank)
+
+	miasma_turf.air_update_turf()
 
 /mob/living/carbon/proc/handle_blood()
 	return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

i kept getting told that having a really high spec heat for pluoxium to fix a conservation of energy issue is bad so i figure that having a really low spec heat for miasma to fix a conservation of energy issue is also bad so i fixed it

## Changelog
:cl:
balance: Miasma now has the same spec heat as oxygen
fix: Miasma now uses proper gas merging to generate
/:cl: