### PR TITLE
Buffs food processor

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -17,7 +17,7 @@
 
 /obj/machinery/processor/RefreshParts()
 	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
-		rating_amount = B.rating
+		rating_amount = (B.rating + 1)
 	for(var/obj/item/stock_parts/manipulator/M in component_parts)
 		rating_speed = M.rating
 

--- a/code/modules/food_and_drinks/kitchen_machinery/processor.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/processor.dm
@@ -152,6 +152,12 @@
 	name = "slime processor"
 	desc = "An industrial grinder with a sticker saying appropriated for science department. Keep hands clear of intake area while operating."
 
+/obj/machinery/processor/slime/RefreshParts()
+	for(var/obj/item/stock_parts/matter_bin/B in component_parts)
+		rating_amount = B.rating
+	for(var/obj/item/stock_parts/manipulator/M in component_parts)
+		rating_speed = (M.rating + 1)
+
 /obj/machinery/processor/slime/Initialize()
 	. = ..()
 	var/obj/item/circuitboard/machine/B = new /obj/item/circuitboard/machine/processor/slime(null)


### PR DESCRIPTION
## About The Pull Request

Makes food processor more usefull by making it from 1-2-3-4 to 2-3-4-5 
part wise
## Why It's Good For The Game

This makes it more inline with slime processor as your able to get 2-3-4-5 from each level not counting the potion. It also helps cooks make more and different food as they dont have to worry about losing out on wheat/meat

Well some have worried about slimes, that has been corrected Slime processor now just gets speed up rather then the 2-3-4-5

## Changelog
:cl:
balance: Food processors have been upgraded giving an extra food process per each level (1-2-3-4 turns into 2-3-4-5 part wise)
balance: Slime processor's now get a speed buff so your not waiting 12 years for that 60 gray slime process you did
/:cl: