### PR TITLE
Cloth can now be used to make padded floor tiles

### DIFF
--- a/code/game/objects/items/stacks/sheets/sheet_types.dm
+++ b/code/game/objects/items/stacks/sheets/sheet_types.dm
@@ -375,6 +375,7 @@ GLOBAL_LIST_INIT(cloth_recipes, list ( \
 	new/datum/stack_recipe("black gloves", /obj/item/clothing/gloves/color/black, 3), \
 	null, \
 	new/datum/stack_recipe("blindfold", /obj/item/clothing/glasses/sunglasses/blindfold, 2), \
+	new/datum/stack_recipe("padded floor tile", /obj/item/stack/tile/padded, 1), \
 	null, \
 	))
 


### PR DESCRIPTION

## About The Pull Request

1 cloth can make 1 tile of padded floor

## Why It's Good For The Game

THEY LOOK SO NICE, they are fun to place around and rest against it says so.

## Changelog
:cl:
add: Cloth now can be crafted into a padded floor for adv snuggles or a nice looking cell
/:cl:
