### PR TITLE
Fix warden runtime

### DIFF
--- a/code/modules/projectiles/guns/energy.dm
+++ b/code/modules/projectiles/guns/energy.dm
@@ -65,9 +65,6 @@
 	update_icon()
 
 /obj/item/gun/energy/Destroy()
-	//no need to delete them, since contents are already deleted in atom/movable/Destroy().
-	cell = null
-	ammo_type = null
 	STOP_PROCESSING(SSobj, src)
 	return ..()
 


### PR DESCRIPTION
Fixes #11772

Don't need to null out ammo_type and cell when we're qdel further down the stack. Issue with there being an update icon down the line and the destroy proc having already nulled it.