### PR TITLE
Honey Palm can be distill into mead

### DIFF
--- a/code/modules/hydroponics/grown/flowers.dm
+++ b/code/modules/hydroponics/grown/flowers.dm
@@ -318,3 +318,4 @@
 	bitesize_mod = 8
 	tastes = list("wax" = 1)
 	foodtype = SUGAR
+	distill_reagent = /datum/reagent/consumable/ethanol/mead


### PR DESCRIPTION

## About The Pull Request

Turns out is hard to get mead? So now you can make it with end of line hard to get Honey Palm.
Yes, mead is distilled booze with honey in it, this works from a IRL view

## Why It's Good For The Game

Makes more people able to get mead out side of Rng kegs, now with Rng plants!

## Changelog
:cl:
add: Honey Palm now distills into mead rather then wine
/:cl:
