### PR TITLE
uplink content updates with the current population

### DIFF
--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -119,13 +119,13 @@ GLOBAL_LIST_EMPTY(uplinks)
 		return
 	active = TRUE
 	if(user)
-		ui_interact(user)
 		//update the saved population
 		var/previous_player_population = saved_player_population
 		saved_player_population = GLOB.joined_player_list.len
 		//if population has changed, update uplink items
 		if(saved_player_population != previous_player_population)
 			uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted, filters)
+		ui_interact(user)
 
 	// an unlocked uplink blocks also opening the PDA or headset menu
 	return COMPONENT_NO_INTERACT

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -28,6 +28,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 	var/compact_mode = FALSE
 	var/debug = FALSE
 	var/saved_player_population = 0
+	var/list/filters = list()
 
 /datum/component/uplink/Initialize(_owner, _lockable = TRUE, _enabled = FALSE, datum/game_mode/_gamemode, starting_tc = 20, datum/ui_state/_checkstate, datum/traitor_class/traitor_class)
 	if(!isitem(parent))
@@ -48,7 +49,6 @@ GLOBAL_LIST_EMPTY(uplinks)
 		RegisterSignal(parent, COMSIG_PEN_ROTATED, .proc/pen_rotation)
 
 	GLOB.uplinks += src
-	var/list/filters = list()
 	if(istype(traitor_class))
 		filters = traitor_class.uplink_filters
 		starting_tc = traitor_class.TC
@@ -121,10 +121,10 @@ GLOBAL_LIST_EMPTY(uplinks)
 	if(user)
 		ui_interact(user)
 		//update the saved population
-		previous_player_population = saved_player_population
+		var/previous_player_population = saved_player_population
 		saved_player_population = GLOB.joined_player_list.len
 		//if population has changed, update uplink items
-		if(saved_player_population != current_player_population)
+		if(saved_player_population != previous_player_population)
 			uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted, filters)
 
 	// an unlocked uplink blocks also opening the PDA or headset menu

--- a/code/datums/components/uplink.dm
+++ b/code/datums/components/uplink.dm
@@ -124,7 +124,11 @@ GLOBAL_LIST_EMPTY(uplinks)
 		saved_player_population = GLOB.joined_player_list.len
 		//if population has changed, update uplink items
 		if(saved_player_population != previous_player_population)
-			uplink_items = get_uplink_items(gamemode, TRUE, allow_restricted, filters)
+			//make sure discounts are not rerolled
+			var/old_discounts = uplink_items["Discounted Gear"]
+			uplink_items = get_uplink_items(gamemode, FALSE, allow_restricted, filters)
+			if(old_discounts)
+				uplink_items["Discounted Gear"] = old_discounts
 		ui_interact(user)
 
 	// an unlocked uplink blocks also opening the PDA or headset menu
@@ -200,7 +204,7 @@ GLOBAL_LIST_EMPTY(uplinks)
 			if(item in buyable_items)
 				var/datum/uplink_item/I = buyable_items[item]
 				//check to make sure people cannot buy items when the player pop is below the requirement
-				if(saved_player_population >= I.player_minimum)
+				if(GLOB.joined_player_list.len >= I.player_minimum)
 					MakePurchase(usr, I)
 				. = TRUE
 		if("lock")


### PR DESCRIPTION
## About The Pull Request
uplink content updates with population, so items that are locked by population 
this is hopefully good (however there is probably a better way to do this that I am not aware of?)

it effectively works by checking the current population and the population at when you last opened the uplink, and if they're different, getting the contents of the uplink again. also if you try buying something from an opened uplink but the current population has changed to not allow you to buy it, it'll stop you buying it.

## Why It's Good For The Game
imagine wanting your gamer population locked item but half the station latejoin after you get your uplink

also probably good if #11763 gets merged due to more things being population locked in the uplink and latejoiners shouldn't be stopping you from getting it?


## Changelog
:cl:
tweak: uplink content updates with current population
/:cl:
