### PR TITLE
Shuffles around and buffs resisting embedded objects

### DIFF
--- a/modular_citadel/code/modules/mob/living/carbon/human/human.dm
+++ b/modular_citadel/code/modules/mob/living/carbon/human/human.dm
@@ -2,16 +2,15 @@
 	return
 
 /mob/living/carbon/human/resist_embedded()
-	if(handcuffed || legcuffed || (wear_suit && wear_suit.breakouttime))
+	if(handcuffed || (wear_suit && wear_suit.breakouttime))
 		return
-	if(CHECK_MOBILITY(src, MOBILITY_MOVE) && !on_fire)
+	if(CHECK_MOBILITY(src, MOBILITY_USE))
 		for(var/obj/item/bodypart/L in bodyparts)
 			if(istype(L) && L.embedded_objects.len)
 				for(var/obj/item/I in L.embedded_objects)
 					if(istype(I) && I.w_class >= WEIGHT_CLASS_NORMAL)	//minimum weight class to insta-ripout via resist
-						remove_embedded_unsafe(L, I, src, 1.5)	//forcefully call the remove embedded unsafe proc but with extra pain multiplier. if you want to remove it less painfully, examine and remove it carefully.
+						remove_embedded_unsafe(L, I, src, 1)	//forcefully call the remove embedded unsafe proc but with extra pain multiplier. if you want to remove it less painfully, examine and remove it carefully.
 						return TRUE //Hands are occupied
-	return
 
 /mob/living/carbon/human/proc/remove_embedded_unsafe(obj/item/bodypart/L, obj/item/I, mob/user, painmul = 1)
 	if(!I || !L || I.loc != src || !(I in L.embedded_objects))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Legcuffs no longer prevent this
Checks for MOBILITY_USE instead of MOBILLITY_MOVe
Does not require not being on fire
1x pain instead of 1.5x pain
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Barely used feature, what's the point if tapping B after one single embed with a spear sends you to just above crit? I get you're supposed to remove it "carefully" but it's punishing enough without this.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Resisting embedded objects is now less damaging/restrictive on its use.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
