### PR TITLE
Pawnch Update 2.5: I swear this will be the last one for a while. + some slight fixes

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_clothing.dm
+++ b/code/datums/components/crafting/recipes/recipes_clothing.dm
@@ -39,6 +39,30 @@
 	time = 10
 	reqs = list(/obj/item/paper = 20)
 	category = CAT_CLOTHING
+	
+/datum/crafting_recipe/armwraps
+	name = "armwraps"
+	result = /obj/item/clothing/gloves/fingerless/pugilist
+	time = 60
+	tools = list(TOOL_WIRECUTTER)
+	reqs = list(/obj/item/stack/sheet/cloth = 4,
+				/obj/item/stack/sheet/silk = 2,
+				/obj/item/stack/sheet/leather = 2)
+	category = CAT_CLOTHING
+
+/datum/crafting_recipe/armwrapsplusone
+	name = "armwraps of mighty fists"
+	result = /obj/item/clothing/gloves/fingerless/pugilist/magic
+	time = 300
+	tools = list(TOOL_WIRECUTTER, /obj/item/book/codex_gigas, /obj/item/clothing/head/wizard, /obj/item/clothing/suit/wizrobe)
+	reqs = list(/obj/item/stack/sheet/cloth = 2,
+				/obj/item/stack/sheet/leather = 2,
+				/obj/item/stack/sheet/durathread = 2,
+				/datum/reagent/consumable/ethanol/sake = 100,
+				/datum/reagent/consumable/ethanol/wizz_fizz = 100,
+				/obj/item/stack/sheet/sinew = 1,
+				/obj/item/stack/sheet/mineral/gold = 50)
+	category = CAT_CLOTHING
 
 ////////
 //Huds//

--- a/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
+++ b/code/datums/components/crafting/recipes/recipes_weapon_and_ammo.dm
@@ -298,7 +298,7 @@
 	subcategory = CAT_AMMO
 
 /datum/crafting_recipe/ashen_arrow
-	name = "Fire Hardened Arrow"
+	name = "Ashen Arrow"
 	result = /obj/item/ammo_casing/caseless/arrow/ash
 	tools = list(TOOL_WELDER)
 	time = 30

--- a/code/datums/martial/cqc.dm
+++ b/code/datums/martial/cqc.dm
@@ -168,24 +168,29 @@
 		return FALSE
 	add_to_streak("D",D)
 	var/obj/item/I = null
-	var/damage = (damage_roll(A,D)*0.5)
+	var/damage = damage_roll(A,D)
+	var/stunthreshold = A.dna.species.punchstunthreshold
 	if(check_streak(A,D))
 		return TRUE
-	if(prob(65))
-		if(CHECK_MOBILITY(D, MOBILITY_MOVE) || !restraining)
+	if(CHECK_MOBILITY(D, MOBILITY_MOVE) || !restraining)
+		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+		if(damage >= stunthreshold)	
 			I = D.get_active_held_item()
 			D.visible_message("<span class='warning'>[A] strikes [D]'s jaw with their hand!</span>", \
-								"<span class='userdanger'>[A] strikes your jaw, disorienting you!</span>")
+							"<span class='userdanger'>[A] strikes your jaw, disorienting you!</span>")
 			playsound(get_turf(D), 'sound/weapons/cqchit1.ogg', 50, 1, -1)
-			if(I && D.temporarilyRemoveItemFromInventory(I))
-				A.put_in_hands(I)
+			D.drop_all_held_items()
 			D.Jitter(2)
-			D.apply_damage(damage, BRUTE)
-	else
-		D.visible_message("<span class='danger'>[A] attempted to disarm [D]!</span>", \
-							"<span class='userdanger'>[A] attempted to disarm [D]!</span>")
-		playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
-	log_combat(A, D, "disarmed (CQC)", "[I ? " grabbing \the [I]" : ""]")
+			D.Dizzy(damage)
+			D.apply_damage(damage*2 + 20, STAMINA)
+			D.apply_damage(damage*0.5, BRUTE)
+		else
+			D.visible_message("<span class='danger'>[A] strikes [D] in the chest!</span>", \
+							"<span class='userdanger'>[A] strikes in chest!</span>")
+			playsound(D, 'sound/weapons/cqchit1.ogg', 25, 1, -1)
+			D.apply_damage(damage + 15, STAMINA)
+			D.apply_damage(damage*0.5, BRUTE)
+		log_combat(A, D, "disarmed (CQC)", "[I ? " grabbing \the [I]" : ""]")
 	if(restraining && A.pulling == D)
 		log_combat(A, D, "knocked out (Chokehold)(CQC)")
 		D.visible_message("<span class='danger'>[A] puts [D] into a chokehold!</span>", \

--- a/code/datums/martial/krav_maga.dm
+++ b/code/datums/martial/krav_maga.dm
@@ -98,13 +98,13 @@
 /datum/martial_art/krav_maga/proc/leg_sweep(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	var/obj/item/bodypart/affecting = D.get_bodypart(BODY_ZONE_CHEST)
 	var/armor_block = D.run_armor_check(affecting, "melee")
-	var/damage = damage_roll(A,D)
+	var/damage = (damage_roll(A,D)*2 + 25)
 	if(!CHECK_MOBILITY(D, MOBILITY_STAND))
 		return FALSE
 	D.visible_message("<span class='warning'>[A] leg sweeps [D]!</span>", \
 					  	"<span class='userdanger'>[A] leg sweeps you!</span>")
 	playsound(get_turf(A), 'sound/effects/hit_kick.ogg', 50, 1, -1)
-	D.apply_damage(damage + 25, STAMINA, affecting, armor_block)
+	D.apply_damage(damage, STAMINA, affecting, armor_block)
 	D.DefaultCombatKnockdown(80, override_hardstun = 1, override_stamdmg = 0)
 	log_combat(A, D, "leg sweeped")
 	return TRUE
@@ -165,14 +165,15 @@
 		return TRUE
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
 	var/armor_block = D.run_armor_check(affecting, "melee")
-	var/damage = (damage_roll(A,D)*2)
-	if(D.mobility_flags & MOBILITY_STAND)
+	var/damage = damage_roll(A,D)
+	var/stunthreshold = A.dna.species.punchstunthreshold
+	if(CHECK_MOBILITY(D, MOBILITY_STAND))
 		D.visible_message("<span class='danger'>[A] reprimands [D]!</span>", \
 					"<span class='userdanger'>You're slapped by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
 		to_chat(A, "<span class='danger'>You jab [D]!</span>")
 		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
 		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		D.apply_damage(damage + 5, STAMINA, affecting, armor_block)
+		D.apply_damage(damage*2 + 15, STAMINA, affecting, armor_block)
 		log_combat(A, D, "punched nonlethally")
 	else
 		D.visible_message("<span class='danger'>[A] reprimands [D]!</span>", \
@@ -180,11 +181,12 @@
 		to_chat(A, "<span class='danger'>You stomp [D]!</span>")
 		A.do_attack_animation(D, ATTACK_EFFECT_KICK)
 		playsound(D, 'sound/effects/hit_punch.ogg', 50, TRUE, -1)
-		D.apply_damage(damage + 10, STAMINA, affecting, armor_block)
+		D.apply_damage(damage*2 + 20, STAMINA, affecting, armor_block)
 		log_combat(A, D, "stomped nonlethally")
-	if(prob(D.getStaminaLoss()))
+	if(damage >= stunthreshold)
 		D.visible_message("<span class='warning'>[D] sputters and recoils in pain!</span>", "<span class='userdanger'>You recoil in pain as you are jabbed in a nerve!</span>")
 		D.drop_all_held_items()
+	
 	return TRUE
 
 //Krav Maga Gloves

--- a/code/datums/martial/rising_bass.dm
+++ b/code/datums/martial/rising_bass.dm
@@ -1,5 +1,5 @@
-#define REPULSE_PUNCH_COMBO "HDHD"
-#define SHOULDER_FLIP_COMBO "GHDGHH"
+#define REPULSE_PUNCH_COMBO "HDD"
+#define SHOULDER_FLIP_COMBO "DHDHG"
 #define FOOT_SMASH_COMBO "HH"
 #define SIDE_KICK_COMBO "skick"
 #define DEFT_SWITCH_COMBO "deft"
@@ -37,7 +37,6 @@
 	return FALSE
 
 
-//Repulse Punch - Slams the opponent far away from you.
 /datum/action/risingbassmove
 	name = ""
 	icon_icon = 'icons/mob/actions/actions_items.dmi'
@@ -89,7 +88,7 @@
 						  "<span class='userdanger'>[A] kicks you in the side, forcing you to step away!</span>")
 		playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		D.apply_damage(damage, BRUTE, BODY_ZONE_CHEST)
-		D.DefaultCombatKnockdown(60)
+		D.DefaultCombatKnockdown(60, override_hardstun = 1, override_stam = damage)
 		var/L = !checkfordensity(H,D) ? (!checkfordensity(K,D) ? D.loc : K) : H
 		D.forceMove(L)
 		log_combat(A, D, "side kicked (Rising Bass)")
@@ -97,24 +96,25 @@
 	return TRUE
 
 /datum/martial_art/the_rising_bass/proc/shoulderFlip(mob/living/carbon/human/A, mob/living/carbon/human/D)
-	var/damage = (damage_roll(A,D) + 25)
-	if(CHECK_MOBILITY(D, MOBILITY_STAND))
-		var/turf/H = get_step(A, get_dir(D,A))
-		var/L = checkfordensity(H,D) ? H : A.loc
-		A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
-		D.visible_message("<span class='warning'>[A] flips [D] over their shoulder, slamming them into the ground!</span>", \
-						  "<span class='userdanger'>[A] flips you over their shoulder, slamming you into the ground!</span>")
-		playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
-		D.emote("scream")
-		D.apply_damage(damage, BRUTE, BODY_ZONE_CHEST)
-		D.apply_damage(damage, BRUTE, BODY_ZONE_HEAD)
+	var/damage = damage_roll(A,D)
+	var/stunthreshold = A.dna.species.punchstunthreshold
+	var/turf/H = get_step(A, get_dir(D,A))
+	var/L = checkfordensity(H,D) ? H : A.loc
+	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+	D.visible_message("<span class='warning'>[A] flips [D] over their shoulder, slamming them into the ground!</span>", \
+					  "<span class='userdanger'>[A] flips you over their shoulder, slamming you into the ground!</span>")
+	playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
+	D.emote("scream")
+	D.apply_damage(damage + 10, BRUTE, BODY_ZONE_CHEST)
+	D.apply_damage(damage + 10, BRUTE, BODY_ZONE_HEAD)
+	if(damage >= stunthreshold)
 		D.Sleeping(60)
-		D.DefaultCombatKnockdown(300)
-		D.forceMove(L)
-		log_combat(A, D, "shoulder flipped (Rising Bass)")
-		return TRUE
-	return FALSE
+	D.DefaultCombatKnockdown(300, override_hardstun = 1, override_stam = 50)
+	D.forceMove(L)
+	log_combat(A, D, "shoulder flipped (Rising Bass)")
+	return TRUE
 
+//Repulse Punch - Slams the opponent far away from you.
 /datum/martial_art/the_rising_bass/proc/repulsePunch(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	var/damage = damage_roll(A,D)
 	if(CHECK_MOBILITY(D, MOBILITY_STAND) && repulsecool < world.time)
@@ -125,7 +125,8 @@
 		var/atom/F = get_edge_target_turf(D, get_dir(A, get_step_away(D, A)))
 		D.throw_at(F, 10, 1)
 		D.apply_damage(damage, BRUTE, BODY_ZONE_CHEST)
-		D.DefaultCombatKnockdown(90)
+		D.DefaultCombatKnockdown(90, override_hardstun = 1, override_stam = damage*2)
+		D.confused += min(damage, 20)
 		log_combat(A, D, "repulse punched (Rising Bass)")
 		repulsecool = world.time + 3 SECONDS
 		return TRUE
@@ -162,7 +163,23 @@
 	add_to_streak("D",D)
 	if(check_streak(A,D))
 		return TRUE
-	return ..()
+	var/damage = damage_roll(A,D)
+	var/stunthreshold = A.dna.species.punchstunthreshold
+	A.do_attack_animation(D, ATTACK_EFFECT_PUNCH)
+	if(CHECK_MOBILITY(D, MOBILITY_STAND) && damage >= stunthreshold)
+		D.visible_message("<span class='danger'>[A] trips [D]!</span>", \
+					"<span class='userdanger'>You're tripped by [A]!</span>", "<span class='hear'>You hear something thump against the floor!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You trip [D]!</span>")
+		D.DefaultCombatKnockdown(10, override_hardstun = 0.01, override_stam = damage)
+		D.Dizzy(damage)
+	else
+		D.visible_message("<span class='danger'>[A] jabs [D] in the stomach!</span>", \
+					"<span class='userdanger'>You're jabbed in the stomach by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
+		to_chat(A, "<span class='danger'>You jab [D] in the stomach!</span>")
+		D.apply_damage(damage*2 + 10, STAMINA)
+		D.disgust = min(damage, 20)
+	playsound(D, 'sound/weapons/punchmiss.ogg', 25, 1, -1)
+	return TRUE
 
 /datum/martial_art/the_rising_bass/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("H",D)
@@ -203,9 +220,9 @@
 	to_chat(usr, "<b><i>You retreat inward and recall the teachings of the Rising Bass...</i></b>")
 
 	to_chat(usr, "<span class='notice'>Side Kick</span>: Forces opponent to step to the side.")
-	to_chat(usr, "<span class='notice'>Shoulder Flip</span>: Grab Harm Disarm Grab Harm Harm. Flips opponent over your shoulder and stuns.")
-	to_chat(usr, "<span class='notice'>Repulse Punch</span>: Harm Disarm Harm Disarm. Slams the opponent far away from you.")
-	to_chat(usr, "<span class='notice'>Foot Smash</span>: Harm Harm. Stuns opponent, minor damage.")
+	to_chat(usr, "<span class='notice'>Shoulder Flip</span>: Disarm Harm Disarm Harm Grab. Flips opponent over your shoulder and stuns.")
+	to_chat(usr, "<span class='notice'>Repulse Punch</span>: Harm Disarm Disarm. Slams the opponent far away from you.")
+	to_chat(usr, "<span class='notice'>Foot Smash</span>: Harm Harm. Knocks opponent prone, minor damage.")
 	to_chat(usr, "<span class='notice'>Deft Switch</span>: Switches the opponent's held item for your own. Most useful with nothing in your hand.")
 
 /datum/martial_art/the_rising_bass/teach(mob/living/carbon/human/H, make_temporary = FALSE)

--- a/code/datums/martial/rising_bass.dm
+++ b/code/datums/martial/rising_bass.dm
@@ -109,7 +109,7 @@
 	D.apply_damage(damage + 10, BRUTE, BODY_ZONE_HEAD)
 	if(damage >= stunthreshold)
 		D.Sleeping(60)
-	D.DefaultCombatKnockdown(300, override_hardstun = 1, override_stam = 50)
+	D.DefaultCombatKnockdown(300, override_hardstun = 1, override_stamdmg = 50)
 	D.forceMove(L)
 	log_combat(A, D, "shoulder flipped (Rising Bass)")
 	return TRUE
@@ -125,7 +125,7 @@
 		var/atom/F = get_edge_target_turf(D, get_dir(A, get_step_away(D, A)))
 		D.throw_at(F, 10, 1)
 		D.apply_damage(damage, BRUTE, BODY_ZONE_CHEST)
-		D.DefaultCombatKnockdown(90, override_hardstun = 1, override_stam = damage*2)
+		D.DefaultCombatKnockdown(90, override_hardstun = 1, override_stamdmg = damage*2)
 		D.confused += min(damage, 20)
 		log_combat(A, D, "repulse punched (Rising Bass)")
 		repulsecool = world.time + 3 SECONDS
@@ -170,7 +170,7 @@
 		D.visible_message("<span class='danger'>[A] trips [D]!</span>", \
 					"<span class='userdanger'>You're tripped by [A]!</span>", "<span class='hear'>You hear something thump against the floor!</span>", COMBAT_MESSAGE_RANGE, A)
 		to_chat(A, "<span class='danger'>You trip [D]!</span>")
-		D.DefaultCombatKnockdown(10, override_hardstun = 0.01, override_stam = damage)
+		D.DefaultCombatKnockdown(10, override_hardstun = 0.01, override_stamdmg = damage)
 		D.Dizzy(damage)
 	else
 		D.visible_message("<span class='danger'>[A] jabs [D] in the stomach!</span>", \

--- a/code/datums/martial/rising_bass.dm
+++ b/code/datums/martial/rising_bass.dm
@@ -88,7 +88,7 @@
 						  "<span class='userdanger'>[A] kicks you in the side, forcing you to step away!</span>")
 		playsound(get_turf(A), 'sound/weapons/thudswoosh.ogg', 50, 1, -1)
 		D.apply_damage(damage, BRUTE, BODY_ZONE_CHEST)
-		D.DefaultCombatKnockdown(60, override_hardstun = 1, override_stam = damage)
+		D.DefaultCombatKnockdown(60, override_hardstun = 1, override_stamdmg = damage)
 		var/L = !checkfordensity(H,D) ? (!checkfordensity(K,D) ? D.loc : K) : H
 		D.forceMove(L)
 		log_combat(A, D, "side kicked (Rising Bass)")

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -23,7 +23,7 @@
 		return TRUE
 	return FALSE
 
-///Gnashing Teeth: Harm Harm, consistent 20 force punch on every second harm punch, has a chance to crit
+///Gnashing Teeth: Harm Harm, high force punch on every second harm punch, has a chance to crit for near triple damage
 /datum/martial_art/the_sleeping_carp/proc/strongPunch(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	///this var is so that the strong punch is always aiming for the body part the user is targeting and not trying to apply to the chest before deviating
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
@@ -44,7 +44,7 @@
 		playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 		log_combat(A, D, "strong punched (Sleeping Carp)")//so as to not double up on logging
 	D.apply_damage((damage + 15) + crit_damage, BRUTE, affecting)
-	return
+	return TRUE
 
 ///Crashing Wave Kick: Harm Disarm combo, throws people seven tiles backwards
 /datum/martial_art/the_sleeping_carp/proc/launchKick(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -57,7 +57,7 @@
 	D.throw_at(throw_target, 7, 14, A)
 	D.apply_damage(damage, BRUTE, BODY_ZONE_CHEST)
 	log_combat(A, D, "launchkicked (Sleeping Carp)")
-	return
+	return TRUE
 
 ///Keelhaul: Harm Grab combo, knocks people down, deals stamina damage while they're on the floor
 /datum/martial_art/the_sleeping_carp/proc/dropKick(mob/living/carbon/human/A, mob/living/carbon/human/D)
@@ -77,7 +77,7 @@
 		D.visible_message("<span class='warning'>[A] kicks [D] in the head!</span>", \
 					"<span class='userdanger'>You are kicked in the head by [A]!</span>", "<span class='hear'>You hear a sickening sound of flesh hitting flesh!</span>", COMBAT_MESSAGE_RANGE, A)
 	log_combat(A, D, "dropkicked (Sleeping Carp)")
-	return
+	return TRUE
 
 /datum/martial_art/the_sleeping_carp/grab_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("G",D)
@@ -89,6 +89,7 @@
 /datum/martial_art/the_sleeping_carp/harm_act(mob/living/carbon/human/A, mob/living/carbon/human/D)
 	add_to_streak("H",D)
 	var/damage = (damage_roll(A,D) + 5)
+	var/stunthreshold = A.dna.species.punchstunthreshold
 	if(check_streak(A,D))
 		return TRUE
 	var/obj/item/bodypart/affecting = D.get_bodypart(ran_zone(A.zone_selected))
@@ -99,6 +100,9 @@
 	to_chat(A, "<span class='danger'>You [atk_verb] [D]!</span>")
 	D.apply_damage(damage, BRUTE, affecting)
 	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
+	if(CHECK_MOBILITY(D, MOBILITY_STAND) && damage >= stunthreshold)
+		to_chat(D, "<span class='danger'>You stumble and fall!</span>")
+		D.DefaultCombatKnockdown(10, override_hardstun = 0.01, override_stam = damage)
 	log_combat(A, D, "punched (Sleeping Carp)")
 	return TRUE
 

--- a/code/datums/martial/sleeping_carp.dm
+++ b/code/datums/martial/sleeping_carp.dm
@@ -102,7 +102,7 @@
 	playsound(get_turf(D), 'sound/weapons/punch1.ogg', 25, TRUE, -1)
 	if(CHECK_MOBILITY(D, MOBILITY_STAND) && damage >= stunthreshold)
 		to_chat(D, "<span class='danger'>You stumble and fall!</span>")
-		D.DefaultCombatKnockdown(10, override_hardstun = 0.01, override_stam = damage)
+		D.DefaultCombatKnockdown(10, override_hardstun = 0.01, override_stamdmg = damage)
 	log_combat(A, D, "punched (Sleeping Carp)")
 	return TRUE
 

--- a/code/game/machinery/computer/arcade.dm
+++ b/code/game/machinery/computer/arcade.dm
@@ -55,7 +55,7 @@
 		/obj/item/stack/tile/fakespace/loaded = ARCADE_WEIGHT_TRICK,
 		/obj/item/stack/tile/fakepit/loaded = ARCADE_WEIGHT_TRICK,
 		/obj/item/restraints/handcuffs/fake = ARCADE_WEIGHT_TRICK,
-		/obj/item/clothing/gloves/fingerless/pugilist/rapid/hug = ARCADE_WEIGHT_TRICK,
+		/obj/item/clothing/gloves/fingerless/pugilist/hug = ARCADE_WEIGHT_TRICK,
 
 		/obj/item/grenade/chem_grenade/glitter/pink = ARCADE_WEIGHT_TRICK,
 		/obj/item/grenade/chem_grenade/glitter/blue = ARCADE_WEIGHT_TRICK,

--- a/code/modules/clothing/gloves/miscellaneous.dm
+++ b/code/modules/clothing/gloves/miscellaneous.dm
@@ -52,7 +52,7 @@
 	name = "armwraps of unyielding resolve"
 	desc = "A series of armwraps, soaked in holy water. Makes you pretty keen to smite evil magic users."
 	resistance_flags = FIRE_PROOF | ACID_PROOF
-	enhancement = 1 //It is not magic that makes you punch harder, but force of will. Trust me.
+	enhancement = 2 //It is not magic that makes you punch harder, but force of will. Trust me.
 	secondary_trait = TRAIT_ANTIMAGIC
 	var/chaplain_spawnable = TRUE
 
@@ -115,14 +115,15 @@
 	if(input)
 		warcry = input
 
-/obj/item/clothing/gloves/fingerless/pugilist/rapid/hug
+/obj/item/clothing/gloves/fingerless/pugilist/hug
 	name = "Hugs of the North Star"
 	desc = "The armbands of a humble friend. Makes you pretty keen to go let everyone know how much you appreciate them!"
-	warcry = "owo" //Shouldn't ever come into play
+	icon_state = "rapid"
+	item_state = "rapid"
 	enhancement = 0
 	secondary_trait = TRAIT_PACIFISM //You are only here to hug and be friends!
 
-/obj/item/clothing/gloves/fingerless/pugilist/rapid/hug/Touch(mob/target, proximity = TRUE)
+/obj/item/clothing/gloves/fingerless/pugilist/hug/Touch(mob/target, proximity = TRUE)
 	if(!isliving(target))
 		return
 
@@ -135,9 +136,6 @@
 	else
 		M.changeNext_move(CLICK_CD_RAPID)
 
-	return FALSE
-
-/obj/item/clothing/gloves/fingerless/pugilist/rapid/hug/AltClick(mob/user)
 	return FALSE
 
 /obj/item/clothing/gloves/botanic_leather

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1615,8 +1615,7 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			"You hear a slap."
 		)
 		return FALSE
-	else if(attacker_style && attacker_style.disarm_act(user,target))
-		return 1
+		
 	else
 		user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
 
@@ -1624,7 +1623,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 			user.adjustStaminaLossBuffered(1)
 		else
 			user.adjustStaminaLossBuffered(3)
-
+		
+		if(attacker_style && attacker_style.disarm_act(user,target))
+			return TRUE
+		
 		if(target.w_uniform)
 			target.w_uniform.add_fingerprint(user)
 		//var/randomized_zone = ran_zone(user.zone_selected) CIT CHANGE - comments out to prevent compiling errors

--- a/code/modules/mob/living/carbon/human/species.dm
+++ b/code/modules/mob/living/carbon/human/species.dm
@@ -1499,10 +1499,12 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 
 		var/miss_chance = 100//calculate the odds that a punch misses entirely. considers stamina and brute damage of the puncher. punches miss by default to prevent weird cases
 		if(user.dna.species.punchdamagelow)
+			if(HAS_TRAIT(user, TRAIT_PUGILIST)) //pugilists have a flat 10% miss chance
+				miss_chance = 10
 			if(atk_verb == ATTACK_EFFECT_KICK) //kicks never miss (provided your species deals more than 0 damage)
 				miss_chance = 0
 			else
-				miss_chance = min(10 + ((puncherstam + puncherbrute)*0.5), 100) //probability of miss has a base of 10, and modified based on half your stamina and brute total. Capped at max 100 and min 0 to prevent weirdness in prob()
+				miss_chance = min(10 + ((puncherstam + puncherbrute)*0.5), 100) //probability of miss has a base of 10, and modified based on half brute total. Capped at max 100 to prevent weirdness in prob()
 
 		if(!damage || !affecting || prob(miss_chance))//future-proofing for species that have 0 damage/weird cases where no zone is targeted
 			playsound(target.loc, user.dna.species.miss_sound, 25, TRUE, -1)
@@ -1618,7 +1620,10 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 	else
 		user.do_attack_animation(target, ATTACK_EFFECT_DISARM)
 
-		user.adjustStaminaLossBuffered(3) //CITADEL CHANGE - makes disarmspam cause staminaloss
+		if(HAS_TRAIT(user, TRAIT_PUGILIST))//CITADEL CHANGE - makes disarmspam cause staminaloss, pugilists can do it almost effortlessly
+			user.adjustStaminaLossBuffered(1)
+		else
+			user.adjustStaminaLossBuffered(3)
 
 		if(target.w_uniform)
 			target.w_uniform.add_fingerprint(user)
@@ -1647,8 +1652,12 @@ GLOBAL_LIST_EMPTY(roundstart_race_names)
 		if(!(target.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE)) //CITADEL CHANGE
 			randn += 25 //CITADEL CHANGE - Makes it harder to disarm outside of combat mode
 		if(user.pulling == target)
-			randn += -20 //If you have the time to get someone in a grab, you should have a greater chance at snatching the thing in their hand. Will be made completely obsolete by the grab rework but i've got a poor track record for releasing big projects on time so w/e i guess
-
+			randn -= 20 //If you have the time to get someone in a grab, you should have a greater chance at snatching the thing in their hand. Will be made completely obsolete by the grab rework but i've got a poor track record for releasing big projects on time so w/e i guess
+		if(HAS_TRAIT(user, TRAIT_PUGILIST))
+			randn -= 25 //if you are a pugilist, you're slapping that item from them pretty reliably
+		if(HAS_TRAIT(target, TRAIT_PUGILIST))
+			randn += 25 //meanwhile, pugilists are less likely to get disarmed
+		
 		if(randn <= 35)//CIT CHANGE - changes this back to a 35% chance to accomodate for the above being commented out in favor of right-click pushing
 			var/obj/item/I = null
 			if(target.pulling)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Firstly, what I fixed: Hugs of the North Star are no longer nodrop, ashen arrows are actually called that in the crafting menu (I'm touching it here while I'm touching crafting), flag checks and knockdown overrides were added into various moves for martial arts.

**Pugilists and Armwraps:**
Pugilists can now disarm you more easily, and you can't disarm them as easily. I don't like RNG disarm but kev likes it so eeeeeeh. This means pugilist gloves can serve as a means of protecting yourself from RNG! Also they get a stamina discount.

Pugilists have a standard flat 10% miss chance regardless of stamina or brute damage. This is basically what old punches were like, while everyone else gets to suffer under dreaded dice rolling growing ever more unfavorable as they throw punches.

Armwraps can be crafted. You can even make magical ones. Yay!

Armbands of the Everlasting Will (the chaplain ones) now are a +2.

**Martial Arts**
The four main martial arts now have some updates and added in functionality for stun thresholds being met that they otherwise lost when they gained martial arts. _**Most if not all stamina damage dealt by martial arts has been increased.**_ This is because it was really damn low before given stamina regeneration makes it somewhat mandatory for stamina damage to be dealt out in bursts. This was mostly touching the flat damage and not the rng values, which are not increased by targets in and out of combat mode.

**Edit:** Also martial artists are spending stamina when they disarm as they should. Missed this in my last update.

**CQC**
Disarm act isn't a weird version of the RNG disarm anymore, it's a big brother version to the Krav Maga disarm jab. You do a pretty okayish amount of stamina damage, and if you roll a stun punch, you dizzy them and cause them to drop their weapons. There is no miss chance for this. This hasn't changed any other functionality to disarm. This is what leads up to Consecutive CQC, so it being a sequence of strikes makes sense. This also makes that move actually worth using. You're still not going to use it because grab harm exists but we'll get onto CQC's various issues at a later date.

**Rising Bass**
The moves Repulse Punch and Shoulder Flip have had their combos reduced by a few moves and an altered move sequence. Rising Bass also has a disarm act override that is suitably fitting for being a rakish arsehole, which Rising Bass seems to promote.

Repulse Punch has a lighter knockdown and a little more stamina damage. You can perform a Repulse Punch by Harm Disarm Disarm (think Crashing Wave Kick but two more disarms). This move still has an inbuilt cooldown by the way, so don't worry too much about it being spammed.

Shoulder Flip works even on people who are already on the floor. This move also does less actual brute damage but does a fairly respectable amount of stamina damage. If you roll damage over the stun threshold, however, it also puts your target to sleep. This move used to do this already, but I had to make it slightly less reliable given I shaved off a hit to complete it. The move sequence is now Disarm Harm Disarm Harm Grab (the old move sequence was Grab Harm Disarm Grab Harm Harm which I don't think I can ever see anyone pulling off especially given they had to be standing as well)

Disarms are now a trip if you roll above the stun threshold, or a punch to the stomach for some stamina damage. It causes disgust. Have fun.

**Sleeping Carp**
Harm punches can floor people if you get a stun punch. It's not that big a deal but it can make rolling high for damage a little more rewarding. **_This does not affect Gnashing Teeth._**

**Krav Maga**
Disarm act has had it's RNG chance to disarm you changed to a stun punch. Should prevent too much disarm spam.

## Why It's Good For The Game

I cannot stop touching punch code aaaaah.

## Changelog
:cl:
add: You can now craft armwraps!
balance: Pugilists disarm you more easily and are harder to disarm. They also get a discount on disarm.
balance: Pugilists only suffer a flat 10% chance to miss you. It's just like old punches! Kinda.
balance: Chaplain's armbands are a +2, up from a +1!
balance: Martial artists spend stamina when they disarm.
balance: Rising Bass had several moves shortened and made stronger. Has a disarm override attack which does stamina damage and trips people on a disarm stun punch.
balance: CQC had it's disarm move altered to be a stronger version of Krav Maga's. Dizzies and disarms on a disarm stun punch or just does some stamina damage and brute damage.
balance: Sleeping Carp can punch you to the floor on a harm stun punch.
fix: Hugs of the Northstar are no longer nodrop.
fix: Adding in some overrides and proper flag checks for martial arts.
fix: Stun thresholding stops disarm spams at extremely high stamina loss.
tweak: Ashen Arrows are actually called Ashen Arrows in the crafting menu.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
