### PR TITLE
Fixes and standarizes a few liver troubles. Re-enables liver failure.

### DIFF
--- a/code/__DEFINES/movespeed_modification.dm
+++ b/code/__DEFINES/movespeed_modification.dm
@@ -79,3 +79,5 @@
 #define MOVESPEED_ID_HUNGRY                             "HUNGRY"
 #define MOVESPEED_ID_DAMAGE_SLOWDOWN                    "DAMAGE"
 #define MOVESPEED_ID_DAMAGE_SLOWDOWN_FLYING				"FLYING"
+
+#define MOVESPEED_ID_CIRRHOSIS							"CIRRHOSIS"

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -275,10 +275,8 @@ SLIME SCANNER
 			//LIVER
 			else if(istype(O, /obj/item/organ/liver))
 				var/obj/item/organ/liver/L = O
-				if(H.undergoing_liver_failure() && H.stat != DEAD) //might be depreciated
+				if(L.organ_flags & ORGAN_FAILING && H.stat != DEAD) //might be depreciated
 					temp_message += "<span class='danger'>Subject is suffering from liver failure: Apply Corazone and begin a liver transplant immediately!</span>"
-				if(L.swelling > 20)
-					temp_message += " <span class='danger'>Subject is suffering from an enlarged liver.</span>" //i.e. shrink their liver or give them a transplant.
 
 			//HEART
 			else if(ishuman(M) && (istype(O, /obj/item/organ/heart)))

--- a/code/modules/mob/living/carbon/life.dm
+++ b/code/modules/mob/living/carbon/life.dm
@@ -28,10 +28,8 @@
 	if(stat != DEAD)
 		handle_brain_damage()
 
-	/* BUG_PROBABLE_CAUSE
 	if(stat != DEAD)
 		handle_liver()
-	*/
 
 	if(stat == DEAD)
 		stop_sound_channel(CHANNEL_HEARTBEAT)
@@ -690,27 +688,8 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
 	if((!dna && !liver) || (NOLIVER in dna.species.species_traits))
 		return
-	if(liver)
-		if(liver.damage < liver.maxHealth)
-			liver.organ_flags |= ORGAN_FAILING
-			liver_failure()
-	else
+	if(!liver || liver.organ_flags & ORGAN_FAILING)
 		liver_failure()
-
-/mob/living/carbon/proc/undergoing_liver_failure()
-	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
-	if(liver && liver.failing)
-		return TRUE
-
-/mob/living/carbon/proc/return_liver_damage()
-	var/obj/item/organ/liver/liver = getorganslot(ORGAN_SLOT_LIVER)
-	if(liver)
-		return liver.damage
-
-/mob/living/carbon/proc/applyLiverDamage(var/d)
-	var/obj/item/organ/liver/L = getorganslot(ORGAN_SLOT_LIVER)
-	if(L)
-		L.damage += d
 
 /mob/living/carbon/proc/liver_failure()
 	reagents.end_metabolization(src, keep_liverless = TRUE) //Stops trait-based effects on reagents, to prevent permanent buffs
@@ -718,8 +697,8 @@ GLOBAL_LIST_INIT(ballmer_windows_me_msg, list("Yo man, what if, we like, uh, put
 	if(HAS_TRAIT(src, TRAIT_STABLELIVER))
 		return
 	adjustToxLoss(4, TRUE,  TRUE)
-	if(prob(30))
-		to_chat(src, "<span class='warning'>You feel a stabbing pain in your abdomen!</span>")
+	if(prob(15))
+		to_chat(src, "<span class='danger'>You feel a stabbing pain in your abdomen!</span>")
 
 
 ////////////////

--- a/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/alcohol_reagents.dm
@@ -43,8 +43,8 @@ All effects don't start immediately, but rather get worse over time; the rate is
 			booze_power *= 0.7
 		C.drunkenness = max((C.drunkenness + (sqrt(volume) * booze_power * ALCOHOL_RATE)), 0) //Volume, power, and server alcohol rate effect how quickly one gets drunk
 		var/obj/item/organ/liver/L = C.getorganslot(ORGAN_SLOT_LIVER)
-		if (istype(L))
-			C.applyLiverDamage((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * L.alcohol_tolerance, 0))/150)
+		if(L)
+			L.applyOrganDamage((max(sqrt(volume) * (boozepwr ** ALCOHOL_EXPONENT) * L.alcohol_tolerance, 0))/150)
 	return ..()
 
 /datum/reagent/consumable/ethanol/reaction_obj(obj/O, reac_volume)
@@ -1646,7 +1646,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 	glass_icon_state = "pina_colada"
 	glass_name = "Pina Colada"
 	glass_desc = "If you like pina coladas, and getting caught in the rain... well, you'll like this drink."
-	
+
 /datum/reagent/consumable/ethanol/grasshopper
 	name = "Grasshopper"
 	description = "A fresh and sweet dessert shooter. Difficult to look manly while drinking this."
@@ -2354,7 +2354,7 @@ All effects don't start immediately, but rather get worse over time; the rate is
 /datum/reagent/consumable/ethanol/hotlime_miami/on_mob_life(mob/living/carbon/M)
 	M.set_drugginess(50)
 	M.adjustStaminaLoss(-2)
-	return ..() 
+	return ..()
 
 /datum/reagent/consumable/ethanol/fruit_wine
 	name = "Fruit Wine"

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -263,9 +263,9 @@
 /datum/reagent/medicine/silver_sulfadiazine/overdose_start(mob/living/M)
 	metabolization_rate = 15 * REAGENTS_METABOLISM
 	M.adjustBruteLoss(2*REM, 0)
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.applyLiverDamage(1)
+	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+	if(L)
+		L.applyOrganDamage(1)
 	..()
 	. = 1
 
@@ -326,9 +326,9 @@
 datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	metabolization_rate = 15 * REAGENTS_METABOLISM
 	M.adjustBruteLoss(2*REM, 0)
-	if(iscarbon(M))
-		var/mob/living/carbon/C = M
-		C.applyLiverDamage(1)
+	var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+	if(L)
+		L.applyOrganDamage(1)
 	..()
 	. = 1
 

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1070,11 +1070,11 @@
 	to_chat(M, "<span class='userdanger'>You start feeling your guts twisting painfully!</span>")
 	SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "[type]_overdose", /datum/mood_event/overdose, name)
 
-/datum/reagent/iron/overdose_process(mob/living/carbon/C)
+/datum/reagent/iron/overdose_process(mob/living/M)
 	if(prob(20))
-		var/obj/item/organ/liver/L = C.getorganslot(ORGAN_SLOT_LIVER)
-		if (istype(L))
-			C.applyLiverDamage(2) //mild until the fabled med rework comes out. the organ damage galore
+		var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
+		if(L)
+			L.applyOrganDamage(2)
 	..()
 
 /datum/reagent/gold

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -1,7 +1,6 @@
 #define LIVER_DEFAULT_HEALTH 100 //amount of damage required for liver failure
 #define LIVER_DEFAULT_TOX_TOLERANCE 3 //amount of toxins the liver can filter out
 #define LIVER_DEFAULT_TOX_LETHALITY 0.01 //lower values lower how harmful toxins are to the liver
-#define LIVER_SWELLING_MOVE_MODIFY "pharma"
 
 /obj/item/organ/liver
 	name = "liver"
@@ -15,12 +14,14 @@
 	healing_factor = STANDARD_ORGAN_HEALING
 	decay_factor = STANDARD_ORGAN_DECAY
 
+	high_threshold_passed = "<span class='warning'>You feel a stange ache in your abdomen, almost like a stitch. This pain is encumbering your movements.</span>"
+	high_threshold_cleared = "<span class='notice'>The stitching ache in your abdomen passes away, unencumbering your movements.</span>"
+	now_fixed = "<span class='notice'>The stabbing pain in your abdomen slowly calms down into a more tolerable ache.</span>"
+
 	var/alcohol_tolerance = ALCOHOL_RATE//affects how much damage the liver takes from alcohol
-	var/failing //is this liver failing?
 	var/toxTolerance = LIVER_DEFAULT_TOX_TOLERANCE//maximum amount of toxins the liver can just shrug off
 	var/toxLethality = LIVER_DEFAULT_TOX_LETHALITY//affects how much damage toxins do to the liver
 	var/filterToxins = TRUE //whether to filter toxins
-	var/swelling = 0
 	var/cachedmoveCalc = 1
 
 /obj/item/organ/liver/on_life()
@@ -28,8 +29,6 @@
 
 	if(istype(C))
 		if(!(organ_flags & ORGAN_FAILING))//can't process reagents with a failing liver
-			//slowly heal liver damage
-			damage = max(0, damage - 0.1)
 
 			if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
 				//handle liver toxin filtration
@@ -46,42 +45,41 @@
 			if(damage > 10 && prob(damage/3))//the higher the damage the higher the probability
 				to_chat(C, "<span class='warning'>You feel a dull pain in your abdomen.</span>")
 
-	if(damage > maxHealth)//cap liver damage
-		damage = maxHealth
-
-	if(swelling >= 10)
-		pharmacokinesis()
-
 /obj/item/organ/liver/prepare_eat()
 	var/obj/S = ..()
 	S.reagents.add_reagent(/datum/reagent/iron, 5)
 	return S
 
-//Just in case
+/obj/item/organ/liver/applyOrganDamage(d, maximum = maxHealth)
+	. = ..()
+	if(!.)
+		return
+	if(damage >= high_threshold)
+		var/move_calc = 1+((round(damage) - high_threshold)/(high_threshold/3))
+		owner.add_movespeed_modifier(MOVESPEED_ID_CIRRHOSIS, TRUE, 100, NONE, override = TRUE, multiplicative_slowdown = move_calc)
+		sizeMoveMod(move_calc, owner)
+	else
+		owner.remove_movespeed_modifier(MOVESPEED_ID_CIRRHOSIS)
+		sizeMoveMod(1, owner)
+
+/obj/item/organ/liver/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = TRUE)
+	. = ..()
+	if(. && damage >= high_threshold)
+		var/move_calc = 1+((round(damage) - high_threshold)/(high_threshold/3))
+		M.add_movespeed_modifier(MOVESPEED_ID_CIRRHOSIS, TRUE, 100, NONE, override = TRUE, multiplicative_slowdown = move_calc)
+		sizeMoveMod(move_calc, owner)
+
 /obj/item/organ/liver/Remove(special = FALSE)
 	if(!QDELETED(owner))
-		owner.remove_movespeed_modifier(LIVER_SWELLING_MOVE_MODIFY)
-		owner.ResetBloodVol() //At the moment, this shouldn't allow application twice. You either have this OR a thirsty ferret.
+		owner.remove_movespeed_modifier(MOVESPEED_ID_CIRRHOSIS)
 		sizeMoveMod(1, owner)
 	return ..()
 
-//Applies some of the effects to the patient.
-/obj/item/organ/liver/proc/pharmacokinesis()
-	var/moveCalc = 1+((round(swelling) - 9)/3)
-	if(moveCalc == cachedmoveCalc)//reduce calculations
-		return
-	if(prob(5))
-		to_chat(owner, "<span class='notice'>You feel a stange ache in your side, almost like a stitch. This pain is affecting your movements and making you feel lightheaded.</span>")
-	var/mob/living/carbon/human/H = owner
-	H.add_movespeed_modifier(LIVER_SWELLING_MOVE_MODIFY, TRUE, 100, NONE, override = TRUE, multiplicative_slowdown = moveCalc)
-	H.AdjustBloodVol(moveCalc/3)
-	sizeMoveMod(moveCalc, H)
-
-/obj/item/organ/liver/proc/sizeMoveMod(var/value, mob/living/carbon/human/H)
+/obj/item/organ/liver/proc/sizeMoveMod(value, mob/living/carbon/C)
 	if(cachedmoveCalc == value)
 		return
-	H.next_move_modifier /= cachedmoveCalc
-	H.next_move_modifier *= value
+	C.next_move_modifier /= cachedmoveCalc
+	C.next_move_modifier *= value
 	cachedmoveCalc = value
 
 /obj/item/organ/liver/fly

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -143,8 +143,9 @@
 	var/healing_amount = -(maxHealth * healing_factor)
 	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health
 	healing_amount -= owner.satiety > 0 ? 4 * healing_factor * owner.satiety / MAX_SATIETY : 0
-	applyOrganDamage(healing_amount) //to FERMI_TWEAK
-	//Make it so each threshold is stuck.
+	if(healing_amount)
+		applyOrganDamage(healing_amount) //to FERMI_TWEAK
+		//Make it so each threshold is stuck.
 
 /obj/item/organ/examine(mob/user)
 	. = ..()
@@ -205,14 +206,15 @@
 ///Adjusts an organ's damage by the amount "d", up to a maximum amount, which is by default max damage
 /obj/item/organ/proc/applyOrganDamage(var/d, var/maximum = maxHealth)	//use for damaging effects
 	if(!d) //Micro-optimization.
-		return
+		return FALSE
 	if(maximum < damage)
-		return
+		return FALSE
 	damage = CLAMP(damage + d, 0, maximum)
-	var/mess = check_damage_thresholds(owner)
+	var/mess = check_damage_thresholds()
 	prev_damage = damage
 	if(mess && owner)
 		to_chat(owner, mess)
+	return TRUE
 
 ///SETS an organ's damage to the amount "d", and in doing so clears or sets the failing flag, good for when you have an effect that should fix an organ if broken
 /obj/item/organ/proc/setOrganDamage(var/d)	//use mostly for admin heals
@@ -224,7 +226,7 @@
   * description: By checking our current damage against our previous damage, we can decide whether we've passed an organ threshold.
   *				 If we have, send the corresponding threshold message to the owner, if such a message exists.
   */
-/obj/item/organ/proc/check_damage_thresholds(var/M)
+/obj/item/organ/proc/check_damage_thresholds()
 	if(damage == prev_damage)
 		return
 	var/delta = damage - prev_damage

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/enlargement.dm
@@ -54,15 +54,15 @@
 		return..()
 
 	var/mob/living/carbon/human/H = M
-	var/obj/item/organ/genital/breasts/B = M.getorganslot(ORGAN_SLOT_BREASTS)
 	//If they've opted out, then route processing though liver.
 	if(!(H.client?.prefs.cit_toggles & BREAST_ENLARGEMENT))
 		var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
 		if(L)
-			L.swelling += 0.05
+			L.applyOrganDamage(0.25)
 		else
 			H.adjustToxLoss(1)
 		return..()
+	var/obj/item/organ/genital/breasts/B = M.getorganslot(ORGAN_SLOT_BREASTS)
 	//otherwise proceed as normal
 	if(!B) //If they don't have breasts, give them breasts.
 
@@ -95,7 +95,8 @@
 /datum/reagent/fermi/breast_enlarger/overdose_process(mob/living/carbon/M) //Turns you into a female if male and ODing, doesn't touch nonbinary and object genders.
 	if(!(M.client?.prefs.cit_toggles & FORCED_FEM))
 		var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
-		L.swelling+= 0.05
+		if(L)
+			L.applyOrganDamage(0.25)
 		return ..()
 
 	var/obj/item/organ/genital/penis/P = M.getorganslot(ORGAN_SLOT_PENIS)
@@ -130,7 +131,8 @@
 	var/obj/item/organ/genital/breasts/B = M.getorganslot(ORGAN_SLOT_BREASTS)
 	if(!(M.client?.prefs.cit_toggles & BREAST_ENLARGEMENT) || !B)
 		var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
-		L.swelling-= 0.05
+		if(L)
+			L.applyOrganDamage(-0.25)
 		return ..()
 	B.modify_size(-0.05)
 	return ..()
@@ -208,14 +210,14 @@
 	if(!ishuman(M))
 		return ..()
 	var/mob/living/carbon/human/H = M
-	var/obj/item/organ/genital/penis/P = H.getorganslot(ORGAN_SLOT_PENIS)
 	if(!(H.client?.prefs.cit_toggles & PENIS_ENLARGEMENT))
 		var/obj/item/organ/liver/L = H.getorganslot(ORGAN_SLOT_LIVER)
 		if(L)
-			L.swelling += 0.05
+			L.applyOrganDamage(0.25)
 		else
 			H.adjustToxLoss(1)
 		return ..()
+	var/obj/item/organ/genital/penis/P = H.getorganslot(ORGAN_SLOT_PENIS)
 	//otherwise proceed as normal
 	if(!P)//They do have a preponderance for escapism, or so I've heard.
 
@@ -241,7 +243,8 @@
 		return ..()
 	if(!(M.client?.prefs.cit_toggles & FORCED_MASC))
 		var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
-		L.swelling+= 0.05
+		if(L)
+			L.applyOrganDamage(0.25)
 		return..()
 
 	var/obj/item/organ/genital/breasts/B = M.getorganslot(ORGAN_SLOT_BREASTS)
@@ -278,7 +281,8 @@
 	var/obj/item/organ/genital/penis/P = H.getorganslot(ORGAN_SLOT_PENIS)
 	if(!(H.client?.prefs.cit_toggles & PENIS_ENLARGEMENT) || !P)
 		var/obj/item/organ/liver/L = M.getorganslot(ORGAN_SLOT_LIVER)
-		L.swelling-= 0.05
+		if(L)
+			L.applyOrganDamage(-0.25)
 		return..()
 
 	P.modify_size(-0.1)


### PR DESCRIPTION
## About The Pull Request
Removes liver swelling variable and its associated blood volume whackiness, retained the movement slowdown effects and converted them to check the standard organ damage instead.
Also removed a few awful liver damage procs previous to the organ damage refactor port in favor of `ApplyOrganDamage`.
And most of all, uncomments handle_liver().

## Why It's Good For The Game
Swelling was snowflakey and Fermis didn't bother to fully convert the eyes and liver damage procs when they ported the refactor.
The reason why liver failure was borked was because it was triggering if the organ damage was lower than the maximum health, instead of equal or higher.
This will close #11550.

## Changelog
:cl:
fix: Liver failure is back!
tweak: standarized a few (prefs off) side effects from enlargment chems on livers to do organ damage instead without the blood volume whackiness.
tweak: High liver damage now slows mobs down.
/:cl:
