### PR TITLE
Stechkin and ASP ammo boxes in uplink and ASP ammo boxes

### DIFF
--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -406,7 +406,7 @@
 
 /obj/item/storage/box/syndie_kit/pistol
 
-/obj/item/storage/box/syndie_kit/revolver/PopulateContents()
+/obj/item/storage/box/syndie_kit/pistol/PopulateContents()
 	new /obj/item/gun/ballistic/automatic/pistol(src)
 	new /obj/item/ammo_box/magazine/m10mm(src)
 

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -404,6 +404,12 @@
 	new /obj/item/gun/ballistic/revolver(src)
 	new /obj/item/ammo_box/a357(src)
 
+/obj/item/storage/box/syndie_kit/pistol
+
+/obj/item/storage/box/syndie_kit/revolver/PopulateContents()
+	new /obj/item/gun/ballistic/automatic/pistol(src)
+	new /obj/item/ammo_box/magazine/m10mm(src)
+
 /obj/item/storage/box/syndie_kit/contract_kit
 	name = "contractor kit"
 	desc = "Supplied to Syndicate contractors in active mission areas."

--- a/code/modules/projectiles/ammunition/ballistic/pistol.dm
+++ b/code/modules/projectiles/ammunition/ballistic/pistol.dm
@@ -21,6 +21,11 @@
 	desc = "A 10mm incendiary bullet casing."
 	projectile_type = /obj/item/projectile/bullet/incendiary/c10mm
 
+/obj/item/ammo_casing/c10mm/soporific
+	name = ".10mm soporific bullet casing"
+	desc = "A 10mm soporific bullet casing."
+	projectile_type = /obj/item/projectile/bullet/c10mm/soporific
+
 // 9mm (Stechkin APS)
 
 /obj/item/ammo_casing/c9mm

--- a/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
+++ b/code/modules/projectiles/boxes_magazines/ammo_boxes.dm
@@ -52,6 +52,29 @@
 	ammo_type = /obj/item/ammo_casing/c10mm
 	max_ammo = 20
 
+/obj/item/ammo_box/c10mm/fire
+	name = "ammo box (10mm Incendiary)"
+	icon_state = "10mmbox"
+	ammo_type = /obj/item/ammo_casing/c10mm/fire
+	max_ammo = 20
+
+/obj/item/ammo_box/c10mm/hp
+	name = "ammo box (10mm Hollow Point)"
+	icon_state = "10mmbox"
+	ammo_type = /obj/item/ammo_casing/c10mm/hp
+	max_ammo = 20
+
+/obj/item/ammo_box/c10mm/ap
+	name = "ammo box (10mm Armour Piercing)"
+	icon_state = "10mmbox"
+	ammo_type = /obj/item/ammo_casing/c10mm/ap
+	max_ammo = 20
+
+/obj/item/ammo_box/c10mm/soporific
+	name = "ammo box (10mm Soporific)"
+	ammo_type = /obj/item/ammo_casing/c10mm/soporific
+	max_ammo = 20
+
 /obj/item/ammo_box/c45
 	name = "ammo box (.45)"
 	icon_state = "45box"

--- a/code/modules/projectiles/boxes_magazines/external/pistol.dm
+++ b/code/modules/projectiles/boxes_magazines/external/pistol.dm
@@ -25,6 +25,13 @@
 	desc= "A gun magazine. Loaded with rounds which penetrate armour, but are less effective against normal targets."
 	ammo_type = /obj/item/ammo_casing/c10mm/ap
 
+/obj/item/ammo_box/magazine/m10mm/soporific
+	name = "pistol magazine (10mm soporific)"
+	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
+	icon_state = "9x19pS"
+	desc = "A gun magazine. Loaded with rounds which inject the target with a variety of illegal substances to induce sleep in the target."
+	ammo_type = /obj/item/ammo_casing/c10mm/soporific
+
 /obj/item/ammo_box/magazine/m45
 	name = "handgun magazine (.45)"
 	icon_state = "45-8"

--- a/code/modules/projectiles/guns/ballistic/pistol.dm
+++ b/code/modules/projectiles/guns/ballistic/pistol.dm
@@ -21,6 +21,38 @@
 	var/obj/item/suppressor/S = new(src)
 	install_suppressor(S)
 
+//(reskinnable stetchkin)
+/obj/item/gun/ballistic/automatic/pistol/modular
+	name = "modular pistol"
+	desc = "A small, easily concealable 10mm handgun. Has a threaded barrel for suppressors."
+	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
+	icon_state = "cde"
+	can_unsuppress = TRUE
+	obj_flags = UNIQUE_RENAME
+	unique_reskin = list("Default" = "cde",
+						"N-99" = "n99",
+						"Stealth" = "stealthpistol",
+						"HKVP-78" = "vp78",
+						"Luger" = "p08b",
+						"Mk.58" = "secguncomp",
+						"PX4 Storm" = "px4"
+						)
+
+/obj/item/gun/ballistic/automatic/pistol/modular/update_icon()
+	..()
+	if(current_skin)
+		icon_state = "[unique_reskin[current_skin]][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
+	else
+		icon_state = "[initial(icon_state)][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
+	if(magazine && suppressed)
+		cut_overlays()
+		add_overlay("[unique_reskin[current_skin]]-magazine-sup")	//Yes, this means the default iconstate can't have a magazine overlay
+	else if (magazine)
+		cut_overlays()
+		add_overlay("[unique_reskin[current_skin]]-magazine")
+	else
+		cut_overlays()
+
 /obj/item/gun/ballistic/automatic/pistol/m1911
 	name = "\improper M1911"
 	desc = "A classic .45 handgun with a small magazine capacity."
@@ -92,3 +124,34 @@
 		to_chat(user, "<span class='notice'>..and falls into view. Whew, that was a close one.</span>")
 		user.dropItemToGround(src)
 
+////////////Anti Tank Pistol////////////
+
+/obj/item/gun/ballistic/automatic/pistol/antitank
+	name = "Anti Tank Pistol"
+	desc = "A massively impractical and silly monstrosity of a pistol that fires .50 calliber rounds. The recoil is likely to dislocate your wrist."
+	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
+	icon_state = "atp"
+	item_state = "pistol"
+	recoil = 4
+	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
+	fire_delay = 50
+	burst_size = 1
+	can_suppress = 0
+	w_class = WEIGHT_CLASS_NORMAL
+	actions_types = list()
+	fire_sound = 'sound/weapons/blastcannon.ogg'
+	spread = 20		//damn thing has no rifling.
+
+/obj/item/gun/ballistic/automatic/pistol/antitank/update_icon()
+	..()
+	if(magazine)
+		cut_overlays()
+		add_overlay("atp-mag")
+	else
+		cut_overlays()
+	icon_state = "[initial(icon_state)][chambered ? "" : "-e"]"
+
+/obj/item/gun/ballistic/automatic/pistol/antitank/syndicate
+	name = "Syndicate Anti Tank Pistol"
+	desc = "A massively impractical and silly monstrosity of a pistol that fires .50 calliber rounds. The recoil is likely to dislocate a variety of joints without proper bracing."
+	pin = /obj/item/firing_pin/implant/pindicate

--- a/code/modules/projectiles/projectile/bullets/pistol.dm
+++ b/code/modules/projectiles/projectile/bullets/pistol.dm
@@ -34,3 +34,17 @@
 	name = "10mm incendiary bullet"
 	damage = 15
 	fire_stacks = 2
+
+/obj/item/projectile/bullet/c10mm/soporific
+	name ="10mm soporific bullet"
+	nodamage = TRUE
+
+/obj/item/projectile/bullet/c10mm/soporific/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+	if((blocked != 100) && isliving(target))
+		var/mob/living/L = target
+		L.blur_eyes(6)
+		if(L.getStaminaLoss() >= 60)
+			L.Sleeping(300)
+		else
+			L.adjustStaminaLoss(25)

--- a/code/modules/uplink/uplink_items/uplink_ammo.dm
+++ b/code/modules/uplink/uplink_items/uplink_ammo.dm
@@ -15,6 +15,12 @@
 	cost = 1
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/ammo/pistol/box
+	name = "Ammo Box - 10mm"
+	desc = "An additional box of 10mm ammo. The box has 20 cases inside, does not come with a magazine."
+	item = /obj/item/ammo_box/c10mm
+	illegal_tech = FALSE
+
 /datum/uplink_item/ammo/pistolap
 	name = "10mm Armour Piercing Magazine"
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
@@ -22,6 +28,12 @@
 	item = /obj/item/ammo_box/magazine/m10mm/ap
 	cost = 2
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
+
+/datum/uplink_item/ammo/pistolap/box
+	name = "Ammo Box - 10mm Armour Piercing"
+	desc = "An additional box of 10mm Armour Piercing ammo. The box has 20 cases inside, does not come with a magazine."
+	item = /obj/item/ammo_box/c10mm/ap
+	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/pistolhp
 	name = "10mm Hollow Point Magazine"
@@ -31,6 +43,12 @@
 	cost = 3
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/ammo/pistolhp/box
+	name = "Ammo Box - 10mm Hollow Point"
+	desc = "An additional box of 10mm Hollow Point ammo. The box has 20 cases inside, does not come with a magazine."
+	item = /obj/item/ammo_box/c10mm/hp
+	illegal_tech = FALSE
+
 /datum/uplink_item/ammo/pistolfire
 	name = "10mm Incendiary Magazine"
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. \
@@ -39,12 +57,24 @@
 	cost = 2
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 
+/datum/uplink_item/ammo/pistolfire/box
+	name = "Ammo Box - 10mm Incendiary"
+	desc = "An additional box of 10mm Incendiary ammo. The box has 20 cases inside, does not come with a magazine."
+	item = /obj/item/ammo_box/magazine/m10mm/fire
+	illegal_tech = FALSE
+
 /datum/uplink_item/ammo/pistolzzz
 	name = "10mm Soporific Magazine"
 	desc = "An additional 8-round 10mm magazine; compatible with the Stechkin Pistol. Loaded with soporific rounds that put the target to sleep. \
 			NOTE: Soporific is not instant acting due to the constraints of the round's scale. Will usually require three shots to take effect."
 	item = /obj/item/ammo_box/magazine/m10mm/soporific
 	cost = 2
+
+/datum/uplink_item/ammo/pistolzzz/box
+	name = "Ammo Box - 10mm Soporific"
+	desc = "An additional box of 10mm Soporific ammo. The box has 20 cases inside, does not come with a magazine."
+	item = /obj/item/ammo_box/c10mm/soporific
+	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/shotgun
 	cost = 2
@@ -211,6 +241,12 @@
 	item = /obj/item/ammo_box/magazine/pistolm9mm
 	cost = 2
 	include_modes = list(/datum/game_mode/nuclear)
+
+/datum/uplink_item/ammo/pistolaps
+	name = "Ammo Box - 9mm"
+	desc = "An additional box of 9mm ammo. The box has 30 cases inside, does not come with a magazine."
+	item = /obj/item/ammo_box/c9mm
+	illegal_tech = FALSE
 
 /datum/uplink_item/ammo/flechetteap
 	name = "Armor Piercing Flechette Magazine"

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -9,9 +9,9 @@
 
 /datum/uplink_item/dangerous/pistol
 	name = "Stechkin Pistol"
-	desc = "A small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines and is compatible \
+	desc = "A sleek box containing a small, easily concealable handgun that uses 10mm auto rounds in 8-round magazines. The handgun is compatible \
 			with suppressors."
-	item = /obj/item/gun/ballistic/automatic/pistol
+	item = /obj/item/storage/box/syndie_kit/pistol
 	cost = 7
 	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
 

--- a/modular_citadel/code/modules/projectiles/guns/ballistic/handguns.dm
+++ b/modular_citadel/code/modules/projectiles/guns/ballistic/handguns.dm
@@ -1,34 +1,3 @@
-////////////Anti Tank Pistol////////////
-
-/obj/item/gun/ballistic/automatic/pistol/antitank
-	name = "Anti Tank Pistol"
-	desc = "A massively impractical and silly monstrosity of a pistol that fires .50 calliber rounds. The recoil is likely to dislocate your wrist."
-	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
-	icon_state = "atp"
-	item_state = "pistol"
-	recoil = 4
-	mag_type = /obj/item/ammo_box/magazine/sniper_rounds
-	fire_delay = 50
-	burst_size = 1
-	can_suppress = 0
-	w_class = WEIGHT_CLASS_NORMAL
-	actions_types = list()
-	fire_sound = 'sound/weapons/blastcannon.ogg'
-	spread = 20		//damn thing has no rifling.
-
-/obj/item/gun/ballistic/automatic/pistol/antitank/update_icon()
-	..()
-	if(magazine)
-		cut_overlays()
-		add_overlay("atp-mag")
-	else
-		cut_overlays()
-	icon_state = "[initial(icon_state)][chambered ? "" : "-e"]"
-
-/obj/item/gun/ballistic/automatic/pistol/antitank/syndicate
-	name = "Syndicate Anti Tank Pistol"
-	desc = "A massively impractical and silly monstrosity of a pistol that fires .50 calliber rounds. The recoil is likely to dislocate a variety of joints without proper bracing."
-	pin = /obj/item/firing_pin/implant/pindicate
 
 ///foam stealth pistol///
 
@@ -55,72 +24,6 @@
 	else
 		cut_overlays()
 	icon_state = "[initial(icon_state)][chambered ? "" : "-e"]"
-
-//////10mm soporific bullets//////
-
-/obj/item/projectile/bullet/c10mm/soporific
-	name ="10mm soporific bullet"
-	nodamage = TRUE
-
-/obj/item/projectile/bullet/c10mm/soporific/on_hit(atom/target, blocked = FALSE)
-	. = ..()
-	if((blocked != 100) && isliving(target))
-		var/mob/living/L = target
-		L.blur_eyes(6)
-		if(L.getStaminaLoss() >= 60)
-			L.Sleeping(300)
-		else
-			L.adjustStaminaLoss(25)
-
-/obj/item/ammo_casing/c10mm/soporific
-	name = ".10mm soporific bullet casing"
-	desc = "A 10mm soporific bullet casing."
-	projectile_type = /obj/item/projectile/bullet/c10mm/soporific
-
-/obj/item/ammo_box/magazine/m10mm/soporific
-	name = "pistol magazine (10mm soporific)"
-	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
-	icon_state = "9x19pS"
-	desc = "A gun magazine. Loaded with rounds which inject the target with a variety of illegal substances to induce sleep in the target."
-	ammo_type = /obj/item/ammo_casing/c10mm/soporific
-
-/obj/item/ammo_box/c10mm/soporific
-	name = "ammo box (10mm soporific)"
-	ammo_type = /obj/item/ammo_casing/c10mm/soporific
-	max_ammo = 24
-
-//////modular pistol////// (reskinnable stetchkins)
-
-/obj/item/gun/ballistic/automatic/pistol/modular
-	name = "modular pistol"
-	desc = "A small, easily concealable 10mm handgun. Has a threaded barrel for suppressors."
-	icon = 'modular_citadel/icons/obj/guns/cit_guns.dmi'
-	icon_state = "cde"
-	can_unsuppress = TRUE
-	obj_flags = UNIQUE_RENAME
-	unique_reskin = list("Default" = "cde",
-						"NT-99" = "n99",
-						"Stealth" = "stealthpistol",
-						"HKVP-78" = "vp78",
-						"Luger" = "p08b",
-						"Mk.58" = "secguncomp",
-						"PX4 Storm" = "px4"
-						)
-
-/obj/item/gun/ballistic/automatic/pistol/modular/update_icon()
-	..()
-	if(current_skin)
-		icon_state = "[unique_reskin[current_skin]][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
-	else
-		icon_state = "[initial(icon_state)][chambered ? "" : "-e"][suppressed ? "-suppressed" : ""]"
-	if(magazine && suppressed)
-		cut_overlays()
-		add_overlay("[unique_reskin[current_skin]]-magazine-sup")	//Yes, this means the default iconstate can't have a magazine overlay
-	else if (magazine)
-		cut_overlays()
-		add_overlay("[unique_reskin[current_skin]]-magazine")
-	else
-		cut_overlays()
 
 /////////RAYGUN MEMES/////////
 


### PR DESCRIPTION
## About The Pull Request

Demodulizes Sleeper ammo for the 10mm gun as well as reskinkable Stechkins/Anti-tank gun
all 10mm ammo now has a box that can be gotton in the uplink for the same amount as a mag. 
These boxes no longer count as illegal tech.
The Stechkin now also comes in a box like her brother the revolver with a spare mag.

## Why It's Good For The Game

Ammo is hard to get in the stechkin/ASP other then spawning loads of easy swap mags, that you discard and never pickup or care about again. This makes it worth it to reload your mags and care for them as well as helps against the horrable trade of ammo from tc. As its wayyy harder to sustain yourself on ammo then before. All in all this is mostly to help traitors and the like that have a low budget and need to get that little bit more firepower to keep people at bay/suppressed - Really helps out Contractors and non-lethal traitors if they can get more sleeper ammo for cheap as well. 

## Changelog
:cl:
add: Stechkin now comes with a spare mag
add: Both the Stechkin and ASP Stechkin now have all their ammo types in side boxes that can be gotten via uplink
code: demodulize the 10mm ammo, modular pistol and anti-tank guns
tweak: 10mm sleeper boxes now hold 20 rounds rather then 24
/:cl: