### PR TITLE
/carbon adjustStaminaLoss is now armor-piercing *as intended* before our modularized bandaid

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -15,7 +15,7 @@
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
 	var/obj/item/bodypart/BP = isbodypart(affected_zone)? affected_zone : (get_bodypart(check_zone(affected_zone)) || bodyparts[1])
-	if(amount > 0? BP.receive_damage(0, 0, amount) : BP.heal_damage(0, 0, abs(amount)))
+	if(amount > 0? BP.receive_damage(0, 0, amount * incomingstammult) : BP.heal_damage(0, 0, abs(amount)))
 		update_damage_overlays()
 	if(updating_health)
 		updatehealth()

--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -14,16 +14,12 @@
 /mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE, affected_zone = BODY_ZONE_CHEST)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	var/obj/item/bodypart/BP
-	if(isbodypart(affected_zone)) //we specified a bodypart object
-		BP = def_zone
-	else
-		BP = get_bodypart(check_zone(affecteed_zone)) || bodyparts[1]
-	if(amount > 0? BP.receieve_damage(0, 0, amount) : BP.heal_damage(0, 0, abs(amount)))
+	var/obj/item/bodypart/BP = isbodypart(affected_zone)? affected_zone : (get_bodypart(check_zone(affected_zone)) || bodyparts[1])
+	if(amount > 0? BP.receive_damage(0, 0, amount) : BP.heal_damage(0, 0, abs(amount)))
 		update_damage_overlays()
 	if(updating_health)
 		updatehealth()
-	updatestamina()
+	update_stamina()
 	if((combat_flags & COMBAT_FLAG_HARD_STAMCRIT) && amount > 20)
 		incomingstammult = max(0.01, incomingstammult/(amount*0.05))
 	return amount

--- a/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/damage_procs.dm
@@ -14,7 +14,16 @@
 /mob/living/carbon/adjustStaminaLoss(amount, updating_health = TRUE, forced = FALSE, affected_zone = BODY_ZONE_CHEST)
 	if(!forced && (status_flags & GODMODE))
 		return FALSE
-	apply_damage(amount > 0 ? amount*incomingstammult : amount, STAMINA, affected_zone)
+	var/obj/item/bodypart/BP
+	if(isbodypart(affected_zone)) //we specified a bodypart object
+		BP = def_zone
+	else
+		BP = get_bodypart(check_zone(affecteed_zone)) || bodyparts[1]
+	if(amount > 0? BP.receieve_damage(0, 0, amount) : BP.heal_damage(0, 0, abs(amount)))
+		update_damage_overlays()
+	if(updating_health)
+		updatehealth()
+	updatestamina()
 	if((combat_flags & COMBAT_FLAG_HARD_STAMCRIT) && amount > 20)
 		incomingstammult = max(0.01, incomingstammult/(amount*0.05))
 	return amount


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

title
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

adjustXLoss procs are supposed to be armor piercing (that's a lie: it's not just armor piercing per se, it just ignores the zone's usual armor checks, physiology and species checks. it still respects limb damage modifiers like on robotic limbs but i'm not doing anything about that because that would require redesigning the damage system of the game which is not really necessary/important right now for me to do), this one is no different. if you want stuff to respect armor use apply_damage instead (or we can make a new overall damage proc that does the same if necessary).
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
experimental: adjustStaminaLoss on carbons is now a direct setter-ish proc instead of something that checks physiology/species mods, as per intent.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->

### THIS WILL BUFF STUNBATONS, AS THEY USE THIS.