### PR TITLE
Maybe fixes looms - Looming Threads now can work with 4

### DIFF
--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -10,25 +10,25 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/loom/attackby(/obj/item/I, mob/user)
+/obj/structure/loom/attackby(obj/item/I, mob/user)
 	if(weave(I, user))
 		return
 	return ..()
 
-/obj/structure/loom/wrench_act(mob/living/user, /obj/item/I)
+/obj/structure/loom/wrench_act(mob/living/user, obj/item/I)
 	..()
 	default_unfasten_wrench(user, I, 5)
 	return TRUE
 
 ///Handles the weaving.
-/obj/structure/loom/proc/weave(/obj/item/stack/sheet/S, mob/user)
+/obj/structure/loom/proc/weave(obj/item/stack/sheet/S, mob/user)
 	if(!istype(S) || !S.is_fabric)
 		user.show_message("<span class='notice'>This can not be loomed!</span>", MSG_VISUAL)
 		return FALSE
 	if(!anchored)
 		user.show_message("<span class='notice'>The loom needs to be wrenched down.</span>", MSG_VISUAL)
 		return FALSE
-	if(S.amount < FABRIC_PER_SHEET)
+	if(S.amount =< FABRIC_PER_SHEET)
 		user.show_message("<span class='notice'>You need at least [FABRIC_PER_SHEET] units of fabric before using this.</span>", 1)
 		return FALSE
 	user.show_message("<span class='notice'>You start weaving \the [S.name] through the loom..</span>", MSG_VISUAL)

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -10,7 +10,7 @@
 	density = TRUE
 	anchored = TRUE
 
-/obj/structure/loom/attackby(obj/item/I, mob/user)
+/obj/structure/loom/attackby(/obj/item/I, mob/user)
 	if(weave(I, user))
 		return
 	return ..()
@@ -21,7 +21,7 @@
 	return TRUE
 
 ///Handles the weaving.
-/obj/structure/loom/proc/weave(obj/item/stack/sheet/S, mob/user)
+/obj/structure/loom/proc/weave(/obj/item/stack/sheet/S, mob/user)
 	if(!istype(S) || !S.is_fabric)
 		return FALSE
 	if(!anchored)

--- a/code/game/objects/structures/loom.dm
+++ b/code/game/objects/structures/loom.dm
@@ -15,7 +15,7 @@
 		return
 	return ..()
 
-/obj/structure/loom/wrench_act(mob/living/user, obj/item/I)
+/obj/structure/loom/wrench_act(mob/living/user, /obj/item/I)
 	..()
 	default_unfasten_wrench(user, I, 5)
 	return TRUE
@@ -23,6 +23,7 @@
 ///Handles the weaving.
 /obj/structure/loom/proc/weave(/obj/item/stack/sheet/S, mob/user)
 	if(!istype(S) || !S.is_fabric)
+		user.show_message("<span class='notice'>This can not be loomed!</span>", MSG_VISUAL)
 		return FALSE
 	if(!anchored)
 		user.show_message("<span class='notice'>The loom needs to be wrenched down.</span>", MSG_VISUAL)


### PR DESCRIPTION
## About The Pull Request

Adds a = sign so that 4 cloth/cotton will work rather then needing 5+

## Why It's Good For The Game

Using 4s should work 

## Changelog
:cl:
add: Makes Looms now work with 4 sheets/cotton rather then needing 5+
add: Feedback when you can not loom an item
/:cl:
