### PR TITLE
fixes dummies having some default features on changing them to the same species

### DIFF
--- a/code/modules/mob/living/carbon/human/dummy.dm
+++ b/code/modules/mob/living/carbon/human/dummy.dm
@@ -44,5 +44,6 @@ GLOBAL_LIST_EMPTY(dummy_mob_list)
 		return
 	var/mob/living/carbon/human/dummy/D = GLOB.human_dummy_list[slotnumber]
 	if(istype(D))
+		D.set_species(/datum/species/human,icon_update = TRUE, pref_load = TRUE) //for some fucking reason, if you don't change the species every time, some species will dafault certain things when it's their own species on the mannequin two times in a row, like lizards losing spines and tails setting to smooth. If you can find a fix for this that isn't this, good on you
 		D.wipe_state()
 		D.in_use = FALSE


### PR DESCRIPTION
## About The Pull Request

title

# This really isn't a fix, but I delved into the code for three fucking hours to find _a_ fix, and this was it. It works, but it _probably_ isn't a fix for the cause of the problem.

if you want to see the bug:
- go to character appearance
- make a lizard character with some aquatic spines
- save the character
- switch to another lizard character
- switch back
- presto the spines are gone
- switch to a non lizard character
- switch back
- presto the spines are there again

## Why It's Good For The Game

bug fix

## Changelog
:cl:
fix: fixes dummies having some default features on changing them to the same species
/:cl:
