### PR TITLE
Shuffles resist embed higher up on the resist chain

### DIFF
--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -645,11 +645,6 @@
 		attempt_resist_grab(FALSE)
 		// Return as we should only resist one thing at a time. Give clickdelay if the grab wasn't passive.
 		return old_gs? TRUE : FALSE
-
-	if(CHECK_MOBILITY(src, MOBILITY_USE) && resist_embedded()) //Citadel Change for embedded removal memes - requires being able to use items.
-		// DO NOT GIVE DEFAULT CLICKDELAY - This is a combat action.
-		changeNext_move(CLICK_CD_MELEE)
-		return FALSE
 		
 	// unbuckling yourself. stops the chain if you try it.
 	if(buckled && last_special <= world.time)
@@ -673,10 +668,17 @@
 			resist_fire() //stop, drop, and roll
 			// Give clickdelay
 			return TRUE
+
 	if(resting) //cit change - allows resisting out of resting
 		resist_a_rest() // ditto
 		// DO NOT GIVE CLCIKDELAY - resist_a_rest() handles spam prevention. Somewhat.
 		return FALSE
+
+	if(CHECK_MOBILITY(src, MOBILITY_USE) && resist_embedded()) //Citadel Change for embedded removal memes - requires being able to use items.
+		// DO NOT GIVE DEFAULT CLICKDELAY - This is a combat action.
+		changeNext_move(CLICK_CD_MELEE)
+		return FALSE
+
 	if(last_special <= world.time)
 		resist_restraints() //trying to remove cuffs.
 		// DO NOT GIVE CLICKDELAY - last_special handles this.

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -646,6 +646,11 @@
 		// Return as we should only resist one thing at a time. Give clickdelay if the grab wasn't passive.
 		return old_gs? TRUE : FALSE
 
+	if(CHECK_MOBILITY(src, MOBILITY_USE) && resist_embedded()) //Citadel Change for embedded removal memes - requires being able to use items.
+		// DO NOT GIVE DEFAULT CLICKDELAY - This is a combat action.
+		changeNext_move(CLICK_CD_MELEE)
+		return FALSE
+		
 	// unbuckling yourself. stops the chain if you try it.
 	if(buckled && last_special <= world.time)
 		log_combat(src, buckled, "resisted buckle")
@@ -676,10 +681,7 @@
 		resist_restraints() //trying to remove cuffs.
 		// DO NOT GIVE CLICKDELAY - last_special handles this.
 		return FALSE
-	if(CHECK_MOBILITY(src, MOBILITY_USE) && resist_embedded()) //Citadel Change for embedded removal memes - requires being able to use items.
-		// DO NOT GIVE DEFAULT CLICKDELAY - This is a combat action.
-		changeNext_move(CLICK_CD_MELEE)
-		return FALSE
+
 
 /// Proc to resist a grab. moving_resist is TRUE if this began by someone attempting to move. Return FALSE if still grabbed/failed to break out. Use this instead of resist_grab() directly.
 /mob/proc/attempt_resist_grab(moving_resist, forced, log = TRUE)

--- a/code/modules/mob/living/living.dm
+++ b/code/modules/mob/living/living.dm
@@ -684,7 +684,6 @@
 		// DO NOT GIVE CLICKDELAY - last_special handles this.
 		return FALSE
 
-
 /// Proc to resist a grab. moving_resist is TRUE if this began by someone attempting to move. Return FALSE if still grabbed/failed to break out. Use this instead of resist_grab() directly.
 /mob/proc/attempt_resist_grab(moving_resist, forced, log = TRUE)
 	if(!pulledby)	//not being grabbed


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

this also fixes it uh, nto working due to me breaking it lmao

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Wish there was a better way to do this but in the majority of cases where you have a resistable item in you it's more important to get it out than to resist everything else

@deathride58 please think of a way to make this better because this can result in people critting themselves trying to resist resting status, but if I don't do this there's no other interface option for resisting embeds.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Embed resist is now higher up on the resist attempt chain.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
