### PR TITLE
Minor action datum refactor and spellcasting fix.

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -179,7 +179,7 @@
 //	#define SPEECH_FORCED 7
 #define COMSIG_MOB_ANTAG_ON_GAIN "mob_antag_on_gain"			//from base of /datum/antagonist/on_gain(): (antag_datum)
 
-#define COMSIG_MOB_SPELL_CAST_CHECK "mob_spell_cast_check"			//called from base of /obj/effect/proc_holder/spell/cast_check(): (spell)
+#define COMSIG_MOB_SPELL_CAN_CAST "mob_spell_can_cast"			//called from base of /obj/effect/proc_holder/spell/can_cast(): (spell)
 
 // /mob/living signals
 #define COMSIG_LIVING_REGENERATE_LIMBS "living_regenerate_limbs"	//from base of /mob/living/regenerate_limbs(): (noheal, excluded_limbs)

--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -513,7 +513,7 @@
 	if(owner && GLOB.common_report && SSticker.current_state == GAME_STATE_FINISHED)
 		SSticker.show_roundend_report(owner.client, FALSE)
 
-/datum/action/report/IsAvailable()
+/datum/action/report/IsAvailable(silent = FALSE)
 	return 1
 
 /datum/action/report/Topic(href,href_list)

--- a/code/controllers/subsystem/vote.dm
+++ b/code/controllers/subsystem/vote.dm
@@ -763,7 +763,7 @@ SUBSYSTEM_DEF(vote)
 		remove_from_client()
 		Remove(owner)
 
-/datum/action/vote/IsAvailable()
+/datum/action/vote/IsAvailable(silent = FALSE)
 	return 1
 
 /datum/action/vote/proc/remove_from_client()

--- a/code/datums/action.dm
+++ b/code/datums/action.dm
@@ -95,7 +95,7 @@
 /datum/action/proc/Process()
 	return
 
-/datum/action/proc/IsAvailable()
+/datum/action/proc/IsAvailable(silent = FALSE)
 	if(!owner)
 		return FALSE
 	var/mob/living/L = owner
@@ -134,7 +134,7 @@
 
 			ApplyIcon(button, force)
 
-		if(!IsAvailable())
+		if(!IsAvailable(TRUE))
 			button.color = transparent_when_unavailable ? rgb(128,0,0,128) : rgb(128,0,0)
 		else
 			button.color = rgb(255,255,255,255)
@@ -308,7 +308,7 @@
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "vortex_recall"
 
-/datum/action/item_action/vortex_recall/IsAvailable()
+/datum/action/item_action/vortex_recall/IsAvailable(silent = FALSE)
 	if(istype(target, /obj/item/hierophant_club))
 		var/obj/item/hierophant_club/H = target
 		if(H.teleporting)
@@ -320,7 +320,7 @@
 	background_icon_state = "bg_clock"
 	buttontooltipstyle = "clockcult"
 
-/datum/action/item_action/clock/IsAvailable()
+/datum/action/item_action/clock/IsAvailable(silent = FALSE)
 	if(!is_servant_of_ratvar(owner))
 		return 0
 	return ..()
@@ -329,7 +329,7 @@
 	name = "Create Judicial Marker"
 	desc = "Allows you to create a stunning Judicial Marker at any location in view. Click again to disable."
 
-/datum/action/item_action/clock/toggle_visor/IsAvailable()
+/datum/action/item_action/clock/toggle_visor/IsAvailable(silent = FALSE)
 	if(!is_servant_of_ratvar(owner))
 		return 0
 	if(istype(target, /obj/item/clothing/glasses/judicial_visor))
@@ -408,7 +408,7 @@
 /datum/action/item_action/jetpack_stabilization
 	name = "Toggle Jetpack Stabilization"
 
-/datum/action/item_action/jetpack_stabilization/IsAvailable()
+/datum/action/item_action/jetpack_stabilization/IsAvailable(silent = FALSE)
 	var/obj/item/tank/jetpack/J = target
 	if(!istype(J) || !J.on)
 		return 0
@@ -465,7 +465,7 @@
 /datum/action/item_action/organ_action
 	check_flags = AB_CHECK_CONSCIOUS
 
-/datum/action/item_action/organ_action/IsAvailable()
+/datum/action/item_action/organ_action/IsAvailable(silent = FALSE)
 	var/obj/item/organ/I = target
 	if(!I.owner)
 		return 0
@@ -634,32 +634,32 @@
 		return FALSE
 	if(target)
 		var/obj/effect/proc_holder/S = target
-		S.Click()
+		S.Trigger(usr)
 		return TRUE
 
-/datum/action/spell_action/IsAvailable()
+/datum/action/spell_action/IsAvailable(silent = FALSE)
 	if(!target)
 		return FALSE
 	return TRUE
 
 /datum/action/spell_action/spell
 
-/datum/action/spell_action/spell/IsAvailable()
+/datum/action/spell_action/spell/IsAvailable(silent = FALSE)
 	if(!target)
 		return FALSE
 	var/obj/effect/proc_holder/spell/S = target
 	if(owner)
-		return S.can_cast(owner, FALSE, TRUE)
+		return S.can_cast(owner, FALSE, silent)
 	return FALSE
 
 /datum/action/spell_action/alien
 
-/datum/action/spell_action/alien/IsAvailable()
+/datum/action/spell_action/alien/IsAvailable(silent = FALSE)
 	if(!target)
 		return FALSE
 	var/obj/effect/proc_holder/alien/ab = target
 	if(owner)
-		return ab.cost_check(ab.check_turf,owner,1)
+		return ab.cost_check(ab.check_turf,owner,silent)
 	return FALSE
 
 
@@ -701,7 +701,7 @@
 	button.maptext_width = 24
 	button.maptext_height = 12
 
-/datum/action/cooldown/IsAvailable()
+/datum/action/cooldown/IsAvailable(silent = FALSE)
 	return next_use_time <= world.time
 
 /datum/action/cooldown/proc/StartCooldown()

--- a/code/datums/dash_weapon.dm
+++ b/code/datums/dash_weapon.dm
@@ -19,7 +19,7 @@
 	dashing_item = dasher
 	holder = user
 
-/datum/action/innate/dash/IsAvailable()
+/datum/action/innate/dash/IsAvailable(silent = FALSE)
 	if(current_charges > 0)
 		return TRUE
 	else

--- a/code/datums/elements/spellcasting.dm
+++ b/code/datums/elements/spellcasting.dm
@@ -12,7 +12,7 @@
 		RegisterSignal(target, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 		RegisterSignal(target, COMSIG_ITEM_DROPPED, .proc/on_drop)
 	else if(ismob(target))
-		RegisterSignal(target, COMSIG_MOB_SPELL_CAST_CHECK, .proc/on_cast)
+		RegisterSignal(target, COMSIG_MOB_SPELL_CAN_CAST, .proc/on_cast)
 		stacked_spellcasting_by_user[target]++
 	else
 		return ELEMENT_INCOMPATIBLE
@@ -21,24 +21,24 @@
 
 /datum/element/spellcasting/Detach(datum/target)
 	. = ..()
-	UnregisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOB_SPELL_CAST_CHECK))
+	UnregisterSignal(target, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED, COMSIG_MOB_SPELL_CAN_CAST))
 	if(users_by_item[target])
 		var/mob/user = users_by_item[target]
 		stacked_spellcasting_by_user[user]--
 		if(!stacked_spellcasting_by_user[user])
 			stacked_spellcasting_by_user -= user
-			UnregisterSignal(user, COMSIG_MOB_SPELL_CAST_CHECK)
+			UnregisterSignal(user, COMSIG_MOB_SPELL_CAN_CAST)
 	else if(ismob(target))
 		stacked_spellcasting_by_user[target]--
 		if(!stacked_spellcasting_by_user[target])
 			stacked_spellcasting_by_user -= target
 
 /datum/element/spellcasting/proc/on_equip(datum/source, mob/equipper, slot)
-	if(!(slot in cast_slots))
+	if(!(slot & cast_slots))
 		return
 	users_by_item[source] = equipper
 	if(!stacked_spellcasting_by_user[equipper])
-		RegisterSignal(equipper, COMSIG_MOB_SPELL_CAST_CHECK, .proc/on_cast)
+		RegisterSignal(equipper, COMSIG_MOB_SPELL_CAN_CAST, .proc/on_cast)
 	stacked_spellcasting_by_user[equipper]++
 
 /datum/element/spellcasting/proc/on_drop(datum/source, mob/user)
@@ -48,7 +48,7 @@
 	stacked_spellcasting_by_user[user]--
 	if(!stacked_spellcasting_by_user[user])
 		stacked_spellcasting_by_user -= user
-		UnregisterSignal(user, COMSIG_MOB_SPELL_CAST_CHECK)
+		UnregisterSignal(user, COMSIG_MOB_SPELL_CAN_CAST)
 
 /datum/element/spellcasting/proc/on_cast(mob/caster, obj/effect/proc_holder/spell)
 	return cast_flags

--- a/code/game/machinery/launch_pad.dm
+++ b/code/game/machinery/launch_pad.dm
@@ -57,7 +57,7 @@
 	var/turf/target = locate(target_x, target_y, z)
 	ghost.forceMove(target)
 
-/obj/machinery/launchpad/proc/isAvailable()
+/obj/machinery/launchpad/proc/isAvailable(silent = FALSE)
 	if(stat & NOPOWER)
 		return FALSE
 	if(panel_open)
@@ -198,7 +198,7 @@
 	QDEL_NULL(briefcase)
 	return ..()
 
-/obj/machinery/launchpad/briefcase/isAvailable()
+/obj/machinery/launchpad/briefcase/isAvailable(silent = FALSE)
 	if(closed)
 		return FALSE
 	return ..()

--- a/code/game/objects/items/robot/robot_upgrades.dm
+++ b/code/game/objects/items/robot/robot_upgrades.dm
@@ -663,21 +663,19 @@
 	var/maxReduction = 1
 
 
-/obj/effect/proc_holder/silicon/cyborg/vtecControl/Click(mob/living/silicon/robot/user)
-	var/mob/living/silicon/robot/self = usr
-
+/obj/effect/proc_holder/silicon/cyborg/vtecControl/Trigger(mob/living/silicon/robot/user)
 	currentState = (currentState + 1) % 3
 
-	if(istype(self))
+	if(istype(user))
 		switch(currentState)
 			if (0)
-				self.speed = initial(self.speed)
+				user.speed = initial(user.speed)
 			if (1)
-				self.speed = initial(self.speed) - maxReduction * 0.5
+				user.speed = initial(user.speed) - maxReduction * 0.5
 			if (2)
-				self.speed = initial(self.speed) - maxReduction * 1
+				user.speed = initial(user.speed) - maxReduction * 1
 
 	action.button_icon_state = "Chevron_State_[currentState]"
 	action.UpdateButtonIcon()
 
-	return
+	return TRUE

--- a/code/modules/antagonists/changeling/changeling_power.dm
+++ b/code/modules/antagonists/changeling/changeling_power.dm
@@ -28,8 +28,7 @@
 	action.Remove(user)
 	return
 
-/obj/effect/proc_holder/changeling/Click()
-	var/mob/user = usr
+/obj/effect/proc_holder/changeling/Trigger(mob/user)
 	if(!user || !user.mind || !user.mind.has_antag_datum(/datum/antagonist/changeling))
 		return
 	try_to_sting(user)

--- a/code/modules/antagonists/changeling/powers/tiny_prick.dm
+++ b/code/modules/antagonists/changeling/powers/tiny_prick.dm
@@ -3,8 +3,7 @@
 	desc = "Stabby stabby."
 	var/sting_icon = null
 
-/obj/effect/proc_holder/changeling/sting/Click()
-	var/mob/user = usr
+/obj/effect/proc_holder/changeling/sting/Trigger(mob/user)
 	if(!user || !user.mind)
 		return
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
@@ -74,8 +73,7 @@
 	action_icon_state = "ling_sting_transform"
 	action_background_icon_state = "bg_ling"
 
-/obj/effect/proc_holder/changeling/sting/transformation/Click()
-	var/mob/user = usr
+/obj/effect/proc_holder/changeling/sting/transformation/Trigger(mob/user)
 	var/datum/antagonist/changeling/changeling = user.mind.has_antag_datum(/datum/antagonist/changeling)
 	if(changeling.chosen_sting)
 		unset_sting(user)

--- a/code/modules/antagonists/clockcult/clock_helpers/hierophant_network.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/hierophant_network.dm
@@ -35,7 +35,7 @@
 	var/span_for_name = "heavy_brass"
 	var/span_for_message = "brass"
 
-/datum/action/innate/hierophant/IsAvailable()
+/datum/action/innate/hierophant/IsAvailable(silent = FALSE)
 	if(!is_servant_of_ratvar(owner))
 		return FALSE
 	return ..()

--- a/code/modules/antagonists/clockcult/clock_items/clock_weapons/_call_weapon.dm
+++ b/code/modules/antagonists/clockcult/clock_items/clock_weapons/_call_weapon.dm
@@ -12,7 +12,7 @@
 	var/obj/item/clockwork/weapon/weapon_type //The type of weapon to create
 	var/obj/item/clockwork/weapon/weapon
 
-/datum/action/innate/call_weapon/IsAvailable()
+/datum/action/innate/call_weapon/IsAvailable(silent = FALSE)
 	if(!is_servant_of_ratvar(owner))
 		qdel(src)
 		return

--- a/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
+++ b/code/modules/antagonists/clockcult/clock_mobs/_eminence.dm
@@ -232,7 +232,7 @@
 	background_icon_state = "bg_clock"
 	buttontooltipstyle = "clockcult"
 
-/datum/action/innate/eminence/IsAvailable()
+/datum/action/innate/eminence/IsAvailable(silent = FALSE)
 	if(!iseminence(owner))
 		qdel(src)
 		return
@@ -283,7 +283,7 @@
 	desc = "Initiates a mass recall, warping all servants to the Ark after a short delay. This can only be used once."
 	button_icon_state = "Spatial Gateway"
 
-/datum/action/innate/eminence/mass_recall/IsAvailable()
+/datum/action/innate/eminence/mass_recall/IsAvailable(silent = FALSE)
 	. = ..()
 	if(.)
 		var/obj/structure/destructible/clockwork/massive/celestial_gateway/G = GLOB.ark_of_the_clockwork_justiciar

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -150,7 +150,7 @@
 	/obj/item/clothing/head/helmet/space,
 	/obj/item/clothing/shoes/magboots)) //replace this only if ratvar is up
 
-/datum/action/innate/clockwork_armaments/IsAvailable()
+/datum/action/innate/clockwork_armaments/IsAvailable(silent = FALSE)
 	if(!is_servant_of_ratvar(owner))
 		qdel(src)
 		return

--- a/code/modules/antagonists/cult/blood_magic.dm
+++ b/code/modules/antagonists/cult/blood_magic.dm
@@ -17,7 +17,7 @@
 		qdel(X)
 	..()
 
-/datum/action/innate/cult/blood_magic/IsAvailable()
+/datum/action/innate/cult/blood_magic/IsAvailable(silent = FALSE)
 	if(!iscultist(owner))
 		return FALSE
 	return ..()
@@ -118,7 +118,7 @@
 		hand_magic = null
 	..()
 
-/datum/action/innate/cult/blood_spell/IsAvailable()
+/datum/action/innate/cult/blood_spell/IsAvailable(silent = FALSE)
 	if(!iscultist(owner) || owner.incapacitated()  || !charges)
 		return FALSE
 	return ..()

--- a/code/modules/antagonists/cult/cult_comms.dm
+++ b/code/modules/antagonists/cult/cult_comms.dm
@@ -6,7 +6,7 @@
 	buttontooltipstyle = "cult"
 	check_flags = AB_CHECK_RESTRAINED|AB_CHECK_STUN|AB_CHECK_CONSCIOUS
 
-/datum/action/innate/cult/IsAvailable()
+/datum/action/innate/cult/IsAvailable(silent = FALSE)
 	if(!iscultist(owner))
 		return FALSE
 	return ..()
@@ -51,7 +51,7 @@
 	name = "Spiritual Communion"
 	desc = "Conveys a message from the spirit realm that all cultists can hear."
 
-/datum/action/innate/cult/comm/spirit/IsAvailable()
+/datum/action/innate/cult/comm/spirit/IsAvailable(silent = FALSE)
 	if(iscultist(owner.mind.current))
 		return TRUE
 
@@ -72,7 +72,7 @@
 	name = "Assert Leadership"
 	button_icon_state = "cultvote"
 
-/datum/action/innate/cult/mastervote/IsAvailable()
+/datum/action/innate/cult/mastervote/IsAvailable(silent = FALSE)
 	var/datum/antagonist/cult/C = owner.mind.has_antag_datum(/datum/antagonist/cult,TRUE)
 	if(!C || C.cult_team.cult_vote_called || !ishuman(owner))
 		return FALSE
@@ -137,7 +137,7 @@
 				to_chat(B.current,"<span class='cultlarge'>[Nominee] has won the cult's support and is now their master. Follow [Nominee.p_their()] orders to the best of your ability!</span>")
 	return TRUE
 
-/datum/action/innate/cult/master/IsAvailable()
+/datum/action/innate/cult/master/IsAvailable(silent = FALSE)
 	if(!owner.mind || !owner.mind.has_antag_datum(/datum/antagonist/cult/master) || GLOB.cult_narsie)
 		return 0
 	return ..()
@@ -220,9 +220,9 @@
 	CM.attached_action = src
 	..()
 
-/datum/action/innate/cult/master/cultmark/IsAvailable()
+/datum/action/innate/cult/master/cultmark/IsAvailable(silent = FALSE)
 	if(cooldown > world.time)
-		if(!CM.active)
+		if(!CM.active && !silent)
 			to_chat(owner, "<span class='cultlarge'><b>You need to wait [DisplayTimeText(cooldown - world.time)] before you can mark another target!</b></span>")
 		return FALSE
 	return ..()
@@ -299,7 +299,7 @@
 	name = "Mark a Blood Target for the Cult"
 	desc = "Marks a target for the entire cult to track."
 
-/datum/action/innate/cult/master/cultmark/ghost/IsAvailable()
+/datum/action/innate/cult/master/cultmark/ghost/IsAvailable(silent = FALSE)
 	if(istype(owner, /mob/dead/observer) && iscultist(owner.mind.current))
 		return TRUE
 	else
@@ -313,7 +313,7 @@
 	var/cooldown = 0
 	var/base_cooldown = 600
 
-/datum/action/innate/cult/ghostmark/IsAvailable()
+/datum/action/innate/cult/ghostmark/IsAvailable(silent = FALSE)
 	if(istype(owner, /mob/dead/observer) && iscultist(owner.mind.current))
 		return TRUE
 	else
@@ -389,11 +389,11 @@
 	PM.attached_action = src
 	..()
 
-/datum/action/innate/cult/master/pulse/IsAvailable()
+/datum/action/innate/cult/master/pulse/IsAvailable(silent = FALSE)
 	if(!owner.mind || !owner.mind.has_antag_datum(/datum/antagonist/cult/master))
 		return FALSE
 	if(cooldown > world.time)
-		if(!PM.active)
+		if(!PM.active && !silent)
 			to_chat(owner, "<span class='cultlarge'><b>You need to wait [DisplayTimeText(cooldown - world.time)] before you can pulse again!</b></span>")
 		return FALSE
 	return ..()

--- a/code/modules/antagonists/cult/cult_items.dm
+++ b/code/modules/antagonists/cult/cult_items.dm
@@ -207,7 +207,7 @@
 	phasein = /obj/effect/temp_visual/dir_setting/cult/phase
 	phaseout = /obj/effect/temp_visual/dir_setting/cult/phase/out
 
-/datum/action/innate/dash/cult/IsAvailable()
+/datum/action/innate/dash/cult/IsAvailable(silent = FALSE)
 	if(iscultist(holder) && current_charges)
 		return TRUE
 	else
@@ -227,7 +227,7 @@
 	sword = bastard
 	holder = user
 
-/datum/action/innate/cult/spin2win/IsAvailable()
+/datum/action/innate/cult/spin2win/IsAvailable(silent = FALSE)
 	if(iscultist(holder) && cooldown <= world.time)
 		return TRUE
 	else

--- a/code/modules/antagonists/cult/rune_spawn_action.dm
+++ b/code/modules/antagonists/cult/rune_spawn_action.dm
@@ -14,7 +14,7 @@
 	var/obj/effect/temp_visual/cult/rune_spawn/rune_center_type
 	var/rune_color
 
-/datum/action/innate/cult/create_rune/IsAvailable()
+/datum/action/innate/cult/create_rune/IsAvailable(silent = FALSE)
 	if(!rune_type || cooldown > world.time)
 		return FALSE
 	return ..()

--- a/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
+++ b/code/modules/antagonists/traitor/equipment/Malf_Modules.dm
@@ -43,7 +43,7 @@ GLOBAL_LIST_INIT(blacklisted_malf_machines, typecacheof(list(
 	else
 		owner_AI = owner
 
-/datum/action/innate/ai/IsAvailable()
+/datum/action/innate/ai/IsAvailable(silent = FALSE)
 	. = ..()
 	if(owner_AI && owner_AI.malf_cooldown > world.time)
 		return FALSE

--- a/code/modules/clothing/spacesuits/chronosuit.dm
+++ b/code/modules/clothing/spacesuits/chronosuit.dm
@@ -321,7 +321,7 @@
 	check_flags = AB_CHECK_CONSCIOUS //|AB_CHECK_INSIDE
 	var/obj/item/clothing/suit/space/chronos/chronosuit = null
 
-/datum/action/innate/chrono_teleport/IsAvailable()
+/datum/action/innate/chrono_teleport/IsAvailable(silent = FALSE)
 	return (chronosuit && chronosuit.activated && chronosuit.camera && !chronosuit.teleporting)
 
 /datum/action/innate/chrono_teleport/Activate()

--- a/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/alien_powers.dm
@@ -21,14 +21,13 @@ Doesn't work on other aliens/AI.*/
 	. = ..()
 	action = new(src)
 
-/obj/effect/proc_holder/alien/Click()
-	if(!iscarbon(usr))
-		return 1
-	var/mob/living/carbon/user = usr
-	if(cost_check(check_turf,user))
+/obj/effect/proc_holder/alien/Trigger(mob/living/carbon/user, skip_cost_check)
+	if(!istype(user))
+		return TRUE
+	if(!skip_cost_check || cost_check(check_turf,user))
 		if(fire(user) && user) // Second check to prevent runtimes when evolving
 			user.adjustPlasma(-plasma_cost)
-	return 1
+	return TRUE
 
 /obj/effect/proc_holder/alien/on_gain(mob/living/carbon/user)
 	return

--- a/code/modules/mob/living/carbon/human/species_types/golems.dm
+++ b/code/modules/mob/living/carbon/human/species_types/golems.dm
@@ -469,7 +469,7 @@
 	var/cooldown = 150
 	var/last_teleport = 0
 
-/datum/action/innate/unstable_teleport/IsAvailable()
+/datum/action/innate/unstable_teleport/IsAvailable(silent = FALSE)
 	if(..())
 		if(world.time > last_teleport + cooldown)
 			return 1

--- a/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/jellypeople.dm
@@ -84,7 +84,7 @@
 	background_icon_state = "bg_alien"
 	required_mobility_flags = NONE
 
-/datum/action/innate/regenerate_limbs/IsAvailable()
+/datum/action/innate/regenerate_limbs/IsAvailable(silent = FALSE)
 	if(..())
 		var/mob/living/carbon/human/H = owner
 		var/list/limbs_to_heal = H.get_missing_limbs()
@@ -223,7 +223,7 @@
 	icon_icon = 'icons/mob/actions/actions_slime.dmi'
 	background_icon_state = "bg_alien"
 
-/datum/action/innate/split_body/IsAvailable()
+/datum/action/innate/split_body/IsAvailable(silent = FALSE)
 	if(..())
 		var/mob/living/carbon/human/H = owner
 		if(H.blood_volume >= BLOOD_VOLUME_SLIME_SPLIT)
@@ -776,7 +776,7 @@
 	..()
 	species = _species
 
-/datum/action/innate/use_extract/IsAvailable()
+/datum/action/innate/use_extract/IsAvailable(silent = FALSE)
 	if(..())
 		if(species && species.current_extract && (world.time > species.extract_cooldown))
 			return TRUE

--- a/code/modules/mob/living/say.dm
+++ b/code/modules/mob/living/say.dm
@@ -354,7 +354,7 @@ GLOBAL_LIST_INIT(department_radio_keys, list(
 
 	if(cultslurring)
 		message = cultslur(message)
-	
+
 	if(clockcultslurring)
 		message = CLOCK_CULT_SLUR(message)
 

--- a/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
+++ b/code/modules/mob/living/simple_animal/hostile/giant_spider.dm
@@ -400,10 +400,9 @@
 	action.button_icon_state = "wrap_[active]"
 	action.UpdateButtonIcon()
 
-/obj/effect/proc_holder/wrap/Click()
-	if(!istype(usr, /mob/living/simple_animal/hostile/poison/giant_spider/nurse))
+/obj/effect/proc_holder/wrap/Trigger(mob/living/simple_animal/hostile/poison/giant_spider/nurse/user)
+	if(!istype(user))
 		return TRUE
-	var/mob/living/simple_animal/hostile/poison/giant_spider/nurse/user = usr
 	activate(user)
 	return TRUE
 
@@ -444,7 +443,7 @@
 	check_flags = AB_CHECK_CONSCIOUS
 	button_icon_state = "lay_eggs"
 
-/datum/action/innate/spider/lay_eggs/IsAvailable()
+/datum/action/innate/spider/lay_eggs/IsAvailable(silent = FALSE)
 	if(..())
 		if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse))
 			return 0
@@ -508,7 +507,7 @@
 	desc = "Send a command to all living spiders."
 	button_icon_state = "command"
 
-/datum/action/innate/spider/comm/IsAvailable()
+/datum/action/innate/spider/comm/IsAvailable(silent = FALSE)
 	if(!istype(owner, /mob/living/simple_animal/hostile/poison/giant_spider/nurse/midwife))
 		return FALSE
 	return TRUE

--- a/code/modules/mob/living/simple_animal/slime/powers.dm
+++ b/code/modules/mob/living/simple_animal/slime/powers.dm
@@ -11,7 +11,7 @@
 	background_icon_state = "bg_alien"
 	var/needs_growth = NO_GROWTH_NEEDED
 
-/datum/action/innate/slime/IsAvailable()
+/datum/action/innate/slime/IsAvailable(silent = FALSE)
 	if(..())
 		var/mob/living/simple_animal/slime/S = owner
 		if(needs_growth == GROWTH_NEEDED)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -513,7 +513,7 @@
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
 	button_icon_state = "sniper_zoom"
 
-/datum/action/item_action/toggle_scope_zoom/IsAvailable()
+/datum/action/item_action/toggle_scope_zoom/IsAvailable(silent = FALSE)
 	. = ..()
 	if(!.)
 		var/obj/item/gun/G = target

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -187,15 +187,18 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	return TRUE
 
 /obj/effect/proc_holder/spell/proc/invocation(mob/user = usr) //spelling the spell out and setting it on recharge/reducing charges amount
+	var/mob/living/L
+	if(isliving(user))
+		L = user
 	switch(invocation_type)
 		if("shout")
-			if(user.can_speak_vocal(invocation))
+			if(!L || L.can_speak_vocal(invocation))
 				if(prob(50))//Auto-mute? Fuck that noise
 					user.say(invocation, forced = "spell")
 				else
 					user.say(replacetext(invocation," ","`"), forced = "spell")
 		if("whisper")
-			if(user.can_speak_vocal(invocation))
+			if(!L || L.can_speak_vocal(invocation))
 				if(prob(50))
 					user.whisper(invocation)
 				else

--- a/code/modules/spells/spell.dm
+++ b/code/modules/spells/spell.dm
@@ -45,6 +45,12 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/singularity_pull()
 	return
 
+/obj/effect/proc_holder/Click()
+	return Trigger(usr, FALSE)
+
+/obj/effect/proc_holder/proc/Trigger(mob/user)
+	return TRUE
+
 /obj/effect/proc_holder/proc/InterceptClickOn(mob/living/caller, params, atom/A)
 	if(caller.ranged_ability != src || ranged_ability_user != caller) //I'm not actually sure how these would trigger, but, uh, safety, I guess?
 		to_chat(caller, "<span class='warning'><b>[caller.ranged_ability.name]</b> has been disabled.</span>")
@@ -150,8 +156,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	if(mobs_blacklist)
 		mobs_blacklist = typecacheof(mobs_blacklist)
 
-/obj/effect/proc_holder/spell/proc/cast_check(skipcharge = FALSE, mob/user = usr) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
-	if(!can_cast(user, skipcharge))
+/obj/effect/proc_holder/spell/proc/cast_check(skipcharge = FALSE, mob/user = usr, skip_can_cast = FALSE) //checks if the spell can be cast based on its settings; skipcharge is used when an additional cast_check is called inside the spell
+	if(!skip_can_cast && !can_cast(user, skipcharge))
 		return FALSE
 
 	if(!skipcharge)
@@ -183,15 +189,17 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 /obj/effect/proc_holder/spell/proc/invocation(mob/user = usr) //spelling the spell out and setting it on recharge/reducing charges amount
 	switch(invocation_type)
 		if("shout")
-			if(prob(50))//Auto-mute? Fuck that noise
-				user.say(invocation, forced = "spell")
-			else
-				user.say(replacetext(invocation," ","`"), forced = "spell")
+			if(user.can_speak_vocal(invocation))
+				if(prob(50))//Auto-mute? Fuck that noise
+					user.say(invocation, forced = "spell")
+				else
+					user.say(replacetext(invocation," ","`"), forced = "spell")
 		if("whisper")
-			if(prob(50))
-				user.whisper(invocation)
-			else
-				user.whisper(replacetext(invocation," ","`"))
+			if(user.can_speak_vocal(invocation))
+				if(prob(50))
+					user.whisper(invocation)
+				else
+					user.whisper(replacetext(invocation," ","`"))
 		if("emote")
 			user.visible_message(invocation, invocation_emote_self) //same style as in mob/living/emote.dm
 
@@ -210,8 +218,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	qdel(action)
 	return ..()
 
-/obj/effect/proc_holder/spell/Click()
-	if(cast_check())
+/obj/effect/proc_holder/spell/Trigger(mob/user, skip_can_cast = TRUE)
+	if(cast_check(FALSE, user, skip_can_cast))
 		choose_targets()
 	return 1
 
@@ -432,7 +440,7 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 	return 1
 
 /obj/effect/proc_holder/spell/proc/can_cast(mob/user = usr, skipcharge = FALSE, silent = FALSE)
-	var/magic_flags = SEND_SIGNAL(user, COMSIG_MOB_SPELL_CAST_CHECK, src)
+	var/magic_flags = SEND_SIGNAL(user, COMSIG_MOB_SPELL_CAN_CAST, src)
 	if(magic_flags & SPELL_SKIP_ALL_REQS)
 		return TRUE
 
@@ -448,9 +456,8 @@ GLOBAL_LIST_INIT(spells, typesof(/obj/effect/proc_holder/spell)) //needed for th
 				to_chat(user, "<span class='notice'>You can't cast this spell here.</span>")
 			return FALSE
 
-	if(!skipcharge)
-		if(!charge_check(user))
-			return FALSE
+	if(!skipcharge && !charge_check(user, silent))
+		return FALSE
 
 	if(user.stat && !stat_allowed && !(magic_flags & SPELL_SKIP_STAT))
 		if(!silent)

--- a/code/modules/spells/spell_types/aimed.dm
+++ b/code/modules/spells/spell_types/aimed.dm
@@ -11,12 +11,11 @@
 	var/current_amount = 0	//How many projectiles left.
 	var/projectiles_per_fire = 1		//Projectiles per fire. Probably not a good thing to use unless you override ready_projectile().
 
-/obj/effect/proc_holder/spell/aimed/Click()
-	var/mob/living/user = usr
+/obj/effect/proc_holder/spell/aimed/Trigger(mob/user, skip_can_cast = TRUE)
 	if(!istype(user))
 		return
 	var/msg
-	if(!can_cast(user, FALSE, TRUE))
+	if(!skip_can_cast && !can_cast(user, FALSE, TRUE))
 		msg = "<span class='warning'>You can no longer cast [name]!</span>"
 		remove_ranged_ability(msg)
 		return

--- a/code/modules/spells/spell_types/lightning.dm
+++ b/code/modules/spells/spell_types/lightning.dm
@@ -15,9 +15,9 @@
 
 	action_icon_state = "lightning"
 
-/obj/effect/proc_holder/spell/targeted/tesla/Click()
-	if(!ready && cast_check())
-		StartChargeup()
+/obj/effect/proc_holder/spell/targeted/tesla/Trigger(mob/user, skip_can_cast = TRUE)
+	if(!ready && cast_check(FALSE, user, skip_can_cast))
+		StartChargeup(user)
 	return 1
 
 /obj/effect/proc_holder/spell/targeted/tesla/proc/StartChargeup(mob/user = usr)

--- a/code/modules/spells/spell_types/mime.dm
+++ b/code/modules/spells/spell_types/mime.dm
@@ -16,12 +16,12 @@
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
 
-/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall/Click()
-	if(usr && usr.mind)
-		if(!usr.mind.miming)
+/obj/effect/proc_holder/spell/aoe_turf/conjure/mime_wall/Trigger(mob/user, skip_can_cast = TRUE)
+	if(user.mind)
+		if(!user.mind.miming)
 			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
 			return
-		invocation = "<B>[usr.real_name]</B> looks as if a wall is in front of [usr.p_them()]."
+		invocation = "<B>[user.real_name]</B> looks as if a wall is in front of [user.p_them()]."
 	else
 		invocation_type ="none"
 	..()
@@ -41,17 +41,12 @@
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
 
-/obj/effect/proc_holder/spell/targeted/mime/speak/Click()
-	if(!usr)
-		return
-	if(!ishuman(usr))
-		return
-	var/mob/living/carbon/human/H = usr
-	if(H.mind.miming)
+/obj/effect/proc_holder/spell/targeted/mime/speak/Trigger(mob/user, skip_can_cast = TRUE)
+	if(user.mind?.miming)
 		still_recharging_msg = "<span class='warning'>You can't break your vow of silence that fast!</span>"
 	else
 		still_recharging_msg = "<span class='warning'>You'll have to wait before you can give your vow of silence again!</span>"
-	..()
+	return ..()
 
 /obj/effect/proc_holder/spell/targeted/mime/speak/cast(list/targets,mob/user = usr)
 	for(var/mob/living/carbon/human/H in targets)
@@ -82,15 +77,15 @@
 	action_icon_state = "mime"
 	action_background_icon_state = "bg_mime"
 
-/obj/effect/proc_holder/spell/targeted/forcewall/mime/Click()
-	if(usr && usr.mind)
-		if(!usr.mind.miming)
+/obj/effect/proc_holder/spell/targeted/forcewall/mime/Trigger(mob/user, skip_can_cast = TRUE)
+	if(user.mind)
+		if(!user.mind.miming)
 			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
 			return
-		invocation = "<B>[usr.real_name]</B> looks as if a blockade is in front of [usr.p_them()]."
+		invocation = "<B>[user.real_name]</B> looks as if a blockade is in front of [user.p_them()]."
 	else
 		invocation_type ="none"
-	..()
+	return ..()
 
 /obj/effect/proc_holder/spell/aimed/finger_guns
 	name = "Finger Guns"
@@ -114,19 +109,18 @@
 	base_icon_state = "mime"
 
 
-/obj/effect/proc_holder/spell/aimed/finger_guns/Click()
-	var/mob/living/carbon/human/owner = usr
-	if(owner.incapacitated())
-		to_chat(owner, "<span class='warning'>You can't properly point your fingers while incapacitated.</span>")
+/obj/effect/proc_holder/spell/aimed/finger_guns/Trigger(mob/user, skip_can_cast = TRUE)
+	if(user.incapacitated())
+		to_chat(user, "<span class='warning'>You can't properly point your fingers while incapacitated.</span>")
 		return
-	if(usr && usr.mind)
-		if(!usr.mind.miming)
+	if(user.mind)
+		if(!user.mind.miming)
 			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
 			return
-		invocation = "<B>[usr.real_name]</B> fires [usr.p_their()] finger gun!"
+		invocation = "<B>[user.real_name]</B> fires [user.p_their()] finger gun!"
 	else
 		invocation_type ="none"
-	..()
+	return ..()
 
 /obj/effect/proc_holder/spell/targeted/touch/mimerope
 	name = "Invisible Rope"
@@ -144,8 +138,8 @@
 	action_background_icon_state = "bg_mime"
 	hand_path = /obj/item/melee/touch_attack/mimerope
 
-/obj/effect/proc_holder/spell/targeted/touch/mimerope/Click()
-	if(usr && usr.mind)
+/obj/effect/proc_holder/spell/targeted/touch/mimerope/Trigger(mob/user, skip_can_cast = TRUE)
+	if(user.mind)
 		if(!usr.mind.miming)
 			to_chat(usr, "<span class='notice'>You must dedicate yourself to silence first.</span>")
 			return

--- a/code/modules/surgery/organs/vocal_cords.dm
+++ b/code/modules/surgery/organs/vocal_cords.dm
@@ -74,7 +74,7 @@
 	..()
 	cords = target
 
-/datum/action/item_action/organ_action/colossus/IsAvailable()
+/datum/action/item_action/organ_action/colossus/IsAvailable(silent = FALSE)
 	if(world.time < cords.next_command)
 		return FALSE
 	if(!owner)
@@ -632,7 +632,7 @@
 	..()
 	cords = target
 
-/datum/action/item_action/organ_action/velvet/IsAvailable()
+/datum/action/item_action/organ_action/velvet/IsAvailable(silent = FALSE)
 	return TRUE
 
 /datum/action/item_action/organ_action/velvet/Trigger()


### PR DESCRIPTION
## About The Pull Request
Refactored the action datum a little to remove a redundant `proc_holder/spell/can_cast` call (from `proc_holder/spell/Click`) from the `action/spell_action/Trigger` chain, it's already done in `action/spell_action/IsAvailable`. Similar improvements for `datum/action/spell_action/alien/cost_check` too.
Fixed an 'in' operator being placed in a bitfield check on spellcasting.dm.
Incorporates #11791.

## Why It's Good For The Game
Fixing a couple mistakes.

## Changelog
:cl:
fix: Wizard robes & co work again now.
fix: Fixed some spell casting message spam.
/:cl:
