### PR TITLE
Yay map fixes - Lumba diry vars

### DIFF
--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -1031,7 +1031,6 @@
 "acK" = (
 /obj/structure/sign/warning/vacuum/external{
 	pixel_x = 30;
-	pixel_y = 0
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -1069,7 +1068,6 @@
 	desc = "In Space, no one can hear you scream, especially if the microphone has been disabled.";
 	name = "Prison Intercom";
 	pixel_x = 32;
-	pixel_y = 0;
 	prison_radio = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -1638,7 +1636,6 @@
 "aeh" = (
 /obj/structure/table,
 /obj/machinery/microwave{
-	pixel_x = 0;
 	pixel_y = 6
 	},
 /turf/open/floor/plasteel,
@@ -1999,7 +1996,6 @@
 	},
 /obj/machinery/status_display/ai{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -3143,7 +3139,6 @@
 /obj/item/assembly/flash/handheld,
 /obj/item/reagent_containers/spray/pepper,
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /obj/machinery/light/small{
@@ -3438,7 +3433,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -3489,7 +3483,6 @@
 /obj/item/radio/intercom{
 	desc = "In Space, no one can hear you scream, especially if the  microphone has been disabled.";
 	name = "Prison Intercom";
-	pixel_x = 0;
 	pixel_y = -32;
 	prison_radio = 1
 	},
@@ -4496,7 +4489,6 @@
 	department = "Robotics";
 	departmentType = 2;
 	name = "Robotics RC";
-	pixel_x = 0;
 	pixel_y = 31;
 	receive_ore_updates = 1
 	},
@@ -4507,7 +4499,6 @@
 /obj/machinery/mecha_part_fabricator,
 /obj/item/radio/intercom{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
@@ -4757,7 +4748,6 @@
 	icon_state = "sink_alt";
 	name = "old sink";
 	pixel_x = 15;
-	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -5340,7 +5330,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -6021,7 +6010,6 @@
 /obj/item/radio/intercom{
 	dir = 2;
 	pixel_x = -29;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -6487,7 +6475,6 @@
 	},
 /obj/item/grenade/barrier{
 	pixel_x = 6;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -7569,7 +7556,6 @@
 	idDoor = "xeno_airlock_exterior";
 	idSelf = "xeno_airlock_control";
 	name = "Access Button";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/machinery/door/firedoor,
@@ -8301,7 +8287,6 @@
 	dir = 4;
 	name = "Xenobiology APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	icon_state = "trimline_fill";
@@ -9280,7 +9265,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -9496,7 +9480,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -11043,7 +11026,6 @@
 "aut" = (
 /obj/item/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -11345,7 +11327,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -11563,7 +11544,6 @@
 	dir = 4;
 	name = "Research Firing Range APC";
 	pixel_x = 28;
-	pixel_y = 0
 	},
 /obj/item/target,
 /obj/item/target,
@@ -11815,7 +11795,6 @@
 	},
 /obj/machinery/status_display/ai{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	icon_state = "trimline_fill";
@@ -12295,7 +12274,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -12779,7 +12757,6 @@
 /obj/item/reagent_containers/syringe,
 /obj/machinery/newscaster{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -12905,7 +12882,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -12954,7 +12930,6 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	name = "Security RC";
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
@@ -13201,7 +13176,6 @@
 /obj/structure/bed,
 /obj/machinery/flasher{
 	id = "insaneflash";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /turf/open/floor/plasteel/freezer,
@@ -13696,7 +13670,6 @@
 	areastring = "/area/crew_quarters/heads/hos";
 	dir = 1;
 	name = "Head of Security's Office APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -13712,7 +13685,6 @@
 	},
 /obj/machinery/recharger,
 /obj/structure/reagent_dispensers/peppertank{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/dark,
@@ -13779,10 +13751,8 @@
 	id = "hosspace";
 	name = "Space Shutters Control";
 	pixel_x = 25;
-	pixel_y = 0
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/dark,
@@ -15659,7 +15629,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
@@ -15732,7 +15701,6 @@
 /area/crew_quarters/heads/hor)
 "aBO" = (
 /obj/item/storage/secure/safe{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /obj/structure/table,
@@ -16468,7 +16436,6 @@
 /obj/machinery/iv_drip,
 /obj/structure/sign/poster/official/cleanliness{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -16626,7 +16593,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	icon_state = "trimline_fill";
@@ -16891,7 +16857,6 @@
 	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	icon_state = "trimline_fill";
@@ -18008,7 +17973,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/white,
@@ -18144,7 +18108,6 @@
 	},
 /obj/machinery/status_display/evac{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
@@ -20094,7 +20057,6 @@
 /obj/machinery/requests_console{
 	department = "Law office";
 	pixel_x = 31;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
@@ -21261,7 +21223,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -22103,7 +22064,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light_switch{
 	pixel_x = -28;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
@@ -22577,7 +22537,6 @@
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/poster/official/enlist{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -22701,7 +22660,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -22727,7 +22685,6 @@
 	dir = 8;
 	name = "Quartermaster's Office APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	icon_state = "trimline_fill";
@@ -23303,7 +23260,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -24483,7 +24439,6 @@
 	},
 /obj/structure/sign/nanotrasen{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -24728,10 +24683,8 @@
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /obj/structure/extinguisher_cabinet{
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/machinery/light/small{
@@ -25329,7 +25282,6 @@
 /obj/structure/dresser,
 /obj/item/radio/intercom{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/carpet/blue,
@@ -26523,7 +26475,6 @@
 	dir = 8;
 	name = "Captain's Office APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -26870,7 +26821,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/computer/bounty{
@@ -27825,7 +27775,6 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Hydroponics APC";
-	pixel_x = 0;
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -28516,7 +28465,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -29172,7 +29120,6 @@
 	frequency = 1423;
 	listening = 0;
 	name = "Interrogation Intercom";
-	pixel_x = 0;
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -29313,7 +29260,6 @@
 	},
 /obj/machinery/newscaster{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -31413,7 +31359,6 @@
 "bdK" = (
 /obj/machinery/requests_console{
 	department = "EVA";
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -31919,7 +31864,6 @@
 	dir = 8;
 	name = "Council Chambers APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
@@ -32295,7 +32239,6 @@
 	dir = 8;
 	name = "Cargo Security APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
@@ -33401,7 +33344,6 @@
 /area/crew_quarters/cafeteria)
 "bhD" = (
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel,
@@ -36459,7 +36401,6 @@
 	dir = 8;
 	name = "Gateway APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -37499,7 +37440,6 @@
 	dir = 1
 	},
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = -29
 	},
 /turf/open/floor/plasteel,
@@ -38166,7 +38106,6 @@
 	departmentType = 0;
 	name = "Genetics Requests Console";
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	icon_state = "trimline_fill";
@@ -39378,7 +39317,6 @@
 	},
 /obj/structure/chair,
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
@@ -40778,7 +40716,6 @@
 	departmentType = 2;
 	name = "Science Requests Console";
 	pixel_x = -32;
-	pixel_y = 0;
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera/autoname{
@@ -41468,7 +41405,6 @@
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
 	pixel_x = 32;
-	pixel_y = 0
 	},
 /obj/item/folder,
 /obj/item/folder,
@@ -43797,7 +43733,6 @@
 	dir = 8;
 	name = "Cloning Lab APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	icon_state = "trimline_fill";
@@ -44652,7 +44587,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /turf/open/floor/plasteel/cult{
@@ -44943,7 +44877,6 @@
 	id = "cmoshutter";
 	name = "CMO Office Shutters";
 	pixel_x = -25;
-	pixel_y = 0;
 	req_access_txt = "40"
 	},
 /turf/open/floor/plasteel/white,
@@ -47007,7 +46940,6 @@
 	department = "Security";
 	departmentType = 5;
 	pixel_x = -30;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	icon_state = "trimline_fill";
@@ -47084,7 +47016,6 @@
 /obj/machinery/power/apc/highcap/five_k{
 	dir = 1;
 	name = "Central Hall APC";
-	pixel_x = 0;
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -47914,7 +47845,6 @@
 	icon_state = "sink_alt";
 	name = "old sink";
 	pixel_x = 15;
-	pixel_y = 0
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -50049,7 +49979,6 @@
 /obj/machinery/light/small,
 /obj/machinery/vending/wallmed{
 	pixel_x = -28;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	icon_state = "trimline_fill";
@@ -50759,7 +50688,6 @@
 	areastring = "/area/ai_monitored/turret_protected/aisat_interior";
 	dir = 1;
 	name = "MiniSat Antechamber APC";
-	pixel_x = 0;
 	pixel_y = 29
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -52934,7 +52862,6 @@
 	dir = 2;
 	name = "MiniSat Foyer APC";
 	pixel_x = -29;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -53002,7 +52929,6 @@
 	dir = 8;
 	name = "MiniSat Exterior APC";
 	pixel_x = -24;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	icon_state = "trimline_fill";
@@ -53664,7 +53590,6 @@
 /obj/machinery/requests_console{
 	department = "Tool Storage";
 	departmentType = 0;
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/item/folder/yellow,
@@ -53825,7 +53750,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/newscaster{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/loading_area{
@@ -55174,7 +55098,6 @@
 	dir = 8;
 	name = "Tool Storage APC";
 	pixel_x = -25;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -55622,7 +55545,6 @@
 	dir = 4;
 	name = "Fore Maintenance APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -55929,7 +55851,6 @@
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -56057,7 +55978,6 @@
 /obj/machinery/announcement_system,
 /obj/machinery/status_display/ai{
 	pixel_x = 31;
-	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -57109,7 +57029,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -57391,7 +57310,6 @@
 	},
 /obj/machinery/status_display/evac{
 	pixel_x = 31;
-	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -57545,7 +57463,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -57577,7 +57494,6 @@
 	id = "atmos";
 	name = "Atmospherics Lockdown";
 	pixel_x = -38;
-	pixel_y = 0;
 	req_access_txt = "24"
 	},
 /turf/open/floor/plasteel,
@@ -57847,7 +57763,6 @@
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
 	pixel_x = 30;
-	pixel_y = 0
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -58657,7 +58572,6 @@
 	dir = 4;
 	name = "Chief Engineer's APC";
 	pixel_x = 26;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -58782,7 +58696,6 @@
 	dir = 8;
 	name = "Locker Room APC";
 	pixel_x = -28;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -59393,7 +59306,6 @@
 	dir = 4;
 	name = "Dormitories APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60333,7 +60245,6 @@
 	dir = 4;
 	name = "Chief Medical Officer's Quarters APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60658,7 +60569,6 @@
 	name = "Lock Control";
 	normaldoorcontrol = 1;
 	pixel_x = 25;
-	pixel_y = 0;
 	specialfunctions = 4
 	},
 /obj/machinery/newscaster{
@@ -61078,7 +60988,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "ceK" = (
 /obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = 0;
 	pixel_y = -32
 	},
 /turf/open/floor/plating,
@@ -61126,7 +61035,6 @@
 /obj/structure/bed,
 /obj/machinery/status_display/ai{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo/private)
@@ -61599,7 +61507,6 @@
 	areastring = "/area/chapel/main";
 	dir = 1;
 	name = "Chapel APC";
-	pixel_x = 0;
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -62561,7 +62468,6 @@
 "cig" = (
 /obj/structure/sign/warning/radiation/rad_area{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	icon_state = "trimline_fill";
@@ -63311,7 +63217,6 @@
 /area/maintenance/aft)
 "cjC" = (
 /obj/structure/mirror{
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/item/lipstick/black,
@@ -63650,7 +63555,6 @@
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
 	pixel_x = 30;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -63947,7 +63851,6 @@
 	},
 /obj/machinery/newscaster{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -64090,7 +63993,6 @@
 	dir = 1;
 	name = "SMES room APC";
 	pixel_x = -26;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -64416,7 +64318,6 @@
 	broadcasting = 1;
 	frequency = 1481;
 	name = "Confessional Intercom";
-	pixel_x = 0;
 	pixel_y = -30
 	},
 /obj/machinery/light/small{
@@ -64437,7 +64338,6 @@
 	broadcasting = 1;
 	frequency = 1481;
 	name = "Confessional Intercom";
-	pixel_x = 0;
 	pixel_y = 30
 	},
 /obj/machinery/light/small{
@@ -64949,7 +64849,6 @@
 	dir = 1;
 	name = "Atmospherics APC";
 	pixel_x = -27;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	icon_state = "trimline_fill";
@@ -68610,7 +68509,6 @@
 	areastring = "/area/hydroponics/garden";
 	dir = 2;
 	name = "Garden APC";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable{
@@ -69318,7 +69216,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /obj/machinery/camera/autoname{
@@ -69369,7 +69266,6 @@
 	dir = 4;
 	name = "Auxillary Base Construction APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -70371,7 +70267,6 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = -26;
-	pixel_y = 0
 	},
 /obj/item/stack/cable_coil/white{
 	pixel_x = 3;
@@ -72121,7 +72016,6 @@
 	},
 /obj/item/radio/intercom{
 	pixel_x = 26;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
@@ -72265,7 +72159,6 @@
 	dir = 4;
 	name = "Starboard Hallway APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -72718,7 +72611,6 @@
 	name = "Auxillary Base Monitor";
 	network = list("auxbase");
 	pixel_x = 25;
-	pixel_y = 0
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -73580,7 +73472,6 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/item/radio/intercom{
-	pixel_x = 0;
 	pixel_y = 23
 	},
 /turf/open/floor/plasteel/dark,
@@ -74023,7 +73914,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel/white,
@@ -74593,7 +74483,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/fireaxecabinet{
 	pixel_x = -31;
-	pixel_y = 0
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	icon_state = "trimline_fill";
@@ -75451,7 +75340,6 @@
 	id = "aux_base_shutters";
 	name = "Public Shutters Control";
 	pixel_x = 24;
-	pixel_y = 0;
 	req_one_access_txt = "32;47;48"
 	},
 /obj/machinery/camera{
@@ -76509,7 +76397,6 @@
 /obj/machinery/flasher{
 	id = "brigflashdoor";
 	pixel_x = -26;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -77128,7 +77015,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/item/storage/secure/safe/HoS{
 	pixel_x = 36;
-	pixel_y = 0
 	},
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -78620,7 +78506,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel,
@@ -78654,7 +78539,6 @@
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
 	pixel_x = 30;
-	pixel_y = 0
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -78665,7 +78549,6 @@
 /obj/item/radio/intercom{
 	dir = 1;
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = -28
 	},
 /turf/open/floor/plasteel/dark,
@@ -79513,7 +79396,6 @@
 	id = "ewradiation";
 	name = "Shutters Control";
 	pixel_x = 33;
-	pixel_y = 0;
 	req_access_txt = "11"
 	},
 /turf/open/floor/plasteel,
@@ -81824,7 +81706,6 @@
 /obj/structure/bed/dogbed/ian,
 /obj/item/radio/intercom{
 	dir = 2;
-	pixel_x = 0;
 	pixel_y = 28
 	},
 /turf/open/floor/wood,
@@ -83804,7 +83685,6 @@
 	dir = 1
 	},
 /obj/structure/sign/warning/securearea{
-	pixel_x = 0;
 	pixel_y = 32
 	},
 /turf/open/floor/plasteel,
@@ -83822,7 +83702,6 @@
 	areastring = "/area/engine/storage";
 	dir = 2;
 	name = "Engineering Storage APC";
-	pixel_x = 0;
 	pixel_y = -26
 	},
 /obj/structure/cable,
@@ -84209,7 +84088,6 @@
 	dir = 4;
 	name = "Electrical Maintenance APC";
 	pixel_x = 24;
-	pixel_y = 0
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -84391,7 +84269,6 @@
 "cXO" = (
 /obj/machinery/status_display/ai{
 	pixel_x = -32;
-	pixel_y = 0
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/chief/private";
@@ -84483,7 +84360,6 @@
 /obj/machinery/camera/autoname,
 /obj/item/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -84507,7 +84383,6 @@
 	},
 /obj/item/radio/intercom{
 	name = "Station Intercom";
-	pixel_x = 0;
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel/cafeteria,


### PR DESCRIPTION
## About The Pull Request

removes all x/y = 0 diry vars they smell bad

## Why It's Good For The Game

Makes master not rng fail...

## Changelog
:cl:
code: Map wise all diry vars of "pixel = 0" have been removed.
/:cl: