### PR TITLE
Makes spells activation only output one message instead of three.

### DIFF
--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -448,9 +448,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				to_chat(user, "<span class='notice'>You can't cast this spell here.</span>")
 			return FALSE
 
-	if(!skipcharge)
-		if(!charge_check(user, silent))
-			return FALSE
+	if(!skipcharge && !charge_check(user, silent))
+		return FALSE
 
 	if(user.stat && !stat_allowed && !(magic_flags & SPELL_SKIP_STAT))
 		if(!silent)

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -449,7 +449,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 			return FALSE
 
 	if(!skipcharge)
-		if(!charge_check(user))
+		if(!charge_check(user, silent))
 			return FALSE
 
 	if(user.stat && !stat_allowed && !(magic_flags & SPELL_SKIP_STAT))


### PR DESCRIPTION
## About The Pull Request
I should refactor the action code a little so can_cast is not called three times because of the action button icon updates sometime later..

## Why It's Good For The Game
Fixing a whoopsie.

## Changelog
Nope.