### PR TITLE
removes hotspot expose from skateboards

### DIFF
--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -133,7 +133,6 @@
 		else
 			playsound(src, 'sound/vehicles/skateboard_roll.ogg', 50, TRUE)
 			if(prob (25))
-				var/turf/location = get_turf(loc)
 				sparks.start() //the most radical way to start plasma fires
 			addtimer(CALLBACK(src, .proc/grind), 2)
 			return

--- a/code/modules/vehicles/scooter.dm
+++ b/code/modules/vehicles/scooter.dm
@@ -134,8 +134,6 @@
 			playsound(src, 'sound/vehicles/skateboard_roll.ogg', 50, TRUE)
 			if(prob (25))
 				var/turf/location = get_turf(loc)
-				if(location)
-					location.hotspot_expose(1000,1000)
 				sparks.start() //the most radical way to start plasma fires
 			addtimer(CALLBACK(src, .proc/grind), 2)
 			return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

removes hotspot_expose(1000,1000)

because that took 1/2.5 = 40% of the air
heated it to 1000k
and mixed it back in

yeah that's why things were so hot.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

why should i get to burn everyone in a hallway by going over a few tables.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
del: skateboards no longer superheat the air (as fast, they still do)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
