### PR TITLE
Fixing spellcasting and edge cases.

### DIFF
--- a/code/datums/elements/spellcasting.dm
+++ b/code/datums/elements/spellcasting.dm
@@ -4,6 +4,7 @@
 	var/cast_flags
 	var/cast_slots
 	var/list/users_by_item = list()
+	var/list/stacked_spellcasting_by_user = list()
 
 /datum/element/spellcasting/Attach(datum/target, _flags, _slots)
 	. = ..()
@@ -12,6 +13,7 @@
 		RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/on_drop)
 	else if(ismob(target))
 		RegisterSignal(target, COMSIG_MOB_SPELL_CAST_CHECK, .proc/on_cast)
+		stacked_spellcasting_by_user[target]++
 	else
 		return ELEMENT_INCOMPATIBLE
 	cast_flags = _flags
@@ -22,16 +24,31 @@
 	UnregisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOB_SPELL_CAST_CHECK))
 	if(users_by_item[target])
 		var/mob/user = users_by_item[target]
-		UnregisterSignal(user, COMSIG_MOB_SPELL_CAST_CHECK)
+		stacked_spellcasting_by_user[user]--
+		if(!stacked_spellcasting_by_user[user])
+			stacked_spellcasting_by_user -= user
+			UnregisterSignal(user, COMSIG_MOB_SPELL_CAST_CHECK)
+	else if(ismob(target))
+		stacked_spellcasting_by_user[target]--
+		if(!stacked_spellcasting_by_user[target])
+			stacked_spellcasting_by_user -= target
 
 /datum/element/spellcasting/proc/on_equip(datum/source, mob/equipper, slot)
-	if(slot in cast_slots)
+	if(!(slot in cast_slots))
+		return
+	users_by_item[source] = equipper
+	if(!stacked_spellcasting_by_user[equipper])
 		RegisterSignal(equipper, COMSIG_MOB_SPELL_CAST_CHECK, .proc/on_cast)
-		users_by_item[source] = equipper
+	stacked_spellcasting_by_user[equipper]++
 
 /datum/element/spellcasting/proc/on_drop(datum/source, mob/user)
-	UnregisterSignal(user, COMSIG_MOB_SPELL_CAST_CHECK)
+	if(!users_by_item[source])
+		return
 	users_by_item -= source
+	stacked_spellcasting_by_user[user]--
+	if(!stacked_spellcasting_by_user[user])
+		stacked_spellcasting_by_user -= user
+		UnregisterSignal(user, COMSIG_MOB_SPELL_CAST_CHECK)
 
 /datum/element/spellcasting/proc/on_cast(mob/caster, obj/effect/proc_holder/spell)
 	return cast_flags

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -436,7 +436,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	if(magic_flags & SPELL_SKIP_ALL_REQS)
 		return TRUE
 
-	if(player_lock && (!user.mind || !(src in user.mind.spell_list) && !(src in user.mob_spell_list)))
+	if(player_lock ? (!user.mind || !(src in user.mind.spell_list) && !(src in user.mob_spell_list)) : !(src in user.mob_spell_list))
 		if(!silent)
 			to_chat(user, "<span class='warning'>You shouldn't have this spell! Something's wrong.</span>")
 		return FALSE
@@ -483,7 +483,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				to_chat(L, "<span class='notice'>You can't get the words out!</span>")
 			return FALSE
 
-	if(!(magic_flags & SPELL_SKIP_MOBTYPE) && ((mobs_whitelist && !mobs_whitelist[user]) || (mobs_blacklist && mobs_blacklist[user])))
+	if(!(magic_flags & SPELL_SKIP_MOBTYPE) && ((mobs_whitelist && !mobs_whitelist[user.type]) || (mobs_blacklist && mobs_blacklist[user.type])))
 		if(!silent)
 			to_chat(user, "<span class='notice'>This spell can't be casted in this current form!</span>")
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
Because whitelists/blacklists were checking the user ref instead of its type, and malformed the player_lock etcetera logic.

Plus added some an extra` stacked_spellcasting_by_user` var since elements are singletons and I may not want users with, let's say, intrinsic spellcasting flags such as SPELL_WIZARD_HAT having such flags removed when dropping any wizard hat around. Idem for spellcasting items with multiple possible slots and similar edge cases. 

## Changelog
N/A