### PR TITLE
Fixes toilet cistern loot spawning on the floor.

### DIFF
--- a/code/game/objects/effects/spawners/lootdrop.dm
+++ b/code/game/objects/effects/spawners/lootdrop.dm
@@ -2,6 +2,7 @@
 	icon = 'icons/effects/landmarks_static.dmi'
 	icon_state = "random_loot"
 	layer = OBJ_LAYER
+	var/spawn_on_turf = TRUE
 	var/lootcount = 1		//how many items will be spawned
 	var/lootdoubles = TRUE	//if the same item can be spawned twice
 	var/list/loot			//a list of possible items to spawn e.g. list(/obj/item, /obj/structure, /obj/effect)
@@ -10,7 +11,7 @@
 /obj/effect/spawner/lootdrop/Initialize(mapload)
 	..()
 	if(loot && loot.len)
-		var/turf/T = get_turf(src)
+		var/atom/A = spawn_on_turf ? get_turf(src) : loc
 		var/loot_spawned = 0
 		while((lootcount-loot_spawned) && loot.len)
 			var/lootspawn = pickweight(loot)
@@ -18,7 +19,7 @@
 				loot.Remove(lootspawn)
 
 			if(lootspawn)
-				var/atom/movable/spawned_loot = new lootspawn(T)
+				var/atom/movable/spawned_loot = new lootspawn(A)
 				if (!fan_out_items)
 					if (pixel_x != 0)
 						spawned_loot.pixel_x = pixel_x
@@ -449,6 +450,7 @@
 /obj/effect/spawner/lootdrop/low_loot_toilet
 	name = "random low toilet spawner"
 	lootcount = 1
+	spawn_on_turf = FALSE
 //Note this is out of a 100 - Meaning the number you see is also the percent its going to pick that
 //This is ment for "low" loot that anyone could fine in a toilet, for better gear use high loot toilet
 	loot = list("" = 30,
@@ -458,41 +460,42 @@
 		/obj/item/clothing/glasses/sunglasses/blindfold = 4,
 		/obj/item/clothing/glasses/sunglasses = 1,
 		/obj/item/toy/plush/random = 5,
-		/obj/effect/spawner/lootdrop/gloves = 5,
-		/obj/effect/spawner/lootdrop/glowstick = 5,
-		/obj/effect/spawner/lootdrop/coin = 3,
-		/obj/effect/spawner/lootdrop/cig_packs = 10,
-		/obj/effect/spawner/lootdrop/cigars_cases = 2,
-		/obj/effect/spawner/lootdrop/space_cash = 5,
+		/obj/effect/spawner/lootdrop/gloves/no_turf = 5,
+		/obj/effect/spawner/lootdrop/glowstick/no_turf = 5,
+		/obj/effect/spawner/lootdrop/coin/no_turf = 3,
+		/obj/effect/spawner/lootdrop/cig_packs/no_turf = 10,
+		/obj/effect/spawner/lootdrop/cigars_cases/no_turf = 2,
+		/obj/effect/spawner/lootdrop/space_cash/no_turf = 5,
 		/obj/item/reagent_containers/food/snacks/grown/cannabis = 5,
 		/obj/item/storage/pill_bottle/dice = 5,
 		/obj/item/toy/cards/deck = 5,
-		/obj/effect/spawner/lootdrop/druggie_pill = 5
+		/obj/effect/spawner/lootdrop/druggie_pill/no_turf = 5
 		)
 
 /obj/effect/spawner/lootdrop/prison_loot_toilet
 	name = "random prison toilet spawner"
 	lootcount = 1
+	spawn_on_turf = FALSE
 //Note this is out of a 100 - Meaning the number you see is also the percent its going to pick that
 //This is ment for "prison" loot that is rather rare and ment for "prisoners if they get a crowbar to fine, or sec.
 	loot = list("" = 10,
 		/obj/item/lighter = 5,
 		/obj/item/poster/random_contraband = 5,
 		/obj/item/clothing/glasses/sunglasses = 5,
-		/obj/effect/spawner/lootdrop/coin = 5,
-		/obj/effect/spawner/lootdrop/cig_packs = 10,
-		/obj/effect/spawner/lootdrop/cigars_cases = 5,
+		/obj/effect/spawner/lootdrop/coin/no_turf = 5,
+		/obj/effect/spawner/lootdrop/cig_packs/no_turf = 10,
+		/obj/effect/spawner/lootdrop/cigars_cases/no_turf = 5,
 		/obj/item/reagent_containers/food/snacks/grown/cannabis = 5,
 		/obj/item/storage/pill_bottle/dice = 5,
 		/obj/item/toy/cards/deck = 5,
-		/obj/effect/spawner/lootdrop/druggie_pill = 5,
+		/obj/effect/spawner/lootdrop/druggie_pill/no_turf = 5,
 		/obj/item/kitchen/knife = 5,
 		/obj/item/screwdriver = 5,
-		/obj/item/crowbar/red = 0.5, //Dont you need a crowbar to open this?
+		/obj/item/crowbar/red = 1, //Dont you need a crowbar to open this?
 		/obj/item/stack/medical/bruise_pack = 3,
 		/obj/item/reagent_containers/food/drinks/bottle/vodka = 2,
 		/obj/item/radio = 5,
-		/obj/item/flashlight = 4.5,
+		/obj/item/flashlight = 4,
 		/obj/item/clothing/mask/breath = 2,
 		/obj/item/tank/internals/emergency_oxygen = 3,
 		/obj/item/storage/box/mre/menu4/safe = 3,
@@ -502,13 +505,14 @@
 /obj/effect/spawner/lootdrop/high_loot_toilet
 	name = "random high toilet spawner"
 	lootcount = 1
+	spawn_on_turf = FALSE
 //Note this is out of a 100 - Meaning the number you see is also the percent its going to pick that
 //The items inside are always going to be something usefull, illegal and likely traitorous.
 	loot = list(
 		/obj/item/clothing/glasses/sunglasses = 5,
-		/obj/effect/spawner/lootdrop/coin = 5,
-		/obj/effect/spawner/lootdrop/space_cash = 5,
-		/obj/effect/spawner/lootdrop/druggie_pill = 5,
+		/obj/effect/spawner/lootdrop/coin/no_turf = 5,
+		/obj/effect/spawner/lootdrop/space_cash/no_turf = 5,
+		/obj/effect/spawner/lootdrop/druggie_pill/no_turf = 5,
 		/obj/item/storage/fancy/cigarettes/cigpack_syndicate = 5,
 		/obj/item/suppressor = 5,
 		/obj/item/toy/cards/deck/syndicate = 5,
@@ -521,3 +525,24 @@
 		/obj/item/clothing/gloves/combat = 10,
 		/obj/item/clothing/shoes/sneakers/noslip = 10
 		)
+
+/obj/effect/spawner/lootdrop/coin/no_turf
+	spawn_on_turf = FALSE
+
+/obj/effect/spawner/lootdrop/space_cash/no_turf
+	spawn_on_turf = FALSE
+
+/obj/effect/spawner/lootdrop/druggie_pill/no_turf
+	spawn_on_turf = FALSE
+
+/obj/effect/spawner/lootdrop/gloves/no_turf
+	spawn_on_turf = FALSE
+
+/obj/effect/spawner/lootdrop/cig_packs/no_turf
+	spawn_on_turf = FALSE
+
+/obj/effect/spawner/lootdrop/cigars_cases/no_turf
+	spawn_on_turf = FALSE
+
+/obj/effect/spawner/lootdrop/glowstick/no_turf
+	spawn_on_turf = FALSE

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -118,7 +118,7 @@
 /obj/structure/toilet/secret/LateInitialize()
 	. = ..()
 	w_items = 0 //recalculate total weight thanks to the secret.
-	for(var/item/I in contents)
+	for(var/obj/item/I in contents)
 		w_items += I.w_class
 
 /obj/structure/toilet/secret/low_loot

--- a/code/game/objects/structures/watercloset.dm
+++ b/code/game/objects/structures/watercloset.dm
@@ -64,7 +64,7 @@
 			else
 				I.forceMove(drop_location())
 			to_chat(user, "<span class='notice'>You find [I] in the cistern.</span>")
-			w_items -= I.w_class
+			w_items = max(w_items - I.w_class, 0)
 	else
 		open = !open
 		update_icon()
@@ -114,6 +114,12 @@
 		secret = new secret_type(src)
 		secret.desc += "" //In case you want to add something to the item that spawns
 		contents += secret
+
+/obj/structure/toilet/secret/LateInitialize()
+	. = ..()
+	w_items = 0 //recalculate total weight thanks to the secret.
+	for(var/item/I in contents)
+		w_items += I.w_class
 
 /obj/structure/toilet/secret/low_loot
 	secret_type = /obj/effect/spawner/lootdrop/low_loot_toilet


### PR DESCRIPTION
## About The Pull Request
Trilby had the awesome idea of using lootdrop spawners without realizing they were coded to spawn the loot on the floor.
Also tweaking rounding the values of two keys of the prison toiler lootdrop loot table, since we are not using bay's pickweight method yet.

## Why It's Good For The Game
Fixing a few mistakes.

## Changelog
:cl:
fix: Fixed toilet cistern loot spawning on the floor.
/:cl:
