### PR TITLE
Little Holodeck refactor.

### DIFF
--- a/code/__HELPERS/global_lists.dm
+++ b/code/__HELPERS/global_lists.dm
@@ -89,6 +89,14 @@
 
 	INVOKE_ASYNC(GLOBAL_PROC, /proc/init_ref_coin_values) //so the current procedure doesn't sleep because of UNTIL()
 
+	for(var/path in subtypesof(/area/holodeck))
+		var/area/holodeck/A = path
+		var/list/compatibles = initial(A.compatible_holodeck_comps)
+		if(!compatibles || initial(A.abstract_type) == path)
+			continue
+		for(var/comp in compatibles)
+			LAZYADD(GLOB.holodeck_areas_prototypes[comp], A)
+
 //creates every subtype of prototype (excluding prototype) and adds it to list L.
 //if no list/L is provided, one is created.
 /proc/init_subtypes(prototype, list/L)

--- a/code/_globalvars/lists/mapping.dm
+++ b/code/_globalvars/lists/mapping.dm
@@ -50,3 +50,5 @@ GLOBAL_LIST_EMPTY_TYPED(areas_by_type, /area)
 GLOBAL_LIST_EMPTY(all_abstract_markers)
 
 GLOBAL_LIST_EMPTY(stationroom_landmarks) //List of all spawns for stationrooms
+
+GLOBAL_LIST_EMPTY(holodeck_areas_prototypes) //List of holodeck area prototypes per holodeck computer type

--- a/code/game/area/areas/holodeck.dm
+++ b/code/game/area/areas/holodeck.dm
@@ -6,6 +6,8 @@
 	hidden = TRUE
 
 	var/obj/machinery/computer/holodeck/linked
+	var/list/compatible_holodeck_comps
+	var/abstract_type = /area/holodeck
 	var/restricted = 0 // if true, program goes on emag list
 
 /*
@@ -53,6 +55,8 @@
 */
 /area/holodeck/rec_center
 	name = "\improper Recreational Holodeck"
+	compatible_holodeck_comps = list(/obj/machinery/computer/holodeck)
+	abstract_type = /area/holodeck/rec_center
 
 /area/holodeck/rec_center/offline
 	name = "Holodeck - Offline"

--- a/code/modules/holodeck/area_copy.dm
+++ b/code/modules/holodeck/area_copy.dm
@@ -63,23 +63,38 @@ GLOBAL_LIST_INIT(duplicate_forbidden_vars_by_type, typecacheof_assoc_list(list(
 
 	var/src_min_x = 99999
 	var/src_min_y = 99999
+	var/src_max_x = 0
+	var/src_max_y = 0
 	var/list/refined_src = new/list()
 
-	for (var/turf/T in turfs_src)
+	for (var/i in turfs_src)
+		var/turf/T = i
 		src_min_x = min(src_min_x,T.x)
 		src_min_y = min(src_min_y,T.y)
-	for (var/turf/T in turfs_src)
+		src_max_x = max(src_max_x,T.y)
+		src_max_y = max(src_max_y,T.y)
+	for (var/i in turfs_src)
+		var/turf/T = i
 		refined_src[T] = "[T.x - src_min_x].[T.y - src_min_y]"
 
 	var/trg_min_x = 99999
 	var/trg_min_y = 99999
+	var/trg_max_x = 0
+	var/trg_max_y = 0
 	var/list/refined_trg = new/list()
 
-	for (var/turf/T in turfs_trg)
+	for (var/i in turfs_trg)
+		var/turf/T = i
 		trg_min_x = min(trg_min_x,T.x)
 		trg_min_y = min(trg_min_y,T.y)
-	for (var/turf/T in turfs_trg)
-		refined_trg["[T.x - trg_min_x].[T.y - trg_min_y]"] = T
+		trg_max_x = max(trg_max_x,T.y)
+		trg_max_y = max(trg_max_y,T.y)
+
+	var/diff_x = round(((src_max_x - src_min_x) - (trg_max_x - trg_min_x))/2)
+	var/diff_y = round(((src_max_y - src_min_y) - (trg_max_y - trg_min_y))/2)
+	for (var/i in turfs_trg)
+		var/turf/T = i
+		refined_trg["[T.x - trg_min_x + diff_x].[T.y - trg_min_y + diff_y]"] = T
 
 	var/list/toupdate = new/list()
 

--- a/code/modules/holodeck/computer.dm
+++ b/code/modules/holodeck/computer.dm
@@ -2,7 +2,10 @@
 	Holodeck Update
 
 	The on-station holodeck area is of type [holodeck_type].
-	All subtypes of [program_type] are loaded into the program cache or emag programs list.
+	All types found in GLOB.holodeck_areas_per_comp_type[src.type], generated on make_datum_references_lists(),
+	are loaded into the program cache or emag programs list.
+	Paths with their abstract_type variable equal to themselves will be skipped.
+
 	If init_program is null, a random program will be loaded on startup.
 	If you don't wish this, set it to the offline program or another of your choosing.
 
@@ -12,7 +15,6 @@
 	3) Create a new control console that uses those areas
 
 	Non-mapped areas should be skipped but you should probably comment them out anyway.
-	The base of program_type will always be ignored; only subtypes will be loaded.
 */
 
 #define HOLODECK_CD 25
@@ -35,7 +37,6 @@
 	// Splitting this up allows two holodecks of the same size
 	// to use the same source patterns.  Y'know, if you want to.
 	var/holodeck_type = /area/holodeck/rec_center	// locate(this) to get the target holodeck
-	var/program_type = /area/holodeck/rec_center	// subtypes of this (but not this itself) are loadable programs
 
 	var/active = FALSE
 	var/damaged = FALSE
@@ -181,7 +182,7 @@
 	return ..()
 
 /obj/machinery/computer/holodeck/proc/generate_program_list()
-	for(var/typekey in subtypesof(program_type))
+	for(var/typekey in GLOB.holodeck_areas_prototypes[type])
 		var/area/holodeck/A = GLOB.areas_by_type[typekey]
 		if(!A || !A.contents.len)
 			continue


### PR DESCRIPTION
## About The Pull Request
Modifies `area/copy_contents_to` to center the results on the target area should it be of different lenghts than the source.
Also replaced the holodeck computer's `program_type` variable with a global list generated as the world loads, to allow for a more selective choices of loadable templates later on.

## Why It's Good For The Game
Fairly minor backend improvements in preparation for a possible holodeck area component (to enable DIY holodeck areas) in the future, and maybe surpass RP's holodecks by also implementing that area refactor I have done months ago at last.

## Changelog
None.