### PR TITLE
The contractor pod now gives regen jelly instead of omnizine

### DIFF
--- a/code/modules/antagonists/traitor/syndicate_contract.dm
+++ b/code/modules/antagonists/traitor/syndicate_contract.dm
@@ -89,7 +89,7 @@
 /datum/syndicate_contract/proc/handleVictimExperience(var/mob/living/M)	// They're off to holding - handle the return timer and give some text about what's going on.
 	addtimer(CALLBACK(src, .proc/returnVictim, M), 4 MINUTES)	// Ship 'em back - dead or alive... 4 minutes wait.
 	if(M.stat != DEAD)	//Even if they weren't the target, we're still treating them the same.
-		M.reagents.add_reagent(/datum/reagent/medicine/omnizine, 20)	// Heal them up - gets them out of crit/soft crit.
+		M.reagents.add_reagent(/datum/reagent/medicine/regen_jelly, 20)	// Heal them up - gets them out of crit/soft crit. -- now 100% toxinlover friendly!!
 		M.flash_act()
 		M.confused += 10
 		M.blur_eyes(5)


### PR DESCRIPTION
## About The Pull Request

title

## Why It's Good For The Game

so the funny jello people don't die because they got clicked or something

## Changelog
:cl:
tweak: The contractor's extraction pods now give regenerative jelly rather than omnizine.
/:cl:
