### PR TITLE
Pop caps Sleeping Carp and Rising Bass to 30 players.

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_stealth.dm
+++ b/code/modules/uplink/uplink_items/uplink_stealth.dm
@@ -51,6 +51,7 @@
 			gain skin as hard as steel and swat bullets from the air, but you also refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/carp
 	cost = 17
+	player_minimum = 30
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 
@@ -60,6 +61,7 @@
 	and dodging all ranged weapon fire, but you will refuse to use dishonorable ranged weaponry."
 	item = /obj/item/book/granter/martial/bass
 	cost = 18
+	player_minimum = 30
 	surplus = 0
 	exclude_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Kev kept saying he was gonna do it and never did so I'm doing it.

Both the martial arts are a pain in the ass to deal with at low populations and low security numbers. I literally designed sleeping carp to be fought by more than one person at a time and if the station just doesn't have the crew to do that, then they can't.

Rising Bass meanwhile is just better at doing what Sleeping Carp does as being a defensive martial art and so quite honestly you can run amok just as badly with it.

If this means the martial arts are never seen as a result of people late joining then I am just going to reduce the numbers down. Alternatively try and suggest if we can't just have items in the uplink unlock later into a round rather than strictly poplocking them. Just to give the crew a little breathing room before big stuff turns up.

## Why It's Good For The Game

People are apparently too scared to fight sleeping carp due to being a powerhouse in a 1v1 and that's made all the worse at lower populations. Now personally I would argue to pony up a posse and go fight the fucker but on cit you just can't gather enough people willing to risk death. Sleeping carp users kill people pretty quick after all.

Rising Bass is just a pain in the fucking ass.

## Changelog
:cl:
balance: Population locks the traitor martial arts. It requires 30 players in a round.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
