### PR TITLE
blacklist ERP chems from mass production (i.e. bees.)

### DIFF
--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -95,6 +95,7 @@
 	taste_description = "strawberry roofies"
 	taste_mult = 2 //Hide the roofies in stronger flavors
 	color = "#FFADFF"//PINK, rgb(255, 173, 255)
+	can_synth = FALSE
 
 /datum/reagent/drug/aphrodisiac/on_mob_life(mob/living/M)
 	if(M && M.client?.prefs.arousable && !(M.client?.prefs.cit_toggles & NO_APHRO))
@@ -120,6 +121,7 @@
 	color = "#FF2BFF"//dark pink
 	addiction_threshold = 20
 	overdose_threshold = 20
+	can_synth = FALSE
 
 /datum/reagent/drug/aphrodisiacplus/on_mob_life(mob/living/M)
 	if(M && M.client?.prefs.arousable && !(M.client?.prefs.cit_toggles & NO_APHRO))
@@ -174,6 +176,7 @@
 	taste_mult = 2
 	color = "#D9D9D9"//rgb(217, 217, 217)
 	reagent_state = SOLID
+	can_synth = FALSE
 
 /datum/reagent/drug/anaphrodisiac/on_mob_life(mob/living/M)
 	if(M && M.client?.prefs.arousable && prob(16))
@@ -191,6 +194,7 @@
 	color = "#D9D9D9"//rgb(217, 217, 217)
 	reagent_state = SOLID
 	overdose_threshold = 20
+	can_synth = FALSE
 
 /datum/reagent/drug/anaphrodisiacplus/on_mob_life(mob/living/M)
 	if(M && M.client?.prefs.arousable)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
title.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
What the fuck.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: erp chems can't be synthed. (i.e. no bees or odysseus hexa.)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
