### PR TITLE
adds rudimentary linux iptables support for fail2topic (and makes fail2topic disabled by default while i'm at it)

### DIFF
--- a/config/config.txt
+++ b/config/config.txt
@@ -510,13 +510,16 @@ DEFAULT_VIEW 21x15
 
 ### FAIL2TOPIC:
 ### Automated IP bans for world/Topic() spammers
+### NOTE FOR WINDOWS HOSTS: This requires you to be running dreamdaemon as an administrator for it to work at all. TGS3 handles this automatically, and honestly there's no reason not to be using TGS3 if you're hosting on Windows.
+### NOTE FOR LINUX HOSTS: This requires manual setup of iptables. Beware that improper configuration of this can and will irreversibly fuck up a server, so please don't tinker with it if you don't know what you're doing.
 ## Enabled
-FAIL2TOPIC_ENABLED
+#FAIL2TOPIC_ENABLED
 ## Minimum wait time in deciseconds between valid requests 
 FAIL2TOPIC_RATE_LIMIT 10
 ## Number of requests after breaching rate limit that triggers a ban
 FAIL2TOPIC_MAX_FAILS 5
 ## Firewall rule name used on physical server
+## FOR LINUX HOSTS: This is used as the chain name. The iptables chain doesn't get created or hooked up to INPUT automatically, so you'll have to get that set up yourself. Recommended name: BYOND
 FAIL2TOPIC_RULE_NAME _dd_fail2topic
 
 ## Enable automatic profiling - Byond 513.1506 and newer only.


### PR DESCRIPTION
Even though Linux dreamdaemon is fairly shite, there's still a variety of reasons why hosts would want to use Linux (budget being one of the biggest reasons). In theory, 513 should have fixed the exploit that made fail2topic necessary in the first place, but apparently it didn't? So this PR gives Linux hosts a way to actually protect their server against one of the more common SS13-specific DoS attack types without having to delve into the nightmare that is deep packet inspection.

To get things set up on Linux, you first have to make sure iptables is installed and the firewall is working. After that, you simply have to create a new chain with the desired name (in this case, I recommend a chain name of BYOND), then set up a rule in the INPUT chain to redirect dreamdaemon traffic to the BYOND chain (alternatively, you could just have all INPUT traffic be redirected to BYOND, though this is strongly not recommended due to Linux dreamdaemon's inherent instability along with the potential for false positives.)

This PR also makes fail2topic be disabled by default. This will not affect live servers at all, this mainly just stops a netsh command prompt from popping open every single time you try to boot up a local test server, something that makes inexperienced coders fairly paranoid.

## Changelog
:cl: Bhijn
server: Fail2Topic now supports Linux. Do beware that this requires some sysop experience to properly set up!
config: Fail2Topic is now disabled by default, and the out-of-the-box config files have been updated to be a little more detailed.
/:cl:
