### PR TITLE
Fixes a bunch of gripes people had with lambda.

### DIFF
--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -267,7 +267,6 @@
 /area/space)
 "aaT" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 1;
 	height = 4;
 	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
@@ -382,7 +381,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -538,7 +536,6 @@
 	dir = 4
 	},
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -630,9 +627,7 @@
 /obj/machinery/button/door{
 	id = "permawindows";
 	name = "Emergency Shutters";
-	normaldoorcontrol = 0;
-	pixel_y = 25;
-	specialfunctions = 1
+	pixel_y = 25
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -700,7 +695,6 @@
 /area/science/research)
 "acb" = (
 /obj/machinery/doppler_array/research/science{
-	icon_state = "tdoppler";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -745,7 +739,6 @@
 	dir = 5
 	},
 /obj/machinery/button/massdriver{
-	dir = 2;
 	id = "toxinsdriver";
 	pixel_x = 24;
 	pixel_y = 24
@@ -1023,14 +1016,13 @@
 /obj/effect/decal/cleanable/tomato_smudge,
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/medical/abandoned)
 "acK" = (
 /obj/structure/sign/warning/vacuum/external{
-	pixel_x = 30;
+	pixel_x = 30
 	},
 /turf/open/floor/plating,
 /area/science/mixing)
@@ -1243,7 +1235,6 @@
 /area/security/prison)
 "adm" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "SecJusticeChamber";
 	name = "Justice Vent"
 	},
@@ -1290,7 +1281,7 @@
 /area/maintenance/fore)
 "ads" = (
 /turf/closed/wall/r_wall,
-/area/science/nanite)
+/area/science/circuit)
 "adt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1303,7 +1294,7 @@
 	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel/white,
-/area/science/nanite)
+/area/science/circuit)
 "adu" = (
 /turf/closed/wall/r_wall,
 /area/science/storage)
@@ -1396,7 +1387,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -1474,9 +1464,9 @@
 /area/science/research)
 "adR" = (
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/fore";
 	dir = 1;
 	name = "Fore Maintenance APC";
-	areastring = "/area/maintenance/fore";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -1497,8 +1487,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/storage/fancy/donut_box,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "adT" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1510,13 +1502,13 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "adU" = (
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "adV" = (
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "adW" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -1539,7 +1531,7 @@
 	light_color = "#cee5d2"
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "adX" = (
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/random{
@@ -1556,9 +1548,10 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/item/integrated_electronics/analyzer,
 /obj/item/integrated_circuit_printer,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "adY" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -1577,7 +1570,7 @@
 /obj/item/stock_parts/cell/high,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "adZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/machinery/portable_atmospherics/canister/toxins,
@@ -1652,10 +1645,8 @@
 "aej" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
-	name = "Unisex Showers";
-	req_access_txt = "0"
+	name = "Unisex Showers"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -1668,7 +1659,6 @@
 /area/security/prison)
 "ael" = (
 /obj/machinery/sparker{
-	dir = 2;
 	id = "executionburn";
 	pixel_x = -25
 	},
@@ -1929,7 +1919,7 @@
 	pixel_x = -26
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aeM" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -1943,20 +1933,19 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "aeN" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "aeO" = (
 /obj/structure/chair/office/light{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aeP" = (
 /obj/machinery/status_display/ai{
 	pixel_x = 32
@@ -1966,7 +1955,7 @@
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aeQ" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
@@ -1985,16 +1974,21 @@
 /turf/open/floor/plasteel/white,
 /area/science/storage)
 "aeT" = (
-/obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/science/storage)
+/obj/docking_port/stationary{
+	dwidth = 1;
+	height = 4;
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
+	},
+/obj/structure/fans/tiny/invisible,
+/turf/open/space,
+/area/space)
 "aeU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /obj/machinery/status_display/ai{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
@@ -2016,7 +2010,6 @@
 	pixel_x = 32
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -2091,8 +2084,7 @@
 /area/security/prison)
 "afj" = (
 /obj/machinery/door/airlock{
-	name = "Unisex Restroom";
-	req_access_txt = "0"
+	name = "Unisex Restroom"
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -2112,7 +2104,6 @@
 /area/security/execution/education)
 "afm" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
-	dir = 2;
 	name = "justice injector"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -2223,7 +2214,6 @@
 /area/security/processing)
 "aft" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -2301,7 +2291,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/table/reinforced,
@@ -2375,25 +2364,9 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "afH" = (
 /obj/structure/table/reinforced,
-/obj/item/nanite_scanner{
-	pixel_x = -4;
-	pixel_y = -4
-	},
-/obj/item/nanite_scanner{
-	pixel_x = 4;
-	pixel_y = -4
-	},
-/obj/item/nanite_remote{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/nanite_remote{
-	pixel_x = 4;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -2405,8 +2378,11 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/bot,
+/obj/machinery/cell_charger{
+	pixel_y = 5
+	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "afI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -2420,7 +2396,7 @@
 	},
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "afJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -2487,7 +2463,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -2569,7 +2544,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/general/visible,
 /obj/machinery/door/window/brigdoor{
-	dir = 2;
 	name = "Justice Chamber";
 	req_access_txt = "3"
 	},
@@ -2629,7 +2603,6 @@
 "agg" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -2725,7 +2698,7 @@
 	icon_state = "2-4"
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "agp" = (
 /obj/effect/landmark/start/scientist,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -2740,7 +2713,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "agq" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -2762,7 +2735,7 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "agr" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Secure Storage";
@@ -2833,7 +2806,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -2955,6 +2927,8 @@
 /obj/structure/table/optable{
 	name = "Robotics Operating Table"
 	},
+/obj/item/tank/internals/anesthetic,
+/obj/item/clothing/mask/breath,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "agH" = (
@@ -3110,7 +3084,6 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "SecJusticeChamber";
 	layer = 4;
 	name = "Justice Vent Control";
@@ -3263,7 +3236,6 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "ahj" = (
-/obj/machinery/nanite_program_hub,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -3282,7 +3254,7 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "ahk" = (
 /obj/structure/disposalpipe/junction{
 	dir = 1
@@ -3296,13 +3268,13 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "ahl" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "ahm" = (
 /obj/structure/disposalpipe/segment{
 	dir = 10
@@ -3319,16 +3291,11 @@
 	dir = 8
 	},
 /obj/structure/table/reinforced,
-/obj/item/storage/box/disks_nanite{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/storage/box/disks_nanite{
-	pixel_x = 4;
-	pixel_y = 2
+/obj/machinery/cell_charger{
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "ahn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -3349,7 +3316,7 @@
 	pixel_x = 24
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aho" = (
 /obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /obj/effect/turf_decal/delivery,
@@ -3380,7 +3347,6 @@
 	},
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/science/storage";
-	dir = 2;
 	name = "Toxins Storage APC";
 	pixel_y = -25
 	},
@@ -3404,7 +3370,6 @@
 /area/maintenance/fore/secondary)
 "aht" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -3500,7 +3465,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -3598,7 +3562,6 @@
 /area/security/processing)
 "ahN" = (
 /obj/machinery/computer/shuttle/labor{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -3635,7 +3598,6 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -3651,7 +3613,6 @@
 /area/science/xenobiology)
 "ahU" = (
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk,
@@ -3666,9 +3627,8 @@
 /area/science/xenobiology)
 "ahX" = (
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
-	name = "euthanization chamber freezer";
-	icon_state = "freezer_1";
-	dir = 4
+	dir = 4;
+	name = "euthanization chamber freezer"
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
@@ -3721,8 +3681,9 @@
 /area/science/xenobiology)
 "aid" = (
 /obj/machinery/airalarm/directional/north,
+/obj/machinery/vending/assist,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aie" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -3736,29 +3697,30 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "aif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "aig" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aih" = (
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aii" = (
 /obj/machinery/status_display/evac{
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/loading_area,
+/obj/structure/table,
+/obj/item/stack/sheet/glass/fifty,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aij" = (
 /obj/machinery/door/airlock/research{
 	name = "Toxins Secure Storage";
@@ -3871,7 +3833,6 @@
 /area/maintenance/fore/secondary)
 "ait" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4135,7 +4096,6 @@
 /turf/open/floor/plating,
 /area/science/xenobiology)
 "aiY" = (
-/obj/machinery/computer/nanite_cloud_controller,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile/neutral{
@@ -4148,8 +4108,17 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/closet/crate,
+/obj/item/gun/energy/laser/practice,
+/obj/item/gun/energy/laser/practice,
+/obj/item/target/syndicate,
+/obj/item/target/syndicate,
+/obj/item/target/clown,
+/obj/item/target/clown,
+/obj/item/target/alien,
+/obj/item/target/alien,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aiZ" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4161,23 +4130,22 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "aja" = (
 /obj/machinery/firealarm{
 	dir = 1;
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "ajb" = (
 /obj/structure/disposalpipe/trunk{
 	dir = 1
 	},
 /obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "ajc" = (
-/obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -4190,13 +4158,14 @@
 	dir = 8
 	},
 /obj/machinery/light,
+/obj/structure/table,
+/obj/item/screwdriver,
+/obj/item/multitool,
+/obj/item/pen,
+/obj/item/paper_bin,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "ajd" = (
-/obj/machinery/computer/nanite_chamber_control{
-	icon_state = "computer";
-	dir = 1
-	},
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -4208,10 +4177,12 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/integrated_circuit_printer,
+/obj/item/integrated_electronics/analyzer,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aje" = (
-/obj/machinery/nanite_chamber,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -4222,8 +4193,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/item/stock_parts/cell/high,
+/obj/item/stock_parts/cell/high,
+/obj/item/integrated_electronics/wirer,
+/obj/item/integrated_electronics/debugger,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "ajf" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -4232,9 +4208,9 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/mixing";
 	dir = 8;
 	name = "Toxins Lab APC";
-	areastring = "/area/science/mixing";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -4318,7 +4294,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Toxins - Lab";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /obj/effect/turf_decal/delivery,
@@ -4497,7 +4472,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/mecha_part_fabricator,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = 28
 	},
 /turf/open/floor/plasteel,
@@ -4573,7 +4547,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4603,7 +4576,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4645,7 +4617,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair,
@@ -4660,7 +4631,6 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_y = 24;
 	prison_radio = 1
@@ -4680,7 +4650,6 @@
 	name = "Cell Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_y = 25;
-	req_access_txt = "0";
 	specialfunctions = 4
 	},
 /obj/structure/chair,
@@ -4710,9 +4679,7 @@
 	},
 /obj/machinery/meter,
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "gas ports"
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -4732,7 +4699,6 @@
 /area/security/execution/education)
 "ajT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -4744,9 +4710,8 @@
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	dir = 8;
-	icon_state = "sink_alt";
 	name = "old sink";
-	pixel_x = 15;
+	pixel_x = 15
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -4845,7 +4810,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -4910,7 +4874,6 @@
 /area/science/xenobiology)
 "akj" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -4950,7 +4913,7 @@
 /area/science/xenobiology)
 "akp" = (
 /turf/closed/wall,
-/area/science/nanite)
+/area/science/circuit)
 "akq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -4973,13 +4936,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
-/area/science/nanite)
+/area/science/circuit)
 "akr" = (
 /turf/closed/wall,
 /area/science/misc_lab/range)
 "aks" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -5067,7 +5029,6 @@
 /area/science/mixing)
 "akA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -5119,7 +5080,6 @@
 /obj/item/storage/box/monkeycubes,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -5148,7 +5108,6 @@
 	},
 /obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -5175,7 +5134,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -5192,7 +5150,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5270,7 +5227,6 @@
 "akU" = (
 /obj/machinery/power/apc{
 	areastring = "/area/security/execution/education";
-	dir = 2;
 	name = "Prisoner Education Chamber APC";
 	pixel_y = -24
 	},
@@ -5322,7 +5278,6 @@
 "ala" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/computer/security/labor{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -5578,12 +5533,10 @@
 	pixel_x = -4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Xenobiology Lab - Fore";
-	dir = 2;
 	network = list("ss13","rd")
 	},
 /turf/open/floor/plasteel/white,
@@ -5634,7 +5587,6 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5653,7 +5605,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5661,7 +5612,6 @@
 "alC" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -5670,7 +5620,6 @@
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5780,7 +5729,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -5824,7 +5772,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -5845,7 +5792,6 @@
 /area/science/robotics/lab)
 "alY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -5935,7 +5881,6 @@
 "amf" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6007,8 +5952,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	dir = 2;
-	pixel_x = -29;
+	pixel_x = -29
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -6091,7 +6035,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -6107,7 +6050,6 @@
 	pixel_y = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -6117,7 +6059,6 @@
 /obj/structure/table,
 /obj/item/stack/cable_coil/random,
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6126,7 +6067,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -6243,7 +6183,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6399,8 +6338,7 @@
 	pixel_y = -3
 	},
 /obj/machinery/camera/motion{
-	c_tag = "Armory Motion Sensor";
-	dir = 2
+	c_tag = "Armory Motion Sensor"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -6473,7 +6411,7 @@
 	pixel_y = 1
 	},
 /obj/item/grenade/barrier{
-	pixel_x = 6;
+	pixel_x = 6
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -6707,7 +6645,6 @@
 /area/science/robotics/lab)
 "anE" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -6818,7 +6755,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6857,7 +6793,6 @@
 /area/science/robotics/lab)
 "anU" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -6865,7 +6800,6 @@
 "anV" = (
 /obj/machinery/turnstile{
 	dir = 1;
-	icon_state = "turnstile_map";
 	name = "Genpop Exit Turnstile";
 	req_access_txt = "70"
 	},
@@ -6887,7 +6821,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -6916,7 +6849,6 @@
 /area/security/prison)
 "anY" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -6939,7 +6871,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -6966,7 +6897,7 @@
 	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "aob" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -7247,7 +7178,6 @@
 /area/security/armory)
 "aoo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7370,7 +7300,6 @@
 /area/science/xenobiology)
 "aoy" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -7389,7 +7318,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7445,7 +7373,6 @@
 "aoE" = (
 /obj/machinery/processor/slime,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -7455,7 +7382,6 @@
 /area/science/xenobiology)
 "aoF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7484,7 +7410,6 @@
 /area/science/xenobiology)
 "aoI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -7629,7 +7554,6 @@
 /area/science/research)
 "aoQ" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7644,7 +7568,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -7664,7 +7587,6 @@
 /area/maintenance/fore)
 "aoU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -7711,11 +7633,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -7773,7 +7693,6 @@
 /area/security/prison)
 "api" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -7873,7 +7792,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -7939,7 +7857,6 @@
 /area/security/prison)
 "apu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8001,7 +7918,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -8015,14 +7931,12 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "apB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -8109,7 +8023,6 @@
 	icon_state = "secbot1";
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
-	on = 1;
 	weaponscheck = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8161,7 +8074,6 @@
 /area/science/xenobiology)
 "apK" = (
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /obj/structure/disposalpipe/trunk{
@@ -8270,7 +8182,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8285,10 +8196,9 @@
 	areastring = "/area/science/xenobiology";
 	dir = 4;
 	name = "Xenobiology APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -8353,11 +8263,9 @@
 /area/science/misc_lab/range)
 "aqe" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -8430,7 +8338,6 @@
 /area/science/robotics/lab)
 "aqm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -8461,7 +8368,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -8504,7 +8410,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -8533,7 +8438,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -8563,7 +8467,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -8588,7 +8491,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -8715,7 +8617,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -8726,7 +8627,6 @@
 "aqN" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
@@ -8997,7 +8897,6 @@
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -9031,14 +8930,12 @@
 	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "ark" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -9055,7 +8952,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -9075,7 +8971,6 @@
 /area/science/mixing)
 "arq" = (
 /obj/machinery/sparker/toxmix{
-	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -9153,7 +9048,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -9254,11 +9148,9 @@
 "arF" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -9270,7 +9162,6 @@
 /area/security/prison)
 "arG" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
@@ -9509,7 +9400,6 @@
 "arW" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -10062,7 +9952,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -10099,7 +9988,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -10132,7 +10020,6 @@
 /area/science/misc_lab/range)
 "asS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -10160,7 +10047,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10178,9 +10064,7 @@
 /turf/open/floor/engine,
 /area/science/mixing)
 "asY" = (
-/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/dp_vent_pump/high_volume/incinerator_toxmix,
 /obj/effect/landmark/blobstart,
 /turf/open/floor/engine,
 /area/science/mixing)
@@ -10197,7 +10081,6 @@
 /area/science/mixing)
 "atb" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -10352,7 +10235,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -10429,7 +10311,6 @@
 /area/security/armory)
 "aty" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10470,7 +10351,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -10501,7 +10381,6 @@
 	dir = 10
 	},
 /obj/machinery/computer/camera_advanced/xenobio{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10534,7 +10413,6 @@
 	dir = 6
 	},
 /obj/machinery/computer/camera_advanced/xenobio{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10570,7 +10448,6 @@
 "atI" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -10615,14 +10492,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "atM" = (
 /obj/machinery/sparker/toxmix{
-	dir = 2;
 	pixel_x = 25
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/toxins_mixing_input{
@@ -10753,14 +10628,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "atW" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -10771,7 +10644,6 @@
 	sortType = 14
 	},
 /obj/effect/turf_decal/trimline/white/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -10779,9 +10651,9 @@
 "atY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/science/robotics/mechbay";
 	dir = 1;
 	name = "Mech Bay APC";
-	areastring = "/area/science/robotics/mechbay";
 	pixel_y = 28
 	},
 /obj/structure/cable{
@@ -10814,7 +10686,6 @@
 /area/science/robotics/mechbay)
 "auc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -10855,7 +10726,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -10910,11 +10780,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11028,13 +10896,12 @@
 	pixel_y = 26
 	},
 /turf/open/floor/plasteel,
-/area/science/nanite)
+/area/science/circuit)
 "auu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11237,7 +11104,6 @@
 /area/science/server)
 "auM" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -11251,7 +11117,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -11375,7 +11240,6 @@
 /area/science/robotics/mechbay)
 "ava" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -11402,7 +11266,6 @@
 /area/hallway/primary/fore)
 "avc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -11428,7 +11291,6 @@
 	pixel_y = 3
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/item/paper/guides/jobs/security/range{
@@ -11461,7 +11323,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -11534,7 +11395,6 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/rack,
@@ -11542,7 +11402,7 @@
 	areastring = "/area/science/misc_lab/range";
 	dir = 4;
 	name = "Research Firing Range APC";
-	pixel_x = 28;
+	pixel_x = 28
 	},
 /obj/item/target,
 /obj/item/target,
@@ -11603,7 +11463,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -11727,7 +11586,6 @@
 "avB" = (
 /obj/machinery/camera{
 	c_tag = "Server Room";
-	dir = 2;
 	network = list("ss13","rd");
 	pixel_x = 22
 	},
@@ -11750,7 +11608,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11793,10 +11650,9 @@
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -11812,7 +11668,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11846,11 +11701,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -11866,7 +11719,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -11877,7 +11729,6 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -11891,7 +11742,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -11902,25 +11752,21 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "avO" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "avP" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -12234,7 +12080,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
@@ -12252,7 +12097,6 @@
 /area/science/server)
 "aws" = (
 /obj/machinery/computer/rdservercontrol{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -12261,7 +12105,6 @@
 /obj/structure/cable,
 /obj/machinery/power/apc{
 	areastring = "/area/science/server";
-	dir = 2;
 	name = "Server Room APC";
 	pixel_y = -23
 	},
@@ -12665,7 +12508,6 @@
 /area/science/robotics/mechbay)
 "awP" = (
 /obj/effect/turf_decal/trimline/white/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12713,7 +12555,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -12725,7 +12566,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -12743,7 +12583,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -12755,7 +12594,7 @@
 	},
 /obj/item/reagent_containers/syringe,
 /obj/machinery/newscaster{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel/freezer,
 /area/security/prison)
@@ -12814,7 +12653,6 @@
 	},
 /obj/machinery/turnstile{
 	dir = 1;
-	icon_state = "turnstile_map";
 	name = "Genpop Exit Turnstile";
 	req_access_txt = "70"
 	},
@@ -12918,9 +12756,9 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/warden";
 	dir = 4;
 	name = "Warden's Office APC";
-	areastring = "/area/security/warden";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -12951,7 +12789,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -12971,7 +12808,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -13026,11 +12862,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13050,11 +12884,9 @@
 /area/science/research)
 "axo" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -13067,11 +12899,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13156,7 +12986,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13203,7 +13032,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13213,7 +13041,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/button/door{
@@ -13233,7 +13060,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -13264,7 +13090,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -13279,7 +13104,6 @@
 	layer = 2.9
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -13295,14 +13119,12 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -13382,11 +13204,9 @@
 /area/crew_quarters/heads/hor)
 "axS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -13435,7 +13255,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -13465,7 +13284,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -13551,9 +13369,9 @@
 "ayd" = (
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/power/apc{
+	areastring = "/area/security/range";
 	dir = 4;
 	name = "Shooting Range APC";
-	areastring = "/area/security/range";
 	pixel_x = 24
 	},
 /obj/structure/cable{
@@ -13647,7 +13465,6 @@
 	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -13723,8 +13540,7 @@
 "ayq" = (
 /obj/structure/bed,
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Quarters";
-	dir = 2
+	c_tag = "Security - Head of Security's Quarters"
 	},
 /obj/item/bedsheet/hos,
 /obj/machinery/status_display{
@@ -13749,7 +13565,7 @@
 /obj/machinery/button/door{
 	id = "hosspace";
 	name = "Space Shutters Control";
-	pixel_x = 25;
+	pixel_x = 25
 	},
 /obj/machinery/status_display/evac{
 	pixel_y = 32
@@ -13761,14 +13577,12 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "ayu" = (
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -13850,7 +13664,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/door/airlock/research{
-	id_tag = null;
 	name = "Break Room";
 	req_one_access_txt = "47"
 	},
@@ -13880,7 +13693,6 @@
 /obj/machinery/computer/security/research,
 /obj/machinery/camera{
 	c_tag = "Research Director's Office Fore";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -13932,11 +13744,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -13959,7 +13769,6 @@
 /area/science/research)
 "ayR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -14035,7 +13844,6 @@
 /area/security/range)
 "ayZ" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating,
@@ -14150,7 +13958,6 @@
 "azk" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -14231,7 +14038,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -14501,7 +14307,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14532,7 +14337,6 @@
 "azS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14582,7 +14386,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -14834,9 +14637,9 @@
 /area/security/brig)
 "aAo" = (
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/science/research";
 	dir = 1;
 	name = "Research Division APC";
-	areastring = "/area/science/research";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -14969,7 +14772,6 @@
 /area/crew_quarters/heads/hos)
 "aAy" = (
 /obj/machinery/computer/prisoner{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -15016,7 +14818,6 @@
 /area/security/checkpoint/science)
 "aAB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -15030,7 +14831,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15138,7 +14938,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -15195,7 +14994,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
@@ -15203,11 +15001,9 @@
 /area/science/research)
 "aAV" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15288,11 +15084,9 @@
 /area/hallway/primary/fore)
 "aBe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15352,7 +15146,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -15362,11 +15155,9 @@
 /area/hallway/primary/fore)
 "aBn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15385,25 +15176,21 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aBp" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aBq" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -15423,7 +15210,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -15436,7 +15222,6 @@
 /area/security/prison)
 "aBs" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15468,7 +15253,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15478,7 +15262,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -15510,7 +15293,6 @@
 /area/crew_quarters/heads/hos)
 "aBz" = (
 /obj/machinery/computer/security/hos{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -15551,9 +15333,8 @@
 /area/security/checkpoint/science)
 "aBC" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Science Security APC";
 	areastring = "/area/security/checkpoint/science";
+	name = "Science Security APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -15622,7 +15403,6 @@
 "aBH" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -15631,7 +15411,6 @@
 	pixel_y = -28
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -15659,8 +15438,6 @@
 	},
 /obj/structure/chair/stool,
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
@@ -15674,9 +15451,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "RD Office APC";
 	areastring = "/area/crew_quarters/heads/hor";
+	name = "RD Office APC";
 	pixel_y = -27
 	},
 /obj/structure/cable{
@@ -15716,7 +15492,6 @@
 /area/crew_quarters/heads/hor)
 "aBP" = (
 /obj/machinery/computer/aifixer{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -15740,7 +15515,6 @@
 /area/crew_quarters/heads/hor)
 "aBS" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -15768,7 +15542,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15800,7 +15573,6 @@
 "aBZ" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -15829,7 +15601,6 @@
 "aCb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -15840,9 +15611,9 @@
 /area/maintenance/fore/secondary)
 "aCd" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/detectives_office";
 	dir = 8;
 	name = "Detective APC";
-	areastring = "/area/security/detectives_office";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -15897,7 +15668,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/camera{
 	c_tag = "Science Hallway Fore";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -15933,7 +15703,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16120,7 +15889,6 @@
 	},
 /obj/structure/noticeboard{
 	dir = 1;
-	icon_state = "nboard00";
 	pixel_y = -30
 	},
 /turf/open/floor/plasteel/white,
@@ -16173,7 +15941,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16434,7 +16201,7 @@
 /obj/item/bedsheet/medical,
 /obj/machinery/iv_drip,
 /obj/structure/sign/poster/official/cleanliness{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/white,
 /area/security/brig)
@@ -16576,7 +16343,6 @@
 "aDq" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -16591,10 +16357,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16608,32 +16373,26 @@
 	},
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "aDu" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = 26;
 	pixel_y = 6;
 	req_one_access_txt = "29"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "aDv" = (
 /obj/machinery/button/door{
-	dir = 2;
 	id = "Skynet_launch";
 	name = "Mech Bay Door Control";
 	pixel_x = -26;
@@ -16644,11 +16403,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -16678,11 +16435,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -16753,14 +16508,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -16828,7 +16581,6 @@
 /area/security/brig)
 "aDN" = (
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
@@ -16855,10 +16607,9 @@
 	dir = 4
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -16875,7 +16626,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -17030,11 +16780,9 @@
 "aEf" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -17060,11 +16808,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17084,16 +16830,15 @@
 	dir = 8
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/primary/fore";
 	dir = 8;
 	name = "Fore Primary Hallway APC";
-	areastring = "/area/hallway/primary/fore";
 	pixel_x = -24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -17241,7 +16986,6 @@
 	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17298,7 +17042,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -17414,7 +17157,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -17427,7 +17169,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -17542,7 +17283,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -17652,9 +17392,8 @@
 /area/science/explab)
 "aFe" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Experimentation Lab APC";
 	areastring = "/area/science/explab";
+	name = "Experimentation Lab APC";
 	pixel_y = -24
 	},
 /obj/structure/cable,
@@ -17673,9 +17412,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/brig";
 	dir = 1;
 	name = "Brig APC";
-	areastring = "/area/security/brig";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -17712,7 +17451,6 @@
 /area/science/lab)
 "aFk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -17733,7 +17471,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -17817,7 +17554,6 @@
 /area/security/brig)
 "aFv" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -17927,7 +17663,6 @@
 /area/quartermaster/office)
 "aFH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -17959,14 +17694,12 @@
 /area/asteroid/nearstation)
 "aFM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aFN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -18001,7 +17734,6 @@
 "aFR" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18018,7 +17750,6 @@
 /area/science/research)
 "aFT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18065,11 +17796,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -18102,11 +17831,10 @@
 /area/hallway/primary/fore)
 "aFZ" = (
 /obj/structure/chair/sofa{
-	icon_state = "sofamiddle";
 	dir = 8
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
@@ -18292,11 +18020,9 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18415,11 +18141,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18430,7 +18154,6 @@
 	},
 /obj/effect/landmark/start/security_officer,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18518,7 +18241,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -18572,7 +18294,6 @@
 	light_color = "#c1caff"
 	},
 /obj/structure/chair/sofa{
-	icon_state = "sofamiddle";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18708,7 +18429,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18887,11 +18607,9 @@
 "aHr" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -18903,11 +18621,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -18929,14 +18645,12 @@
 /area/science/lab)
 "aHu" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/primary/fore)
 "aHv" = (
 /obj/structure/chair/sofa/corner{
-	icon_state = "sofacorner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -18944,9 +18658,9 @@
 "aHw" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
+	areastring = "/area/storage/art";
 	dir = 8;
 	name = "Art Storage APC";
-	areastring = "/area/storage/art";
 	pixel_x = -25
 	},
 /obj/item/paper_bin,
@@ -18979,14 +18693,12 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aHB" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -18996,14 +18708,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aHD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -19011,7 +18721,6 @@
 "aHE" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19028,7 +18737,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19084,7 +18792,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19093,7 +18800,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19110,7 +18816,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -19149,14 +18854,13 @@
 /area/security/courtroom)
 "aHS" = (
 /obj/docking_port/stationary{
-	name = "mining shuttle bay";
-	icon_state = "pinonalert";
-	dir = 1;
-	id = "mining_home";
-	width = 7;
-	height = 5;
 	dwidth = 3;
-	roundstart_template = /datum/map_template/shuttle/mining/box
+	height = 5;
+	icon_state = "pinonalert";
+	id = "mining_home";
+	name = "mining shuttle bay";
+	roundstart_template = /datum/map_template/shuttle/mining/box;
+	width = 7
 	},
 /turf/open/space,
 /area/space)
@@ -19173,7 +18877,6 @@
 /area/hallway/primary/fore)
 "aHW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19210,7 +18913,6 @@
 /area/hallway/primary/fore)
 "aIc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -19321,7 +19023,6 @@
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -19626,11 +19327,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -19648,9 +19347,9 @@
 /area/security/brig)
 "aIy" = (
 /obj/machinery/power/apc{
+	areastring = "/area/lawoffice";
 	dir = 1;
 	name = "Law Office APC";
-	areastring = "/area/lawoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
@@ -19746,7 +19445,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -19777,7 +19475,6 @@
 /area/crew_quarters/heads/hor)
 "aIK" = (
 /obj/docking_port/stationary{
-	dir = 1;
 	dwidth = 5;
 	height = 7;
 	id = "supply_home";
@@ -19843,7 +19540,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -19875,7 +19571,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19885,7 +19580,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -19893,7 +19587,6 @@
 "aIV" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -19903,7 +19596,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -19954,7 +19646,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -19988,11 +19679,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/tile/red{
@@ -20002,7 +19691,6 @@
 /area/security/brig)
 "aJe" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20010,7 +19698,6 @@
 "aJf" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20025,7 +19712,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -20047,7 +19733,6 @@
 /area/lawoffice)
 "aJj" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20055,7 +19740,7 @@
 "aJk" = (
 /obj/machinery/requests_console{
 	department = "Law office";
-	pixel_x = 31;
+	pixel_x = 31
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
@@ -20121,7 +19806,6 @@
 /area/security/courtroom)
 "aJr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20146,7 +19830,6 @@
 	id = "QMLoad"
 	},
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "QMLoaddoor";
 	name = "Supply Dock Loading Door"
 	},
@@ -20167,7 +19850,6 @@
 /area/quartermaster/storage)
 "aJx" = (
 /obj/machinery/door/poddoor{
-	density = 1;
 	id = "QMLoaddoor2";
 	name = "Supply Dock Loading Door"
 	},
@@ -20238,7 +19920,6 @@
 /area/hallway/primary/fore)
 "aJG" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -20264,7 +19945,6 @@
 /area/hallway/primary/fore)
 "aJI" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20282,7 +19962,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20331,7 +20010,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20346,11 +20024,9 @@
 "aJQ" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -20370,7 +20046,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner,
@@ -20426,7 +20101,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -20473,7 +20147,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -20512,7 +20185,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20627,11 +20299,9 @@
 /area/maintenance/fore)
 "aKu" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20664,7 +20334,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20672,7 +20341,6 @@
 "aKx" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -20680,11 +20348,9 @@
 /area/hallway/primary/fore)
 "aKy" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -20703,15 +20369,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20728,7 +20391,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20738,7 +20400,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20748,7 +20409,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20761,11 +20421,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
-	icon_state = "trimline_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -20778,11 +20436,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20802,15 +20458,12 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/corner{
-	icon_state = "trimline_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20829,11 +20482,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -20852,7 +20503,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -20879,7 +20529,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -20896,7 +20545,6 @@
 /area/hallway/primary/fore)
 "aKJ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -20916,11 +20564,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -20975,7 +20621,6 @@
 /area/security/brig)
 "aKP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -20987,7 +20632,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21023,7 +20667,6 @@
 /area/security/brig)
 "aKU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -21072,7 +20715,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21114,7 +20756,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -21215,7 +20856,6 @@
 "aLn" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -21228,16 +20868,15 @@
 /area/hallway/primary/fore)
 "aLo" = (
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/miningoffice";
 	dir = 1;
 	name = "Mining APC";
-	areastring = "/area/quartermaster/miningoffice";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/item/radio/intercom{
@@ -21279,11 +20918,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21305,7 +20942,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -21330,7 +20966,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -21353,7 +20988,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/navbeacon{
@@ -21510,7 +21144,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21522,7 +21155,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/arrows/red,
@@ -21536,7 +21168,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21550,7 +21181,6 @@
 	},
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right";
 	name = "Outer Window"
 	},
@@ -21694,7 +21324,6 @@
 	req_access_txt = "31"
 	},
 /obj/machinery/button/door{
-	dir = 2;
 	id = "QMLoaddoor2";
 	layer = 4;
 	name = "Loading Doors";
@@ -21703,14 +21332,12 @@
 	req_access_txt = "31"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aLZ" = (
 /obj/machinery/conveyor/inverted{
-	icon_state = "conveyor_map_inverted";
 	dir = 9;
 	id = "QMLoad2"
 	},
@@ -21737,7 +21364,6 @@
 "aMc" = (
 /obj/machinery/conveyor{
 	dir = 6;
-	icon_state = "conveyor_map";
 	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
@@ -21815,7 +21441,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -21880,14 +21505,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aMr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/layer1{
-	icon_state = "connector_map-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -21898,7 +21521,6 @@
 	},
 /obj/machinery/computer/security/telescreen/interrogation{
 	dir = 4;
-	icon_state = "telescreen";
 	layer = 4;
 	pixel_x = -28
 	},
@@ -21914,14 +21536,12 @@
 	},
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
 	prison_radio = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21940,7 +21560,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -21948,7 +21567,6 @@
 "aMx" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
-	dir = 2;
 	name = "Prison Intercom (General)";
 	pixel_x = -25;
 	pixel_y = -2;
@@ -21958,7 +21576,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -21968,7 +21585,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
@@ -21986,9 +21602,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/door/window/westleft{
-	base_state = "left";
-	dir = 8;
-	icon_state = "left";
 	name = "Outer Window"
 	},
 /obj/machinery/door/window/brigdoor{
@@ -22062,13 +21675,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light_switch{
-	pixel_x = -28;
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel/grimy,
 /area/lawoffice)
 "aME" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -22085,9 +21697,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Courtroom APC";
 	areastring = "/area/security/courtroom";
+	name = "Courtroom APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -22157,7 +21768,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -22211,7 +21821,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -22223,7 +21832,6 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -22282,14 +21890,12 @@
 /area/quartermaster/storage)
 "aMX" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aMY" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/rack,
@@ -22298,7 +21904,6 @@
 /area/quartermaster/miningoffice)
 "aMZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22309,7 +21914,6 @@
 "aNb" = (
 /obj/machinery/computer/shuttle/mining,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22317,7 +21921,6 @@
 "aNc" = (
 /obj/machinery/computer/security/mining,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22336,7 +21939,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -22418,11 +22020,9 @@
 "aNn" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -22535,7 +22135,7 @@
 "aNy" = (
 /obj/structure/filingcabinet/chestdrawer,
 /obj/structure/sign/poster/official/enlist{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/neutral{
@@ -22653,7 +22253,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -22665,11 +22264,9 @@
 /area/hallway/primary/central)
 "aNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -22683,10 +22280,9 @@
 	areastring = "/area/quartermaster/qm";
 	dir = 8;
 	name = "Quartermaster's Office APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22830,7 +22426,6 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -22853,7 +22448,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22879,7 +22473,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -22933,11 +22526,9 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -22969,7 +22560,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -22981,9 +22571,9 @@
 	dir = 5
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/science/lab";
 	dir = 8;
 	name = "Research and Development Lab APC";
-	areastring = "/area/science/lab";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -22991,7 +22581,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23145,8 +22734,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/door/airlock/grunge{
-	name = "Courtroom";
-	opacity = 1
+	name = "Courtroom"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
@@ -23161,7 +22749,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23186,7 +22773,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23200,7 +22786,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23269,7 +22854,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23282,7 +22866,6 @@
 /area/quartermaster/miningoffice)
 "aOP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23391,7 +22974,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23405,14 +22987,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/science/lab)
 "aPe" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -23433,14 +23013,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aPh" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -23461,7 +23039,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23488,7 +23065,6 @@
 /area/security/brig)
 "aPl" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -23496,7 +23072,6 @@
 "aPm" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -23511,7 +23086,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -23570,7 +23144,6 @@
 /area/quartermaster/qm)
 "aPt" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23604,7 +23177,6 @@
 "aPv" = (
 /obj/effect/landmark/start/shaft_miner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23615,7 +23187,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23631,7 +23202,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23648,7 +23218,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23665,7 +23234,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -23676,7 +23244,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -23684,7 +23251,6 @@
 "aPF" = (
 /obj/structure/closet/emcloset,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -23743,7 +23309,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -23821,7 +23386,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -23830,7 +23394,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -24194,7 +23757,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -24235,7 +23797,6 @@
 	pixel_x = -5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24245,7 +23806,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -24343,11 +23903,9 @@
 /area/crew_quarters/heads/captain/private)
 "aQG" = (
 /obj/structure/chair/sofa{
-	icon_state = "sofamiddle";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /obj/item/radio/intercom{
@@ -24368,7 +23926,6 @@
 /area/science/explab)
 "aQI" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -24376,7 +23933,6 @@
 "aQJ" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/hor/private";
-	dir = 2;
 	name = "Research Director's Quarters APC";
 	pixel_y = -24
 	},
@@ -24437,7 +23993,7 @@
 	req_access_txt = "63"
 	},
 /obj/structure/sign/nanotrasen{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -24446,7 +24002,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -24454,7 +24009,6 @@
 "aQR" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -24507,12 +24061,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/item/radio/intercom{
-	freerange = 0;
-	frequency = 1459;
 	name = "Station Intercom (General)";
 	pixel_x = -29
 	},
@@ -24531,7 +24082,6 @@
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -24546,14 +24096,12 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aRa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24564,12 +24112,10 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/closet/secure_closet/quartermaster,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24577,7 +24123,6 @@
 "aRc" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -24593,7 +24138,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -24604,7 +24148,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -24681,7 +24224,7 @@
 	},
 /obj/machinery/computer/med_data/laptop,
 /obj/machinery/computer/security/telescreen/entertainment{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 29
@@ -24697,9 +24240,8 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
-	dir = 2;
-	name = "Captain's Quarters APC";
 	areastring = "/area/crew_quarters/heads/captain/private";
+	name = "Captain's Quarters APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -24726,7 +24268,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -24738,7 +24279,6 @@
 /area/hallway/primary/fore)
 "aRt" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -24780,9 +24320,7 @@
 /obj/item/aiModule/core/freeformcore,
 /obj/structure/window/reinforced,
 /obj/machinery/door/window{
-	base_state = "left";
 	dir = 4;
-	icon_state = "left";
 	name = "Core Modules";
 	req_access_txt = "20"
 	},
@@ -24805,9 +24343,7 @@
 	dir = 1
 	},
 /obj/machinery/door/window/westleft{
-	base_state = "left";
 	dir = 2;
-	icon_state = "left";
 	layer = 3.1;
 	name = "Cyborg Upload Console Window";
 	req_access_txt = "16"
@@ -25103,7 +24639,6 @@
 "aSa" = (
 /obj/structure/noticeboard/qm{
 	dir = 1;
-	icon_state = "nboard00";
 	pixel_y = -30
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
@@ -25111,11 +24646,9 @@
 /area/quartermaster/qm)
 "aSb" = (
 /obj/machinery/computer/security/qm{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light_switch{
@@ -25127,7 +24660,6 @@
 "aSc" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25280,7 +24812,6 @@
 "aSs" = (
 /obj/structure/dresser,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = 28
 	},
 /turf/open/floor/carpet/blue,
@@ -25317,11 +24848,9 @@
 "aSw" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25360,11 +24889,9 @@
 "aSA" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25496,8 +25023,7 @@
 	},
 /obj/item/lighter,
 /obj/machinery/camera{
-	c_tag = "Bar";
-	dir = 2
+	c_tag = "Bar"
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -25536,9 +25062,9 @@
 	dir = 1
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/crew_quarters/bar";
 	dir = 1;
 	name = "Bar APC";
-	areastring = "/area/crew_quarters/bar";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -25553,7 +25079,6 @@
 	dir = 1
 	},
 /obj/machinery/chem_dispenser/drinks{
-	icon_state = "soda_dispenser";
 	dir = 8
 	},
 /obj/structure/table,
@@ -25600,7 +25125,6 @@
 "aSU" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -25628,7 +25152,6 @@
 /area/hydroponics)
 "aSY" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -25711,7 +25234,6 @@
 "aTg" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -25722,7 +25244,6 @@
 "aTi" = (
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -25730,7 +25251,6 @@
 "aTj" = (
 /obj/machinery/vending/snack/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -25766,7 +25286,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -25779,28 +25298,24 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTp" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aTq" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aTr" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -25808,7 +25323,6 @@
 /area/quartermaster/storage)
 "aTs" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -26020,11 +25534,9 @@
 /area/ai_monitored/turret_protected/ai_upload)
 "aTS" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -26113,7 +25625,6 @@
 	icon_state = "1-4"
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26157,7 +25668,6 @@
 	dir = 4
 	},
 /obj/machinery/chem_dispenser/drinks/beer{
-	icon_state = "booze_dispenser";
 	dir = 8
 	},
 /obj/structure/table,
@@ -26166,7 +25676,6 @@
 "aUd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -26182,7 +25691,6 @@
 /area/hydroponics)
 "aUf" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26196,7 +25704,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26215,7 +25722,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -26325,7 +25831,6 @@
 /area/hallway/primary/central)
 "aUx" = (
 /obj/vehicle/ridden/scooter{
-	icon_state = "scooter";
 	dir = 8
 	},
 /obj/machinery/firealarm{
@@ -26333,7 +25838,6 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26396,11 +25900,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26473,7 +25975,7 @@
 	areastring = "/area/crew_quarters/heads/captain";
 	dir = 8;
 	name = "Captain's Office APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -26512,7 +26014,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -26600,7 +26101,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -26616,13 +26116,11 @@
 /area/crew_quarters/bar/atrium)
 "aVg" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26717,7 +26215,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/green{
@@ -26727,7 +26224,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -26757,7 +26253,6 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -26768,7 +26263,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26823,7 +26317,6 @@
 	pixel_y = -28
 	},
 /obj/machinery/computer/bounty{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -26842,9 +26335,8 @@
 /area/hallway/primary/central)
 "aVz" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Bay APC";
 	areastring = "/area/quartermaster/storage";
+	name = "Cargo Bay APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -26876,11 +26368,9 @@
 /area/quartermaster/office)
 "aVB" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26936,7 +26426,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -26965,12 +26454,10 @@
 /obj/structure/table,
 /obj/item/export_scanner,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Quartermaster's Office";
-	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plasteel,
@@ -26988,11 +26475,9 @@
 "aVO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27137,7 +26622,6 @@
 /area/crew_quarters/bar)
 "aWh" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27148,7 +26632,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27162,7 +26645,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -27174,7 +26656,6 @@
 /obj/structure/table/glass,
 /obj/item/book/manual/hydroponics_pod_people,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27185,7 +26666,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/status_display/ai{
@@ -27217,7 +26697,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27232,7 +26711,6 @@
 /area/hydroponics)
 "aWq" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -27261,7 +26739,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -27281,7 +26758,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -27303,7 +26779,6 @@
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27330,7 +26805,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27349,7 +26823,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27376,7 +26849,6 @@
 /area/quartermaster/office)
 "aWD" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27384,20 +26856,18 @@
 "aWE" = (
 /obj/effect/turf_decal/stripes/full,
 /turf/open/floor/plasteel{
-	icon_state = "yellowsiding";
-	dir = 1
+	dir = 1;
+	icon_state = "yellowsiding"
 	},
 /area/quartermaster/office)
 "aWF" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "aWG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -27420,7 +26890,6 @@
 	pixel_x = -22
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -27437,7 +26906,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27459,7 +26927,6 @@
 /area/maintenance/fore)
 "aWO" = (
 /obj/structure/chair/sofa/corp/left{
-	icon_state = "corp_sofaend_left";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -27529,7 +26996,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -27575,7 +27041,6 @@
 /area/hallway/primary/central)
 "aXa" = (
 /obj/machinery/computer/security/telescreen/aiupload{
-	icon_state = "telescreen";
 	dir = 4
 	},
 /turf/closed/wall/r_wall,
@@ -27596,9 +27061,8 @@
 	},
 /obj/effect/landmark/start/cyborg,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "AI Upload Access APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload_foyer";
+	name = "AI Upload Access APC";
 	pixel_y = -27
 	},
 /obj/item/radio/intercom{
@@ -27643,11 +27107,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27689,7 +27151,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27720,7 +27181,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -27777,7 +27237,6 @@
 	pixel_y = 23
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27797,9 +27256,9 @@
 /area/hydroponics)
 "aXr" = (
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/central/secondary";
 	dir = 8;
 	name = "Central Maintenance APC";
-	areastring = "/area/maintenance/central/secondary";
 	pixel_x = -24
 	},
 /obj/structure/cable{
@@ -27844,8 +27303,7 @@
 	id = "commissaryshutter";
 	name = "Commissary Shutter Control";
 	pixel_x = 3;
-	pixel_y = -25;
-	req_access_txt = "0"
+	pixel_y = -25
 	},
 /obj/structure/chair/stool,
 /obj/effect/decal/cleanable/dirt,
@@ -27883,7 +27341,6 @@
 /obj/structure/chair/comfy/brown,
 /obj/effect/landmark/start/captain,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -27896,7 +27353,6 @@
 /area/maintenance/fore)
 "aXz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -27924,7 +27380,6 @@
 "aXB" = (
 /obj/effect/turf_decal/caution,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -27938,7 +27393,6 @@
 /area/hallway/primary/central)
 "aXD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -27982,7 +27436,6 @@
 /area/quartermaster/warehouse)
 "aXL" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28086,7 +27539,6 @@
 	dir = 8
 	},
 /obj/structure/chair/sofa/corp/right{
-	icon_state = "corp_sofaend_right";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -28096,7 +27548,6 @@
 /area/crew_quarters/heads/captain)
 "aXX" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28156,7 +27607,6 @@
 "aYc" = (
 /obj/machinery/light/small,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -28300,7 +27750,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -28316,7 +27765,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28358,7 +27806,6 @@
 /area/crew_quarters/bar)
 "aYp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sink{
@@ -28392,7 +27839,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/extinguisher_cabinet{
@@ -28409,7 +27855,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sink{
@@ -28422,7 +27867,6 @@
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/seed_extractor,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28470,7 +27914,6 @@
 /area/quartermaster/warehouse)
 "aYB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -28494,7 +27937,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28505,11 +27947,9 @@
 /area/hallway/primary/central)
 "aYF" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28554,11 +27994,9 @@
 /area/quartermaster/warehouse)
 "aYL" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -28628,7 +28066,6 @@
 /area/crew_quarters/heads/captain)
 "aYS" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/carpet/red,
@@ -28657,7 +28094,6 @@
 "aYW" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28666,7 +28102,6 @@
 "aYX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -28679,7 +28114,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28690,11 +28124,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -28704,7 +28136,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28719,7 +28150,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -28730,7 +28160,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /mob/living/simple_animal/bot/medbot{
@@ -28748,7 +28177,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -28803,7 +28231,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -28905,7 +28332,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28933,9 +28359,9 @@
 /area/hallway/primary/central)
 "aZx" = (
 /obj/machinery/power/apc{
+	areastring = "/area/quartermaster/warehouse";
 	dir = 4;
 	name = "Cargo Warehouse APC";
-	areastring = "/area/quartermaster/warehouse";
 	pixel_x = 26
 	},
 /obj/structure/cable{
@@ -28943,7 +28369,6 @@
 	pixel_y = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -28962,7 +28387,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -28974,14 +28398,12 @@
 	sortType = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aZA" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29009,7 +28431,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29031,7 +28452,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29079,7 +28499,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29114,7 +28533,6 @@
 /obj/item/folder/red,
 /obj/item/taperecorder,
 /obj/item/radio/intercom{
-	anyai = 1;
 	broadcasting = 1;
 	frequency = 1423;
 	listening = 0;
@@ -29150,7 +28568,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -29196,7 +28613,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29219,7 +28635,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29234,9 +28649,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/item/clothing/head/that{
-	throwforce = 1
-	},
+/obj/item/clothing/head/that,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
 "aZW" = (
@@ -29258,7 +28671,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -29266,7 +28679,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -29282,7 +28694,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29300,7 +28711,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -29326,7 +28736,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29345,7 +28754,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29389,9 +28797,9 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/hallway/secondary/command";
 	dir = 1;
 	name = "Command Hallway APC";
-	areastring = "/area/hallway/secondary/command";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -29407,7 +28815,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29432,7 +28839,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29451,11 +28857,9 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29484,7 +28888,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -29655,9 +29058,9 @@
 	pixel_x = 32
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/crew_quarters/theatre";
 	dir = 1;
 	name = "Theatre APC";
-	areastring = "/area/crew_quarters/theatre";
 	pixel_y = 25
 	},
 /obj/structure/cable{
@@ -29682,9 +29085,6 @@
 /area/crew_quarters/bar)
 "baB" = (
 /obj/machinery/door/window/southleft{
-	base_state = "left";
-	dir = 2;
-	icon_state = "left";
 	name = "Bar Delivery";
 	req_access_txt = "25"
 	},
@@ -29696,7 +29096,6 @@
 /area/crew_quarters/bar)
 "baC" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -29724,7 +29123,6 @@
 "baG" = (
 /obj/machinery/biogenerator,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29765,7 +29163,6 @@
 "baK" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29775,14 +29172,12 @@
 /obj/item/folder/yellow,
 /obj/structure/disposalpipe/junction/flip,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baM" = (
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Cargo Desk";
 	req_access_txt = "50"
 	},
@@ -29797,7 +29192,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29806,14 +29200,12 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "baP" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29821,7 +29213,6 @@
 "baQ" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -29832,14 +29223,12 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baS" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -29850,14 +29239,12 @@
 /area/quartermaster/office)
 "baT" = (
 /obj/effect/turf_decal/caution{
-	icon_state = "caution";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29870,7 +29257,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29883,7 +29269,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -29893,7 +29278,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -29905,7 +29289,6 @@
 /obj/effect/landmark/start/cargo_technician,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -29993,14 +29376,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bbf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -30143,7 +29524,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -30179,7 +29559,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -30271,7 +29650,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 8
 	},
 /obj/structure/disposalpipe/segment,
@@ -30281,7 +29659,6 @@
 "bbz" = (
 /obj/effect/turf_decal/arrows/red,
 /obj/effect/turf_decal/stripes/red/line{
-	icon_state = "warningline_red";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -30453,7 +29830,6 @@
 	pixel_y = -36
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -30465,7 +29841,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -30481,7 +29856,6 @@
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -30491,7 +29865,6 @@
 /area/hallway/secondary/service)
 "bbW" = (
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment,
@@ -30567,7 +29940,6 @@
 /area/quartermaster/office)
 "bcf" = (
 /obj/machinery/computer/card{
-	icon_state = "computer";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -30587,7 +29959,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -30634,11 +30005,9 @@
 /area/bridge/meeting_room)
 "bcp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -30785,7 +30154,6 @@
 "bcK" = (
 /obj/structure/closet/crate/hydroponics,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -30816,7 +30184,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -30830,7 +30197,6 @@
 /area/security/prison)
 "bcQ" = (
 /obj/effect/turf_decal/arrows/red{
-	icon_state = "arrows_red";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -30881,34 +30247,31 @@
 /area/maintenance/department/cargo)
 "bcV" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
+/obj/item/stack/packageWrap,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bcW" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bcX" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -30924,11 +30287,9 @@
 /area/quartermaster/sorting)
 "bcY" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/hand_labeler_refill,
@@ -30942,11 +30303,9 @@
 /area/quartermaster/sorting)
 "bcZ" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -31002,7 +30361,6 @@
 /area/maintenance/department/cargo)
 "bdg" = (
 /obj/machinery/computer/communications{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/machinery/light/small{
@@ -31118,7 +30476,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -31150,9 +30507,9 @@
 	dir = 6
 	},
 /obj/machinery/power/apc/highcap/ten_k{
+	areastring = "/area/teleporter";
 	dir = 1;
 	name = "Teleporter APC";
-	areastring = "/area/teleporter";
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -31385,8 +30742,7 @@
 	dir = 8
 	},
 /obj/machinery/camera/motion{
-	c_tag = "E.V.A. Storage";
-	dir = 2
+	c_tag = "E.V.A. Storage"
 	},
 /obj/machinery/cell_charger,
 /obj/structure/table,
@@ -31411,7 +30767,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -31497,7 +30852,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31525,7 +30879,6 @@
 /area/crew_quarters/bar)
 "bdZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31556,7 +30909,6 @@
 "bed" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31635,11 +30987,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -31648,7 +30998,6 @@
 /obj/structure/disposaloutlet,
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "trashsort"
 	},
@@ -31665,14 +31014,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31693,14 +31040,12 @@
 /area/quartermaster/sorting)
 "bep" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "beq" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -31712,7 +31057,6 @@
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "trashsort"
 	},
@@ -31744,7 +31088,6 @@
 /area/maintenance/department/cargo)
 "bev" = (
 /obj/machinery/modular_computer/console/preset/command{
-	icon_state = "console";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -31811,11 +31154,9 @@
 /area/bridge)
 "beA" = (
 /obj/machinery/computer/cargo/request{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -31845,7 +31186,6 @@
 /area/teleporter)
 "beD" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -31862,7 +31202,7 @@
 	areastring = "/area/bridge/meeting_room";
 	dir = 8;
 	name = "Council Chambers APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /turf/open/floor/carpet,
 /area/bridge/meeting_room)
@@ -31876,7 +31216,6 @@
 /area/bridge/meeting_room)
 "beG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -31891,7 +31230,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -31969,9 +31307,9 @@
 	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/machinery/power/apc{
+	areastring = "/area/ai_monitored/storage/eva";
 	dir = 8;
 	name = "E.V.A. Storage APC";
-	areastring = "/area/ai_monitored/storage/eva";
 	pixel_x = -24
 	},
 /turf/open/floor/plasteel,
@@ -32035,7 +31373,6 @@
 "beX" = (
 /obj/effect/landmark/start/bartender,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -32150,7 +31487,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -32163,14 +31499,12 @@
 "bfp" = (
 /obj/machinery/vending/wardrobe/hydro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32178,7 +31512,6 @@
 "bfr" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -32186,7 +31519,6 @@
 "bfs" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -32237,7 +31569,7 @@
 	areastring = "/area/security/checkpoint/supply";
 	dir = 8;
 	name = "Cargo Security APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /obj/machinery/camera{
 	c_tag = "Security Post - Cargo";
@@ -32247,7 +31579,6 @@
 /area/security/checkpoint/supply)
 "bfy" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -32275,7 +31606,6 @@
 /area/maintenance/department/cargo)
 "bfC" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -32286,11 +31616,9 @@
 /area/quartermaster/sorting)
 "bfD" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -32459,7 +31787,6 @@
 "bfT" = (
 /obj/effect/landmark/start/cargo_technician,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32512,7 +31839,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -32581,9 +31907,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/bridge/showroom/corporate";
 	dir = 4;
 	name = "Nanotrasen Corporate Showroom APC";
-	areastring = "/area/bridge/showroom/corporate";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/dark,
@@ -32674,7 +32000,6 @@
 /area/crew_quarters/cafeteria)
 "bgq" = (
 /obj/machinery/computer/arcade/battle{
-	icon_state = "arcade";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32716,7 +32041,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -32725,7 +32049,6 @@
 	pixel_x = -28
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -32757,11 +32080,9 @@
 /area/crew_quarters/kitchen/backroom)
 "bgB" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/kitchen,
@@ -32779,11 +32100,9 @@
 /area/crew_quarters/kitchen)
 "bgD" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -32824,7 +32143,6 @@
 "bgH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
-	icon_state = "conveyor_map_inverted";
 	id = "trashsort"
 	},
 /turf/open/floor/plating,
@@ -32843,7 +32161,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -32923,7 +32240,6 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
-	icon_state = "conveyor_map";
 	dir = 6;
 	id = "garbage"
 	},
@@ -32986,7 +32302,6 @@
 /area/bridge)
 "bgV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -32996,7 +32311,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -33032,7 +32346,6 @@
 /area/teleporter)
 "bgZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -33054,7 +32367,6 @@
 /area/maintenance/fore)
 "bhc" = (
 /obj/machinery/door/window/westleft{
-	dir = 8;
 	name = "Bridge Deliveries";
 	req_access_txt = "19"
 	},
@@ -33098,7 +32410,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33155,11 +32466,9 @@
 "bhn" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33208,7 +32517,6 @@
 	},
 /obj/structure/rack,
 /obj/machinery/door/window/northleft{
-	dir = 1;
 	name = "Jetpack Storage";
 	pixel_x = -1;
 	req_access_txt = "19"
@@ -33243,7 +32551,6 @@
 	pixel_y = -3
 	},
 /obj/machinery/door/window/northleft{
-	dir = 1;
 	name = "Magboot Storage";
 	pixel_x = -1;
 	req_access_txt = "19"
@@ -33359,11 +32666,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/storage/box/donkpockets,
@@ -33371,11 +32676,9 @@
 /area/crew_quarters/kitchen)
 "bhG" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33385,22 +32688,18 @@
 	pixel_y = 28
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bhI" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33411,11 +32710,9 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -33423,22 +32720,18 @@
 "bhK" = (
 /obj/machinery/vending/wardrobe/chef_wardrobe,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bhL" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/structure/closet/secure_closet/freezer/fridge,
@@ -33512,7 +32805,6 @@
 "bhU" = (
 /obj/machinery/conveyor/inverted{
 	dir = 5;
-	icon_state = "conveyor_map_inverted";
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -33523,7 +32815,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/machinery/conveyor{
-	icon_state = "conveyor_map";
 	dir = 10;
 	id = "garbage"
 	},
@@ -33546,7 +32837,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/security/armory";
-	dir = 2;
 	name = "Armoury APC";
 	pixel_y = -26
 	},
@@ -33599,7 +32889,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -33617,7 +32906,6 @@
 	},
 /obj/item/storage/box/zipties,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -33680,7 +32968,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -33745,22 +33032,18 @@
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bir" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -33909,7 +33192,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -33967,7 +33249,6 @@
 "biO" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -33981,7 +33262,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -34040,22 +33320,18 @@
 "biW" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "biX" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
@@ -34064,11 +33340,9 @@
 "biY" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34079,22 +33353,18 @@
 /obj/item/hand_labeler_refill,
 /obj/item/stack/packageWrap,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bja" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -34105,22 +33375,18 @@
 /obj/structure/table,
 /obj/item/book/manual/chef_recipes,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bjc" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34136,11 +33402,9 @@
 /area/crew_quarters/kitchen)
 "bjd" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34185,11 +33449,9 @@
 "bjh" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/storage/bag/tray,
@@ -34233,7 +33495,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34277,7 +33538,6 @@
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -34429,7 +33689,6 @@
 /area/crew_quarters/cafeteria)
 "bjK" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/rack,
@@ -34459,7 +33718,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -34490,7 +33748,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -34508,11 +33765,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34521,11 +33776,9 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34539,11 +33792,9 @@
 	layer = 5
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34551,11 +33802,9 @@
 "bjU" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/reagentgrinder,
@@ -34564,11 +33813,9 @@
 "bjV" = (
 /obj/effect/landmark/start/cook,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -34578,11 +33825,9 @@
 "bjW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34592,11 +33837,9 @@
 /area/crew_quarters/kitchen)
 "bjX" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/vending/dinnerware,
@@ -34666,7 +33909,6 @@
 /mob/living/simple_animal/bot/cleanbot{
 	auto_patrol = 1;
 	icon_state = "cleanbot1";
-	mode = 0;
 	name = "Mopficcer Sweepsky"
 	},
 /turf/open/floor/plasteel,
@@ -34736,11 +33978,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -34839,11 +34079,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -34853,11 +34091,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -34867,11 +34103,9 @@
 /area/crew_quarters/kitchen)
 "bks" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -34881,11 +34115,9 @@
 "bkt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -34898,7 +34130,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple{
@@ -34965,7 +34196,6 @@
 "bkA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -35010,14 +34240,12 @@
 	},
 /obj/machinery/door/window/eastright{
 	base_state = "left";
-	dir = 4;
 	icon_state = "left";
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -35036,13 +34264,11 @@
 /area/maintenance/disposal)
 "bkG" = (
 /obj/machinery/door/window/eastright{
-	dir = 4;
 	name = "Danger: Conveyor Access";
 	req_access_txt = "12"
 	},
 /obj/machinery/conveyor{
 	backwards = 1;
-	dir = 2;
 	forwards = 2;
 	id = "garbage"
 	},
@@ -35051,7 +34277,6 @@
 "bkH" = (
 /obj/machinery/conveyor/inverted{
 	dir = 9;
-	icon_state = "conveyor_map_inverted";
 	id = "garbage"
 	},
 /turf/open/floor/plating,
@@ -35172,11 +34397,9 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35190,7 +34413,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -35200,11 +34422,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35215,11 +34435,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35230,11 +34448,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35252,11 +34468,9 @@
 /area/crew_quarters/cafeteria)
 "bkY" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -35341,7 +34555,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35528,7 +34741,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/security{
@@ -35538,7 +34750,6 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
-	icon_state = "direction_sci";
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel,
@@ -35628,11 +34839,9 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel/cafeteria,
@@ -35663,11 +34872,9 @@
 /area/crew_quarters/kitchen)
 "blE" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
@@ -35678,11 +34885,9 @@
 /area/crew_quarters/kitchen)
 "blF" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/processor,
@@ -35690,11 +34895,9 @@
 /area/crew_quarters/kitchen)
 "blG" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -35819,11 +35022,9 @@
 /area/crew_quarters/kitchen)
 "blX" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/table,
@@ -35986,8 +35187,7 @@
 "bmo" = (
 /obj/structure/table,
 /obj/machinery/camera{
-	c_tag = "Gateway - Atrium";
-	dir = 2
+	c_tag = "Gateway - Atrium"
 	},
 /obj/effect/turf_decal/bot{
 	dir = 1
@@ -36005,7 +35205,6 @@
 "bmq" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36034,7 +35233,6 @@
 "bms" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36043,7 +35241,6 @@
 /obj/effect/turf_decal/tile/bar,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36054,7 +35251,6 @@
 	},
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36065,11 +35261,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -36083,7 +35277,6 @@
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36091,7 +35284,6 @@
 "bmy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36099,7 +35291,6 @@
 "bmz" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36113,7 +35304,6 @@
 	pixel_x = -25
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36169,18 +35359,15 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bmJ" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36216,11 +35403,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/disposal/bin,
@@ -36233,7 +35418,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36244,7 +35428,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -36257,7 +35440,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/north,
@@ -36268,16 +35450,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	dir = 1;
 	name = "Departure Lounge APC";
-	areastring = "/area/hallway/secondary/exit/departure_lounge";
 	pixel_y = 24
 	},
 /turf/open/floor/plasteel,
@@ -36288,7 +35469,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -36302,7 +35482,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36314,7 +35493,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -36324,7 +35502,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/twohanded/required/kirbyplants/random,
@@ -36335,7 +35512,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -36399,7 +35575,7 @@
 	areastring = "/area/gateway";
 	dir = 8;
 	name = "Gateway APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
@@ -36447,7 +35623,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -36528,7 +35703,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -36706,12 +35880,10 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/sign/directions/supply{
 	dir = 4;
-	icon_state = "direction_supply";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/evac{
 	dir = 4;
-	icon_state = "direction_evac";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/medical{
@@ -36942,7 +36114,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Chapel Port";
-	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/chapel{
@@ -36976,7 +36147,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bnM" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37000,7 +36170,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37058,7 +36227,6 @@
 "bnU" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -37078,8 +36246,8 @@
 /obj/structure/closet/crate/goldcrate,
 /obj/machinery/camera/motion{
 	c_tag = "Vault";
-	network = list("vault");
-	dir = 1
+	dir = 1;
+	network = list("vault")
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/nuke_storage)
@@ -37179,7 +36347,6 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37190,7 +36357,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -37204,7 +36370,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -37214,7 +36379,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37257,7 +36421,6 @@
 /area/storage/emergency/starboard)
 "bop" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37299,7 +36462,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bou" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37386,7 +36548,6 @@
 "boE" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -37396,7 +36557,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -37412,7 +36572,6 @@
 /area/science/xenobiology)
 "boH" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37431,7 +36590,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boJ" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37445,7 +36603,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boK" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37456,7 +36613,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boL" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37470,7 +36626,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37482,7 +36637,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "boP" = (
 /obj/docking_port/stationary{
-	dheight = 0;
 	dir = 4;
 	dwidth = 9;
 	height = 25;
@@ -37526,7 +36680,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37556,7 +36709,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37605,7 +36757,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -37634,7 +36785,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37654,7 +36804,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpk" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37687,7 +36836,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpn" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -37698,7 +36846,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpo" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37742,7 +36889,6 @@
 /area/maintenance/port/fore)
 "bpu" = (
 /obj/machinery/mineral/stacking_unit_console{
-	dir = 2;
 	machinedir = 8;
 	pixel_x = 32
 	},
@@ -37750,7 +36896,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -37816,7 +36961,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -37830,7 +36974,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -37842,14 +36985,12 @@
 "bpF" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bpG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -37915,7 +37056,6 @@
 	req_access_txt = "55"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -37940,7 +37080,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpN" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -37964,7 +37103,6 @@
 "bpP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Fuel Pipe to Incinerator"
 	},
 /obj/structure/cable/yellow{
@@ -37999,7 +37137,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bpS" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -38056,7 +37193,6 @@
 "bpZ" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38066,15 +37202,15 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/genetics";
 	dir = 1;
 	name = "Genetics Lab APC";
-	areastring = "/area/medical/genetics";
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
+/obj/structure/closet/secure_closet/medical1,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bqb" = (
@@ -38090,9 +37226,9 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
+/obj/structure/closet/secure_closet/personal/patient,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bqd" = (
@@ -38102,12 +37238,10 @@
 	},
 /obj/machinery/requests_console{
 	department = "Genetics";
-	departmentType = 0;
 	name = "Genetics Requests Console";
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -38121,7 +37255,6 @@
 /area/medical/genetics)
 "bqe" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -38129,7 +37262,6 @@
 "bqf" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/table/glass,
@@ -38148,7 +37280,6 @@
 "bqg" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/noticeboard{
@@ -38229,7 +37360,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38245,7 +37375,6 @@
 /area/medical/abandoned)
 "bqt" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -38319,7 +37448,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38341,15 +37469,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38373,7 +37498,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38511,7 +37635,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqK" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
@@ -38535,7 +37658,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqN" = (
 /obj/machinery/computer/scan_consolenew{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -38562,7 +37684,6 @@
 /area/medical/genetics)
 "bqQ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38588,11 +37709,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38658,22 +37777,18 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "brb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38704,7 +37819,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -38721,7 +37835,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38759,7 +37872,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -38777,7 +37889,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Creamatorium";
-	dir = 2;
 	name = "chapel camera"
 	},
 /turf/open/floor/plasteel/dark,
@@ -38910,14 +38021,12 @@
 /obj/effect/landmark/start/geneticist,
 /obj/structure/chair/office/light,
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bru" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -38965,7 +38074,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -38999,7 +38107,6 @@
 /area/library)
 "brE" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -39062,7 +38169,6 @@
 /area/medical/genetics)
 "brL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/table/glass,
@@ -39101,7 +38207,6 @@
 "brN" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "5"
 	},
 /obj/structure/cable{
@@ -39132,7 +38237,6 @@
 "brO" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -39140,7 +38244,6 @@
 "brP" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39163,7 +38266,6 @@
 /area/medical/morgue)
 "brT" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39200,7 +38302,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -39279,7 +38380,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/sign/directions/evac{
@@ -39294,7 +38394,6 @@
 /area/library)
 "bsh" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39308,7 +38407,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsi" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39322,7 +38420,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsj" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39333,7 +38430,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bsk" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
@@ -39377,7 +38473,6 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39399,15 +38494,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39420,7 +38512,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -39455,7 +38546,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39490,7 +38580,6 @@
 	pixel_x = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39500,7 +38589,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -39531,14 +38619,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bsC" = (
 /obj/structure/chair/comfy/teal{
-	icon_state = "comfychair";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -39581,9 +38667,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/library";
 	dir = 4;
 	name = "Library APC";
-	areastring = "/area/library";
 	pixel_x = 24
 	},
 /turf/open/floor/carpet,
@@ -39618,7 +38704,6 @@
 /obj/effect/turf_decal/bot_white/right,
 /obj/machinery/light,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -39651,14 +38736,12 @@
 "bsT" = (
 /obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "bsU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/computer/cloning,
@@ -39687,7 +38770,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -39710,7 +38792,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39741,7 +38822,6 @@
 	req_access_txt = "5"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39790,17 +38870,16 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "btd" = (
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
+/obj/machinery/bloodbankgen,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bte" = (
@@ -39808,18 +38887,20 @@
 	icon_state = "4-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/medical/virology";
 	dir = 1;
 	name = "Virology APC";
-	areastring = "/area/medical/virology";
 	pixel_y = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
+/obj/structure/table/glass,
+/obj/item/radio/headset/headset_med,
+/obj/item/hand_labeler,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "btf" = (
@@ -39827,7 +38908,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39837,7 +38917,6 @@
 /obj/machinery/disposal/bin,
 /obj/structure/disposalpipe/trunk,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39845,7 +38924,6 @@
 "bth" = (
 /obj/machinery/smartfridge/chemistry/virology/preloaded,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -39860,9 +38938,8 @@
 "btj" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Abandoned Medical Lab APC";
 	areastring = "/area/medical/abandoned";
+	name = "Abandoned Medical Lab APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -39916,7 +38993,6 @@
 	location = "9.2-Escape-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -39984,7 +39060,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -39992,7 +39067,6 @@
 "btu" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -40029,40 +39103,36 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
+/obj/item/reagent_containers/spray/cleaner,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/syringe/antiviral,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "btA" = (
 /obj/structure/table/glass,
-/obj/item/folder/white,
-/obj/item/folder/white,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
+/obj/item/book/manual/wiki/infections,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "btB" = (
 /obj/machinery/vending/wardrobe/chem_wardrobe,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btC" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40072,7 +39142,6 @@
 	layer = 2.7
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40101,7 +39170,6 @@
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40118,18 +39186,15 @@
 /obj/item/stack/packageWrap,
 /obj/item/hand_labeler,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btI" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40144,28 +39209,24 @@
 /area/crew_quarters/kitchen/backroom)
 "btK" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "btL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics/cloning)
 "btN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -40213,9 +39274,11 @@
 /area/medical/storage)
 "btT" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/folder/white,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "btU" = (
@@ -40240,11 +39303,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -40267,7 +39328,6 @@
 /area/library)
 "bua" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40279,7 +39339,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bub" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40288,7 +39347,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buc" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40302,7 +39360,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bud" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40311,7 +39368,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bue" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40322,7 +39378,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buf" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40335,7 +39390,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bug" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40344,12 +39398,10 @@
 /area/hallway/secondary/exit/departure_lounge)
 "buh" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/computer/arcade,
@@ -40357,7 +39409,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bui" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -40388,8 +39439,11 @@
 	receive_ore_updates = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
+	},
+/obj/item/storage/box/syringes{
+	pixel_x = 5;
+	pixel_y = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
@@ -40483,11 +39537,9 @@
 /obj/structure/table,
 /obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40509,11 +39561,9 @@
 	pixel_x = 3
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40522,7 +39572,6 @@
 /obj/machinery/rnd/production/techfab/department/medical,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40552,12 +39601,10 @@
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay Storage";
-	dir = 2;
 	name = "medbay camera";
 	network = list("ss13","medbay")
 	},
@@ -40580,7 +39627,6 @@
 "buC" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40588,7 +39634,6 @@
 "buD" = (
 /obj/effect/landmark/start/geneticist,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40631,7 +39676,6 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40649,11 +39693,9 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40664,9 +39706,9 @@
 	},
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "buJ" = (
@@ -40718,7 +39760,6 @@
 	receive_ore_updates = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -40786,15 +39827,16 @@
 "buX" = (
 /obj/structure/disposalpipe/segment,
 /obj/structure/table/glass,
-/obj/item/book/manual/wiki/infections,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
+/obj/item/clothing/glasses/hud/health,
+/obj/item/healthanalyzer,
+/obj/item/clothing/gloves/color/latex,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "buY" = (
@@ -40807,11 +39849,9 @@
 /obj/item/book/manual/wiki/chemistry,
 /obj/item/book/manual/wiki/grenades,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -40820,11 +39860,9 @@
 /obj/structure/table/glass,
 /obj/item/storage/box/syringes,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -40844,7 +39882,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40866,11 +39903,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -40907,7 +39942,6 @@
 	},
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -40915,7 +39949,6 @@
 "bvg" = (
 /obj/machinery/vending/wardrobe/medi_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -40943,9 +39976,8 @@
 /area/medical/storage)
 "bvk" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Medbay Storage APC";
 	areastring = "/area/medical/storage";
+	name = "Medbay Storage APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -41015,7 +40047,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -41048,9 +40079,7 @@
 	dir = 4
 	},
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bvw" = (
 /obj/structure/table/wood,
@@ -41061,9 +40090,7 @@
 	pixel_x = 1;
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bvx" = (
 /obj/effect/landmark/carpspawn,
@@ -41084,9 +40111,8 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Head of Personnel APC";
 	areastring = "/area/crew_quarters/heads/hop";
+	name = "Head of Personnel APC";
 	pixel_y = -24
 	},
 /turf/open/floor/wood,
@@ -41124,7 +40150,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -41135,7 +40160,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41147,9 +40171,9 @@
 "bvE" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bvF" = (
@@ -41170,7 +40194,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -41191,7 +40214,6 @@
 	},
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -41207,13 +40229,13 @@
 	network = list("ss13","medbay")
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
+/obj/item/radio/headset/headset_med,
+/obj/item/folder/white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bvJ" = (
@@ -41223,11 +40245,9 @@
 "bvK" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41273,7 +40293,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -41293,7 +40312,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -41329,15 +40347,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -41350,7 +40365,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41391,25 +40405,19 @@
 /obj/machinery/door/morgue{
 	name = "Study"
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bvZ" = (
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bwa" = (
 /obj/structure/table/wood,
 /obj/machinery/newscaster{
-	pixel_x = 32;
+	pixel_x = 32
 	},
 /obj/item/folder,
 /obj/item/folder,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bwb" = (
 /obj/machinery/light/small{
@@ -41425,12 +40433,18 @@
 "bwd" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
+	},
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/grenade/chem_grenade,
+/obj/item/screwdriver{
+	pixel_x = -2;
+	pixel_y = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -41460,7 +40474,6 @@
 "bwf" = (
 /obj/machinery/door/airlock/grunge{
 	name = "Morgue";
-	opacity = 1;
 	req_access_txt = "5"
 	},
 /obj/structure/cable{
@@ -41499,7 +40512,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -41510,7 +40522,6 @@
 /area/maintenance/port/fore)
 "bwi" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -41564,7 +40575,6 @@
 /area/medical/virology)
 "bwr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -41576,11 +40586,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -41599,18 +40607,15 @@
 /obj/item/stack/cable_coil,
 /obj/item/stack/cable_coil,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -41625,7 +40630,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41636,7 +40640,6 @@
 	},
 /obj/structure/reagent_dispensers/water_cooler,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41647,7 +40650,6 @@
 	},
 /obj/structure/chair/sofa/right,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41659,7 +40661,6 @@
 	},
 /obj/structure/chair/sofa,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41702,14 +40703,12 @@
 /obj/structure/table,
 /obj/item/storage/box/cups,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwC" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41747,7 +40746,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41853,7 +40851,6 @@
 "bwS" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -41897,7 +40894,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -41931,7 +40927,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -41939,7 +40934,6 @@
 "bwY" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -41950,7 +40944,6 @@
 	location = "9.3-Escape-3"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -41970,7 +40963,6 @@
 "bxd" = (
 /obj/machinery/sleeper,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -41981,11 +40973,9 @@
 /area/medical/chemistry)
 "bxf" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -42037,7 +41027,6 @@
 /area/medical/medbay/central)
 "bxm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42051,7 +41040,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42072,7 +41060,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42125,22 +41112,18 @@
 "bxt" = (
 /obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxu" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42296,7 +41279,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -42309,7 +41291,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -42317,7 +41298,6 @@
 "bxQ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -42331,7 +41311,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -42345,7 +41324,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42377,7 +41355,6 @@
 /area/medical/virology)
 "bxX" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -42390,7 +41367,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42400,7 +41376,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -42414,7 +41389,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42432,7 +41406,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42442,14 +41415,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bye" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -42468,7 +41439,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -42485,7 +41455,6 @@
 /area/medical/cryo)
 "byh" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -42518,7 +41487,6 @@
 /area/hallway/primary/starboard)
 "byj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42528,7 +41496,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -42542,7 +41509,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42561,7 +41527,6 @@
 /obj/structure/chair/comfy/black,
 /obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -42572,7 +41537,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -42759,7 +41723,6 @@
 /area/medical/cryo)
 "byH" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -42779,7 +41742,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -42832,7 +41794,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42863,11 +41824,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -42899,14 +41858,12 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "byW" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -42949,11 +41906,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -42990,11 +41945,9 @@
 "bzf" = (
 /obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -43243,7 +42196,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical/chemistry";
-	dir = 2;
 	name = "Chemistry Lab APC";
 	pixel_y = -25
 	},
@@ -43268,18 +42220,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bzH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -43418,7 +42367,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -43435,7 +42383,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -43470,7 +42417,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -43482,7 +42428,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -43492,11 +42437,9 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -43514,7 +42457,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -43532,7 +42474,6 @@
 /area/maintenance/disposal)
 "bAf" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -43551,7 +42492,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43567,7 +42507,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43580,7 +42519,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43603,7 +42541,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43633,7 +42570,6 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -43644,7 +42580,6 @@
 "bAp" = (
 /obj/machinery/vending/wardrobe/viro_wardrobe,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43663,7 +42598,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/structure/disposalpipe/junction/yjunction{
-	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -43718,7 +42652,6 @@
 "bAu" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43731,10 +42664,9 @@
 	areastring = "/area/medical/genetics/cloning";
 	dir = 8;
 	name = "Cloning Lab APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -43760,7 +42692,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -43779,7 +42710,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -43801,7 +42731,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -43809,7 +42738,6 @@
 "bAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -43845,7 +42773,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -43856,14 +42783,12 @@
 "bAD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bAE" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43871,7 +42796,6 @@
 "bAF" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43884,11 +42808,9 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43898,7 +42820,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43906,7 +42827,6 @@
 "bAI" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -43963,9 +42883,7 @@
 	name = "Private Study";
 	req_access_txt = "37"
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bAO" = (
 /obj/machinery/airalarm/directional/west,
@@ -43985,11 +42903,9 @@
 "bAQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44008,7 +42924,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -44020,7 +42935,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -44099,6 +43013,10 @@
 /obj/item/storage/box/masks,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/storage/box/gloves{
+	pixel_x = 3;
+	pixel_y = 4
+	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBd" = (
@@ -44141,7 +43059,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -44151,7 +43068,6 @@
 /obj/machinery/door/airlock/virology{
 	autoclose = 0;
 	frequency = 1449;
-	icon_state = "closed";
 	id_tag = "virology_airlock_interior";
 	name = "Virology Interior Airlock";
 	req_access_txt = "39"
@@ -44240,6 +43156,7 @@
 "bBm" = (
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line,
+/obj/item/reagent_containers/spray/cleaner,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bBn" = (
@@ -44322,7 +43239,6 @@
 "bBu" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/cryo";
-	dir = 2;
 	name = "Cryogenics APC";
 	pixel_y = -24
 	},
@@ -44340,7 +43256,6 @@
 	pixel_y = 32
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -44371,7 +43286,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44410,7 +43324,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44424,7 +43337,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44475,7 +43387,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44493,7 +43404,6 @@
 /area/medical/medbay/lobby)
 "bBG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44527,7 +43437,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -44540,7 +43449,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -44550,7 +43458,6 @@
 /area/medical/medbay/central)
 "bBM" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -44576,9 +43483,7 @@
 	pixel_x = -30
 	},
 /obj/effect/landmark/blobstart,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bBQ" = (
 /obj/structure/chair/comfy/brown{
@@ -44588,9 +43493,7 @@
 /obj/machinery/computer/security/telescreen/entertainment{
 	pixel_y = 30
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bBR" = (
 /obj/structure/rack{
@@ -44603,9 +43506,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bBS" = (
 /obj/structure/chair/office/dark{
@@ -44673,7 +43574,6 @@
 	dir = 4
 	},
 /obj/effect/mapping_helpers/airlock/unres{
-	icon_state = "airlock_unres_helper";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -44696,7 +43596,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -44716,7 +43615,6 @@
 /area/medical/medbay/central)
 "bCd" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44761,7 +43659,6 @@
 "bCj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44795,7 +43692,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -44814,7 +43710,6 @@
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -44824,7 +43719,6 @@
 /area/medical/medbay/front_office)
 "bCr" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -44832,7 +43726,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44846,14 +43739,12 @@
 /area/security/checkpoint/medical)
 "bCu" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bCv" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44864,7 +43755,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -44889,7 +43779,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
@@ -44907,7 +43796,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -44921,7 +43809,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /mob/living/simple_animal/pet/penguin/emperor{
@@ -44932,7 +43819,6 @@
 /area/crew_quarters/heads/cmo)
 "bCA" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -44953,7 +43839,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/computer/security/telescreen/cmo{
@@ -44993,25 +43878,19 @@
 /area/maintenance/department/medical)
 "bCF" = (
 /obj/machinery/vending/wardrobe/curator_wardrobe,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCG" = (
 /obj/structure/destructible/cult/tome,
 /obj/item/clothing/under/suit/red,
 /obj/item/book/codex_gigas,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCH" = (
 /obj/structure/bookcase{
 	name = "Forbidden Knowledge"
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCI" = (
 /obj/structure/table/wood,
@@ -45023,18 +43902,14 @@
 /obj/item/radio/intercom{
 	pixel_y = -29
 	},
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCJ" = (
 /obj/structure/table/wood,
 /obj/item/taperecorder,
 /obj/item/storage/photo_album,
 /obj/item/camera,
-/turf/open/floor/plasteel/cult{
-	dir = 2
-	},
+/turf/open/floor/plasteel/cult,
 /area/library)
 "bCK" = (
 /obj/machinery/firealarm{
@@ -45126,7 +44001,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45134,7 +44008,6 @@
 "bCV" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45174,7 +44047,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45185,7 +44057,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45198,7 +44069,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -45212,16 +44082,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -45253,7 +44120,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -45263,7 +44129,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45389,7 +44254,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -45418,7 +44282,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -45444,7 +44307,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -45464,7 +44326,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -45474,7 +44335,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -45495,14 +44355,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/keycard_auth{
 	pixel_x = 30
 	},
 /obj/machinery/computer/med_data{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45595,7 +44453,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -45621,7 +44478,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -45633,7 +44489,6 @@
 	},
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -45670,7 +44525,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -45710,7 +44564,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -45738,7 +44591,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -45751,14 +44603,12 @@
 	},
 /obj/item/pen,
 /obj/machinery/camera{
-	c_tag = "Security Post - Engineering";
-	dir = 2
+	c_tag = "Security Post - Engineering"
 	},
 /obj/machinery/newscaster{
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -45769,7 +44619,6 @@
 /area/hallway/secondary/command)
 "bDU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/structure/disposalpipe/segment{
@@ -45779,7 +44628,6 @@
 /area/crew_quarters/heads/hop/private)
 "bDV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -45799,7 +44647,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -45813,14 +44660,12 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bDZ" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -45829,7 +44674,6 @@
 /obj/structure/chair,
 /obj/effect/landmark/start/virologist,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -45839,7 +44683,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -45933,7 +44776,6 @@
 /area/medical/medbay/front_office)
 "bEi" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/freezer,
@@ -45971,7 +44813,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable,
@@ -45992,7 +44833,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/holopad,
@@ -46011,7 +44851,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/table/glass,
@@ -46032,7 +44871,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/landmark/start/chief_medical_officer,
@@ -46056,7 +44894,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/east,
@@ -46187,7 +45024,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber Fore";
-	dir = 2;
 	network = list("aicore")
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -46278,7 +45114,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -46312,7 +45147,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -46322,7 +45156,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46337,6 +45170,7 @@
 /area/medical/virology)
 "bER" = (
 /obj/structure/table,
+/obj/item/storage/box/gloves,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bES" = (
@@ -46347,7 +45181,6 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -46364,7 +45197,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46388,7 +45220,6 @@
 /area/medical/cryo)
 "bEV" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -46408,14 +45239,15 @@
 /area/medical/virology)
 "bEY" = (
 /obj/structure/table,
-/obj/item/storage/box/gloves,
 /obj/machinery/light{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
+/obj/machinery/reagentgrinder,
+/obj/item/stack/sheet/mineral/plasma,
+/obj/item/stack/sheet/mineral/plasma,
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bEZ" = (
@@ -46423,16 +45255,15 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "bFa" = (
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/medical";
 	dir = 8;
 	name = "Medbay Security APC";
-	areastring = "/area/security/checkpoint/medical";
 	pixel_x = -25
 	},
 /obj/structure/cable,
@@ -46462,11 +45293,9 @@
 /area/security/checkpoint/medical)
 "bFc" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46497,7 +45326,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/suit_storage_unit/cmo,
@@ -46505,7 +45333,6 @@
 /area/crew_quarters/heads/cmo)
 "bFf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -46525,7 +45352,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -46545,11 +45371,9 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/computer/card/minor/cmo{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/machinery/requests_console{
@@ -46724,7 +45548,6 @@
 /area/ai_monitored/turret_protected/ai)
 "bFA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -46752,13 +45575,12 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/security/checkpoint/engineering";
 	dir = 8;
 	name = "Engineering Security APC";
-	areastring = "/area/security/checkpoint/engineering";
 	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -46777,7 +45599,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -46801,7 +45622,6 @@
 "bFL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/lobby";
-	dir = 2;
 	name = "Medbay Lobby APC";
 	pixel_y = -24
 	},
@@ -46819,7 +45639,6 @@
 	pixel_y = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -46832,7 +45651,6 @@
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/quartermaster/qm/private";
-	dir = 2;
 	name = "Quartermaster's Quarters APC";
 	pixel_y = -24
 	},
@@ -46911,11 +45729,9 @@
 "bFX" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -46938,10 +45754,9 @@
 /obj/machinery/requests_console{
 	department = "Security";
 	departmentType = 5;
-	pixel_x = -30;
+	pixel_x = -30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -46990,7 +45805,6 @@
 	},
 /obj/item/radio/off,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -47040,7 +45854,6 @@
 "bGi" = (
 /obj/machinery/power/apc{
 	areastring = "/area/medical/medbay/front_office";
-	dir = 2;
 	name = "Medbay Front Office APC";
 	pixel_y = -24
 	},
@@ -47081,14 +45894,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGm" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -47102,7 +45913,6 @@
 	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/item/radio/intercom{
@@ -47150,6 +45960,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGq" = (
@@ -47166,6 +45977,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bGr" = (
@@ -47173,7 +45985,6 @@
 /obj/machinery/light,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -47195,11 +46006,9 @@
 /area/storage/emergency/starboard)
 "bGu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47209,7 +46018,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light_switch{
@@ -47221,7 +46029,6 @@
 "bGw" = (
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/hop/private";
-	dir = 2;
 	name = "Head of Personnel's Quarters APC";
 	pixel_y = -24
 	},
@@ -47574,7 +46381,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -47594,7 +46400,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -47685,7 +46490,6 @@
 "bHn" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -47698,7 +46502,6 @@
 	pixel_x = -27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47708,10 +46511,10 @@
 /obj/machinery/door/window{
 	base_state = "rightsecure";
 	dir = 4;
-	obj_integrity = 300;
 	icon_state = "rightsecure";
 	layer = 4.1;
 	name = "Secondary AI Core Access";
+	obj_integrity = 300;
 	pixel_x = 4;
 	req_access_txt = "16"
 	},
@@ -47752,14 +46555,12 @@
 	pixel_y = 7
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
 	pixel_y = 27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47786,7 +46587,6 @@
 "bHs" = (
 /obj/effect/landmark/start/ai/secondary,
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	listening = 0;
 	name = "Custom Channel";
@@ -47799,7 +46599,6 @@
 	pixel_x = 27
 	},
 /obj/item/radio/intercom{
-	anyai = 1;
 	freerange = 1;
 	frequency = 1447;
 	name = "Private Channel";
@@ -47809,10 +46608,10 @@
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 8;
-	obj_integrity = 300;
 	icon_state = "leftsecure";
 	layer = 4.1;
 	name = "Tertiary AI Core Access";
+	obj_integrity = 300;
 	pixel_x = -3;
 	req_access_txt = "16"
 	},
@@ -47841,9 +46640,8 @@
 /obj/structure/sink/kitchen{
 	desc = "A sink used for washing one's hands and face. It looks rusty and home-made";
 	dir = 8;
-	icon_state = "sink_alt";
 	name = "old sink";
-	pixel_x = 15;
+	pixel_x = 15
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -47871,7 +46669,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -47880,7 +46677,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -47888,7 +46684,6 @@
 "bHD" = (
 /obj/machinery/iv_drip,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47900,7 +46695,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47908,7 +46702,6 @@
 "bHF" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47928,7 +46721,6 @@
 	light_color = "#cee5d2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47946,7 +46738,6 @@
 "bHI" = (
 /obj/machinery/airalarm/directional/north,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47957,7 +46748,6 @@
 	light_color = "#706891"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -47965,16 +46755,19 @@
 "bHK" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHL" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
+/obj/structure/table,
+/obj/item/clothing/suit/straight_jacket,
+/obj/item/clothing/mask/muzzle,
+/obj/item/soap/nanotrasen,
+/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bHM" = (
@@ -47992,7 +46785,6 @@
 /obj/item/wrench,
 /obj/item/multitool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -48092,9 +46884,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/solars/starboard/aft";
 	dir = 8;
 	name = "Starboard Quarter Solar APC";
-	areastring = "/area/maintenance/solars/starboard/aft";
 	pixel_x = -26;
 	pixel_y = 3
 	},
@@ -48138,7 +46930,6 @@
 	dir = 1
 	},
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -48147,7 +46938,6 @@
 /obj/machinery/requests_console{
 	department = "AI";
 	departmentType = 5;
-	dir = 2;
 	pixel_x = -30;
 	pixel_y = -30
 	},
@@ -48182,9 +46972,9 @@
 /obj/machinery/door/window{
 	base_state = "leftsecure";
 	dir = 8;
-	obj_integrity = 300;
 	icon_state = "leftsecure";
 	name = "Primary AI Core Access";
+	obj_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/newscaster/security_unit{
@@ -48207,14 +46997,13 @@
 /obj/machinery/door/window{
 	base_state = "rightsecure";
 	dir = 4;
-	obj_integrity = 300;
 	icon_state = "rightsecure";
 	name = "Primary AI Core Access";
+	obj_integrity = 300;
 	req_access_txt = "16"
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
-	dir = 2;
 	network = list("aicore")
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -48303,7 +47092,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -48344,7 +47132,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -48364,7 +47151,6 @@
 /obj/structure/table,
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -48383,7 +47169,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -48392,7 +47177,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -48448,9 +47232,9 @@
 /area/maintenance/department/cargo)
 "bII" = (
 /obj/machinery/power/apc{
+	areastring = "/area/maintenance/starboard";
 	dir = 4;
 	name = "Starboard Maintenance APC";
-	areastring = "/area/maintenance/starboard";
 	pixel_x = 26
 	},
 /obj/structure/cable,
@@ -48710,7 +47494,6 @@
 /area/maintenance/bar)
 "bJn" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -48834,9 +47617,8 @@
 /area/medical/medbay/central)
 "bJz" = (
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Surgery APC";
 	areastring = "/area/medical/surgery";
+	name = "Surgery APC";
 	pixel_y = -26
 	},
 /obj/machinery/light,
@@ -48861,7 +47643,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -48922,7 +47703,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/firealarm{
@@ -48945,7 +47725,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -48958,7 +47737,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -48971,7 +47749,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -48991,7 +47768,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/white,
@@ -49001,7 +47777,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -49022,7 +47797,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49035,7 +47809,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49049,7 +47822,6 @@
 	pixel_y = 15
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49058,7 +47830,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49071,7 +47842,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49087,7 +47857,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49178,7 +47947,6 @@
 /area/maintenance/solars/starboard/aft)
 "bJW" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -49191,8 +47959,7 @@
 /obj/machinery/power/solar_control{
 	dir = 8;
 	id = "aftstarboard";
-	name = "Starboard Quarter Solar Control";
-	track = 0
+	name = "Starboard Quarter Solar Control"
 	},
 /obj/structure/cable,
 /obj/structure/cable{
@@ -49216,7 +47983,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49233,7 +47999,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -49338,7 +48103,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49358,7 +48122,6 @@
 	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49391,7 +48154,6 @@
 	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49406,7 +48168,6 @@
 /obj/machinery/microwave,
 /obj/structure/table/glass,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -49422,14 +48183,12 @@
 	pixel_y = 22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bKu" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/white,
@@ -49454,11 +48213,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -49469,7 +48226,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49503,7 +48259,6 @@
 "bKD" = (
 /obj/structure/curtain,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49545,11 +48300,9 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -49568,7 +48321,6 @@
 	pixel_x = 30
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49580,7 +48332,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -49607,9 +48358,8 @@
 /area/maintenance/port)
 "bKO" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Port Maintenance APC";
 	areastring = "/area/maintenance/port";
+	name = "Port Maintenance APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -49645,7 +48395,6 @@
 	pixel_x = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49653,14 +48402,12 @@
 "bKS" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Abandoned Garden APC";
 	areastring = "/area/hydroponics/garden/abandoned";
+	name = "Abandoned Garden APC";
 	pixel_y = -26
 	},
 /obj/structure/cable,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -49684,11 +48431,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -49700,7 +48445,6 @@
 	},
 /obj/machinery/vending/cigarette,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49714,7 +48458,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -49729,7 +48472,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -49783,14 +48525,13 @@
 /area/medical)
 "bLf" = (
 /obj/machinery/power/apc{
+	areastring = "/area/medical/patients_rooms/room_a";
 	dir = 8;
 	name = "Patient Room A APC";
-	areastring = "/area/medical/patients_rooms/room_a";
 	pixel_x = -26
 	},
 /obj/structure/cable,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49806,7 +48547,6 @@
 /obj/structure/bed,
 /obj/item/bedsheet/medical,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49817,7 +48557,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -49863,7 +48602,6 @@
 /area/maintenance/central)
 "bLo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -49873,7 +48611,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49891,7 +48628,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49908,7 +48644,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49919,7 +48654,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49935,7 +48669,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
@@ -49948,7 +48681,6 @@
 	},
 /obj/machinery/vending/cola/random,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -49977,10 +48709,9 @@
 "bLw" = (
 /obj/machinery/light/small,
 /obj/machinery/vending/wallmed{
-	pixel_x = -28;
+	pixel_x = -28
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -49993,7 +48724,6 @@
 	},
 /obj/item/clothing/neck/stethoscope,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50001,7 +48731,6 @@
 "bLy" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -50040,7 +48769,6 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/item/surgical_drapes,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50050,7 +48778,6 @@
 /obj/item/book/manual/wiki/surgery,
 /obj/item/surgical_drapes,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -50076,7 +48803,6 @@
 "bLG" = (
 /obj/structure/closet/crate/freezer/blood,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50091,7 +48817,6 @@
 	layer = 2.9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50114,7 +48839,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50124,7 +48848,6 @@
 /area/quartermaster/qm/private)
 "bLN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm{
@@ -50152,7 +48875,6 @@
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -50166,7 +48888,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -50301,9 +49022,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bMa" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /obj/machinery/computer/security/telescreen{
 	desc = "Used for watching the RD's goons from the safety of his office.";
 	dir = 4;
@@ -50322,7 +49041,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -50401,9 +49119,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bMi" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /obj/machinery/computer/security/telescreen/minisat{
 	dir = 8;
 	pixel_x = 28
@@ -50416,7 +49132,6 @@
 "bMj" = (
 /obj/machinery/vending/coffee,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
@@ -50475,11 +49190,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -50569,7 +49282,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -50669,11 +49381,9 @@
 	layer = 2.9
 	},
 /obj/machinery/atmospherics/pipe/layer_manifold{
-	icon_state = "manifoldlayer";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50693,7 +49403,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50703,7 +49412,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50740,7 +49448,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50748,7 +49455,6 @@
 "bMM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50775,7 +49481,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bMQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -50787,7 +49492,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50839,7 +49543,6 @@
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/medical";
-	dir = 2;
 	name = "Breakroom APC";
 	pixel_y = -24
 	},
@@ -50910,7 +49613,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -50927,7 +49629,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bNi" = (
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -50944,7 +49645,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -50968,11 +49668,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -51007,15 +49705,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -51037,7 +49732,6 @@
 "bNp" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -51166,7 +49860,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -51220,7 +49913,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bNE" = (
 /obj/structure/transit_tube/diagonal{
-	icon_state = "diagonal";
 	dir = 8
 	},
 /turf/open/space,
@@ -51232,7 +49924,6 @@
 "bNG" = (
 /obj/machinery/vending/hydroseeds,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -51248,11 +49939,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -51265,28 +49954,24 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -51300,7 +49985,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51308,11 +49992,9 @@
 "bNP" = (
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51321,7 +50003,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51332,7 +50013,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51341,7 +50021,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -51349,11 +50028,9 @@
 "bNT" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51363,7 +50040,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -51371,7 +50047,6 @@
 "bNV" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -51408,7 +50083,6 @@
 /area/hallway/secondary/exit)
 "bNX" = (
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -51422,14 +50096,12 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bNZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -51438,7 +50110,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -51661,9 +50332,7 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bOm" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -51833,7 +50502,6 @@
 	},
 /obj/machinery/turretid{
 	control_area = "/area/ai_monitored/turret_protected/aisat/foyer";
-	enabled = 1;
 	icon_state = "control_stun";
 	name = "Antechamber Turret Control";
 	pixel_x = -32;
@@ -51918,7 +50586,6 @@
 "bOA" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/transit_tube/junction{
-	icon_state = "junction0";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -52008,7 +50675,6 @@
 /area/space/nearstation)
 "bOI" = (
 /obj/structure/transit_tube/junction{
-	icon_state = "junction0";
 	dir = 8
 	},
 /obj/structure/lattice/catwalk,
@@ -52195,7 +50861,6 @@
 /area/hallway/primary/aft)
 "bOW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -52329,7 +50994,6 @@
 /area/hallway/primary/aft)
 "bPc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -52517,7 +51181,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52527,7 +51190,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52647,7 +51309,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52677,11 +51338,9 @@
 	sortType = 10
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52710,11 +51369,9 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -52845,7 +51502,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52858,9 +51514,8 @@
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/ai_monitored/turret_protected/aisat/foyer";
-	dir = 2;
 	name = "MiniSat Foyer APC";
-	pixel_x = -29;
+	pixel_x = -29
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -52869,7 +51524,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "bPK" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -52878,7 +51532,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -52893,7 +51546,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52906,14 +51558,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "bPP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52927,10 +51577,9 @@
 	areastring = "/area/aisat";
 	dir = 8;
 	name = "MiniSat Exterior APC";
-	pixel_x = -24;
+	pixel_x = -24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -52941,7 +51590,6 @@
 /area/space/nearstation)
 "bPS" = (
 /obj/structure/transit_tube/diagonal{
-	icon_state = "diagonal";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -52978,14 +51626,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -53079,14 +51725,11 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway Port";
-	dir = 4;
-	name = "security camera";
-	network = list("ss13")
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
@@ -53104,7 +51747,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -53130,7 +51772,6 @@
 /area/ai_monitored/storage/satellite)
 "bQm" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -53162,7 +51803,6 @@
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53172,14 +51812,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bQq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -53193,7 +51831,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -53305,7 +51942,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -53344,24 +51980,19 @@
 /obj/machinery/portable_atmospherics/canister/air,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible/layer1{
 	dir = 1;
-	icon_state = "connector_map-1";
 	name = "Auxiliary MiniSat Distribution Port"
 	},
 /turf/open/floor/plasteel,
 /area/ai_monitored/storage/satellite)
 "bQL" = (
-/obj/machinery/porta_turret/ai{
-	dir = 2
-	},
+/obj/machinery/porta_turret/ai,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "bQM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -53371,11 +52002,9 @@
 /area/hallway/primary/starboard)
 "bQN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53406,11 +52035,9 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -53433,7 +52060,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -53449,7 +52075,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -53460,7 +52085,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "N2O to Pure"
 	},
 /obj/effect/turf_decal/tile/red,
@@ -53479,7 +52103,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -53493,7 +52116,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -53588,7 +52210,6 @@
 /obj/structure/table,
 /obj/machinery/requests_console{
 	department = "Tool Storage";
-	departmentType = 0;
 	pixel_y = 30
 	},
 /obj/item/folder/yellow,
@@ -53652,7 +52273,6 @@
 /obj/structure/table/wood,
 /obj/item/instrument/violin,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/carpet,
@@ -53669,7 +52289,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -53702,11 +52321,9 @@
 /area/crew_quarters/dorms)
 "bRo" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/carpet,
@@ -53720,14 +52337,12 @@
 "bRq" = (
 /obj/structure/showcase/mecha/ripley,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
 "bRr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -53738,7 +52353,6 @@
 /area/crew_quarters/fitness/recreation)
 "bRt" = (
 /obj/machinery/cryopod{
-	icon_state = "cryopod-open";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -53761,7 +52375,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/green/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -53891,7 +52504,6 @@
 "bRM" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -53911,7 +52523,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -53930,14 +52541,12 @@
 	dir = 10
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical)
 "bRR" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -53957,7 +52566,6 @@
 	},
 /obj/structure/sign/directions/science{
 	dir = 1;
-	icon_state = "direction_sci";
 	pixel_y = 32
 	},
 /obj/structure/sign/directions/command{
@@ -53972,18 +52580,15 @@
 	pixel_x = -22
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bRU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -54005,7 +52610,6 @@
 /area/crew_quarters/fitness/recreation)
 "bRW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54023,11 +52627,9 @@
 "bRY" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54035,11 +52637,9 @@
 "bRZ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54089,7 +52689,6 @@
 /area/tcommsat/computer)
 "bSh" = (
 /obj/structure/showcase/cyborg/old{
-	dir = 2;
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54151,7 +52750,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -54211,7 +52809,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54219,7 +52816,6 @@
 "bSv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -54243,7 +52839,6 @@
 "bSx" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54273,7 +52868,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -54294,18 +52888,15 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bSD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54319,7 +52910,6 @@
 	pixel_x = 29
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54329,7 +52919,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -54349,7 +52938,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54434,11 +53022,9 @@
 /area/tcommsat/computer)
 "bSW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54514,9 +53100,9 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/computer";
 	dir = 4;
 	name = "Telecomms Control Room APC";
-	areastring = "/area/tcommsat/computer";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/grimy,
@@ -54665,7 +53251,6 @@
 /area/storage/primary)
 "bTp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -54699,11 +53284,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -54716,11 +53299,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -54737,11 +53318,9 @@
 /area/crew_quarters/fitness/recreation)
 "bTv" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -54801,7 +53380,6 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54817,15 +53395,12 @@
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner,
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -54833,14 +53408,12 @@
 "bTC" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bTD" = (
 /obj/effect/turf_decal/trimline/green/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -54881,9 +53454,9 @@
 /area/storage/tech)
 "bTI" = (
 /obj/machinery/power/apc{
+	areastring = "/area/storage/tech";
 	dir = 8;
 	name = "Tech Storage APC";
-	areastring = "/area/storage/tech";
 	pixel_x = -27
 	},
 /obj/structure/cable{
@@ -54975,7 +53548,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -54998,11 +53570,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55096,7 +53666,7 @@
 	areastring = "/area/storage/primary";
 	dir = 8;
 	name = "Tool Storage APC";
-	pixel_x = -25;
+	pixel_x = -25
 	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -55262,7 +53832,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55291,11 +53860,9 @@
 "bUo" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -55326,16 +53893,13 @@
 /area/crew_quarters/fitness/recreation)
 "bUr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
@@ -55350,7 +53914,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -55402,7 +53965,6 @@
 /area/crew_quarters/fitness/recreation)
 "bUx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -55416,7 +53978,6 @@
 "bUy" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -55441,11 +54002,9 @@
 "bUA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55523,14 +54082,12 @@
 /area/storage/tech)
 "bUN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -55543,7 +54100,7 @@
 	areastring = "/area/maintenance/fore";
 	dir = 4;
 	name = "Fore Maintenance APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
@@ -55625,18 +54182,16 @@
 "bUY" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "bUZ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/wood,
@@ -55665,7 +54220,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/supply{
@@ -55776,7 +54330,6 @@
 "bVk" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -55784,7 +54337,6 @@
 	location = "aft1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55795,11 +54347,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55825,7 +54375,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -55841,7 +54390,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/structure/sign/directions/medical{
 	dir = 4;
-	icon_state = "direction_med";
 	pixel_y = 40
 	},
 /obj/structure/sign/directions/engineering{
@@ -55856,11 +54404,9 @@
 /area/hallway/primary/aft)
 "bVp" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -55874,7 +54420,6 @@
 	uses = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -55899,7 +54444,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Port";
-	dir = 2;
 	network = list("ss13","tcomms")
 	},
 /turf/open/floor/plasteel/dark/telecomms,
@@ -55909,7 +54453,6 @@
 	dir = 4
 	},
 /obj/machinery/computer/arcade/orion_trail{
-	icon_state = "arcade";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55961,7 +54504,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -55976,7 +54518,7 @@
 	},
 /obj/machinery/announcement_system,
 /obj/machinery/status_display/ai{
-	pixel_x = 31;
+	pixel_x = 31
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -56063,18 +54605,15 @@
 /area/medical/morgue)
 "bVI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -56085,14 +54624,12 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bVK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -56100,7 +54637,6 @@
 	location = "starboard3"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -56199,11 +54735,9 @@
 /area/library)
 "bVQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light_switch{
@@ -56244,7 +54778,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/light_switch{
@@ -56270,7 +54803,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/structure/sign/directions/evac{
@@ -56292,26 +54824,21 @@
 "bVX" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/dorms)
 "bVY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56402,7 +54929,6 @@
 /area/tcommsat/computer)
 "bWm" = (
 /obj/machinery/computer/message_monitor{
-	icon_state = "computer";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -56483,11 +55009,9 @@
 /area/crew_quarters/fitness/recreation)
 "bWs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -56503,7 +55027,6 @@
 /area/crew_quarters/dorms)
 "bWu" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -56522,7 +55045,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -56546,14 +55068,12 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
 "bWy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -56576,7 +55096,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/carpet,
@@ -56604,11 +55123,9 @@
 "bWF" = (
 /obj/structure/closet/secure_closet/engineering_chief,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/status_display/ai{
@@ -56663,7 +55180,6 @@
 /obj/machinery/telecomms/processor/preset_three,
 /obj/machinery/camera{
 	c_tag = "Telecomms - Server Room - Fore-Starboard";
-	dir = 2;
 	network = list("ss13","tcomms")
 	},
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -56689,7 +55205,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -56772,7 +55287,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -56828,11 +55342,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56850,7 +55362,6 @@
 "bXb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -56883,12 +55394,10 @@
 /area/tcommsat/server)
 "bXh" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -56957,18 +55466,15 @@
 "bXr" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bXs" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -57076,11 +55582,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57093,11 +55597,9 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57107,11 +55609,9 @@
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -57235,7 +55735,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -57254,7 +55753,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -57308,13 +55806,12 @@
 	pixel_x = 3
 	},
 /obj/machinery/status_display/evac{
-	pixel_x = 31;
+	pixel_x = 31
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
 "bXT" = (
 /obj/structure/transit_tube/station{
-	icon_state = "closed_station0";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -57327,7 +55824,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -57335,11 +55831,9 @@
 "bXU" = (
 /obj/structure/chair,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/machinery/camera/autoname,
@@ -57347,7 +55841,6 @@
 /area/medical/virology)
 "bXV" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57355,7 +55848,6 @@
 "bXW" = (
 /obj/machinery/airalarm/directional/south,
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
@@ -57445,18 +55937,15 @@
 "bYe" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bYf" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -57522,7 +56011,6 @@
 "bYk" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -57576,7 +56064,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57616,7 +56103,6 @@
 /area/engine/break_room)
 "bYs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -57647,9 +56133,8 @@
 /area/maintenance/starboard/aft)
 "bYw" = (
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Starboard Quarter Maintenance APC";
 	areastring = "/area/maintenance/starboard/aft";
+	name = "Starboard Quarter Maintenance APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -57679,7 +56164,6 @@
 /area/maintenance/starboard/aft)
 "bYA" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -57714,9 +56198,9 @@
 /area/tcommsat/server)
 "bYF" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/tcommsat/server";
 	dir = 4;
 	name = "Telecomms Server Room APC";
-	areastring = "/area/tcommsat/server";
 	pixel_x = 25
 	},
 /obj/machinery/light/small{
@@ -57737,12 +56221,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -57761,7 +56243,7 @@
 	dir = 4;
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
-	pixel_x = 30;
+	pixel_x = 30
 	},
 /turf/open/floor/carpet,
 /area/tcommsat/computer)
@@ -57832,7 +56314,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -57886,7 +56367,6 @@
 "bYU" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile,
@@ -57901,7 +56381,6 @@
 	},
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58021,7 +56500,6 @@
 "bZk" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/item/flashlight,
@@ -58065,7 +56543,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58192,11 +56669,9 @@
 "bZA" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/computer/card/minor/ce{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -58204,7 +56679,6 @@
 /area/crew_quarters/heads/chief)
 "bZB" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -58213,11 +56687,9 @@
 "bZC" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -58236,7 +56708,6 @@
 	dir = 8
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -58281,7 +56752,6 @@
 /area/engine/break_room)
 "bZG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/grimy,
@@ -58310,12 +56780,10 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -58323,7 +56791,6 @@
 "bZJ" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -58372,7 +56839,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -58397,11 +56863,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -58422,7 +56886,6 @@
 /area/crew_quarters/fitness/recreation)
 "bZT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/camera{
@@ -58437,7 +56900,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
@@ -58467,7 +56929,6 @@
 "bZY" = (
 /obj/machinery/power/apc{
 	areastring = "/area/crew_quarters/toilet";
-	dir = 2;
 	name = "Restrooms APC";
 	pixel_y = -26
 	},
@@ -58479,7 +56940,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -58492,7 +56952,6 @@
 	dir = 8
 	},
 /obj/machinery/computer/station_alert{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -58570,7 +57029,7 @@
 	areastring = "/area/crew_quarters/heads/chief";
 	dir = 4;
 	name = "Chief Engineer's APC";
-	pixel_x = 26;
+	pixel_x = 26
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -58610,7 +57069,6 @@
 "cah" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -58632,7 +57090,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -58662,7 +57119,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -58694,7 +57150,7 @@
 	areastring = "/area/crew_quarters/locker";
 	dir = 8;
 	name = "Locker Room APC";
-	pixel_x = -28;
+	pixel_x = -28
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -58713,7 +57169,6 @@
 /area/crew_quarters/locker)
 "cav" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -58793,14 +57248,12 @@
 "caB" = (
 /obj/structure/urinal{
 	dir = 8;
-	icon_state = "urinal";
 	pixel_x = 28
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "caC" = (
 /obj/machinery/computer/apc_control{
-	icon_state = "computer";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -58860,7 +57313,6 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -59043,9 +57495,9 @@
 "caP" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
+	areastring = "/area/storage/tcom";
 	dir = 8;
 	name = "Telecomms Storage APC";
-	areastring = "/area/storage/tcom";
 	pixel_x = -28
 	},
 /obj/structure/cable,
@@ -59120,7 +57572,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -59168,7 +57619,6 @@
 	},
 /obj/structure/fans/tiny,
 /obj/effect/turf_decal/trimline/blue/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -59178,7 +57628,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -59193,7 +57642,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59207,7 +57655,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59244,7 +57691,6 @@
 "cbh" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59273,11 +57719,9 @@
 /area/crew_quarters/fitness/recreation)
 "cbk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59304,13 +57748,12 @@
 	areastring = "/area/crew_quarters/dorms";
 	dir = 4;
 	name = "Dormitories APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59424,7 +57867,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59455,7 +57897,6 @@
 "cbx" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -59505,7 +57946,6 @@
 /area/space)
 "cbD" = (
 /obj/structure/transit_tube/curved/flipped{
-	icon_state = "curved1";
 	dir = 1
 	},
 /obj/structure/window/reinforced{
@@ -59513,7 +57953,6 @@
 	},
 /obj/structure/window/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel/dark,
@@ -59566,7 +58005,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59585,7 +58023,6 @@
 /area/medical/patients_rooms/room_a)
 "cbK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -59648,7 +58085,6 @@
 /area/crew_quarters/fitness/recreation)
 "cbO" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -59656,7 +58092,6 @@
 "cbP" = (
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -59672,7 +58107,6 @@
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -59701,7 +58135,6 @@
 /area/science/robotics/lab)
 "cbU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -59720,7 +58153,6 @@
 /obj/structure/table/reinforced,
 /obj/machinery/recharger,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -59824,7 +58256,6 @@
 "cch" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -59832,7 +58263,6 @@
 "cci" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -59889,18 +58319,16 @@
 /area/crew_quarters/fitness/recreation)
 "ccn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cco" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
 /obj/machinery/computer/holodeck{
 	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -59927,14 +58355,12 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet/black,
 /area/crew_quarters/dorms)
 "ccr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/camera{
@@ -59950,7 +58376,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -59961,7 +58386,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet/black,
@@ -59981,7 +58405,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60076,7 +58499,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -60097,7 +58519,6 @@
 /area/asteroid/nearstation)
 "ccI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -60147,7 +58568,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -60161,7 +58581,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -60200,7 +58619,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -60243,7 +58661,7 @@
 	areastring = "/area/crew_quarters/heads/cmo/private";
 	dir = 4;
 	name = "Chief Medical Officer's Quarters APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -60260,7 +58678,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/wood,
@@ -60273,7 +58690,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60284,7 +58700,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -60311,7 +58726,6 @@
 /obj/machinery/recharger,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -60427,7 +58841,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -60578,7 +58991,6 @@
 "cdI" = (
 /obj/machinery/power/apc{
 	areastring = "/area/maintenance/dormitory";
-	dir = 2;
 	name = "Dormitory Maintenance APC";
 	pixel_y = -28
 	},
@@ -60613,7 +59025,6 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet,
@@ -60627,7 +59038,6 @@
 	pixel_x = 27
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -60636,7 +59046,6 @@
 /obj/machinery/microwave,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -60678,7 +59087,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
@@ -60689,7 +59097,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -60751,7 +59158,6 @@
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -60789,7 +59195,6 @@
 /area/crew_quarters/toilet)
 "ceh" = (
 /obj/machinery/requests_console{
-	announcementConsole = 0;
 	department = "Engineering";
 	departmentType = 4;
 	name = "Engineering RC"
@@ -60956,7 +59361,6 @@
 /area/maintenance/aft)
 "ceH" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/camera/autoname,
@@ -60973,7 +59377,6 @@
 	},
 /obj/structure/bedsheetbin,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61003,7 +59406,6 @@
 /area/engine/break_room)
 "ceM" = (
 /obj/machinery/door/window/southright{
-	dir = 2;
 	name = "Engineering Deliveries";
 	req_access_txt = "10"
 	},
@@ -61019,11 +59421,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -61033,14 +59433,13 @@
 /obj/item/bedsheet/cmo,
 /obj/structure/bed,
 /obj/machinery/status_display/ai{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /turf/open/floor/carpet/blue,
 /area/crew_quarters/heads/cmo/private)
 "ceP" = (
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61048,7 +59447,6 @@
 "ceQ" = (
 /obj/structure/closet/secure_closet/engineering_personal,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61056,7 +59454,6 @@
 "ceR" = (
 /obj/machinery/vending/tool,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61077,7 +59474,6 @@
 /area/hallway/primary/aft)
 "ceU" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61090,7 +59486,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61199,7 +59594,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61209,7 +59603,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61252,7 +59645,6 @@
 /area/maintenance/aft)
 "cfq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61274,7 +59666,6 @@
 /area/crew_quarters/locker)
 "cfs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
-	icon_state = "trimline_end_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61284,7 +59675,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -61294,7 +59684,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61315,7 +59704,6 @@
 /area/engine/gravity_generator)
 "cfx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -61336,7 +59724,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -61423,7 +59810,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61437,7 +59823,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61466,7 +59851,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -61477,7 +59861,6 @@
 	light_color = "#d8b1b1"
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet,
@@ -61609,7 +59992,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61622,7 +60004,6 @@
 "cgl" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -61679,7 +60060,6 @@
 /area/engine/gravity_generator)
 "cgs" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -61740,7 +60120,6 @@
 	},
 /obj/structure/closet/radiation,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -61852,7 +60231,6 @@
 /area/chapel/main)
 "cgP" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -61944,9 +60322,9 @@
 /area/crew_quarters/heads/chief)
 "chd" = (
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/engine/gravity_generator";
 	dir = 1;
 	name = "Gravity Generator APC";
-	areastring = "/area/engine/gravity_generator";
 	pixel_y = 24
 	},
 /obj/structure/cable/yellow{
@@ -61969,7 +60347,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62006,7 +60383,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -62079,7 +60455,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -62128,7 +60503,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -62177,7 +60551,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62238,7 +60611,6 @@
 "chK" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62308,29 +60680,24 @@
 "chR" = (
 /obj/machinery/washing_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "chS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "chT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/light{
@@ -62430,7 +60797,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -62459,17 +60825,15 @@
 /area/engine/break_room)
 "cif" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/execution/education)
 "cig" = (
 /obj/structure/sign/warning/radiation/rad_area{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62479,11 +60843,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -62600,7 +60962,6 @@
 "cis" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/n2o{
-	icon_state = "filter_on";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red,
@@ -62637,7 +60998,6 @@
 "civ" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/components/trinary/filter/atmos/co2{
-	icon_state = "filter_on";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62731,7 +61091,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/trinary/filter/atmos/plasma{
-	icon_state = "filter_on";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -62764,7 +61123,6 @@
 /area/maintenance/port)
 "ciE" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on/layer3{
-	icon_state = "inje_map-2";
 	dir = 4
 	},
 /turf/open/floor/plating/airless,
@@ -62793,12 +61151,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Arrivals Hallway Stern";
-	dir = 2;
 	name = "arrivals camera"
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -62852,7 +61208,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -62889,7 +61244,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -62936,14 +61290,12 @@
 	},
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ciZ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63018,7 +61370,6 @@
 "cjg" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63153,7 +61504,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63166,7 +61516,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -63179,7 +61528,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63260,7 +61608,6 @@
 "cjG" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -63276,7 +61623,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/freezer,
@@ -63467,7 +61813,6 @@
 /area/engine/atmos)
 "ckg" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	dir = 2;
 	name = "Pure to Fuel Pipe"
 	},
 /turf/open/floor/plasteel,
@@ -63519,7 +61864,6 @@
 /area/chapel/main)
 "cko" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/camera{
@@ -63553,7 +61897,7 @@
 "ckr" = (
 /obj/machinery/vending/coffee,
 /obj/machinery/newscaster{
-	pixel_x = 30;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/fitness/recreation)
@@ -63740,7 +62084,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63849,7 +62192,7 @@
 	dir = 4
 	},
 /obj/machinery/newscaster{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
@@ -63981,7 +62324,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -63991,7 +62333,7 @@
 	areastring = "/area/engine/engine_smes";
 	dir = 1;
 	name = "SMES room APC";
-	pixel_x = -26;
+	pixel_x = -26
 	},
 /obj/structure/cable{
 	icon_state = "0-2";
@@ -64117,7 +62459,6 @@
 /area/engine/atmos)
 "clA" = (
 /obj/machinery/atmospherics/components/trinary/filter/atmos{
-	icon_state = "filter_on";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64127,11 +62468,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -64170,7 +62509,6 @@
 /obj/item/storage/crayons,
 /obj/item/storage/crayons,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -64178,7 +62516,6 @@
 "clG" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/engine/break_room";
-	dir = 2;
 	name = "Engineering Foyer APC";
 	pixel_y = -24
 	},
@@ -64224,7 +62561,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64232,7 +62568,6 @@
 "clL" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64250,12 +62585,10 @@
 "clO" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64276,11 +62609,9 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -64396,7 +62727,6 @@
 /area/crew_quarters/heads/chief)
 "cmf" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -64430,14 +62760,12 @@
 "cmi" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64476,7 +62804,6 @@
 "cmm" = (
 /obj/machinery/door/window/westleft{
 	base_state = "right";
-	dir = 8;
 	icon_state = "right"
 	},
 /obj/effect/spawner/lootdrop/maintenance,
@@ -64490,7 +62817,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64542,7 +62868,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -64589,7 +62914,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64604,7 +62928,6 @@
 /obj/item/wrench,
 /obj/item/clothing/glasses/meson/engine,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -64625,7 +62948,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64634,7 +62956,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/grunge{
 	name = "Vacant Office";
-	opacity = 1;
 	req_access_txt = "32"
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -64677,7 +62998,6 @@
 /area/security/vacantoffice/a)
 "cmJ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -64696,14 +63016,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64719,14 +63037,12 @@
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -64847,10 +63163,9 @@
 	areastring = "/area/engine/atmos";
 	dir = 1;
 	name = "Atmospherics APC";
-	pixel_x = -27;
+	pixel_x = -27
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64896,7 +63211,6 @@
 	pixel_x = -28
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -64928,7 +63242,6 @@
 /area/engine/atmos)
 "cnj" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/extinguisher_cabinet{
@@ -65001,7 +63314,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65036,7 +63348,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65065,7 +63376,6 @@
 /area/security/vacantoffice/a)
 "cnz" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -65088,7 +63398,6 @@
 /area/chapel/office)
 "cnC" = (
 /obj/machinery/computer/arcade{
-	icon_state = "arcade";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -65096,14 +63405,12 @@
 "cnD" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
@@ -65158,11 +63465,9 @@
 "cnH" = (
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -65240,11 +63545,9 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -65257,15 +63560,12 @@
 /area/hydroponics/garden)
 "cnQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65280,7 +63580,6 @@
 /obj/item/weldingtool,
 /obj/item/clothing/head/welding,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -65310,7 +63609,6 @@
 	products = list(/obj/item/clothing/under/rank/engineering/engineer = 4, /obj/item/clothing/shoes/sneakers/orange = 4, /obj/item/clothing/head/hardhat = 4, /obj/item/storage/belt/utility = 4, /obj/item/clothing/glasses/meson/engine = 4, /obj/item/clothing/gloves/color/yellow = 2, /obj/item/screwdriver = 12, /obj/item/crowbar = 12, /obj/item/wirecutters = 12, /obj/item/multitool = 12, /obj/item/wrench = 12, /obj/item/t_scanner = 12, /obj/item/stock_parts/cell = 8, /obj/item/weldingtool = 8, /obj/item/clothing/head/welding = 8, /obj/item/light/tube = 10, /obj/item/clothing/suit/fire = 4, /obj/item/stock_parts/scanning_module = 5, /obj/item/stock_parts/micro_laser = 5, /obj/item/stock_parts/matter_bin = 5, /obj/item/stock_parts/manipulator = 5)
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -65406,7 +63704,7 @@
 	pixel_x = 32
 	},
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "cod" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -65466,7 +63764,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65476,14 +63773,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "col" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -65491,7 +63786,6 @@
 "com" = (
 /obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -65534,7 +63828,6 @@
 /area/crew_quarters/locker)
 "cos" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -65556,11 +63849,9 @@
 /area/chapel/office)
 "cou" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -65571,7 +63862,6 @@
 	pixel_x = -24
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/freezer,
@@ -65628,11 +63918,9 @@
 /area/crew_quarters/dorms)
 "coE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -65655,11 +63943,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -65769,7 +64055,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -65782,7 +64067,6 @@
 	},
 /obj/machinery/meter,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -65827,7 +64111,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66079,7 +64362,6 @@
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/trimline/blue/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -66158,10 +64440,8 @@
 	dir = 4
 	},
 /obj/machinery/power/apc{
-	dir = 2;
-	lighting = 3;
-	name = "Chapel Office APC";
 	areastring = "/area/chapel/office";
+	name = "Chapel Office APC";
 	pixel_y = -25
 	},
 /turf/open/floor/plasteel/grimy,
@@ -66183,8 +64463,8 @@
 /area/chapel/office)
 "cpB" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "crematoriumChapel";
-	dir = 1
+	dir = 1;
+	id = "crematoriumChapel"
 	},
 /obj/machinery/light,
 /obj/item/radio/intercom{
@@ -66221,7 +64501,6 @@
 /area/hydroponics/garden)
 "cpG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -66240,7 +64519,6 @@
 /obj/effect/landmark/start/depsec/engineering,
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66251,7 +64529,6 @@
 	},
 /obj/machinery/rnd/production/circuit_imprinter,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -66274,7 +64551,6 @@
 /area/maintenance/port/fore)
 "cpM" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/machinery/camera/autoname,
@@ -66313,7 +64589,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66356,7 +64631,6 @@
 "cpT" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -66382,7 +64656,6 @@
 	},
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66459,7 +64732,6 @@
 /area/hallway/secondary/entry)
 "cqh" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -66500,7 +64772,6 @@
 /area/hallway/secondary/entry)
 "cql" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -66508,7 +64779,6 @@
 "cqm" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
@@ -66641,7 +64911,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -66675,7 +64944,6 @@
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /obj/machinery/light{
@@ -66729,7 +64997,6 @@
 "cqF" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/vending/wardrobe/atmos_wardrobe,
@@ -66754,7 +65021,6 @@
 	pixel_y = 10
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/power/apc{
@@ -66959,11 +65225,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -67001,18 +65265,15 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/storage/satellite)
 "crl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67054,7 +65315,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -67256,7 +65516,6 @@
 /area/hallway/primary/fore)
 "crL" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/chair{
@@ -67272,7 +65531,6 @@
 /area/hallway/secondary/entry)
 "crM" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67324,7 +65582,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67486,7 +65743,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67509,7 +65765,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67525,7 +65780,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -67654,7 +65908,6 @@
 	pixel_y = 23
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67827,7 +66080,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/chair{
@@ -67850,7 +66102,6 @@
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -67863,15 +66114,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67886,15 +66134,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -67902,7 +66147,6 @@
 "ctc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67913,7 +66157,6 @@
 "ctd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -67921,7 +66164,6 @@
 /area/hallway/secondary/entry)
 "cte" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67937,7 +66179,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -67953,7 +66194,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68042,7 +66282,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68058,7 +66297,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68078,7 +66316,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68094,7 +66331,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68116,7 +66352,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68154,14 +66389,12 @@
 /area/engine/engine_smes)
 "ctw" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ctx" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/airalarm/directional/north,
@@ -68175,7 +66408,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -68193,7 +66425,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68212,7 +66443,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -68220,6 +66450,9 @@
 "ctC" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
+	},
+/obj/structure/cable{
+	icon_state = "2-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -68269,7 +66502,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -68306,7 +66538,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68329,7 +66560,6 @@
 "ctP" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/binary/valve{
-	dir = 2;
 	name = "output gas to space"
 	},
 /turf/open/floor/plasteel,
@@ -68394,7 +66624,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68479,7 +66708,6 @@
 	dir = 9
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -68506,7 +66734,6 @@
 "cuk" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hydroponics/garden";
-	dir = 2;
 	name = "Garden APC";
 	pixel_y = -26
 	},
@@ -68535,7 +66762,6 @@
 /obj/item/t_scanner,
 /obj/item/t_scanner,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -68605,7 +66831,6 @@
 /area/engine/atmos)
 "cuA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -68639,7 +66864,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -68653,7 +66877,6 @@
 	dir = 6
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -68671,7 +66894,6 @@
 /area/engine/atmos)
 "cuH" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -68694,11 +66916,12 @@
 /turf/open/floor/plating,
 /area/maintenance/disposal/incinerator)
 "cuL" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 2
+/obj/machinery/door/poddoor{
+	id = "SecJusticeChamber";
+	name = "Justice Vent"
 	},
-/turf/closed/wall/r_wall,
-/area/maintenance/disposal/incinerator)
+/turf/open/floor/plating,
+/area/security/execution/education)
 "cuM" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/public/glass/incinerator/atmos_interior,
@@ -68735,7 +66958,6 @@
 "cuS" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68744,7 +66966,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68756,7 +66977,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68768,7 +66988,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -68778,7 +66997,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -68857,7 +67075,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -68871,7 +67088,6 @@
 	dir = 9
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -68950,7 +67166,6 @@
 /area/engine/atmos)
 "cvr" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -68967,7 +67182,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2;
 	name = "Incinerator Output Pump"
 	},
 /turf/open/space,
@@ -69015,9 +67229,7 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/obj/machinery/atmospherics/components/binary/pump/on{
-	dir = 2
-	},
+/obj/machinery/atmospherics/components/binary/pump/on,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -69042,7 +67254,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -69138,7 +67349,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -69165,7 +67375,6 @@
 "cvR" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/grimy,
@@ -69209,7 +67418,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -69264,7 +67472,7 @@
 	areastring = "/area/construction/mining/aux_base";
 	dir = 4;
 	name = "Auxillary Base Construction APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -69277,7 +67485,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile,
@@ -69332,9 +67539,9 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/power/apc{
+	areastring = "/area/hallway/secondary/entry";
 	dir = 4;
 	name = "Entry Hall APC";
-	areastring = "/area/hallway/secondary/entry";
 	pixel_x = 24
 	},
 /obj/structure/cable,
@@ -69398,33 +67605,25 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cws" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
 /obj/machinery/power/emitter/anchored{
 	dir = 4;
 	state = 2
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cwt" = (
-/obj/structure/cable/yellow{
-	icon_state = "4-8"
+/obj/machinery/door/poddoor{
+	id = "SecJusticeChamber";
+	name = "Justice Vent"
 	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/open/floor/plating,
+/area/security/execution/education)
 "cwu" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-8"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/science/circuit)
 "cwv" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -69502,7 +67701,6 @@
 /area/construction/mining/aux_base)
 "cwE" = (
 /obj/docking_port/stationary/public_mining_dock{
-	icon_state = "pinonfar";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -69601,7 +67799,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Cargobay Fore";
-	dir = 2;
 	name = "cargo camera"
 	},
 /turf/open/floor/plating,
@@ -69654,7 +67851,6 @@
 	},
 /obj/effect/turf_decal/tile/red,
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -69684,7 +67880,6 @@
 "cwZ" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -69692,7 +67887,6 @@
 /area/hallway/secondary/entry)
 "cxa" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/stripes/corner{
@@ -69763,11 +67957,9 @@
 /area/hallway/secondary/entry)
 "cxi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -69796,7 +67988,6 @@
 "cxl" = (
 /obj/structure/chair/stool,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel/chapel{
@@ -69821,11 +68012,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "cxo" = (
-/obj/machinery/power/apc{
-	areastring = "/area/science/nanite";
-	name = "Nanite Lab APC";
-	pixel_x = -24
-	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
@@ -69835,17 +68021,20 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/machinery/power/apc{
+	areastring = "/area/science/circuit";
+	name = "Circuitry Lab APC";
+	pixel_x = -24
+	},
+/obj/structure/target_stake,
 /turf/open/floor/plasteel/dark,
-/area/science/nanite)
+/area/science/circuit)
 "cxp" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
-	},
-/obj/structure/cable/yellow{
-	icon_state = "1-4"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -69893,19 +68082,20 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cxv" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
 /obj/machinery/power/emitter/anchored{
 	dir = 8;
 	state = 2
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cxw" = (
 /obj/machinery/power/rad_collector/anchored,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -69940,7 +68130,6 @@
 /area/space/nearstation)
 "cxC" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70039,9 +68228,7 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "cxN" = (
-/obj/structure/disposaloutlet{
-	dir = 2
-	},
+/obj/structure/disposaloutlet,
 /obj/structure/disposalpipe/trunk{
 	dir = 8
 	},
@@ -70064,7 +68251,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70163,7 +68349,6 @@
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/light,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70172,7 +68357,6 @@
 "cyc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -70204,7 +68388,6 @@
 "cyh" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70213,7 +68396,6 @@
 "cyi" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -70241,7 +68423,6 @@
 "cym" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -70265,7 +68446,7 @@
 	pixel_y = 26
 	},
 /obj/item/radio/intercom{
-	pixel_x = -26;
+	pixel_x = -26
 	},
 /obj/item/stack/cable_coil/white{
 	pixel_x = 3;
@@ -70448,11 +68629,9 @@
 /area/engine/storage_shared)
 "cyF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -70480,7 +68659,6 @@
 "cyJ" = (
 /obj/machinery/rnd/production/protolathe/department/cargo,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -70642,12 +68820,12 @@
 /area/space)
 "cze" = (
 /obj/docking_port/stationary{
-	icon_state = "pinonalert";
 	dir = 8;
-	width = 3;
-	height = 4;
 	dwidth = 1;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default
+	height = 4;
+	icon_state = "pinonalert";
+	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
+	width = 3
 	},
 /obj/structure/fans/tiny/invisible,
 /turf/open/space/basic,
@@ -70737,6 +68915,7 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
+/obj/machinery/power/rad_collector/anchored,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "czp" = (
@@ -70785,17 +68964,12 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
 "czu" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 2
-	},
-/turf/open/floor/plating,
-/area/hallway/secondary/entry)
+/turf/closed/wall/r_wall,
+/area/science/circuit)
 "czv" = (
 /obj/item/storage/toolbox/artistic,
 /turf/open/floor/plating,
@@ -70855,15 +69029,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/binary/pump{
@@ -70910,7 +69081,6 @@
 /area/gateway)
 "czF" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/sign/departments/science{
@@ -71004,7 +69174,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71040,7 +69209,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71064,11 +69232,9 @@
 /area/bridge)
 "czV" = (
 /obj/effect/turf_decal/box/white/corners{
-	icon_state = "box_corners_white";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71106,7 +69272,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /obj/machinery/camera/autoname{
@@ -71153,21 +69318,18 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "cAb" = (
 /obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "0-4"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71186,7 +69348,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -71194,7 +69355,6 @@
 "cAd" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71205,7 +69365,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71221,11 +69380,9 @@
 "cAh" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71277,7 +69434,6 @@
 	pixel_y = -5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -71338,6 +69494,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cAu" = (
@@ -71361,11 +69520,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71378,7 +69535,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -71417,7 +69573,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -71442,11 +69597,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71471,7 +69624,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71495,11 +69647,9 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71507,11 +69657,9 @@
 "cAD" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -71526,7 +69674,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -71554,11 +69701,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71568,11 +69713,9 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71597,11 +69740,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71625,11 +69766,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71655,11 +69794,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71682,11 +69819,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71711,11 +69846,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71740,11 +69873,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71755,7 +69886,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -71779,11 +69909,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71813,11 +69941,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71897,7 +70023,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -71905,7 +70030,6 @@
 "cBb" = (
 /obj/machinery/computer/arcade,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -71930,7 +70054,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
@@ -71940,7 +70063,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -71976,11 +70098,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -71993,7 +70113,6 @@
 "cBj" = (
 /obj/machinery/computer/slot_machine,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -72004,7 +70123,6 @@
 	pixel_x = 12
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72014,7 +70132,7 @@
 	dir = 8
 	},
 /obj/item/radio/intercom{
-	pixel_x = 26;
+	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark/corner,
 /area/engine/atmos)
@@ -72024,14 +70142,12 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72041,7 +70157,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -72050,7 +70165,6 @@
 "cBo" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72060,18 +70174,15 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
 "cBq" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72081,7 +70192,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72098,7 +70208,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72108,7 +70217,6 @@
 	uses = 10
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72119,7 +70227,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72130,14 +70237,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
@@ -72147,7 +70252,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72157,7 +70261,7 @@
 	areastring = "/area/hallway/primary/starboard";
 	dir = 4;
 	name = "Starboard Hallway APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -72166,14 +70270,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cBA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72186,7 +70288,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72194,7 +70295,6 @@
 "cBC" = (
 /obj/machinery/airalarm/directional/west,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72208,7 +70308,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72219,7 +70318,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -72230,7 +70328,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72244,7 +70341,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72254,16 +70350,15 @@
 	icon_state = "0-8"
 	},
 /obj/machinery/power/apc/highcap/five_k{
+	areastring = "/area/hallway/primary/aft";
 	dir = 4;
 	name = "Aft Hallway APC";
-	areastring = "/area/hallway/primary/aft";
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72280,11 +70375,9 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -72350,7 +70443,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/navbeacon{
@@ -72364,7 +70456,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -72434,14 +70525,12 @@
 /area/hallway/primary/aft)
 "cBZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cCa" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/machinery/navbeacon{
@@ -72456,11 +70545,9 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72469,11 +70556,9 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72484,7 +70569,6 @@
 	},
 /obj/effect/landmark/start/chaplain,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72503,21 +70587,18 @@
 	light_color = "#fff4bc"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/dorms)
 "cCf" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cCg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -72525,7 +70606,6 @@
 "cCh" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72534,7 +70614,6 @@
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72544,7 +70623,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72553,7 +70631,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72566,7 +70643,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72609,7 +70685,7 @@
 	dir = 8;
 	name = "Auxillary Base Monitor";
 	network = list("auxbase");
-	pixel_x = 25;
+	pixel_x = 25
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/cable{
@@ -72620,7 +70696,6 @@
 "cCp" = (
 /obj/effect/landmark/event_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72636,7 +70711,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/yjunction{
-	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
@@ -72657,7 +70731,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72668,7 +70741,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72692,7 +70764,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72717,18 +70788,15 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cCx" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -72742,7 +70810,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72787,11 +70854,9 @@
 /area/hallway/primary/aft)
 "cCD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72803,7 +70868,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -72853,7 +70917,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72878,7 +70941,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -72898,7 +70960,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -72935,7 +70996,6 @@
 /area/crew_quarters/fitness/recreation)
 "cCQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -72975,7 +71035,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -72986,7 +71045,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73002,7 +71060,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73012,7 +71069,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73026,11 +71082,9 @@
 /area/aisat)
 "cCY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -73061,14 +71115,12 @@
 /area/ai_monitored/turret_protected/ai)
 "cDc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDd" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -73080,7 +71132,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73090,7 +71141,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/extinguisher_cabinet{
@@ -73105,7 +71155,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73115,7 +71164,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73134,7 +71182,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73145,14 +71192,12 @@
 	icon_state = "2-4"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
 "cDl" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73164,7 +71209,6 @@
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73174,14 +71218,12 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "cDo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73192,7 +71234,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73200,7 +71241,6 @@
 "cDq" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -73210,7 +71250,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -73218,7 +71257,6 @@
 "cDs" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
@@ -73311,7 +71349,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
@@ -73319,7 +71356,6 @@
 /area/hallway/secondary/command)
 "cDA" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -73435,7 +71471,6 @@
 /area/maintenance/fore/secondary)
 "cDP" = (
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73450,7 +71485,6 @@
 "cDR" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -73592,7 +71626,6 @@
 /area/medical/morgue)
 "cEf" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/atmos/mix_output{
-	icon_state = "vent_map_siphon_on-2";
 	dir = 1
 	},
 /turf/open/floor/engine/air,
@@ -73616,9 +71649,9 @@
 	icon_state = "0-2"
 	},
 /obj/machinery/power/apc{
+	areastring = "/area/medical/morgue";
 	dir = 4;
 	name = "Morgue APC";
-	areastring = "/area/medical/morgue";
 	pixel_x = 26
 	},
 /turf/open/floor/plasteel/dark,
@@ -73732,7 +71765,6 @@
 "cEm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -73893,7 +71925,6 @@
 /area/medical/morgue)
 "cEy" = (
 /obj/machinery/firealarm{
-	dir = 2;
 	pixel_y = 24
 	},
 /obj/effect/turf_decal/bot,
@@ -73901,11 +71932,9 @@
 /area/science/mixing)
 "cEz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -73915,15 +71944,14 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
+/obj/structure/closet/wardrobe/chemistry_white,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cEA" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/closet/secure_closet/chemical,
@@ -73937,17 +71965,19 @@
 /obj/item/wrench/medical,
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "cEC" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/computer/pandemic,
@@ -74048,14 +72078,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cEM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74082,7 +72110,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74095,7 +72122,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74129,11 +72155,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74146,7 +72170,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -74157,7 +72180,6 @@
 /area/hallway/primary/starboard)
 "cER" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74170,14 +72192,12 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "cET" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74208,7 +72228,6 @@
 /area/crew_quarters/locker)
 "cEW" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74218,11 +72237,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -74296,7 +72313,6 @@
 	pixel_x = 24
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/carpet/royalblack,
@@ -74319,7 +72335,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74329,11 +72344,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74341,7 +72354,6 @@
 "cFg" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -74391,7 +72403,6 @@
 	},
 /obj/machinery/disposal/bin,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/disposalpipe/trunk{
@@ -74407,7 +72418,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/monkey_recycler,
@@ -74481,10 +72491,9 @@
 "cFv" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/structure/fireaxecabinet{
-	pixel_x = -31;
+	pixel_x = -31
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74512,18 +72521,15 @@
 /area/engine/atmos)
 "cFA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFB" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -74547,7 +72553,6 @@
 /area/crew_quarters/fitness/recreation)
 "cFD" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/closet/crate,
@@ -74568,11 +72573,9 @@
 "cFG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -74597,7 +72600,6 @@
 /area/crew_quarters/fitness/recreation)
 "cFK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -74863,15 +72865,16 @@
 "cFX" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cFY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
+	},
+/obj/machinery/vr_sleeper{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
@@ -74948,7 +72951,6 @@
 "cGe" = (
 /obj/machinery/vending/clothing,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74961,12 +72963,9 @@
 	c_tag = "Locker Room Aft";
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/vending/kink,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -74984,7 +72983,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Dorms - Port Fore";
-	dir = 2;
 	name = "dormitories camera"
 	},
 /obj/structure/sign/poster/official/no_erp{
@@ -75010,7 +73008,6 @@
 /area/crew_quarters/fitness/recreation)
 "cGi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -75039,7 +73036,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75050,7 +73046,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75102,7 +73097,6 @@
 "cGp" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75125,7 +73119,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -75150,11 +73143,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -75225,7 +73216,6 @@
 "cGy" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75245,7 +73235,6 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75255,11 +73244,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/light/small,
@@ -75280,7 +73267,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -75322,14 +73308,12 @@
 /area/medical/virology)
 "cGG" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "cGH" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75360,7 +73344,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75383,7 +73366,6 @@
 /area/engine/atmos)
 "cGL" = (
 /obj/machinery/computer/camera_advanced/base_construction{
-	icon_state = "computer";
 	dir = 1
 	},
 /obj/machinery/light,
@@ -75391,7 +73373,6 @@
 /area/construction/mining/aux_base)
 "cGM" = (
 /obj/machinery/computer/shuttle/mining{
-	icon_state = "computer";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75428,7 +73409,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/yellow{
@@ -75441,7 +73421,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
@@ -75465,7 +73444,6 @@
 "cGT" = (
 /obj/machinery/light/small,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -75488,7 +73466,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -75497,21 +73474,18 @@
 /obj/structure/table,
 /obj/item/storage/fancy/donut_box,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cGX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "cGY" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark,
@@ -75553,7 +73527,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75569,7 +73542,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -75594,7 +73566,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75615,7 +73586,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/button/door{
@@ -75632,6 +73602,9 @@
 	icon_state = "1-2"
 	},
 /obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/space/basic,
 /area/engine/engineering)
 "cHi" = (
@@ -75639,7 +73612,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
@@ -75655,7 +73627,6 @@
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel/white,
@@ -75730,7 +73701,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/navbeacon{
@@ -75741,7 +73711,6 @@
 /area/hallway/primary/aft)
 "cHs" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/navbeacon{
@@ -75755,7 +73724,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -75783,7 +73751,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75791,7 +73758,6 @@
 "cHv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -75802,7 +73768,6 @@
 /area/hallway/primary/aft)
 "cHw" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/navbeacon{
@@ -75832,7 +73797,6 @@
 /area/hallway/secondary/entry)
 "cHy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/navbeacon{
@@ -75885,7 +73849,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75910,11 +73873,9 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/yellow/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/red/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -75930,7 +73891,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75943,7 +73903,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75963,7 +73922,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75974,7 +73932,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -75985,7 +73942,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -75997,7 +73953,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -76019,7 +73974,6 @@
 /area/engine/break_room)
 "cHM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76107,7 +74061,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -76117,7 +74070,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76129,7 +74081,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76140,7 +74091,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76150,7 +74100,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -76181,7 +74130,6 @@
 	},
 /obj/structure/rack,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/screwdriver,
@@ -76298,7 +74246,6 @@
 /area/maintenance/starboard/aft)
 "cIi" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/light{
@@ -76313,14 +74260,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/main)
 "cIk" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -76330,7 +74275,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -76345,11 +74289,9 @@
 	icon_state = "0-4"
 	},
 /obj/machinery/power/solar_control{
-	name = "Port Bow Solar Control";
-	icon_state = "computer";
 	dir = 4;
 	id = "foreport";
-	track = 0
+	name = "Port Bow Solar Control"
 	},
 /obj/structure/cable,
 /obj/structure/sign/warning/vacuum/external{
@@ -76375,7 +74317,6 @@
 /area/security/brig)
 "cIo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
@@ -76395,14 +74336,13 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/flasher{
 	id = "brigflashdoor";
-	pixel_x = -26;
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
 "cIq" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/stripes/red/corner{
-	icon_state = "warninglinecorner_red";
 	dir = 1
 	},
 /obj/structure/disposalpipe/segment,
@@ -76415,11 +74355,9 @@
 /area/security/brig)
 "cIr" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76462,7 +74400,6 @@
 "cIw" = (
 /obj/structure/closet/wardrobe/white,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -76471,7 +74408,6 @@
 "cIx" = (
 /obj/structure/closet/wardrobe/grey,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -76519,42 +74455,36 @@
 /area/gateway)
 "cID" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIF" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cIH" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
 "cII" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -76565,7 +74495,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/status_display/ai{
@@ -76588,7 +74517,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -76598,11 +74526,9 @@
 /area/hallway/primary/starboard)
 "cIM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -76610,12 +74536,10 @@
 /area/hallway/primary/starboard)
 "cIN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -76634,7 +74558,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -76657,7 +74580,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76670,11 +74592,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -76686,12 +74606,10 @@
 	light_color = "#c1caff"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -76786,7 +74704,6 @@
 	},
 /obj/structure/chair/sofa/left,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76799,7 +74716,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/status_display/evac{
@@ -76840,7 +74756,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76858,7 +74773,6 @@
 "cJi" = (
 /obj/structure/closet/secure_closet/personal/patient,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/ai{
@@ -76868,7 +74782,6 @@
 /area/medical/medbay/central)
 "cJj" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -76933,7 +74846,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -76958,8 +74870,7 @@
 	dir = 4
 	},
 /obj/machinery/camera{
-	c_tag = "Security - Head of Security's Office";
-	dir = 2
+	c_tag = "Security - Head of Security's Office"
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/hos)
@@ -77013,7 +74924,7 @@
 /obj/structure/closet/secure_closet/hos,
 /obj/effect/turf_decal/tile/red,
 /obj/item/storage/secure/safe/HoS{
-	pixel_x = 36;
+	pixel_x = 36
 	},
 /obj/machinery/status_display/ai{
 	pixel_y = -32
@@ -77039,7 +74950,6 @@
 /obj/machinery/light,
 /obj/structure/closet/wardrobe/green,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -77056,7 +74966,6 @@
 /area/crew_quarters/locker)
 "cJC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/chair/stool,
@@ -77083,7 +74992,6 @@
 "cJG" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -77138,7 +75046,6 @@
 /obj/structure/reagent_dispensers/watertank/high,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -77202,15 +75109,12 @@
 /area/maintenance/starboard/aft)
 "cJS" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -77301,7 +75205,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -77322,7 +75225,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -77334,18 +75236,15 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cKd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -77359,7 +75258,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/landmark/xeno_spawn,
@@ -77398,9 +75296,6 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cKh" = (
-/obj/structure/cable/yellow{
-	icon_state = "2-4"
-	},
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -77578,11 +75473,9 @@
 "cKA" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -77593,7 +75486,6 @@
 /area/crew_quarters/fitness/recreation)
 "cKC" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -77656,8 +75548,8 @@
 /area/construction)
 "cKI" = (
 /obj/machinery/power/apc{
-	name = "Construction Area APC";
 	areastring = "/area/construction";
+	name = "Construction Area APC";
 	pixel_y = -24
 	},
 /obj/structure/cable{
@@ -77927,7 +75819,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77936,29 +75827,24 @@
 "cLa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cLb" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cLc" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77968,7 +75854,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -77979,7 +75864,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77989,7 +75873,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -77999,7 +75882,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78009,7 +75891,6 @@
 	dir = 10
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78022,7 +75903,6 @@
 "cLj" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78031,7 +75911,6 @@
 /obj/machinery/atmospherics/pipe/simple/green/visible,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78039,7 +75918,6 @@
 "cLl" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78050,12 +75928,9 @@
 /turf/open/floor/carpet,
 /area/crew_quarters/dorms)
 "cLn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 2
-	},
+/obj/effect/turf_decal/tile/neutral,
 /obj/structure/closet/wardrobe/mixed,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -78101,6 +75976,9 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cLs" = (
@@ -78133,7 +76011,6 @@
 /area/engine/storage_shared)
 "cLv" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -78142,7 +76019,6 @@
 "cLw" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -78159,7 +76035,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -78200,7 +76075,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/door/airlock/security/glass{
@@ -78212,7 +76086,6 @@
 /area/security/brig)
 "cLA" = (
 /obj/machinery/turnstile{
-	icon_state = "turnstile_map";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78302,33 +76175,27 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -78336,28 +76203,23 @@
 "cLM" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark/corner{
-	icon_state = "darkcorner";
 	dir = 8
 	},
 /area/hallway/primary/aft)
 "cLO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
@@ -78369,7 +76231,6 @@
 /obj/effect/turf_decal/bot,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -78417,7 +76278,6 @@
 	network = list("minisat")
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
@@ -78439,7 +76299,6 @@
 "cLW" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -78461,15 +76320,12 @@
 /area/maintenance/fore)
 "cLZ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78486,15 +76342,12 @@
 "cMb" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -78530,14 +76383,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/item/radio/intercom{
 	dir = 4;
 	freerange = 1;
 	name = "Station Intercom (Telecomms)";
-	pixel_x = 30;
+	pixel_x = 30
 	},
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -78605,7 +76457,6 @@
 /area/security/range)
 "cMi" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -78623,7 +76474,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -78649,12 +76499,10 @@
 /area/crew_quarters/heads/captain/private)
 "cMl" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera{
 	c_tag = "Science Entrance";
-	dir = 2;
 	name = "science camera";
 	network = list("ss13","rd")
 	},
@@ -78664,7 +76512,6 @@
 /obj/machinery/light,
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/bot,
@@ -78763,22 +76610,18 @@
 /area/crew_quarters/fitness/recreation)
 "cMy" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cMz" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -78887,7 +76730,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -78923,14 +76765,12 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cMM" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /turf/open/floor/plating,
@@ -78973,7 +76813,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79000,7 +76839,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79031,7 +76869,6 @@
 /obj/machinery/plantgenes,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera{
@@ -79042,7 +76879,6 @@
 /area/hydroponics)
 "cMU" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/red{
@@ -79060,15 +76896,13 @@
 /area/hallway/secondary/exit/departure_lounge)
 "cMV" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/machinery/camera{
-	c_tag = "Departure Lounge - Starboard Fore";
-	dir = 2
+	c_tag = "Departure Lounge - Starboard Fore"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -79079,7 +76913,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/camera{
 	c_tag = "Escape Hallway";
-	dir = 2;
 	name = "departures camera"
 	},
 /turf/open/floor/plasteel,
@@ -79090,7 +76923,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library";
-	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/wood,
@@ -79119,7 +76951,6 @@
 "cNa" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79158,11 +76989,9 @@
 "cNd" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79170,7 +76999,6 @@
 "cNe" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -79194,7 +77022,6 @@
 /obj/structure/table,
 /obj/item/storage/box/donkpockets,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79205,7 +77032,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -79241,7 +77067,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -79259,7 +77084,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera{
@@ -79270,7 +77094,6 @@
 /area/engine/atmos)
 "cNm" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -79289,7 +77112,6 @@
 /area/engine/atmos)
 "cNo" = (
 /obj/machinery/computer/arcade{
-	icon_state = "arcade";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -79306,7 +77128,6 @@
 /area/security/vacantoffice/a)
 "cNr" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/wood,
@@ -79314,11 +77135,9 @@
 "cNs" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -79328,7 +77147,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -79355,7 +77173,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -79375,7 +77192,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
@@ -79385,7 +77201,6 @@
 /area/engine/storage)
 "cNz" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -79410,7 +77225,6 @@
 "cNB" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/navbeacon{
@@ -79427,7 +77241,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/purple,
@@ -79454,11 +77267,9 @@
 	},
 /obj/effect/landmark/start/botanist,
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79466,9 +77277,8 @@
 "cNF" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
-	name = "Upload APC";
 	areastring = "/area/ai_monitored/turret_protected/ai_upload";
+	name = "Upload APC";
 	pixel_y = -24
 	},
 /obj/machinery/camera/motion{
@@ -79552,7 +77362,6 @@
 /area/teleporter)
 "cNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/camera/autoname{
@@ -79577,7 +77386,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79585,7 +77393,6 @@
 "cNO" = (
 /obj/machinery/vending/wardrobe/gene_wardrobe,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -79616,7 +77423,6 @@
 /area/medical/virology)
 "cNS" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/freezer,
@@ -79635,7 +77441,6 @@
 	},
 /obj/effect/turf_decal/delivery,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79656,14 +77461,12 @@
 /area/crew_quarters/toilet)
 "cNV" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/grimy,
 /area/hallway/secondary/entry)
 "cNW" = (
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79676,7 +77479,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79699,7 +77501,6 @@
 	dir = 1
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -79712,14 +77513,12 @@
 	pixel_x = 30
 	},
 /obj/machinery/modular_computer/console/preset/engineering{
-	icon_state = "console";
 	dir = 8
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel/dark/corner,
@@ -79728,7 +77527,6 @@
 /obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/bot,
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
@@ -79748,7 +77546,6 @@
 "cOd" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/camera/autoname,
@@ -79777,7 +77574,6 @@
 "cOg" = (
 /obj/structure/disposalpipe/trunk,
 /obj/structure/disposaloutlet{
-	icon_state = "outlet";
 	dir = 8
 	},
 /turf/open/floor/plating/asteroid/airless,
@@ -79935,7 +77731,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -79974,7 +77769,6 @@
 	dir = 5
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -80012,11 +77806,13 @@
 /area/engine/engineering)
 "cOJ" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -80050,6 +77846,9 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 8
 	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cOO" = (
@@ -80057,12 +77856,18 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cOP" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -80175,7 +77980,6 @@
 "cPe" = (
 /obj/effect/landmark/xeno_spawn,
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80241,7 +78045,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -80272,7 +78075,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -80439,11 +78241,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
@@ -80547,7 +78347,6 @@
 /area/maintenance/fore/secondary)
 "cPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80674,9 +78473,8 @@
 "cQo" = (
 /obj/structure/table,
 /obj/machinery/power/apc{
-	dir = 2;
-	name = "Cargo Office APC";
 	areastring = "/area/quartermaster/office";
+	name = "Cargo Office APC";
 	pixel_x = 1;
 	pixel_y = -24
 	},
@@ -80684,7 +78482,6 @@
 	icon_state = "0-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80746,7 +78543,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/light{
@@ -80795,7 +78591,6 @@
 "cQE" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80851,7 +78646,6 @@
 	dir = 8
 	},
 /obj/machinery/camera/autoname{
-	icon_state = "camera";
 	dir = 10
 	},
 /turf/open/floor/plasteel,
@@ -80895,7 +78689,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -80906,14 +78699,12 @@
 /area/hallway/primary/central)
 "cQP" = (
 /obj/structure/chair/sofa/corp{
-	icon_state = "corp_sofamiddle";
 	dir = 8
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
 "cQQ" = (
 /obj/structure/chair/sofa/corp/left{
-	icon_state = "corp_sofaend_left";
 	dir = 8
 	},
 /turf/open/floor/plating,
@@ -80971,7 +78762,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81028,16 +78818,13 @@
 "cRe" = (
 /obj/structure/cable,
 /obj/machinery/power/apc/highcap/five_k{
-	dir = 2;
 	name = "Kitchen APC";
 	pixel_y = -24
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/machinery/food_cart,
@@ -81096,12 +78883,10 @@
 /area/engine/transit_tube)
 "cRl" = (
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
 	dir = 1
 	},
 /obj/machinery/power/apc{
 	areastring = "/area/engine/transit_tube";
-	dir = 2;
 	name = "Transit Tube APC";
 	pixel_y = -26
 	},
@@ -81238,7 +79023,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81280,7 +79064,6 @@
 	icon_state = "2-8"
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81292,7 +79075,6 @@
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/junction/yjunction{
-	icon_state = "pipe-y";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -81309,7 +79091,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/corner{
-	icon_state = "trimline_corner";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81332,7 +79113,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81361,7 +79141,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81421,7 +79200,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81454,7 +79232,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81487,7 +79264,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81517,7 +79293,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81551,7 +79326,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81578,7 +79352,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81602,7 +79375,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/blue/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81630,7 +79402,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/white/line{
-	icon_state = "trimline";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81665,7 +79436,6 @@
 	icon_state = "2-4"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -81704,7 +79474,6 @@
 "cSi" = (
 /obj/structure/bed/dogbed/ian,
 /obj/item/radio/intercom{
-	dir = 2;
 	pixel_y = 28
 	},
 /turf/open/floor/wood,
@@ -81763,46 +79532,42 @@
 /area/crew_quarters/fitness/recreation)
 "cSo" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "cSq" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
-	icon_state = "trimline_corner_fill";
+	dir = 4
+	},
+/obj/machinery/vr_sleeper{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -81810,7 +79575,6 @@
 "cSs" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81818,7 +79582,6 @@
 "cSt" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/light{
@@ -81830,7 +79593,6 @@
 "cSu" = (
 /obj/machinery/airalarm/directional/south,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81843,7 +79605,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/machinery/door/poddoor/preopen{
@@ -81866,6 +79627,9 @@
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cSx" = (
@@ -81875,7 +79639,6 @@
 	},
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/sign/warning/nosmoking{
@@ -81885,7 +79648,6 @@
 /area/engine/atmos)
 "cSy" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -81896,11 +79658,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/red/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /turf/open/floor/plasteel,
@@ -81908,11 +79668,9 @@
 "cSA" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/item/reagent_containers/food/snacks/mint,
@@ -81924,7 +79682,6 @@
 /area/crew_quarters/kitchen)
 "cSB" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -81938,7 +79695,6 @@
 /area/maintenance/port/aft)
 "cSE" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -81948,19 +79704,16 @@
 	icon_state = "1-2"
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cSG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -81996,7 +79749,6 @@
 /area/hallway/primary/central)
 "cSK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -82014,7 +79766,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/engineering{
@@ -82027,7 +79778,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/item/radio/intercom{
@@ -82322,7 +80072,6 @@
 /area/engine/atmos)
 "cTA" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82333,7 +80082,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
@@ -82448,7 +80196,6 @@
 "cTP" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/structure/sign/departments/restroom{
@@ -82458,7 +80205,6 @@
 /area/crew_quarters/fitness/recreation)
 "cTQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 6
 	},
 /obj/structure/sign/departments/restroom{
@@ -82484,12 +80230,10 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/directions/evac{
 	dir = 8;
-	icon_state = "direction_evac";
 	pixel_x = 32
 	},
 /obj/structure/sign/directions/engineering{
@@ -82529,7 +80273,6 @@
 	},
 /obj/structure/sign/directions/medical{
 	dir = 1;
-	icon_state = "direction_med";
 	pixel_y = 40
 	},
 /turf/open/floor/plasteel,
@@ -82539,16 +80282,13 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /obj/structure/sign/directions/medical{
 	dir = 1;
-	icon_state = "direction_med";
 	pixel_x = 32;
 	pixel_y = 40
 	},
@@ -82559,7 +80299,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/departments/engineering{
@@ -82572,7 +80311,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/sign/departments/engineering{
@@ -82588,7 +80326,6 @@
 /area/maintenance/department/cargo)
 "cUb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/cable{
@@ -82609,7 +80346,6 @@
 "cUc" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/departments/holy{
@@ -82654,7 +80390,6 @@
 "cUi" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 9
 	},
 /obj/effect/turf_decal/tile/blue,
@@ -82698,7 +80433,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/extinguisher_cabinet{
@@ -82709,7 +80443,6 @@
 /area/medical/virology)
 "cUp" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
@@ -82725,13 +80458,12 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/green/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/doorButtons/airlock_controller{
 	idExterior = "virology_airlock_exterior";
-	idSelf = "virology_airlock_control";
 	idInterior = "virology_airlock_interior";
+	idSelf = "virology_airlock_control";
 	name = "Virology Access Console";
 	pixel_x = 26;
 	pixel_y = 26;
@@ -82846,7 +80578,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/extinguisher_cabinet{
@@ -82916,7 +80647,6 @@
 /area/maintenance/department/crew_quarters/dorms)
 "cUR" = (
 /obj/structure/chair/sofa/corp/right{
-	icon_state = "corp_sofaend_right";
 	dir = 8
 	},
 /obj/item/storage/daki,
@@ -82971,7 +80701,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -82982,7 +80711,6 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/structure/cable{
@@ -83000,7 +80728,6 @@
 	pixel_y = 30
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/structure/cable{
@@ -83053,7 +80780,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -83080,7 +80806,6 @@
 	},
 /obj/structure/closet/secure_closet/security,
 /obj/effect/turf_decal/trimline/red/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/machinery/airalarm/directional/west,
@@ -83472,7 +81197,6 @@
 "cWo" = (
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/crowbar,
@@ -83490,15 +81214,12 @@
 /area/crew_quarters/fitness/recreation)
 "cWr" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 8
 	},
 /obj/structure/pool/Rboard,
@@ -83555,7 +81276,6 @@
 /area/maintenance/solars/starboard/aft)
 "cWx" = (
 /obj/machinery/power/terminal{
-	icon_state = "term";
 	dir = 8
 	},
 /obj/structure/cable{
@@ -83581,7 +81301,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/machinery/airalarm/directional/west,
@@ -83600,7 +81319,6 @@
 /area/engine/break_room)
 "cWB" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 4
 	},
 /obj/structure/sign/warning/enginesafety{
@@ -83699,7 +81417,6 @@
 "cWL" = (
 /obj/machinery/power/apc{
 	areastring = "/area/engine/storage";
-	dir = 2;
 	name = "Engineering Storage APC";
 	pixel_y = -26
 	},
@@ -83795,7 +81512,6 @@
 /area/crew_quarters/locker)
 "cWV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/machinery/status_display/evac{
@@ -83823,7 +81539,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -83845,7 +81560,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
@@ -83864,7 +81578,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -83880,7 +81593,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue{
@@ -84086,7 +81798,7 @@
 	areastring = "/area/maintenance/department/electrical";
 	dir = 4;
 	name = "Electrical Maintenance APC";
-	pixel_x = 24;
+	pixel_x = 24
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -84186,7 +81898,6 @@
 	pixel_x = 24
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
-	icon_state = "trimline_fill";
 	dir = 5
 	},
 /obj/machinery/vending/medical{
@@ -84203,14 +81914,12 @@
 	},
 /obj/effect/turf_decal/tile,
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 1
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	icon_state = "vent_map_on-1";
 	dir = 8
 	},
 /obj/effect/landmark/event_spawn,
@@ -84244,7 +81953,6 @@
 /area/medical/medbay/central)
 "cXL" = (
 /obj/effect/turf_decal/tile{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile,
@@ -84267,11 +81975,10 @@
 /area/crew_quarters/heads/chief/private)
 "cXO" = (
 /obj/machinery/status_display/ai{
-	pixel_x = -32;
+	pixel_x = -32
 	},
 /obj/machinery/power/apc/highcap/ten_k{
 	areastring = "/area/crew_quarters/heads/chief/private";
-	dir = 2;
 	name = "Chief Engineer's Quarters APC";
 	pixel_y = -24
 	},
@@ -84305,9 +82012,6 @@
 /area/quartermaster/qm/private)
 "cXU" = (
 /obj/structure/cable/yellow{
-	icon_state = "2-8"
-	},
-/obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line{
@@ -84326,16 +82030,18 @@
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "cXW" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
+/turf/closed/wall/r_wall,
+/area/science/circuit)
 "cXX" = (
-/obj/structure/cable/yellow,
 /obj/machinery/power/emitter/anchored{
 	dir = 1;
 	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
@@ -84344,7 +82050,6 @@
 	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	icon_state = "scrub_map_on-3";
 	dir = 8
 	},
 /turf/open/floor/plasteel,
@@ -84365,16 +82070,13 @@
 /area/crew_quarters/cafeteria)
 "cYa" = (
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/bar{
-	icon_state = "tile_corner";
 	dir = 8
 	},
 /obj/machinery/camera{
-	c_tag = "Kitchen Starboard";
-	dir = 2
+	c_tag = "Kitchen Starboard"
 	},
 /obj/machinery/light{
 	dir = 1;
@@ -84391,7 +82093,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -84406,7 +82107,6 @@
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /obj/item/radio/intercom{
@@ -84450,7 +82150,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/line{
-	icon_state = "trimline_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -84466,7 +82165,6 @@
 	icon_state = "1-8"
 	},
 /obj/effect/turf_decal/trimline/yellow/filled/corner{
-	icon_state = "trimline_corner_fill";
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -84494,6 +82192,9213 @@
 /obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/maintenance/aft)
+"ddh" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dfH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dfW" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"dgb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"dgh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dhT" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"diH" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dmw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"dmF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"dnB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"doD" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"drN" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dsE" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"duB" = (
+/obj/effect/turf_decal/trimline/purple/filled/line,
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"duY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"dwu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dxi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dyQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dzF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dAC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"dBn" = (
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"dBy" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dCq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"dCL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage)
+"dEp" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"dFe" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dFt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dFG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"dGX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dIv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"dJU" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dPK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"dQa" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dQT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dRM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"dSS" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"dWj" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"dWs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"dWz" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"dXw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"dZP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ean" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ebs" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"ecb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ect" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"eec" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"eeF" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ehb" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ehe" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"ehl" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"eia" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ely" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"elZ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"eng" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"enm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"eor" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eot" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"eqe" = (
+/obj/effect/turf_decal/caution{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/warehouse)
+"eqk" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"eqX" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"etb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"etT" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eum" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"evX" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"eyJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"ezo" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"eBy" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"eDp" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"eDw" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"eDP" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eFn" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"eFp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"eFR" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"eGt" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eHp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"eHx" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"eIr" = (
+/turf/open/floor/plasteel/cult,
+/area/library)
+"eJn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"eMX" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"eNI" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"ePb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"ePe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ePf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ePw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"eTx" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"eVg" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"eXk" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"eYT" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fah" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"faL" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fbf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"fbg" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"ffU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fhd" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fjA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fjH" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"fjJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"fkp" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"fmA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"fow" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/structure/chair,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"fqz" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"fqL" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"frA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"fsj" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fsz" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"fua" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"fuH" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fvi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fwg" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"fxB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fxW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"fzX" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"fAL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fDN" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fEh" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"fEs" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"fEH" = (
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fIe" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fJs" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fKc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"fLq" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fMa" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fMb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"fMq" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fNq" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"fOG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"fOO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"fPC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"fQN" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"fQZ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"fSW" = (
+/obj/effect/spawner/structure/window/plasma/reinforced,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
+"fTY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"fVC" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"fXb" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"fXq" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"fYk" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fYP" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"fZf" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"fZL" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"fZN" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"gbe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gbn" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"gdL" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"geu" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gev" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ggi" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"giI" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gjl" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"gjs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"gmv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"gnP" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gqj" = (
+/obj/machinery/light/small{
+	dir = 4;
+	light_color = "#d8b1b1"
+	},
+/obj/machinery/light_switch{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/wood,
+/area/crew_quarters/dorms)
+"gra" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"grj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"gsS" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"guj" = (
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"gvF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"gyt" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gyO" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"gyY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"gCs" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"gCt" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"gIr" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"gIA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"gLE" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gMF" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"gMN" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gMV" = (
+/obj/effect/turf_decal/trimline/red/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"gOF" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"gQV" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"gRe" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"gRX" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"gSL" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"gTB" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"gVl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"gVP" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"gZv" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"haK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hbf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hbw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hcn" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"hdz" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"hfX" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hge" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"hhZ" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hne" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"hnu" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"hnx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hof" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"hpB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hqw" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hwC" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hxZ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"hBb" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"hBn" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hBF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hBR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hBS" = (
+/obj/machinery/deepfryer,
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"hCc" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hDp" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"hDI" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"hIv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"hIK" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"hIQ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hIR" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hJo" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"hKf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"hLF" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hLO" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"hMI" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"hQh" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"hST" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hUm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"hVN" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
+	},
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/tesla_coil,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"hWH" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"hWN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"hZd" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"ibP" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"icD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"icF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ihc" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ihw" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ijW" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ikz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/conveyor{
+	backwards = 1;
+	forwards = 2;
+	id = "trashsort"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/sorting)
+"ilr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ilx" = (
+/obj/structure/closet/secure_closet/personal,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"imY" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"inf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"iow" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ioQ" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ipF" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"ipL" = (
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"iqD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"irl" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iup" = (
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ivm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ivT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"iwD" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ixb" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ixl" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iyp" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"iyH" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iza" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iAi" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"iBJ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"iBN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iEh" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iEs" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"iEH" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"iFg" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iGm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"iGy" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"iJE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "2-4"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"iJK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iJM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"iLI" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"iMB" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iME" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iNd" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"iPe" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"iPN" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"iPQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"iSF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"iVC" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"iWu" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"iWA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"iXT" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jbX" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jdI" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"jei" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jeu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jeK" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"jfS" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"jgJ" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"jjH" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"jkm" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jkP" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"joZ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jqb" = (
+/obj/structure/chair,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"jtn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"jtx" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jtU" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"juo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jvo" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"jvp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jza" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jzl" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"jzT" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jCQ" = (
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"jFn" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"jFJ" = (
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
+	},
+/obj/machinery/power/rad_collector/anchored,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"jFN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jGm" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"jGv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jGE" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"jJu" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jKq" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jLE" = (
+/obj/machinery/light/small{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jMn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"jMK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"jNI" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"jPg" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"jPn" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jPp" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"jPE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"jPS" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"jQW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"jRu" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jRE" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jSU" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/storage_shared)
+"jUx" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"jUX" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jXg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"jXp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"jYB" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kag" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"kau" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"kaB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"kcN" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"kdD" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"kdY" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"kfJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"khi" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"khx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kin" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kkw" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"klf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kmR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"kno" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kpD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"ksP" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"ktm" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ktI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"kuT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"kwd" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"kwG" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kxi" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kzJ" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kzK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kBv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"kDs" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/item/twohanded/required/kirbyplants/random,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"kDv" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"kDQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"kDS" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kEK" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kGk" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"kHg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"kHE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"kJA" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"kJG" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kJX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"kKc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"kKJ" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"kNb" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"kNu" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kNH" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kNJ" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"kPe" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kPl" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"kQG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"kTg" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"kUz" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"kVW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kXQ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"kYW" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"lbm" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"lbU" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"lce" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"lcf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"ldv" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"let" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"leP" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"liQ" = (
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"lkU" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/item/radio/intercom{
+	dir = 4;
+	pixel_x = 27
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"llB" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"lnz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lnB" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lou" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lpt" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lpx" = (
+/obj/structure/table,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
+/turf/open/floor/plasteel/white,
+/area/medical/chemistry)
+"lpI" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/machinery/vr_sleeper{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/locker)
+"lpL" = (
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"lqd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/security/brig)
+"lrT" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lss" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ltu" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ltJ" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ltP" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lug" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"lzw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"lAu" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lAF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lAP" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lBj" = (
+/turf/open/floor/plasteel/cult,
+/area/library)
+"lCX" = (
+/obj/machinery/door/firedoor,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lEh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"lKh" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"lKk" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"lLj" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"lLo" = (
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor2";
+	name = "Supply Dock Loading Door"
+	},
+/obj/machinery/conveyor{
+	id = "QMLoad2"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"lLS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"lMc" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"lNj" = (
+/obj/machinery/conveyor{
+	dir = 1;
+	id = "QMLoad"
+	},
+/obj/machinery/door/poddoor{
+	id = "QMLoaddoor";
+	name = "Supply Dock Loading Door"
+	},
+/turf/open/floor/plating,
+/area/quartermaster/storage)
+"lNQ" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"lPG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"lQX" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"lRt" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"lSu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"lTj" = (
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"lTR" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"lWy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"lWO" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"lYr" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"lYR" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"maO" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mbG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mdb" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mdU" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"mes" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mgT" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mjv" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mks" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mln" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"mmq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"mnC" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"mqh" = (
+/obj/structure/chair{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"msN" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"mts" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mtV" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"muM" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"mvo" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"mvq" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mvN" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mwk" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mxS" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"mxW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mxY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mza" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"mAZ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"mBg" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mCp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mDJ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"mEn" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mEp" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mFd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mFO" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mGB" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"mMj" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"mNk" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow,
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"mNW" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mTV" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"mUQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ndS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"neC" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
+"neT" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nfi" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"nfv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ngt" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"njs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nkc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nkH" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nlu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nmx" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nnp" = (
+/obj/machinery/turnstile{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nnI" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nqu" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nrj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nrn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nsK" = (
+/obj/effect/turf_decal/trimline/yellow/filled/corner{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"nsR" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ntq" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"ntW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"nuO" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"nvK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"nwy" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nzQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nAB" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nAF" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"nBd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nDn" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"nFt" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"nGf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"nGs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"nGC" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nHk" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nIA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"nJX" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nKe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"nMT" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"nOP" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"nRc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"nSY" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nUG" = (
+/obj/effect/turf_decal/trimline/purple/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"nVl" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"nXF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"nXH" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"nXM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"nYh" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"nYJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"oad" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"oai" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oaG" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"obN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"ocr" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"ocA" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oeP" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ofD" = (
+/obj/machinery/door/firedoor,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"oiR" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"ojZ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"ong" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"onU" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"oop" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"opw" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oqT" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"ore" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"orS" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oxP" = (
+/obj/structure/showcase/cyborg/old{
+	pixel_y = 20
+	},
+/turf/open/floor/plasteel/grimy,
+/area/tcommsat/computer)
+"ozj" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"oAg" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oAX" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oBz" = (
+/obj/structure/closet/secure_closet/engineering_personal,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"oCd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"oCS" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"oFM" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"oHo" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"oIo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"oJk" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"oJp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oKi" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"oKO" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"oLY" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oMh" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oQL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"oSv" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oSL" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"oSY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"oVv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"oWI" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"oYz" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pad" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"pcz" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pfv" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pht" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"phw" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"phO" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"pmc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pmd" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pnj" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"poC" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pqf" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"pqo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"prf" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ptp" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"puL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pws" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pxf" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"pza" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"pAg" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"pBb" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pDj" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pDu" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pGh" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"pGQ" = (
+/obj/machinery/light{
+	dir = 8;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pHw" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"pKs" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pLo" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"pMK" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pNA" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"pPn" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pQe" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"pTa" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pTW" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pUf" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"pUV" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pVq" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pVI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"pWd" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"pWk" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"pXL" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qae" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qag" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qai" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qax" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"qaH" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"qbQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qcn" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"qee" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"qfI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qil" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qiu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qmF" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"qou" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qoQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"quq" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"qur" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"qvk" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"qvC" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qxc" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qAj" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"qBh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qCl" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"qDa" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"qFo" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"qFC" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"qLL" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"qML" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"qOp" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"qPX" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"qUA" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"qVb" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"raQ" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"rcK" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"rcM" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"reY" = (
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"rfd" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"rfi" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"rfK" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rfR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rga" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rgk" = (
+/obj/effect/turf_decal/tile/bar,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rjv" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"rjC" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"rlr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rml" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rnR" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"rnY" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rpE" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"rqB" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"rqY" = (
+/obj/structure/cable{
+	icon_state = "1-4"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"rsJ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rtm" = (
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/science/circuit)
+"rtD" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"rus" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"rvX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"rwZ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"rxT" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ryg" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ryJ" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"rAb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rBk" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rBB" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rFE" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"rFK" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rGd" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rGm" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"rHQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rIV" = (
+/obj/structure/closet/wardrobe/cargotech,
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/storage)
+"rKH" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"rLf" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"rNy" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rPu" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"rRK" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"rUI" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/brig)
+"rVD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"rXa" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"rXW" = (
+/obj/effect/turf_decal/caution{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/office)
+"rYm" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sbg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"sda" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"sej" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sfW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sgV" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"shr" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"skC" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"skW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"skY" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"spN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"spU" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"spW" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"spX" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/yellow{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"srf" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sug" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"suQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"swC" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/trimline/red/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"sxv" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"syz" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"syW" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"szh" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sAu" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"sCj" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sDf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sEg" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"sFe" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sGf" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sIx" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"sIH" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"sKt" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/light,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"sLu" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"sNl" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sPB" = (
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"sQC" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"sSQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"sVe" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"sVq" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"sXb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"sXl" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"sZd" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"tbM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tbT" = (
+/obj/machinery/power/emitter/anchored{
+	dir = 1;
+	state = 2
+	},
+/obj/structure/cable{
+	icon_state = "0-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"tcG" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tdQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"teA" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"teF" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tfI" = (
+/obj/structure/chair/stool,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"tgv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"thv" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tjc" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/machinery/light/small,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"tjO" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"tkv" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"tkG" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/break_room)
+"tln" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tlP" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/gateway)
+"tnV" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"toy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tpy" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"tpJ" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"tqI" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tsA" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"tvc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"txO" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tzm" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tAf" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"tCW" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tDo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tDs" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"tDv" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tER" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tFj" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tFn" = (
+/obj/effect/turf_decal/trimline/green/filled/line,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"tMI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"tPr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"tPW" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"tQj" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tRb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tSf" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"tTR" = (
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"tUR" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"tVa" = (
+/obj/machinery/porta_turret/ai,
+/turf/open/floor/plating,
+/area/ai_monitored/turret_protected/aisat/foyer)
+"tXU" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"tXX" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"tZa" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"uaq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"uaF" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ubl" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"uci" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"ucq" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ufs" = (
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/turret_protected/aisat/hallway)
+"ugN" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uky" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"ulq" = (
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#c1caff"
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"umI" = (
+/obj/structure/urinal{
+	dir = 8;
+	pixel_x = 28
+	},
+/turf/open/floor/plasteel/freezer,
+/area/crew_quarters/toilet)
+"ung" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"unn" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/machinery/vr_sleeper{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"upC" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"urx" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"usc" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"utM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uum" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"uwg" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uxb" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/white/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uxo" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"uzF" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uDE" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uET" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uFf" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"uIi" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uJe" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"uKJ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uKM" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uLi" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uLH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/green/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
+"uLR" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uMl" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
+"uNK" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
+	},
+/area/hallway/primary/aft)
+"uPt" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uQf" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uRi" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"uRw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uRI" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"uSM" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"uVs" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"uWN" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"uWS" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/surgery)
+"uYv" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"uZm" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"uZH" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vcF" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"vdd" = (
+/obj/structure/chair/comfy/teal{
+	dir = 4
+	},
+/turf/open/floor/wood,
+/area/library)
+"vdw" = (
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"veJ" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vgm" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vgI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vhh" = (
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vlw" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"voR" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/genetics)
+"voS" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vpb" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit)
+"vrE" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vtT" = (
+/obj/machinery/light,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vud" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vvS" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vwv" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/light{
+	dir = 4;
+	light_color = "#e8eaff"
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vxz" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vyQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vzy" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vBE" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/security/prison)
+"vDt" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"vDM" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vDW" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"vFo" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vFP" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vGr" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"vGs" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"vHL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vJb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vJu" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"vKZ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"vLp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"vLQ" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/camera/autoname{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"vMw" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"vOv" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vPs" = (
+/obj/effect/turf_decal/tile{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"vPQ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
+"vTO" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"vWi" = (
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wbD" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wga" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"wgc" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"whc" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"whJ" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"wiI" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"wmc" = (
+/obj/effect/turf_decal/trimline/yellow/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"wmw" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/light/small{
+	dir = 1;
+	light_color = "#ffc1c1";
+	pixel_y = -5
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wnq" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wpg" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wpD" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wrk" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"wrL" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wsH" = (
+/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"wtw" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"wtQ" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"wvy" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wvL" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"wwa" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"wEY" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wGp" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"wHI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wHL" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wJn" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"wMr" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wNs" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"wOD" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"wOQ" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wPh" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 6
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wPG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wQY" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"wUP" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wWM" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"wXX" = (
+/obj/effect/turf_decal/tile/purple{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"wYe" = (
+/obj/effect/turf_decal/tile{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/red,
+/obj/structure/chair{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
+"wZC" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/item/radio/intercom{
+	dir = 1;
+	pixel_y = -29
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"wZU" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 6
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner,
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"wZY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"xag" = (
+/turf/closed/wall,
+/area/science/circuit)
+"xaF" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xaM" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xbp" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 5
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xbA" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xcA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"xdW" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xfQ" = (
+/obj/effect/turf_decal/trimline/neutral/filled/end{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xho" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xhI" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xjG" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xmV" = (
+/turf/open/floor/plasteel/dark,
+/area/science/circuit)
+"xoX" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"xpA" = (
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/command)
+"xqi" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
+"xsi" = (
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xte" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xvg" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xyH" = (
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 10
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/corner{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xyI" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xyK" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xCn" = (
+/obj/effect/turf_decal/trimline/purple/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/white,
+/area/science/research)
+"xEk" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"xFo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xGE" = (
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/prison)
+"xGP" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xGR" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xHG" = (
+/obj/structure/lattice/catwalk,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/space/basic,
+/area/engine/engineering)
+"xJT" = (
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/ai_monitored/storage/satellite)
+"xKa" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xKO" = (
+/obj/machinery/cryopod{
+	dir = 4
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/dorms)
+"xMz" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xNb" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xNh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xOR" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"xQo" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"xQx" = (
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/crew_quarters/fitness/recreation)
+"xSy" = (
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 4
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/purple/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"xSD" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xTY" = (
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xUa" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"xUp" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"xVk" = (
+/turf/closed/wall/r_wall,
+/area/science/circuit)
+"xVl" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xVT" = (
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
+	},
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
+"xWw" = (
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
+/obj/structure/disposalpipe/segment,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/yellow/line{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/red/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"xYq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"xYx" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/machinery/light,
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
+"xZt" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"xZG" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/purple,
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
+"ybo" = (
+/obj/structure/disposaloutlet{
+	dir = 8
+	},
+/obj/structure/disposalpipe/trunk,
+/turf/open/floor/engine,
+/area/science/xenobiology)
+"ybq" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"ydk" = (
+/obj/machinery/light{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
+"yfg" = (
+/obj/machinery/power/rad_collector/anchored,
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
+"yfq" = (
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/machinery/light{
+	dir = 8
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/security/brig)
+"yfG" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/secondary/entry)
+"yga" = (
+/obj/machinery/atmospherics/pipe/simple/yellow/visible,
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/engine/atmos)
+"ygo" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 9
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ygV" = (
+/obj/structure/window/reinforced/spawner/north,
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 1
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
+"ygZ" = (
+/obj/machinery/door/firedoor,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/trimline/neutral/filled/line{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
+"yiX" = (
+/obj/structure/window/reinforced/spawner,
+/obj/structure/window/reinforced{
+	dir = 8;
+	layer = 2.9
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
+	dir = 5
+	},
+/obj/effect/turf_decal/trimline/blue/filled/line{
+	dir = 10
+	},
+/turf/open/floor/plasteel/dark,
+/area/aisat)
 
 (1,1,1) = {"
 aaa
@@ -94684,9 +101589,9 @@ bIY
 bIY
 bIY
 byU
-bAS
+fIe
 bVp
-bAa
+iza
 bKd
 bIY
 bIY
@@ -94934,23 +101839,23 @@ aaa
 aaa
 aaa
 bxN
-bAS
-bLI
-bLI
-bLI
-bLI
-bLI
-bLI
+fIe
+iEh
+iEh
+iEh
+iEh
+iEh
+iEh
 bPK
 bRU
 bYA
-bLI
-bLI
-bLI
-bLI
-bLI
-bLI
-bAa
+iEh
+iEh
+iEh
+iEh
+iEh
+iEh
+iza
 bzY
 aab
 aab
@@ -95190,25 +102095,25 @@ aab
 aab
 aab
 bzS
-bAS
-bEK
-bLL
-bLL
-bLL
-bMM
-bNg
+fIe
+hfX
+kDS
+kDS
+kDS
+dZP
+vwv
 bOa
 bPL
 bVq
 caW
-bMM
-bNg
-bMM
-bLL
-bLL
-bLL
+dZP
+vwv
+dZP
+kDS
+kDS
+kDS
 cAh
-cAE
+yiX
 bzY
 aab
 aav
@@ -95446,9 +102351,9 @@ aab
 aab
 aab
 bzS
-bzU
-bEK
-bKZ
+ltJ
+hfX
+kzJ
 bBW
 bJg
 bJg
@@ -95464,9 +102369,9 @@ bBX
 bSd
 bSS
 bAc
-cAn
-cAG
-cAE
+oSL
+xyH
+yiX
 bzY
 aav
 aab
@@ -95702,9 +102607,9 @@ aav
 aab
 aab
 bzS
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 bzV
 aav
 aaa
@@ -95722,9 +102627,9 @@ aab
 aav
 aab
 bAc
-cAN
-cAG
-cAE
+diH
+xyH
+yiX
 bBY
 aab
 aab
@@ -95958,9 +102863,9 @@ aab
 aav
 aab
 bzS
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 bzV
 aab
 aav
@@ -95980,9 +102885,9 @@ aav
 aab
 aab
 bAc
-cAN
-cAG
-cAE
+diH
+xyH
+yiX
 bzY
 aab
 aab
@@ -96214,9 +103119,9 @@ aab
 aab
 aav
 bzS
-bzU
-bEK
-bKZ
+ltJ
+hfX
+kzJ
 bzV
 aab
 aab
@@ -96238,9 +103143,9 @@ aab
 aab
 aab
 bAc
-cAn
-cAG
-cAE
+oSL
+xyH
+yiX
 bzY
 aab
 aab
@@ -96470,8 +103375,8 @@ aab
 aab
 aab
 bDC
-bAS
-bEK
+fIe
+hfX
 bKY
 bzV
 aab
@@ -96496,9 +103401,9 @@ aab
 aab
 aab
 bAc
-cAN
-cAG
-cAE
+diH
+xyH
+yiX
 bzY
 aab
 aaa
@@ -96726,8 +103631,8 @@ aab
 aab
 aab
 bzS
-bAS
-bEK
+fIe
+hfX
 bJF
 bBW
 aab
@@ -96742,7 +103647,7 @@ bBX
 bBX
 bNC
 bOg
-cuS
+fNq
 bBX
 bBX
 bBX
@@ -96756,7 +103661,7 @@ aab
 bAc
 cBd
 cBh
-bAa
+iza
 bzY
 aaa
 aaa
@@ -96982,8 +103887,8 @@ aac
 aab
 aab
 bzS
-bzU
-byW
+ltJ
+tXU
 bKy
 bzV
 aav
@@ -96999,7 +103904,7 @@ aab
 bBX
 bNC
 bOg
-cuT
+jtU
 bBX
 aab
 aab
@@ -97013,8 +103918,8 @@ aab
 aab
 bAc
 clQ
-cBq
-bAa
+mEp
+iza
 bzY
 aaa
 aaa
@@ -97238,9 +104143,9 @@ aaa
 aac
 aab
 bzS
-bAS
-byW
-bzZ
+fIe
+tXU
+sVq
 bzV
 aab
 aav
@@ -97256,7 +104161,7 @@ aab
 bBX
 bNC
 bOg
-cuS
+fNq
 bBX
 aab
 aab
@@ -97270,9 +104175,9 @@ aab
 aab
 aab
 bYB
-cAN
-cBq
-bAa
+diH
+mEp
+iza
 bJf
 aaa
 aac
@@ -97494,9 +104399,9 @@ aaa
 aaa
 aac
 bzS
-bAS
-byW
-bzZ
+fIe
+tXU
+sVq
 bBW
 aav
 aav
@@ -97528,9 +104433,9 @@ aav
 aav
 aav
 bYB
-cAN
-cBq
-bAa
+diH
+mEp
+iza
 bJf
 aac
 aaa
@@ -97750,9 +104655,9 @@ aaa
 aab
 aaa
 byU
-bzU
-byW
-bzZ
+ltJ
+tXU
+sVq
 bBW
 aab
 aab
@@ -97786,9 +104691,9 @@ aab
 aav
 aab
 bAc
-cAn
-cBq
-bAa
+oSL
+mEp
+iza
 bKd
 aaa
 aab
@@ -98007,8 +104912,8 @@ aaa
 aab
 bxN
 byV
-byW
-bzZ
+tXU
+sVq
 bBW
 aav
 aav
@@ -98027,7 +104932,7 @@ aab
 bBX
 bNC
 bOh
-cuS
+fNq
 bBX
 aab
 aab
@@ -98044,9 +104949,9 @@ bST
 bST
 aav
 bYB
-cAN
-cBq
-bAa
+diH
+mEp
+iza
 bJf
 aab
 aab
@@ -98263,8 +105168,8 @@ aaa
 aaa
 bwP
 bxO
-byW
-bzZ
+tXU
+sVq
 bzV
 aab
 aav
@@ -98284,7 +105189,7 @@ bBX
 bBX
 bNC
 bOg
-cuT
+jtU
 bBX
 aab
 aab
@@ -98302,9 +105207,9 @@ bBX
 bBX
 bST
 bAc
-cAN
-cBq
-bAa
+diH
+mEp
+iza
 bzX
 aab
 aaa
@@ -98519,7 +105424,7 @@ aaa
 aaa
 aaa
 bwP
-bxP
+fah
 byX
 bzV
 aab
@@ -98541,7 +105446,7 @@ bBX
 bME
 bNC
 bOg
-cuS
+fNq
 bBX
 aab
 bBX
@@ -98560,7 +105465,7 @@ bUP
 bST
 aab
 bAc
-bxQ
+gyt
 byX
 cdz
 aab
@@ -98776,7 +105681,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byX
 bzW
 aav
@@ -98817,7 +105722,7 @@ bUP
 bST
 aab
 cbC
-bxP
+fah
 byX
 cdz
 aab
@@ -99033,7 +105938,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byX
 bzX
 aab
@@ -99057,7 +105962,7 @@ bOx
 bOj
 cuW
 can
-bQL
+tVa
 bLJ
 bSf
 bZG
@@ -99074,7 +105979,7 @@ bUP
 bST
 aab
 cbC
-bxQ
+gyt
 byX
 cdz
 aab
@@ -99290,7 +106195,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byX
 bzX
 aab
@@ -99331,7 +106236,7 @@ bUP
 bST
 aab
 cbC
-bxQ
+gyt
 byX
 cdz
 aab
@@ -99547,7 +106452,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byX
 bzX
 aab
@@ -99570,10 +106475,10 @@ bNj
 bNq
 bOk
 bPD
-cDo
+nFt
 ccT
 bLJ
-bSh
+oxP
 bSY
 bTU
 bUR
@@ -99588,7 +106493,7 @@ bUP
 bST
 aab
 cbC
-bxQ
+gyt
 byX
 cdz
 aab
@@ -99804,7 +106709,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byX
 bzX
 aab
@@ -99845,7 +106750,7 @@ bUP
 bST
 aab
 cbC
-bxP
+fah
 byX
 cdz
 aab
@@ -100318,7 +107223,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byZ
 bzX
 aab
@@ -100341,7 +107246,7 @@ bNp
 bNt
 bQm
 bOj
-cDd
+dRM
 cDs
 bLJ
 bSi
@@ -100359,7 +107264,7 @@ bUP
 bST
 aab
 cbC
-cCU
+wUP
 byX
 cdz
 aab
@@ -100575,7 +107480,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byZ
 bzX
 aab
@@ -100598,10 +107503,10 @@ bNj
 bNu
 bOn
 bPG
-cDo
+nFt
 cvc
 bLJ
-bSh
+oxP
 bTb
 bSV
 bUP
@@ -100616,7 +107521,7 @@ bUP
 bST
 aab
 cbC
-cCU
+wUP
 byX
 cdz
 aab
@@ -100832,7 +107737,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byZ
 bzX
 aab
@@ -100854,7 +107759,7 @@ bNX
 bNw
 bPc
 bOj
-cDd
+dRM
 cDq
 cvd
 bLJ
@@ -101089,7 +107994,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byZ
 bzX
 aab
@@ -101113,7 +108018,7 @@ bPs
 bOj
 cDe
 cBc
-bQL
+tVa
 bLJ
 bSl
 bTc
@@ -101130,7 +108035,7 @@ bSU
 bST
 bSc
 bzS
-cCU
+wUP
 byX
 cdz
 aab
@@ -101346,7 +108251,7 @@ aaa
 aaa
 aaa
 bwP
-bxQ
+gyt
 byZ
 bzW
 aav
@@ -101385,8 +108290,8 @@ bUS
 bSV
 bZP
 bZO
-bLI
-bLI
+iEh
+iEh
 cCW
 byX
 cdz
@@ -101603,7 +108508,7 @@ aaa
 aaa
 aaa
 bwP
-bxP
+fah
 byZ
 bzY
 aab
@@ -101625,7 +108530,7 @@ bBX
 bME
 bPv
 bOt
-cDh
+fbg
 bBX
 aab
 bBX
@@ -101862,7 +108767,7 @@ aaa
 bwP
 bxS
 bzb
-bAa
+iza
 bzY
 aab
 aav
@@ -101882,7 +108787,7 @@ bBX
 bBX
 bPv
 bOo
-cDg
+gra
 bBX
 aab
 aab
@@ -101900,9 +108805,9 @@ bBX
 bBX
 bST
 caY
-bxQ
+gyt
 cCX
-bzZ
+sVq
 bzX
 aab
 aaa
@@ -102119,8 +109024,8 @@ aaa
 aab
 bxT
 bzT
-bAb
-bAa
+pmd
+iza
 bBY
 aav
 aav
@@ -102139,7 +109044,7 @@ aab
 bBX
 bPv
 bOp
-cDh
+fbg
 bBX
 aab
 aab
@@ -102156,9 +109061,9 @@ bST
 bST
 aav
 cap
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 cbE
 aab
 aab
@@ -102376,9 +109281,9 @@ aaa
 aab
 aaa
 bxT
-bAR
-bAb
-bAa
+vxz
+pmd
+iza
 bBY
 aab
 aab
@@ -102412,9 +109317,9 @@ aab
 aav
 aab
 bzS
-bzU
-bEK
-bKZ
+ltJ
+hfX
+kzJ
 cbE
 aaa
 aab
@@ -102634,9 +109539,9 @@ aab
 aaa
 aaa
 bAc
-bDJ
-bAb
-bAa
+pPn
+pmd
+iza
 bBY
 aav
 aav
@@ -102668,9 +109573,9 @@ aav
 aav
 aav
 bDC
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 cbE
 aaa
 aaa
@@ -102892,9 +109797,9 @@ aaa
 aaa
 aab
 bAc
-bDJ
-bAb
-bAa
+pPn
+pmd
+iza
 bzY
 aab
 aav
@@ -102910,7 +109815,7 @@ aab
 bBX
 bPv
 bOo
-cDh
+fbg
 bBX
 aab
 aab
@@ -102924,9 +109829,9 @@ aab
 aab
 aab
 bDC
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 caZ
 aac
 aac
@@ -103150,8 +110055,8 @@ aaa
 aab
 aab
 bAc
-bAR
-bAb
+vxz
+pmd
 bKH
 bzY
 aav
@@ -103167,7 +110072,7 @@ aab
 bBX
 bPv
 bOo
-cDg
+gra
 bBX
 aab
 aab
@@ -103181,8 +110086,8 @@ aab
 aab
 bzS
 cnO
-bEK
-bKZ
+hfX
+kzJ
 bzV
 aaa
 aaa
@@ -103324,7 +110229,7 @@ cMv
 cOq
 abY
 ahd
-ahU
+fXq
 aiN
 aiN
 alm
@@ -103408,7 +110313,7 @@ aab
 aab
 aab
 bAc
-bDJ
+pPn
 bFX
 bKa
 bBY
@@ -103424,7 +110329,7 @@ bBX
 bBX
 bPv
 bOo
-cDh
+fbg
 bBX
 bBX
 bBX
@@ -103438,7 +110343,7 @@ aaa
 bzS
 cCT
 cBn
-bKZ
+kzJ
 bzV
 aab
 aaa
@@ -103666,9 +110571,9 @@ aab
 aab
 aab
 bAc
-bDJ
-bAb
-bAa
+pPn
+pmd
+iza
 bzY
 aab
 aab
@@ -103692,9 +110597,9 @@ aaa
 aaa
 aaa
 bxN
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 bzV
 aab
 aab
@@ -103924,9 +110829,9 @@ aab
 aab
 aab
 bAc
-bAR
-bAb
-bAa
+vxz
+pmd
+iza
 bzY
 aab
 aaa
@@ -103948,9 +110853,9 @@ aaa
 aaa
 aaa
 bxN
-bzU
-bEK
-bKZ
+ltJ
+hfX
+kzJ
 bzV
 aab
 aab
@@ -104182,9 +111087,9 @@ aab
 aab
 aab
 bAc
-bDJ
-bAb
-bAa
+pPn
+pmd
+iza
 bzY
 aaa
 aac
@@ -104204,9 +111109,9 @@ aac
 aaa
 aaa
 bxN
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 bzV
 aab
 aab
@@ -104352,7 +111257,7 @@ aeG
 acw
 abY
 ahd
-ahU
+fXq
 aiN
 aiN
 alp
@@ -104440,9 +111345,9 @@ aab
 aab
 aab
 bAc
-bDJ
-bAb
-bAa
+pPn
+pmd
+iza
 bJf
 aac
 aaa
@@ -104460,9 +111365,9 @@ aab
 aac
 aaa
 bxN
-bAS
-bEK
-bKZ
+fIe
+hfX
+kzJ
 bzV
 aab
 aaa
@@ -104698,9 +111603,9 @@ aab
 aab
 aab
 bAc
-bAR
-bAb
-bAa
+vxz
+pmd
+iza
 bKd
 bIY
 chv
@@ -104716,9 +111621,9 @@ bBX
 bSc
 bTe
 bzS
-bzU
-bEK
-bKZ
+ltJ
+hfX
+kzJ
 bBW
 aav
 aac
@@ -104956,25 +111861,25 @@ aaa
 aaa
 aaa
 bxT
-bDJ
-bAb
-bLI
-bLI
+pPn
+pmd
+iEh
+iEh
 bMG
-bMQ
+tdQ
 bNY
 bRT
 bPQ
 bXM
 cuV
-bMQ
+tdQ
 cve
-bMQ
-bLI
-bLI
-bLI
-bEK
-bKZ
+tdQ
+iEh
+iEh
+iEh
+hfX
+kzJ
 bzV
 aav
 aab
@@ -105214,23 +112119,23 @@ aaa
 aaa
 aaa
 bxT
-bDJ
-bLL
-bLL
+pPn
+kDS
+kDS
 bML
-bMR
-bMR
+oLY
+oLY
 bPH
 bQT
 bOw
 caX
-bMR
+oLY
 cvf
-bLL
-bLL
-bLL
-bLL
-bKZ
+kDS
+kDS
+kDS
+kDS
+kzJ
 bzV
 aab
 aav
@@ -105380,7 +112285,7 @@ aeG
 acw
 abY
 ahd
-ahU
+fXq
 aiN
 aiN
 als
@@ -106408,7 +113313,7 @@ acw
 aeJ
 abY
 ahd
-ahU
+fXq
 aiN
 aiN
 alv
@@ -110257,15 +117162,15 @@ aaQ
 aaQ
 acy
 aaQ
-ads
-ads
-ads
-ads
-ads
-ads
-ads
-ads
-ads
+lTR
+lTR
+lTR
+lTR
+lTR
+lTR
+lTR
+lTR
+lTR
 aaQ
 aaQ
 any
@@ -110499,7 +117404,7 @@ aaN
 aab
 aaa
 aaa
-aaT
+aeT
 aaX
 abb
 agk
@@ -110514,15 +117419,15 @@ abH
 agn
 acz
 abe
-ads
+lTR
 adS
 aeL
 afG
 cxo
 ahj
-adS
+lTj
 aiY
-akp
+xag
 anE
 aoj
 anz
@@ -110772,9 +117677,9 @@ adQ
 acA
 acX
 adt
-adT
+rtm
 aeM
-adT
+rtm
 ago
 ahk
 aie
@@ -110791,7 +117696,7 @@ aqc
 aqc
 avE
 awv
-aBs
+kHg
 axl
 aaQ
 azx
@@ -111028,7 +117933,7 @@ aaQ
 aaQ
 acB
 aaQ
-ads
+lTR
 aut
 aeN
 adU
@@ -111036,9 +117941,9 @@ agp
 ahl
 aif
 aja
-akp
+xag
 anU
-aoQ
+nUG
 apa
 arj
 atb
@@ -111048,7 +117953,7 @@ avO
 atW
 ayR
 aPu
-aBs
+kHg
 aCU
 aaV
 azy
@@ -111285,11 +118190,11 @@ aaA
 abp
 acC
 acY
-ads
+lTR
 aid
-adV
+lpL
 afH
-agq
+wNs
 ahm
 aig
 ajb
@@ -111542,13 +118447,13 @@ aaA
 abp
 acD
 boY
-ads
+lTR
 adW
-adV
-afI
+lpL
+gyY
 aoa
-afI
-adV
+gyY
+lpL
 ajc
 abd
 alE
@@ -111563,7 +118468,7 @@ aqd
 azd
 awy
 axS
-aoQ
+nUG
 aaV
 azA
 aAO
@@ -111799,12 +118704,12 @@ aaA
 abp
 acD
 abc
-ads
+lTR
 adX
 aeO
-adV
-agq
-adV
+lpL
+wNs
+lpL
 aih
 ajd
 abd
@@ -111819,7 +118724,7 @@ avU
 aqd
 azd
 aww
-aBs
+kHg
 abt
 aaV
 azB
@@ -112056,11 +118961,11 @@ aaA
 abp
 acD
 cOv
-ads
+lTR
 adY
 aeP
 coc
-agq
+wNs
 ahn
 aii
 aje
@@ -112076,7 +118981,7 @@ avL
 aqd
 azd
 aww
-aBs
+kHg
 aUi
 aaQ
 aaQ
@@ -112333,7 +119238,7 @@ abJ
 abJ
 azf
 aww
-aBs
+kHg
 abt
 any
 azC
@@ -112590,7 +119495,7 @@ arn
 bJo
 azd
 awz
-aBs
+kHg
 aCU
 any
 azD
@@ -112980,12 +119885,12 @@ cvC
 cvC
 cwK
 cqk
-cFB
+ipL
 cqk
 cqk
 cqk
 cyK
-cGH
+iup
 cqk
 cza
 cvG
@@ -113104,7 +120009,7 @@ aro
 abJ
 azd
 aww
-aBs
+kHg
 aFN
 any
 azF
@@ -113361,7 +120266,7 @@ asV
 abJ
 aCi
 awB
-aBs
+kHg
 axl
 any
 azG
@@ -113600,7 +120505,7 @@ acD
 ais
 adu
 aed
-aeT
+aed
 arg
 agw
 afO
@@ -113618,7 +120523,7 @@ atM
 abJ
 bdT
 aww
-aBs
+kHg
 axL
 axL
 axL
@@ -113875,7 +120780,7 @@ arr
 abJ
 azd
 aww
-aBZ
+pza
 axM
 aIJ
 azH
@@ -114132,7 +121037,7 @@ atN
 auP
 azh
 awC
-aBs
+kHg
 axN
 ayE
 azI
@@ -114164,7 +121069,7 @@ aVS
 aWR
 aYS
 aYT
-bad
+ntW
 bbq
 bcu
 bcu
@@ -114389,7 +121294,7 @@ arr
 abJ
 azd
 awz
-aBs
+kHg
 axO
 ayF
 azJ
@@ -114646,7 +121551,7 @@ atO
 abJ
 azi
 awz
-aBs
+kHg
 axL
 ayG
 ayN
@@ -115160,7 +122065,7 @@ apY
 abJ
 azd
 awz
-aBs
+kHg
 axL
 ayI
 azK
@@ -115417,7 +122322,7 @@ abJ
 abJ
 azd
 awz
-aBs
+kHg
 axP
 ayJ
 azL
@@ -115540,7 +122445,7 @@ clH
 clH
 cdL
 cpn
-crM
+tTR
 cqk
 cqk
 cth
@@ -115797,7 +122702,7 @@ cmB
 cnr
 cBo
 cpo
-crM
+tTR
 cqk
 cqk
 cti
@@ -115929,9 +122834,9 @@ arx
 akt
 atS
 auQ
-azk
+duB
 awz
-aBZ
+pza
 axL
 ayL
 azM
@@ -116017,7 +122922,7 @@ bMp
 bQx
 cLB
 bOS
-cLK
+uNK
 boU
 bQY
 bRG
@@ -116054,7 +122959,7 @@ cVi
 cdd
 cdN
 cpp
-crM
+tTR
 cqk
 cqk
 cth
@@ -116188,7 +123093,7 @@ atT
 auR
 azQ
 awE
-aBs
+kHg
 axQ
 ayM
 azN
@@ -116220,7 +123125,7 @@ aVY
 aTF
 aTF
 aSt
-bad
+ntW
 cGw
 cGy
 cGA
@@ -116316,7 +123221,7 @@ cqk
 csh
 ctj
 cub
-cwZ
+nVl
 cvF
 cqg
 cqg
@@ -116445,7 +123350,7 @@ atS
 auS
 azS
 awz
-aBs
+kHg
 axN
 ayN
 azO
@@ -116531,7 +123436,7 @@ bMq
 boU
 cLD
 bOU
-cLK
+uNK
 boU
 bRa
 bRI
@@ -116549,31 +123454,31 @@ cKF
 cKH
 boU
 cCz
-bNU
-bNU
-cCr
-bZn
-bZn
-bZn
-bZn
-bZn
+fvi
+fvi
+uYv
+yfG
+yfG
+yfG
+yfG
+yfG
 bkT
 bQg
-bZn
-bZn
-bZn
-bZn
+yfG
+yfG
+yfG
+yfG
 cCK
-bZn
+yfG
 cHc
-bZn
-cCr
+yfG
+uYv
 cEM
 cHw
 cER
 cth
 cub
-cxa
+gIr
 cvH
 cwj
 cqg
@@ -116702,7 +123607,7 @@ avA
 auQ
 azZ
 awF
-aBs
+kHg
 axR
 aTE
 azO
@@ -116735,7 +123640,7 @@ aTH
 aTH
 boB
 bam
-bvr
+gjl
 bcs
 bdz
 beK
@@ -116788,7 +123693,7 @@ bMr
 boU
 cLE
 bOU
-cLK
+uNK
 boU
 bRb
 bRJ
@@ -116807,23 +123712,23 @@ cKE
 boU
 cCA
 cML
-cfS
-cHu
-cRJ
-cRL
-cRJ
-cRL
+skW
+lCX
+upC
+etb
+upC
+etb
 cRP
-cRL
+etb
 cRR
-cRL
+etb
 cRT
-cRL
-cRJ
+etb
+upC
 cRV
 cRX
 cRY
-cRJ
+upC
 cRZ
 cSa
 cHx
@@ -116959,7 +123864,7 @@ afU
 afU
 aAo
 awG
-aBs
+kHg
 axL
 axL
 azP
@@ -117063,25 +123968,25 @@ cKt
 cKI
 boU
 cBI
-cMP
-cCg
-cCs
-cfj
-cfO
-cfj
-cfj
+hWN
+tSf
+dJU
+ePw
+tqI
+ePw
+ePw
 crf
-cfj
+ePw
 cjw
-cfj
+ePw
 cnv
-cfj
-cfO
+ePw
+tqI
 cSN
 cHb
-cfj
-cfj
-cCs
+ePw
+ePw
+dJU
 cEO
 cHy
 cET
@@ -117214,15 +124119,15 @@ avo
 atf
 awJ
 auT
-azk
+duB
 awH
 aCb
-aDq
+rtD
 aDz
 aFW
 aHr
-aDq
-aDq
+rtD
+rtD
 aJQ
 aKK
 aNn
@@ -117249,7 +124154,7 @@ aTJ
 aTJ
 brk
 bao
-bvr
+gjl
 bcs
 bdB
 beK
@@ -117302,7 +124207,7 @@ bJs
 boU
 cJk
 bOU
-cLK
+uNK
 boU
 bRd
 bRJ
@@ -117321,7 +124226,7 @@ cKJ
 boU
 cWR
 cMQ
-cCh
+wrL
 boU
 cqg
 cqg
@@ -117482,7 +124387,7 @@ aBU
 axn
 aEs
 aEn
-aBs
+kHg
 aPf
 aaQ
 cMl
@@ -117577,8 +124482,8 @@ cKt
 cKK
 boU
 cgm
-cMP
-cCh
+hWN
+wrL
 boU
 cPF
 chI
@@ -117601,7 +124506,7 @@ cqk
 cqk
 ctn
 cuf
-cwZ
+nVl
 cvG
 aab
 aab
@@ -117763,7 +124668,7 @@ aTL
 aTJ
 brk
 bam
-bvr
+gjl
 bct
 bdD
 beK
@@ -117816,7 +124721,7 @@ cVB
 boU
 cLG
 bOU
-cLO
+iGm
 boU
 bRf
 bSo
@@ -117835,7 +124740,7 @@ cKL
 boU
 cCC
 cQV
-cCh
+wrL
 boU
 bYa
 ced
@@ -117858,7 +124763,7 @@ baC
 ctd
 cto
 cuf
-cwZ
+nVl
 cvG
 cvG
 cvG
@@ -118020,7 +124925,7 @@ aTL
 aTJ
 brk
 bam
-bJH
+eNI
 bcl
 bcl
 bcl
@@ -118073,7 +124978,7 @@ bJs
 boU
 cLH
 bOU
-cLO
+iGm
 boU
 bRg
 bRK
@@ -118113,9 +125018,9 @@ cla
 cqq
 cqg
 cqg
-ctM
+hdz
 cuf
-cwZ
+nVl
 cvJ
 cwl
 cwO
@@ -118277,7 +125182,7 @@ aTL
 aTJ
 brl
 bbi
-bxn
+ofD
 bcl
 bdp
 bhl
@@ -118330,7 +125235,7 @@ bJs
 boU
 cLI
 bOV
-cLO
+iGm
 boU
 bDb
 boU
@@ -118372,7 +125277,7 @@ crm
 cqg
 cXa
 cuf
-cwZ
+nVl
 cvG
 cvG
 cvG
@@ -118516,9 +125421,9 @@ aGH
 aCL
 cXq
 aJF
-aFH
-aKH
-aYW
+ngt
+nmx
+xEk
 apg
 aab
 aab
@@ -118534,7 +125439,7 @@ aTK
 aTJ
 brr
 bam
-bvr
+gjl
 bcl
 bdq
 beC
@@ -118587,26 +125492,26 @@ bJs
 boU
 cWN
 bOU
-cCf
-cCr
-bNU
+qUA
+uYv
+fvi
 bSp
 bTl
 bUk
 bZm
 cCx
-bNU
-bNU
-btX
-bNU
-bNU
+fvi
+fvi
+nkH
+fvi
+fvi
 cMK
-cfP
-bNU
-cCr
+pBb
+fvi
+uYv
 cHr
-cMP
-cCi
+hWN
+mwk
 boU
 cdB
 cRW
@@ -118629,7 +125534,7 @@ bYa
 cqg
 ctW
 cuf
-cwZ
+nVl
 cvG
 aab
 aab
@@ -118773,9 +125678,9 @@ aGI
 aBX
 cXq
 aJF
-aFH
-aKH
-aYW
+ngt
+nmx
+xEk
 bym
 aab
 aab
@@ -118791,7 +125696,7 @@ aSt
 aSt
 bdC
 bbj
-bxo
+vDW
 beN
 bdr
 bij
@@ -118844,24 +125749,24 @@ bLS
 boU
 bVo
 cCm
-cbI
+jGv
 cfi
-cbI
-cfS
+jGv
+skW
 cju
 czN
 cCL
-cfS
-cbI
-cfS
+skW
+jGv
+skW
 cEL
-cfS
-cbI
+skW
+jGv
 cEN
-cbI
+jGv
 cHd
-cHu
-cfS
+lCX
+skW
 cRI
 cCE
 boU
@@ -118884,9 +125789,9 @@ cla
 cqt
 crn
 cqg
-ctM
+hdz
 cuf
-cwZ
+nVl
 cvF
 cqg
 cwN
@@ -119030,7 +125935,7 @@ aPi
 aHt
 aHV
 aJF
-aFH
+ngt
 bwV
 aYX
 bBZ
@@ -119102,22 +126007,22 @@ boU
 cBI
 bOX
 cCa
-cCs
-cBy
-cBy
+dJU
+klf
+klf
 bWZ
-cBy
-cBy
-cBy
-cBy
-cBy
-cBy
-cBG
+klf
+klf
+klf
+klf
+klf
+klf
+ulq
 cUG
-cBy
+klf
 cFf
-bKW
-cCs
+sDf
+dJU
 cBR
 bOX
 cHv
@@ -119143,7 +126048,7 @@ cUl
 cqg
 cXb
 cuf
-cxa
+gIr
 cvH
 cwm
 cvH
@@ -119271,8 +126176,8 @@ ati
 auG
 auY
 aBc
-aBp
-aBp
+uMl
+uMl
 aDu
 ayS
 azY
@@ -119287,9 +126192,9 @@ aGK
 aBX
 aIb
 aJF
-aFH
-aKH
-aYW
+ngt
+nmx
+xEk
 cye
 aab
 aab
@@ -119358,7 +126263,7 @@ cRh
 boU
 cBI
 bOX
-cqm
+qoQ
 bQz
 bQz
 bQz
@@ -119398,13 +126303,13 @@ ceG
 cqt
 cRy
 cqg
-ctM
+hdz
 cug
 cyh
 cvK
 cvK
 cue
-cFB
+ipL
 cqk
 cqk
 cqk
@@ -119546,7 +126451,7 @@ aIc
 aJG
 aKx
 aKI
-aYY
+vrE
 apg
 aab
 aab
@@ -119615,16 +126520,16 @@ cTt
 boU
 cBN
 bOX
-cCi
+mwk
 bQz
 cUy
 bRh
 cFn
-cIr
+kDv
 cKA
-cIr
-cIr
-cIr
+kDv
+kDv
+kDv
 cLb
 cLL
 bQz
@@ -119634,7 +126539,7 @@ bZQ
 car
 cFF
 cFO
-cFY
+gCt
 bYJ
 cdB
 bYa
@@ -119665,11 +126570,11 @@ cxm
 cvK
 cvK
 cvK
-cGH
+iup
 cqk
 cza
 czi
-czu
+cwl
 czw
 aab
 aab
@@ -119781,28 +126686,28 @@ anR
 arG
 auk
 bXs
-avM
-avM
+tZa
+tZa
 axC
-aBe
-aBq
-aBq
+gVP
+hCc
+hCc
 aDv
 aEk
 aGJ
 aHA
 aXd
-avM
-avM
-avM
-avM
+tZa
+tZa
+tZa
+tZa
 aPg
 aPj
-aBe
-aBq
-aBq
+gVP
+hCc
+hCc
 aKy
-aKH
+nmx
 cNB
 apg
 aab
@@ -119819,7 +126724,7 @@ aXa
 aWY
 btl
 bam
-bvr
+gjl
 bcw
 bdK
 beT
@@ -119828,8 +126733,8 @@ bgk
 bcw
 cIA
 cNM
-cIE
-cIE
+dWj
+dWj
 cIG
 bjC
 bmj
@@ -119872,7 +126777,7 @@ cRh
 boU
 cBI
 bOX
-cCh
+wrL
 bQA
 cmx
 bRh
@@ -119883,7 +126788,7 @@ cWp
 cJx
 cJx
 cJx
-cLZ
+rGm
 bQz
 cWQ
 bZg
@@ -119891,7 +126796,7 @@ bZg
 bZg
 cJI
 cNb
-cFY
+gCt
 bYJ
 cdB
 bYa
@@ -120060,7 +126965,7 @@ aCM
 aJH
 aJM
 aPW
-aYW
+xEk
 apg
 aab
 aab
@@ -120076,7 +126981,7 @@ aXb
 aWY
 brk
 bpH
-bxo
+vDW
 bcx
 bdL
 beU
@@ -120087,7 +126992,7 @@ cIB
 bjz
 bkk
 bkL
-cIH
+kUz
 biQ
 bmk
 bne
@@ -120104,14 +127009,14 @@ cPo
 bsN
 bte
 btT
-btT
+hLO
 bwi
 bwR
 byh
 bAi
-bAy
+uLH
 bWT
-bAy
+uLH
 bDa
 bsN
 aaA
@@ -120129,7 +127034,7 @@ cPB
 boU
 cBI
 bOX
-cCh
+wrL
 bQA
 cUz
 bRh
@@ -120297,27 +127202,27 @@ aWv
 avG
 aYm
 axi
-axE
-aBm
+pqo
+tDo
 aJX
-aBm
-aBm
-aBm
-aPN
+tDo
+tDo
+tDo
+lkU
 aDQ
 aDF
 bku
-axE
-aPN
-aBm
-aBm
-aBm
-aBm
-aBm
-aBm
+pqo
+lkU
+tDo
+tDo
+tDo
+tDo
+tDo
+tDo
 aLw
-aOn
-aYW
+gmv
+xEk
 apg
 aab
 aab
@@ -120333,7 +127238,7 @@ aXc
 aYf
 btE
 cGt
-bvr
+gjl
 bcw
 bdM
 beV
@@ -120344,7 +127249,7 @@ cIC
 bjA
 bkl
 bkM
-cIH
+kUz
 blP
 bml
 bnf
@@ -120369,7 +127274,7 @@ bAl
 bAz
 bBx
 bCr
-bwr
+iPN
 bsN
 aaA
 aaA
@@ -120386,7 +127291,7 @@ bFI
 boU
 cIy
 bOX
-cCh
+wrL
 bQA
 cmx
 bRh
@@ -120573,8 +127478,8 @@ apk
 aHX
 apk
 bPB
-aOn
-aYW
+gmv
+xEk
 apg
 aab
 aab
@@ -120601,7 +127506,7 @@ cIB
 bjB
 bkm
 bkN
-cIH
+kUz
 biQ
 bmm
 bre
@@ -120643,7 +127548,7 @@ boU
 cFZ
 cBI
 bOX
-cCh
+wrL
 bQA
 bRh
 bRh
@@ -120654,7 +127559,7 @@ cJx
 cJx
 cJx
 cWs
-cLZ
+rGm
 bQz
 bZj
 cJB
@@ -120830,8 +127735,8 @@ aEv
 aHY
 aFl
 aJD
-aOn
-aYW
+gmv
+xEk
 apg
 aab
 aab
@@ -120847,7 +127752,7 @@ aWY
 aWY
 brk
 bam
-bJH
+eNI
 bcw
 bdO
 biG
@@ -120855,9 +127760,9 @@ bfa
 bhs
 bcw
 cID
-cIF
-cIF
-cIF
+iAi
+iAi
+iAi
 cII
 bjC
 bmn
@@ -120880,7 +127785,7 @@ bwT
 bwR
 byk
 bAp
-btT
+hLO
 bBz
 bFc
 bwR
@@ -120911,7 +127816,7 @@ cJx
 cWq
 cJx
 cJx
-cLZ
+rGm
 bQz
 cjU
 cJA
@@ -121087,8 +127992,8 @@ aHu
 aHY
 aFl
 aJD
-aOn
-aYW
+gmv
+xEk
 apg
 aab
 aab
@@ -121104,7 +128009,7 @@ aWY
 aWY
 buq
 bam
-bvr
+gjl
 bcw
 bdQ
 cJK
@@ -121157,21 +128062,21 @@ boU
 cGb
 cBI
 bOX
-cCh
+wrL
 bQz
 cUB
 bRh
 cFG
-cJS
-cJS
-cJS
+hnu
+hnu
+hnu
 cWr
-cJS
-cJS
+hnu
+hnu
 cMy
 cFI
-cfq
-cfq
+gRX
+gRX
 cJC
 cJG
 cFK
@@ -121344,8 +128249,8 @@ aHv
 aHY
 aFl
 aJD
-aOn
-aYW
+gmv
+xEk
 apg
 aab
 aab
@@ -121361,7 +128266,7 @@ cEU
 aWY
 buu
 ban
-bvr
+gjl
 bcw
 bht
 beY
@@ -121414,7 +128319,7 @@ bMs
 boU
 cIz
 bOX
-cCh
+wrL
 bQA
 cUC
 bRh
@@ -121601,8 +128506,8 @@ aGO
 aGO
 aGO
 aKv
-aOn
-aYY
+gmv
+vrE
 apg
 aab
 aab
@@ -121618,7 +128523,7 @@ aOW
 aSt
 brk
 bam
-bvr
+gjl
 bcw
 bdR
 bfa
@@ -121671,26 +128576,26 @@ cVD
 boU
 cgm
 bOX
-cCh
+wrL
 bQA
 cUC
 bRh
 bXb
 bSw
 bVM
-bRW
-cbk
-cbk
+xfQ
+kdD
+kdD
 chS
 ccm
 cFI
 cfs
-cFA
+fwg
 cnQ
-cFA
+fwg
 cFM
 cFV
-cLW
+ilx
 bYJ
 cVK
 chI
@@ -121859,7 +128764,7 @@ aHZ
 aIR
 aLt
 aPc
-aYW
+xEk
 apg
 aOl
 aPa
@@ -121875,7 +128780,7 @@ aPV
 aSt
 brl
 bbi
-bxn
+ofD
 bcw
 bdS
 bfb
@@ -121910,7 +128815,7 @@ byo
 cUo
 cUp
 cUq
-bwr
+iPN
 bsN
 bEa
 bEY
@@ -121928,7 +128833,7 @@ bFI
 boU
 cBI
 bOX
-cCh
+wrL
 bQA
 cUC
 bRh
@@ -121947,7 +128852,7 @@ cEV
 cEV
 cEV
 cFW
-cLW
+ilx
 bYJ
 cdB
 chI
@@ -122117,34 +129022,34 @@ aIS
 aTf
 aTY
 aKJ
-aZa
-aZa
+ojZ
+ojZ
 aZd
-aZv
+uSM
 aQm
 bvQ
-boX
-aZv
-aZv
+sGf
+uSM
+uSM
 bEb
-aZv
+uSM
 biP
-aZv
+uSM
 brX
 bbm
 bvB
 bNH
-bvS
-bvS
-bwg
-aZv
-aZv
+utM
+utM
+iqD
+uSM
+uSM
 cQx
-bvS
-bvS
-bwg
-boX
-aZv
+utM
+utM
+iqD
+sGf
+uSM
 bqS
 bMu
 bNJ
@@ -122185,7 +129090,7 @@ bKj
 bNb
 cBO
 bOZ
-cCh
+wrL
 bQz
 cUC
 bRN
@@ -122199,10 +129104,10 @@ cbP
 cMz
 cFI
 cEW
-cGi
+eJn
 cQH
 cSp
-cGi
+eJn
 cQH
 cMm
 bYJ
@@ -122373,9 +129278,9 @@ aIQ
 aIR
 aJD
 aXg
-aXi
-aXi
-aXi
+tPr
+tPr
+tPr
 aZT
 aZU
 bkc
@@ -122404,7 +129309,7 @@ blq
 aQO
 bmr
 bAr
-bNK
+nrn
 bTr
 aRZ
 cRb
@@ -122442,7 +129347,7 @@ bIt
 boU
 cBI
 bOX
-cCi
+mwk
 bQB
 bQB
 bQB
@@ -122456,12 +129361,12 @@ bQB
 bQB
 bQB
 cIv
-cJI
+kcN
 cQH
 cFY
-cJI
+kcN
 cQH
-cLW
+ilx
 bYJ
 cVL
 bYN
@@ -122637,31 +129542,31 @@ brh
 aZY
 aRY
 bkA
-bpf
+xGR
 aVO
 biO
-bpF
-bpF
-bpF
-bpF
+pcz
+pcz
+pcz
+pcz
 bsp
 blr
-bpF
-bpF
-bpF
-bpF
+pcz
+pcz
+pcz
+pcz
 bmv
 cQE
-bpF
-bpF
-bpF
-bpF
+pcz
+pcz
+pcz
+pcz
 bSv
-bpf
-bpF
+xGR
+pcz
 bDV
 bnn
-bNK
+nrn
 bON
 aRZ
 boR
@@ -122699,7 +129604,7 @@ bFI
 boU
 cBI
 bOX
-cCh
+wrL
 bQB
 bRl
 bWv
@@ -122893,7 +129798,7 @@ axa
 axa
 bap
 aPY
-blg
+shr
 aRH
 aRH
 aRH
@@ -122918,7 +129823,7 @@ bgp
 bgp
 bRS
 aPY
-bNK
+nrn
 aOz
 aRZ
 boR
@@ -122956,7 +129861,7 @@ bFI
 boU
 cWO
 bOX
-cCh
+wrL
 bQB
 coD
 bRP
@@ -123118,12 +130023,12 @@ adx
 adx
 ama
 aNh
-aqx
+vBE
 asO
 aFn
-aqx
-aqx
-aqx
+vBE
+vBE
+vBE
 axI
 awa
 awS
@@ -123131,16 +130036,16 @@ axw
 aye
 aIw
 aWt
-aHC
+wOD
 aMq
-auu
-auu
-axq
-auu
+rVD
+rVD
+pWd
+rVD
 aZj
-aHC
-aHC
-aHC
+wOD
+wOD
+wOD
 aQX
 aqG
 aKL
@@ -123150,7 +130055,7 @@ aMn
 axa
 bap
 aPY
-bwS
+vLQ
 aRH
 bBv
 cck
@@ -123175,7 +130080,7 @@ bPX
 bgp
 cJa
 aPY
-bNK
+nrn
 aOy
 aRZ
 boR
@@ -123213,10 +130118,10 @@ bFH
 boU
 cBM
 bPa
-cCh
+wrL
 bQB
 bRn
-bWx
+gqj
 bQB
 bUw
 bWW
@@ -123398,7 +130303,7 @@ aBl
 aGT
 aBl
 aWQ
-aHE
+xjG
 aqG
 aKM
 aKO
@@ -123407,7 +130312,7 @@ aKO
 axa
 cHZ
 aPY
-bms
+rgk
 aRI
 aSF
 aTT
@@ -123432,7 +130337,7 @@ bgr
 bii
 bgn
 aPY
-bnl
+nBd
 aRZ
 aRZ
 bpt
@@ -123470,7 +130375,7 @@ aaA
 boU
 cBK
 bOX
-cCh
+wrL
 bQB
 bQB
 bQB
@@ -123633,10 +130538,10 @@ afi
 abA
 aWS
 aob
-asQ
-asQ
-asQ
-asQ
+gVl
+gVl
+gVl
+gVl
 axj
 axK
 awc
@@ -123648,14 +130553,14 @@ aAe
 aHD
 aEi
 bpE
-auO
-auO
-auO
+dGX
+dGX
+dGX
 bZZ
-auO
-aFM
+dGX
+kuT
 aIe
-aHG
+fqL
 aJT
 aKN
 aKN
@@ -123664,7 +130569,7 @@ cND
 axa
 bap
 aPY
-bms
+rgk
 aRJ
 aSG
 aSG
@@ -123689,7 +130594,7 @@ bko
 blT
 bDW
 bno
-bnl
+nBd
 aRZ
 cAs
 bpr
@@ -123727,7 +130632,7 @@ aaA
 boU
 cBI
 bOX
-cqm
+qoQ
 bQB
 cph
 cCe
@@ -123912,7 +130817,7 @@ aqG
 aqG
 aPp
 aIe
-aIT
+phw
 aqG
 aKO
 aLy
@@ -123946,7 +130851,7 @@ bls
 blU
 bFm
 bnp
-cGD
+xYx
 aRZ
 boR
 bpr
@@ -123984,7 +130889,7 @@ aaA
 boU
 cBL
 bOX
-cCh
+wrL
 bQB
 cpR
 cEZ
@@ -124159,7 +131064,7 @@ axz
 aqG
 aEu
 aAe
-aHE
+xjG
 aqG
 aCV
 aDI
@@ -124203,7 +131108,7 @@ blt
 blV
 bFJ
 bnq
-bSF
+qae
 aRZ
 boR
 bps
@@ -124241,7 +131146,7 @@ aaA
 boU
 cBI
 bOX
-cCh
+wrL
 bQB
 cpX
 cFc
@@ -124416,7 +131321,7 @@ axA
 aqG
 cDE
 aAe
-aHG
+fqL
 aCl
 aqJ
 aDJ
@@ -124429,13 +131334,13 @@ aIf
 aKX
 aqG
 aNv
-cIo
-cIo
-cIo
+rcM
+rcM
+rcM
 axa
 btt
 aPY
-bms
+rgk
 aRI
 aSG
 aTW
@@ -124460,7 +131365,7 @@ bjH
 bii
 bgn
 aPY
-bnl
+nBd
 aRZ
 boU
 boU
@@ -124498,7 +131403,7 @@ boU
 boU
 cBP
 bPb
-cCk
+uZH
 bQB
 bQB
 bQB
@@ -124511,14 +131416,14 @@ bQB
 bQB
 bQB
 cGm
-bRr
+unn
 bXu
 cQH
 cco
 cor
 cQH
 bXu
-bRr
+unn
 cSq
 bQz
 cdB
@@ -124683,7 +131588,7 @@ aGb
 aGV
 aPr
 aIg
-aMy
+lqd
 aJU
 aQY
 aXQ
@@ -124717,45 +131622,45 @@ bqu
 bgp
 bnu
 bAs
-bNL
-boX
-bNU
+vJb
+sGf
+fvi
 bTt
-bNU
-bNU
+fvi
+fvi
 cec
-cfP
+pBb
 cPl
-bNU
-bNU
-bNU
-bNU
+fvi
+fvi
+fvi
+fvi
 bVI
-bUN
+neT
 cBm
-cCb
+hST
 cEv
 bNv
 bBr
 byf
-cCb
-bUN
-bUN
-bUN
-bNU
+hST
+neT
+neT
+neT
+fvi
 bZR
-cfP
-bNU
+pBb
+fvi
 cjv
-bNU
-btX
+fvi
+nkH
 cBF
-bNU
-bNU
-bNU
+fvi
+fvi
+fvi
 cBQ
 bOX
-cCh
+wrL
 bQB
 bRl
 bWN
@@ -124930,7 +131835,7 @@ axA
 aqG
 aFf
 aAg
-aHE
+xjG
 aqG
 aCX
 aDL
@@ -124949,7 +131854,7 @@ aZN
 axa
 bbt
 aPY
-bmq
+uci
 aRH
 aSK
 aTX
@@ -124976,20 +131881,20 @@ bgn
 bqv
 bqx
 bqz
-brz
+wEY
 bsB
-brz
-bPk
-brz
-bPk
+wEY
+pws
+wEY
+pws
 cPm
-bPk
-brz
+pws
+wEY
 cAB
-brz
-bPk
-brz
-bPk
+wEY
+pws
+wEY
+pws
 bQQ
 cAm
 cuX
@@ -125197,7 +132102,7 @@ aCV
 aqG
 aQn
 aIh
-aIT
+phw
 aqG
 aXP
 aXQ
@@ -125206,7 +132111,7 @@ aYP
 axa
 cCB
 aPY
-bmq
+uci
 aRM
 aSL
 aZV
@@ -125232,47 +132137,47 @@ bii
 cGC
 bns
 bNM
-bpf
-bNV
-bNV
-bSu
-bNV
-bNV
+xGR
+lnB
+lnB
+khi
+lnB
+lnB
 bUo
 clK
-bNV
-bSu
+lnB
+khi
 bAQ
-bNV
-bXh
+lnB
+xTY
 cSG
-bXh
-cCc
+xTY
+ihw
 cEw
 byf
 bBC
 cGd
-cCc
-bXh
-bXh
+ihw
+xTY
+xTY
 cIR
-bKW
-cBy
-cBy
-cBy
+sDf
+klf
+klf
+klf
 cBB
-cBy
-cBy
-cBG
+klf
+klf
+ulq
 clB
 cBH
-cBy
+klf
 bVV
 bOY
 bVk
 bQB
 bRn
-bWx
+gqj
 bQB
 bSw
 bXX
@@ -125283,12 +132188,12 @@ bWV
 bQB
 cWP
 bSw
-cNa
+gMV
 cbS
 ckT
 cTK
 cMx
-cSy
+fEH
 bSw
 cSu
 bQz
@@ -125454,7 +132359,7 @@ aqG
 aqG
 cDV
 aIe
-aKP
+dPK
 aqG
 aqG
 aLA
@@ -125463,7 +132368,7 @@ aLA
 axa
 bap
 aPY
-bmq
+uci
 aRN
 aSM
 aTZ
@@ -125488,7 +132393,7 @@ blx
 bii
 bgn
 bns
-bnl
+nBd
 aRZ
 boU
 boU
@@ -125526,7 +132431,7 @@ boU
 boU
 cTW
 bOX
-cCh
+wrL
 bQB
 bQB
 bQB
@@ -125540,12 +132445,12 @@ bQB
 bQB
 bTw
 bSw
-cNa
+gMV
 cSn
 cSn
 cSn
 cSn
-cSy
+fEH
 bSw
 cSE
 bQz
@@ -125701,7 +132606,7 @@ axB
 ayh
 aFi
 aAj
-aKP
+dPK
 aCn
 aCY
 aDM
@@ -125711,7 +132616,7 @@ aGc
 aGW
 aEq
 aIe
-aMy
+lqd
 aJV
 aKR
 aKR
@@ -125720,7 +132625,7 @@ aNo
 axa
 bap
 aPY
-bmq
+uci
 aRN
 aSN
 aUa
@@ -125745,7 +132650,7 @@ blv
 bii
 bgn
 bns
-bnl
+nBd
 aRZ
 czI
 bpw
@@ -125763,11 +132668,11 @@ bws
 bxt
 bzf
 bsV
-bAE
+lKh
 bBE
 bCU
-bDg
-bDg
+mqh
+mqh
 bEZ
 bFK
 bHC
@@ -125783,32 +132688,32 @@ bMv
 boU
 cBS
 bOX
-cCf
+qUA
 bQC
-bRr
-bSC
+hDI
+ggi
 bZT
 bSw
 bWQ
-cav
-bRr
-bSC
+eqk
+hDI
+ggi
 cbQ
 bZU
 ccV
 cGh
 cPH
-cSo
+jNI
 cSr
-cSo
-cSo
+jNI
+jNI
 cSz
 cGh
 cSF
 cUb
 cSK
 cUc
-bRr
+hDI
 chT
 czC
 bSw
@@ -125968,7 +132873,7 @@ aGd
 aGX
 cDE
 aIe
-aIT
+phw
 aqG
 aKS
 aLB
@@ -125977,7 +132882,7 @@ aKR
 axa
 bap
 aPY
-bRM
+wZC
 aRN
 aSO
 aUb
@@ -126002,7 +132907,7 @@ bkX
 bii
 bGO
 bnt
-bnl
+nBd
 aRZ
 boZ
 cAg
@@ -126020,7 +132925,7 @@ btG
 btG
 bzg
 bzq
-bAE
+lKh
 bBw
 bCm
 bCm
@@ -126069,9 +132974,9 @@ bSw
 csZ
 czC
 bSw
-cav
-bRr
-bRr
+eqk
+hDI
+hDI
 cmb
 cmW
 brT
@@ -126215,7 +133120,7 @@ aqG
 aqG
 cXc
 aAl
-aIT
+phw
 aqG
 aDa
 aEJ
@@ -126225,7 +133130,7 @@ aGe
 aGY
 cDF
 aIi
-aHE
+xjG
 aqG
 aqG
 aqG
@@ -126234,7 +133139,7 @@ aqG
 axa
 bap
 aPY
-blg
+shr
 aRN
 aSP
 aUc
@@ -126259,7 +133164,7 @@ blx
 bii
 bgn
 bns
-bSF
+qae
 aRZ
 boZ
 cOS
@@ -126279,8 +133184,8 @@ bzh
 bzr
 bAF
 bBF
-bCV
-bCV
+kNb
+kNb
 bGu
 bFN
 bFK
@@ -126299,7 +133204,7 @@ cBT
 bPe
 bYs
 bQC
-bRW
+xfQ
 bSD
 bUq
 bVc
@@ -126482,7 +133387,7 @@ aGf
 aqG
 aPp
 aIj
-aRa
+sXb
 aJW
 bRj
 aLC
@@ -126516,7 +133421,7 @@ blv
 bii
 bgn
 bns
-cGD
+xYx
 aRZ
 boZ
 bDx
@@ -126531,10 +133436,10 @@ bux
 bva
 btG
 bwk
-btG
+lpx
 bzl
 bsV
-bAE
+lKh
 bBH
 bCo
 bDm
@@ -126561,30 +133466,30 @@ bSw
 bYo
 bVc
 bYO
-cbh
-cbh
-cbh
-cbh
-cbh
+gQV
+gQV
+gQV
+gQV
+gQV
 cFg
 ccv
 cEY
 bZS
 cTP
 cSt
-cbh
+gQV
 cGk
-cbh
+gQV
 cGl
-cbh
+gQV
 bUy
 cay
 cft
-ccn
+fMq
 cGp
-ccn
-ccn
-ccn
+fMq
+fMq
+fMq
 cyF
 cmb
 cmX
@@ -126729,7 +133634,7 @@ aqG
 aqG
 aFh
 aAl
-aIT
+phw
 aqG
 aqG
 aDH
@@ -126773,7 +133678,7 @@ bly
 bii
 bgn
 bns
-bnl
+nBd
 aRZ
 boZ
 bDx
@@ -126791,7 +133696,7 @@ bwl
 bxa
 bzp
 bsQ
-bAE
+lKh
 bBH
 bCW
 bDo
@@ -126811,7 +133716,7 @@ bCD
 boU
 cBS
 bOU
-cCg
+tSf
 bQC
 bSx
 bSE
@@ -126836,7 +133741,7 @@ bWB
 bWB
 bTw
 bVc
-cfu
+ehe
 cNW
 bRh
 bRh
@@ -126976,23 +133881,23 @@ apj
 aoC
 asS
 aNf
-avH
-auu
-auu
-axq
-auu
-auu
+yfq
+rVD
+rVD
+pWd
+rVD
+rVD
 aCk
-avH
+yfq
 aFk
 aAl
 aIU
 aYZ
-auu
-auu
-auu
-auu
-auu
+rVD
+rVD
+rVD
+rVD
+rVD
 cLx
 aQQ
 aIl
@@ -127000,7 +133905,7 @@ aKu
 aqJ
 aBk
 aLE
-aMw
+jLE
 aNq
 aOr
 bap
@@ -127030,7 +133935,7 @@ blx
 bii
 bgn
 bns
-bnl
+nBd
 aRZ
 czK
 bpx
@@ -127068,7 +133973,7 @@ bCD
 boU
 cBS
 bOU
-cCh
+wrL
 boU
 bQB
 bQB
@@ -127093,7 +133998,7 @@ cdE
 bWB
 bTw
 bVc
-cfu
+ehe
 bQz
 cnU
 bQz
@@ -127218,7 +134123,7 @@ aab
 aab
 aab
 acS
-adm
+cwt
 adF
 ael
 afk
@@ -127253,7 +134158,7 @@ ayi
 cLy
 cdt
 cEt
-aRa
+sXb
 aqJ
 cDx
 aqG
@@ -127305,14 +134210,14 @@ bwn
 bxc
 bzF
 bsQ
-bwC
+eBy
 bCc
 bCX
 bDE
 bEk
 bGk
 bCq
-bwC
+eBy
 bGU
 bJe
 bIy
@@ -127325,15 +134230,15 @@ bMx
 boU
 cBV
 bOU
-cCh
+wrL
 boU
-bRt
-bRt
-bRt
+eVg
+eVg
+eVg
 bSH
-bRt
-bRt
-bRt
+eVg
+eVg
+eVg
 bWB
 bWY
 bWY
@@ -127475,7 +134380,7 @@ aab
 aab
 aab
 acS
-adm
+cwt
 adG
 aem
 afl
@@ -127490,27 +134395,27 @@ apj
 aoe
 aqe
 bdo
-auO
-auO
-auO
-auO
-auO
-auO
+dGX
+dGX
+dGX
+dGX
+dGX
+dGX
 aCF
-auO
-aFM
+dGX
+kuT
 aAn
 aIV
 aJf
-aJO
+hIv
 aKa
 aGo
-aJO
-aJO
+hIv
+hIv
 cLz
 aQR
 aIn
-aRa
+sXb
 aqJ
 aBk
 aLF
@@ -127519,7 +134424,7 @@ aNr
 aOs
 bbv
 aPY
-bmz
+eGt
 aRQ
 cnj
 aUj
@@ -127544,7 +134449,7 @@ bjH
 bgp
 bFQ
 bns
-bnl
+nBd
 aRZ
 boZ
 bpx
@@ -127569,7 +134474,7 @@ bDh
 bEE
 bDh
 bCq
-bwC
+eBy
 cOi
 bJy
 bJC
@@ -127582,7 +134487,7 @@ cPC
 boU
 cBW
 bOV
-cCi
+mwk
 boU
 bRu
 bRX
@@ -127732,7 +134637,7 @@ aab
 aab
 aab
 acS
-adm
+cwt
 cif
 aen
 afm
@@ -127778,7 +134683,7 @@ bbv
 aQb
 aSA
 aRR
-aUf
+sPB
 cAw
 aVm
 aWk
@@ -127801,13 +134706,13 @@ blz
 bgw
 bGg
 bHj
-bnl
+nBd
 aRZ
 boZ
 bpx
 bfs
 bqP
-bru
+voR
 bqT
 bpx
 bsV
@@ -127832,14 +134737,14 @@ bJe
 bIy
 bJL
 bKp
-bRO
+uWS
 bLB
 bIx
 bCD
 boU
 cBX
 bPf
-cCk
+uZH
 boU
 bRv
 bRY
@@ -128002,7 +134907,7 @@ akV
 abA
 apl
 aEI
-atI
+wwa
 aqK
 arY
 atq
@@ -128024,21 +134929,21 @@ aGg
 aqG
 cDW
 aIp
-aRa
+sXb
 azm
 aKV
 aLE
-aMw
+jLE
 aNs
 aOr
 bbw
 aPY
-bmz
+eGt
 aRR
-aUf
+sPB
 czO
 aVm
-aUf
+sPB
 aXl
 aYq
 aYq
@@ -128058,13 +134963,13 @@ blA
 blW
 bJT
 bnv
-bnl
+nBd
 aRZ
 boZ
 bpx
 cNO
 buC
-bru
+voR
 brs
 bsu
 brP
@@ -128096,7 +135001,7 @@ bCD
 boU
 cBS
 bPg
-cqm
+qoQ
 boU
 bRw
 bRw
@@ -128259,7 +135164,7 @@ akW
 amd
 apn
 aof
-atI
+wwa
 aqK
 arZ
 atr
@@ -128292,10 +135197,10 @@ btR
 aQd
 bmI
 aRT
-aUh
+lRt
 cAy
 aUA
-aUh
+lRt
 aXm
 aYs
 aYs
@@ -128305,11 +135210,11 @@ aYs
 aZo
 bfn
 aVo
-bhG
-bhG
-bhG
-bhG
-bkr
+xVT
+xVT
+xVT
+xVT
+iLI
 bki
 bgw
 bgw
@@ -128353,7 +135258,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+wrL
 boU
 bRx
 bRx
@@ -128368,9 +135273,9 @@ bXz
 bXz
 bWB
 bZw
-caB
-caB
-caB
+kPl
+kPl
+kPl
 bWB
 cXf
 bWB
@@ -128547,12 +135452,12 @@ aNt
 aOt
 bby
 aQe
-bmz
+eGt
 aRU
-aUf
+sPB
 cAw
 aVn
-aUf
+sPB
 aXn
 aSX
 aSX
@@ -128563,16 +135468,16 @@ cNJ
 aRO
 bgw
 bhH
-bhG
-bhG
-bhG
-bkr
-bkU
+xVT
+xVT
+xVT
+iLI
+oiR
 blB
 aPb
 bmB
 bnw
-bog
+juo
 aRZ
 bpa
 bpy
@@ -128597,7 +135502,7 @@ bDl
 bEg
 bFd
 bCs
-bwC
+eBy
 bGZ
 bJe
 bIy
@@ -128610,7 +135515,7 @@ cVC
 boU
 cBU
 bPg
-cCh
+wrL
 boU
 bQB
 bQB
@@ -128763,14 +135668,14 @@ aby
 bsn
 adI
 acT
-akL
-akL
-akL
+gSL
+gSL
+gSL
 aqM
-akL
-akL
+gSL
+gSL
 aqt
-akL
+gSL
 apz
 aoh
 att
@@ -128797,19 +135702,19 @@ bdE
 bwH
 aJZ
 cAo
-cLA
+nnp
 aLI
 aEG
 aNu
-cLA
+nnp
 bbz
 aQf
-bmz
+eGt
 aRR
-aUf
+sPB
 cAx
 aVm
-aUf
+sPB
 aXn
 aYq
 aYq
@@ -128819,23 +135724,23 @@ aYq
 bfo
 aRR
 bgB
-bhG
-bhG
+xVT
+xVT
 biX
-bhG
-bkr
-cGB
+xVT
+iLI
+tjc
 blB
 aPb
 bmC
 bnx
-bnl
+nBd
 aRZ
 boZ
 bpx
 bqc
-bqe
-bqe
+onU
+onU
 brL
 bsu
 bsU
@@ -128860,14 +135765,14 @@ bJe
 bIy
 bJO
 bKp
-bRO
+uWS
 bLE
 bIx
 bCD
 boU
 cBY
 bPg
-cCh
+wrL
 boU
 bRy
 bRy
@@ -128901,7 +135806,7 @@ cks
 cjM
 czV
 cfv
-ceU
+hZd
 cCp
 cpH
 cku
@@ -129013,7 +135918,7 @@ abr
 aaa
 aaa
 aaa
-aaT
+aeT
 abX
 acq
 acU
@@ -129061,12 +135966,12 @@ cIq
 aOu
 bbW
 aQg
-bmz
+eGt
 aRR
-aUf
+sPB
 cAw
 aVm
-aUf
+sPB
 aXo
 aYt
 aZk
@@ -129075,13 +135980,13 @@ aSX
 aSX
 cAw
 bft
-bhI
-bhG
+vDt
+xVT
 blF
-biY
-biY
-bkr
-bkU
+hBS
+hBS
+iLI
+oiR
 blC
 aTh
 bmD
@@ -129111,7 +136016,7 @@ bDF
 bET
 bGl
 bGp
-bwG
+msN
 bHa
 bJA
 bJD
@@ -129165,13 +136070,13 @@ cDP
 cJZ
 cKd
 cBp
-cCj
+dCL
 cHg
 cNy
-cCj
-cHC
+dCL
+jSU
 cHE
-cHC
+jSU
 cHF
 cHG
 cHH
@@ -129278,14 +136183,14 @@ ado
 ayv
 acT
 akM
-alB
+fjH
 aSU
-alC
-alC
+tXX
+tXX
 amO
-alB
+fjH
 anZ
-alC
+tXX
 aqA
 atV
 aqL
@@ -129318,7 +136223,7 @@ aNw
 axa
 cIs
 aPY
-bmz
+eGt
 aSQ
 cNE
 cAz
@@ -129333,17 +136238,17 @@ aSX
 cAw
 bfu
 bhJ
-bhG
+xVT
 biq
 biZ
 bjS
-bkr
+iLI
 bkV
 blD
 aTh
 bmE
 bnz
-bwS
+vLQ
 aRZ
 boZ
 bpx
@@ -129368,7 +136273,7 @@ bDn
 bEj
 bCl
 bFM
-bwC
+eBy
 bHb
 bJe
 bIy
@@ -129381,7 +136286,7 @@ bMx
 boU
 cBS
 bPg
-cCi
+mwk
 boU
 bRA
 bRA
@@ -129417,8 +136322,8 @@ ciV
 cfv
 cNs
 csw
-ctB
-ctB
+pUf
+pUf
 cKb
 cSe
 cso
@@ -129566,7 +136471,7 @@ aGm
 arX
 aFh
 aIv
-aHE
+xjG
 aKc
 aLa
 aLL
@@ -129589,18 +136494,18 @@ aYq
 aYq
 cAw
 bgy
-bhI
-bhG
-bhG
+vDt
+xVT
+xVT
 bjh
 bjT
-bkr
-bkU
+iLI
+oiR
 blD
 aTh
 bmF
 bnA
-bRM
+wZC
 aRZ
 boZ
 bpx
@@ -129638,7 +136543,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+wrL
 boU
 aaA
 aaA
@@ -129672,23 +136577,23 @@ cjO
 cjN
 ciV
 cfv
-ceU
+hZd
 coJ
 cyd
 cyd
 cAr
-cUZ
+fjJ
 cnR
-col
-col
+qbQ
+qbQ
 cNz
-col
-col
-col
-col
-col
-col
-col
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
+qbQ
 cLv
 cmZ
 cVW
@@ -129832,7 +136737,7 @@ aNy
 axa
 bcy
 aPY
-bnl
+nBd
 aRO
 aSS
 cAS
@@ -129847,17 +136752,17 @@ aSX
 cAw
 aRR
 bhK
-bhG
-bhG
+xVT
+xVT
 bjb
 bjU
-bkr
-cGB
+iLI
+tjc
 blB
 aPo
 bmG
 bnB
-bmq
+uci
 aRZ
 boZ
 bpx
@@ -129871,7 +136776,7 @@ cEu
 btS
 bvh
 bvM
-bwC
+eBy
 bxk
 byy
 bzw
@@ -129882,7 +136787,7 @@ bDI
 bBI
 bBI
 bBI
-bwC
+eBy
 bHb
 bCl
 bIx
@@ -129895,7 +136800,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+wrL
 boU
 bRB
 bRB
@@ -129934,7 +136839,7 @@ coJ
 cAr
 cAr
 cAr
-cUZ
+fjJ
 cxt
 cmZ
 cmZ
@@ -130089,7 +136994,7 @@ aHL
 aHM
 cWH
 aQh
-bnl
+nBd
 aRO
 aSW
 aUk
@@ -130104,7 +137009,7 @@ bbR
 bfp
 aRO
 bhL
-bhG
+xVT
 bir
 bjV
 bks
@@ -130114,7 +137019,7 @@ blB
 aPo
 bmH
 bnC
-bmq
+uci
 aRZ
 boZ
 bpx
@@ -130128,7 +137033,7 @@ btS
 buG
 bvi
 bwe
-bwG
+msN
 bxl
 byz
 bzx
@@ -130152,7 +137057,7 @@ bCD
 boU
 cBU
 bPg
-cCh
+wrL
 boU
 bRB
 aaA
@@ -130186,7 +137091,7 @@ cfv
 cfv
 cfv
 cfv
-ceU
+hZd
 coJ
 cAr
 cAr
@@ -130194,8 +137099,8 @@ cAr
 cYg
 cxu
 cmZ
-cwT
-cwT
+cwU
+cwU
 cwU
 cwT
 cwT
@@ -130409,7 +137314,7 @@ bCD
 boU
 cBS
 bPg
-cCh
+wrL
 boU
 bRB
 aaA
@@ -130436,14 +137341,14 @@ ceM
 cfz
 che
 cig
-ciZ
-ciZ
-ciZ
+tkG
+tkG
+tkG
 cmJ
 cNm
-ciZ
-ciZ
-cgs
+tkG
+tkG
+nsK
 cty
 cBe
 cJo
@@ -130451,17 +137356,17 @@ cKc
 cYh
 cxt
 cmZ
-cwU
-cwU
+iJE
+jjH
 cws
-cxw
-cwS
-cxw
-cwS
-cxw
-cwS
-cwT
-cwT
+yfg
+tsA
+yfg
+tsA
+yfg
+rqY
+cwU
+cwU
 cwU
 cwT
 cmZ
@@ -130603,7 +137508,7 @@ aNA
 aOx
 bgn
 aPY
-bog
+juo
 aRO
 aSV
 aUe
@@ -130628,7 +137533,7 @@ aTa
 aRZ
 bgn
 bns
-bmq
+uci
 aRZ
 cOQ
 bpx
@@ -130666,7 +137571,7 @@ bMy
 boU
 cBV
 bPg
-cCh
+wrL
 boU
 bRB
 bRB
@@ -130690,7 +137595,7 @@ cWm
 cXO
 bXe
 cdO
-cgs
+nsK
 cgt
 chf
 chY
@@ -130699,8 +137604,8 @@ cNk
 cmA
 ciX
 cjb
-cmn
-cmn
+kpD
+kpD
 ctz
 cDp
 cKf
@@ -130708,18 +137613,18 @@ cru
 cnR
 cyc
 cmZ
-cwT
+jfS
 cHA
-cwt
+cwS
 cyu
 cwS
 czy
 cwS
 cyu
-cwS
-cHA
-cHA
-cHA
+guj
+jjH
+jjH
+mdU
 cwU
 cmZ
 cmZ
@@ -130923,7 +137828,7 @@ bCD
 boU
 cBW
 bPi
-cCi
+mwk
 boU
 ccG
 bRB
@@ -130965,18 +137870,18 @@ crv
 cmZ
 cmZ
 cmZ
-cwU
+jfS
 cvS
-cwu
+cCS
 cyz
-cwu
+cCS
 cyz
-cwu
+cCS
 cyz
 cCS
 cKg
 cwT
-cwU
+jfS
 cwU
 cmZ
 cmZ
@@ -131142,7 +138047,7 @@ aTa
 aRZ
 bgn
 bns
-bmq
+uci
 aRZ
 czP
 bpA
@@ -131180,7 +138085,7 @@ bCD
 boU
 cod
 bPg
-cCh
+wrL
 bDb
 ccK
 bRB
@@ -131222,7 +138127,7 @@ crw
 cLq
 ctA
 cuq
-cwT
+jfS
 cvT
 cwR
 cwS
@@ -131232,7 +138137,7 @@ cwS
 cwS
 cwR
 cKh
-cXW
+cwS
 cXX
 cwU
 cmZ
@@ -131374,7 +138279,7 @@ aHM
 aHM
 bih
 aPY
-bnl
+nBd
 aRV
 aRZ
 aUp
@@ -131399,7 +138304,7 @@ cKk
 blY
 cKm
 cKn
-bmq
+uci
 aRZ
 bpc
 bpA
@@ -131437,7 +138342,7 @@ cVC
 boU
 cBS
 bPg
-cCh
+wrL
 bDb
 cdj
 bRB
@@ -131479,7 +138384,7 @@ cLr
 cOJ
 cON
 cuq
-cwT
+jfS
 cwp
 cwS
 cwT
@@ -131490,7 +138395,7 @@ cwT
 cwS
 cWG
 cwT
-cwS
+tjO
 cwU
 cmZ
 cmZ
@@ -131631,7 +138536,7 @@ aND
 aOy
 bgn
 aPY
-bnl
+nBd
 aRW
 aRZ
 aUq
@@ -131656,7 +138561,7 @@ bit
 bit
 bvp
 bns
-bmq
+uci
 aRZ
 bpc
 bpA
@@ -131694,7 +138599,7 @@ bCD
 boU
 cBU
 bPg
-cCh
+wrL
 bDb
 cep
 bRB
@@ -131717,7 +138622,7 @@ bDR
 bFE
 bGb
 cei
-ceQ
+oBz
 bYV
 cgw
 cJY
@@ -131734,9 +138639,9 @@ csz
 czb
 cNu
 cOK
-cOO
+hof
 cuq
-cwT
+jfS
 cwp
 cwS
 cwT
@@ -131747,7 +138652,7 @@ cwT
 cwS
 cWG
 cwT
-cwS
+tjO
 cwT
 cmZ
 cmZ
@@ -131888,7 +138793,7 @@ aND
 aOz
 bgn
 aPY
-bnl
+nBd
 cla
 cla
 aZu
@@ -131913,7 +138818,7 @@ blH
 bit
 cWM
 bnt
-bmq
+uci
 aRZ
 bpc
 bpA
@@ -131951,7 +138856,7 @@ bCD
 boU
 cGq
 bPg
-cCh
+wrL
 bDb
 ceX
 bRB
@@ -131974,7 +138879,7 @@ bDS
 cpI
 bGc
 cej
-ceQ
+oBz
 cfE
 bYq
 chj
@@ -131991,9 +138896,9 @@ csA
 cDy
 cOG
 cOL
-cOO
+hof
 cuq
-cwT
+jfS
 cwp
 cwS
 cwU
@@ -132004,7 +138909,7 @@ cwU
 cwS
 cWG
 cwT
-cwS
+tjO
 cwT
 cmZ
 cmZ
@@ -132145,7 +139050,7 @@ aND
 aOy
 bgn
 aPY
-bog
+juo
 cla
 aTc
 aUt
@@ -132170,7 +139075,7 @@ bka
 bit
 cIt
 bns
-bmq
+uci
 aRZ
 bpc
 bpA
@@ -132208,7 +139113,7 @@ bCE
 boU
 cBS
 bPg
-cCh
+wrL
 bDb
 cBs
 bRB
@@ -132248,9 +139153,9 @@ csz
 cFu
 cOH
 cOM
-cOO
+hof
 cuq
-cwT
+jfS
 cwp
 cwS
 cwT
@@ -132261,7 +139166,7 @@ cwT
 cwS
 cWG
 cwT
-cwS
+tjO
 cwT
 cmZ
 cmZ
@@ -132402,7 +139307,7 @@ aND
 aND
 cMA
 aPY
-bnl
+nBd
 cla
 aTd
 aUu
@@ -132427,7 +139332,7 @@ blI
 bit
 bgn
 bns
-blg
+shr
 aRZ
 bpd
 bpB
@@ -132465,7 +139370,7 @@ bpc
 boU
 cBS
 bPg
-cCh
+wrL
 bDb
 ccK
 bRB
@@ -132482,7 +139387,7 @@ cEG
 cEH
 cbv
 caJ
-ccP
+spX
 cbY
 bES
 bFG
@@ -132507,7 +139412,7 @@ cOI
 crw
 cOP
 cuq
-cwT
+jfS
 cwp
 cwS
 cwT
@@ -132518,7 +139423,7 @@ cwT
 cwS
 cWG
 cwT
-cwS
+tjO
 cwU
 cmZ
 cmZ
@@ -132659,7 +139564,7 @@ cGW
 aND
 bgn
 aPY
-bnl
+nBd
 cla
 aTe
 aVu
@@ -132684,7 +139589,7 @@ blJ
 bit
 bgn
 bns
-bmq
+uci
 aRZ
 czR
 bpA
@@ -132763,8 +139668,8 @@ cqI
 crA
 coO
 ctC
-cuq
-cwT
+fSW
+lWO
 cwq
 cwR
 cwS
@@ -132774,8 +139679,8 @@ cwS
 cwS
 cwR
 cXU
-cXW
-cXX
+cwS
+tbT
 cwU
 cmZ
 cmZ
@@ -132979,7 +139884,7 @@ cED
 bpe
 cBX
 bPf
-cCk
+uZH
 boU
 bpe
 bSb
@@ -132996,13 +139901,13 @@ cAT
 cAT
 cbv
 caL
-ccP
+spX
 bYn
 cNf
 cdi
 cdP
 cel
-ceU
+hZd
 cqh
 bYq
 chg
@@ -133021,18 +139926,18 @@ crB
 cmZ
 cmZ
 cmZ
-cwU
+jfS
 cwr
-cxp
+xUp
 czc
-cxp
+xUp
 czc
-cxp
+xUp
 cAt
-czc
+xUp
 cXV
 cwT
-cwU
+cHA
 cwU
 cmZ
 cmZ
@@ -133174,92 +140079,92 @@ aOA
 biu
 aQl
 boF
-bph
-bpD
-bpD
-bpD
-bpZ
-bpZ
+nXH
+puL
+puL
+puL
+jCQ
+jCQ
 bBK
 bsr
-bpD
+puL
 bvC
-bpD
-bpD
-bph
-cSB
-cSB
-bpD
+puL
+puL
+nXH
+rYm
+rYm
+puL
 bya
 byJ
 bsA
 bCb
-bph
-bpD
+nXH
+puL
 bLo
 bns
-bNL
-aZv
-bPl
-bPl
-bPl
-bPl
-bPl
-bPl
+vJb
+uSM
+lYr
+lYr
+lYr
+lYr
+lYr
+lYr
 cmE
 bUt
 cWz
-bQM
-bQP
-bQM
+mvo
+oKO
+mvo
 cAD
 abN
 bVw
 bxv
 cIL
-bQP
-bQM
+oKO
+mvo
 cIN
-bQM
+mvo
 cBt
-cBv
+uwg
 cBa
-bPl
-bPl
-cBA
-cBA
-bPl
+lYr
+lYr
+haK
+haK
+lYr
 ceN
-bPl
-bPl
-bPl
+lYr
+lYr
+lYr
 cOC
 cBZ
 bPj
 cHs
-cBv
+uwg
 cTY
-bPl
-bPl
+lYr
+lYr
 cCw
-bPl
-bPl
-bPl
+lYr
+lYr
+lYr
 cHt
 bXe
-bfq
+nuO
 bYW
-cah
-cah
+tfI
+tfI
 ccI
 caL
 cdT
 coE
-bfq
+nuO
 cCN
 cdP
 cem
-ceU
+hZd
 bYq
 bYq
 cii
@@ -133268,10 +140173,10 @@ clI
 cjT
 ckD
 cns
-coj
+qFo
 coP
 cNt
-coj
+qFo
 cpP
 cqK
 crC
@@ -133280,13 +140185,13 @@ ctD
 cCR
 cHh
 cHB
-cwt
-czn
 cwS
 czn
 cwS
-cwS
 czn
+cwS
+hVN
+cwS
 cHA
 cHA
 cHA
@@ -133461,48 +140366,48 @@ bsq
 bNn
 bvR
 bNl
-bTQ
-bTQ
+wGp
+wGp
 cAu
 cAA
-bTQ
-bTQ
-bTQ
-bTQ
+wGp
+wGp
+wGp
+wGp
 cAC
 bPA
 cAF
 bPz
-bTQ
-bTQ
-bTQ
-bTQ
-bTQ
+wGp
+wGp
+wGp
+wGp
+wGp
 cAH
 cAI
-bTQ
+wGp
 cAJ
-cAK
-cAK
+nIA
+nIA
 cAL
-cAK
-cAK
-cAK
-cAK
-cAK
-cAK
+nIA
+nIA
+nIA
+nIA
+nIA
+nIA
 cAM
 cEP
-cAK
+nIA
 cAO
-cAK
-cAK
+nIA
+nIA
 coF
 cAP
 cHD
-cAK
-cAK
-cAK
+nIA
+nIA
+nIA
 cIc
 bXJ
 bYr
@@ -133535,17 +140440,17 @@ cnR
 csD
 ctE
 csD
-cwU
-cwU
+ezo
+jjH
 cxv
-czo
+jFJ
 cwS
-czo
+jFJ
 cwS
+jFJ
 cwS
-czo
-cwT
-cwT
+cwU
+cwU
 cwU
 cwT
 cmZ
@@ -133687,42 +140592,42 @@ bLO
 aND
 bjm
 aZc
-boV
-boV
+jkm
+jkm
 aTn
-bzH
+rsJ
 bFf
 brb
 brd
 bcp
-bzH
-bzH
+rsJ
+rsJ
 cGQ
-boV
+jkm
 bRk
-boV
-boV
+jkm
+jkm
 cQO
-bxY
-boV
-boV
+uDE
+jkm
+jkm
 bBg
-boV
-boV
-boV
-boV
-boV
-bxY
+jkm
+jkm
+jkm
+jkm
+jkm
+uDE
 bTs
 bVb
 bsf
 byi
 bTp
 cSM
-chC
-bPV
+gCs
+sZd
 byR
-bPV
+sZd
 bQN
 bwJ
 bwJ
@@ -133730,45 +140635,45 @@ cUi
 cBJ
 bDc
 bVK
-cIM
-cIM
-cIM
-cIM
+fOO
+fOO
+fOO
+fOO
 cIQ
-cEX
-cBw
-bPV
+dsE
+hwC
+sZd
 cBz
-bPV
-chC
+sZd
+gCs
 bMo
 cBD
-bPV
-bPV
-bPV
-bPV
+sZd
+sZd
+sZd
+sZd
 cTT
 cTX
 cEQ
-chC
-cBw
+gCs
+hwC
 cTZ
-bPV
+sZd
 bYG
-cEX
+dsE
 cvO
 cCy
-bPV
-bPV
+sZd
+sZd
 bXe
-bZJ
+mNk
 clO
 cak
 cbu
 cHJ
 cHN
 cHS
-bZJ
+mNk
 cdq
 cdS
 cdR
@@ -133782,18 +140687,18 @@ cSv
 cjT
 cTF
 cnR
-cok
-col
+sAu
+qbQ
 cWB
-col
+qbQ
 cKZ
-cok
+sAu
 ctw
 cjS
 ctF
 cmZ
-cwT
-cwT
+cwU
+cwU
 cwU
 cwT
 cwT
@@ -134234,9 +141139,9 @@ bzJ
 bUl
 brA
 brY
-bsC
-bsC
-bsC
+urx
+urx
+urx
 buL
 bsg
 bsg
@@ -134745,7 +141650,7 @@ cAf
 bpi
 bQc
 bHi
-bVn
+vpb
 brB
 bsa
 bsE
@@ -134814,7 +141719,7 @@ cTH
 coS
 cnd
 cKO
-cLc
+kYW
 cqO
 crF
 csG
@@ -135002,7 +141907,7 @@ aRj
 bpi
 bQb
 bFn
-bVn
+vpb
 brB
 bsa
 bsF
@@ -135062,12 +141967,12 @@ cdx
 ceZ
 cgA
 chr
-cjg
+yga
 cTB
-cjg
+yga
 cmt
 ckI
-cjg
+yga
 coT
 cpT
 cKP
@@ -135229,8 +142134,8 @@ aOc
 aOP
 aPD
 cym
-aSc
-aSc
+rIV
+rIV
 aUx
 aUB
 aWz
@@ -135241,8 +142146,8 @@ baR
 baX
 bcb
 bel
-ber
-ber
+ikz
+ikz
 bgH
 bda
 cmq
@@ -135328,7 +142233,7 @@ cng
 coY
 cpU
 cKQ
-cLe
+oCS
 cqP
 crI
 csG
@@ -135530,7 +142435,7 @@ bxC
 bsE
 bzK
 brA
-bvZ
+lBj
 bCG
 brA
 bEt
@@ -135585,7 +142490,7 @@ cdy
 cnf
 cdy
 cKQ
-cLf
+hcn
 coU
 crO
 csI
@@ -135773,7 +142678,7 @@ aRj
 bpi
 cMW
 bHi
-bVn
+vpb
 brA
 bsc
 bsE
@@ -135787,7 +142692,7 @@ bxD
 bDt
 bzL
 brA
-bvZ
+lBj
 bCH
 brA
 bEq
@@ -135842,7 +142747,7 @@ cni
 cnf
 cof
 cKQ
-cLg
+wsH
 chu
 crJ
 csJ
@@ -136099,7 +143004,7 @@ cNp
 cnf
 cof
 cKQ
-cLe
+oCS
 coW
 ciw
 csH
@@ -136248,9 +143153,9 @@ aaa
 aaa
 aab
 aab
-aJu
+lNj
 aKl
-aJu
+lNj
 aLW
 aMT
 aNR
@@ -136287,7 +143192,7 @@ bix
 bpi
 bQb
 bHi
-bVn
+vpb
 brB
 bsa
 bsH
@@ -136356,7 +143261,7 @@ cnY
 cnf
 cpV
 cKQ
-cLe
+oCS
 coW
 cix
 csG
@@ -136520,8 +143425,8 @@ aUG
 cyJ
 aWL
 aYF
-aWD
-aWD
+rXW
+rXW
 baS
 cQo
 bce
@@ -136544,7 +143449,7 @@ aRj
 bpi
 bQb
 bFn
-bVn
+vpb
 brB
 bsa
 bsH
@@ -136613,7 +143518,7 @@ cmu
 cnf
 csx
 cKQ
-cLe
+oCS
 coX
 crG
 csI
@@ -136801,7 +143706,7 @@ aQz
 bpi
 bQf
 bJS
-bVn
+vpb
 brB
 bsa
 bsH
@@ -136870,7 +143775,7 @@ cmu
 cnf
 csx
 cKQ
-cLg
+wsH
 cpS
 crN
 csJ
@@ -137034,8 +143939,8 @@ aVz
 aUH
 aXz
 aYL
-aWF
-aWF
+eqe
+eqe
 baT
 bpG
 aUH
@@ -137058,7 +143963,7 @@ ccA
 bpi
 bQb
 bFn
-bVn
+vpb
 brA
 bse
 bsH
@@ -137127,7 +144032,7 @@ cdy
 cnf
 cdy
 cNY
-cLf
+hcn
 cqQ
 cta
 csK
@@ -137276,9 +144181,9 @@ aab
 aab
 aab
 aab
-aJx
+lLo
 aKn
-aJx
+lLo
 aLZ
 aMT
 aNR
@@ -137384,7 +144289,7 @@ cnZ
 cpa
 cuo
 cKQ
-cLf
+hcn
 cqP
 ctb
 csG
@@ -138155,7 +145060,7 @@ cdx
 cdx
 cvj
 cKQ
-cLc
+kYW
 cgB
 crR
 ctH
@@ -138346,12 +145251,12 @@ bqB
 bnL
 brE
 bsh
-bpS
-bpS
+rqB
+rqB
 bua
 blZ
 bvv
-bvZ
+lBj
 brA
 aaA
 aaA
@@ -138412,7 +145317,7 @@ cdy
 cdy
 cdy
 cKQ
-cLc
+kYW
 cqV
 crS
 csN
@@ -138926,7 +145831,7 @@ cXh
 cpc
 cpc
 cKQ
-cLc
+kYW
 cqV
 crU
 cdy
@@ -139183,7 +146088,7 @@ cMg
 cpd
 cpc
 cKT
-cLc
+kYW
 cqV
 crV
 cdy
@@ -139371,9 +146276,9 @@ boI
 bpk
 bpN
 bqF
-bqK
-bpo
-bnM
+reY
+hMI
+eXk
 bsL
 bnL
 bue
@@ -139440,7 +146345,7 @@ coe
 cpc
 cpc
 cKT
-cLc
+kYW
 cqV
 cOf
 cdy
@@ -139697,7 +146602,7 @@ cXi
 cpc
 cpc
 cKQ
-cLc
+kYW
 cqV
 crU
 ccS
@@ -139878,19 +146783,19 @@ aac
 aaa
 aab
 bma
-bmU
+jqb
 bnL
 bot
-boK
+qcn
 bpl
 bip
 bqH
 brn
 brG
-bsj
+fow
 bsL
 bnL
-boK
+qcn
 bma
 aaa
 aaa
@@ -139954,7 +146859,7 @@ coH
 cpQ
 cdy
 cKU
-cLc
+kYW
 cqV
 crV
 cgF
@@ -140135,19 +147040,19 @@ aac
 aaa
 aab
 bma
-bmU
+jqb
 bnL
 bot
-boK
+qcn
 bpm
 bpQ
 bnL
 bro
 bpm
-bsj
+fow
 bsL
 bnL
-boK
+qcn
 bma
 aaa
 aaa
@@ -140211,7 +147116,7 @@ cdy
 cdy
 cdy
 cKQ
-cLc
+kYW
 cqX
 crU
 cgF
@@ -140364,7 +147269,7 @@ aJy
 aKo
 aNa
 aMf
-aMZ
+vPQ
 aPy
 aNa
 aQq
@@ -140404,7 +147309,7 @@ blZ
 bsk
 bsL
 bnL
-boK
+qcn
 bma
 aaa
 aaa
@@ -140621,7 +147526,7 @@ aJz
 aKp
 aLm
 aMe
-aMZ
+vPQ
 aOb
 aNa
 aQq
@@ -140653,11 +147558,11 @@ bmW
 bnL
 bot
 boL
-bpn
-bpS
-bpS
-bpS
-bpn
+kDs
+rqB
+rqB
+rqB
+kDs
 bsl
 bsL
 bnL
@@ -140907,7 +147812,7 @@ aac
 aav
 bma
 bmX
-bnM
+eXk
 btm
 bnL
 bnL
@@ -140982,7 +147887,7 @@ cdx
 cdx
 cvj
 cKX
-cLc
+kYW
 cra
 crX
 csP
@@ -141167,12 +148072,12 @@ bmY
 cMV
 bnL
 boM
-bpo
+hMI
 bnL
-bqK
+reY
 bnL
-bpo
-bnM
+hMI
+eXk
 bnL
 btu
 bui
@@ -141421,17 +148326,17 @@ aaa
 aab
 aab
 bma
-bnO
+uJe
 bov
-boN
+phO
 cHm
 bpT
 bqL
 brq
 cHm
-bnO
+uJe
 bov
-boN
+phO
 bma
 aab
 aaa
@@ -142529,9 +149434,9 @@ cre
 csb
 csT
 ctR
-cuL
+cuN
 cvv
-cuL
+cuN
 cwz
 cnp
 cnp

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -64875,6 +64875,7 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "ctE" = (
@@ -69204,7 +69205,6 @@
 /obj/effect/mapping_helpers/airlock/cyclelink_helper{
 	dir = 1
 	},
-/obj/structure/fans/tiny,
 /turf/open/floor/plating,
 /area/engine/engineering)
 "cCS" = (

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -7641,6 +7641,9 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel,
 /area/security/prison)
 "apo" = (

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -1233,13 +1233,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"adm" = (
-/obj/machinery/door/poddoor{
-	id = "SecJusticeChamber";
-	name = "Justice Vent"
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
 "adn" = (
 /obj/structure/cable{
 	icon_state = "2-4"
@@ -1279,9 +1272,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"ads" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "adt" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -1505,9 +1495,6 @@
 /area/science/circuit)
 "adU" = (
 /turf/open/floor/plasteel,
-/area/science/circuit)
-"adV" = (
-/turf/open/floor/plasteel/dark,
 /area/science/circuit)
 "adW" = (
 /obj/effect/turf_decal/bot,
@@ -1973,16 +1960,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/storage)
-"aeT" = (
-/obj/docking_port/stationary{
-	dwidth = 1;
-	height = 4;
-	roundstart_template = /datum/map_template/shuttle/escape_pod/default;
-	width = 3
-	},
-/obj/structure/fans/tiny/invisible,
-/turf/open/space,
-/area/space)
 "aeU" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -2383,20 +2360,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
-"afI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel/dark,
-/area/science/circuit)
 "afJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -2713,28 +2676,6 @@
 	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/science/circuit)
-"agq" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
 /area/science/circuit)
 "agr" = (
 /obj/machinery/door/airlock/research{
@@ -3609,13 +3550,6 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"ahU" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "ahV" = (
@@ -4911,9 +4845,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/xenobiology)
-"akp" = (
-/turf/closed/wall,
-/area/science/circuit)
 "akq" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -5129,15 +5060,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"akL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "akM" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -5600,22 +5522,6 @@
 	},
 /turf/open/floor/circuit,
 /area/science/xenobiology)
-"alB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"alC" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "alD" = (
 /obj/structure/bodycontainer/morgue,
 /obj/structure/window/reinforced,
@@ -7552,12 +7458,6 @@
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aoQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "aoR" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -8462,15 +8362,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aqx" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "aqy" = (
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
@@ -9980,18 +9871,6 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"asQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "asR" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -10445,13 +10324,6 @@
 "atH" = (
 /turf/closed/wall/r_wall,
 /area/science/server)
-"atI" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "atJ" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
@@ -10897,15 +10769,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"auu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "auv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -11112,15 +10975,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel/dark,
 /area/science/server)
-"auO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "auP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /turf/closed/wall/r_wall,
@@ -11660,18 +11514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"avH" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "avI" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -11737,15 +11579,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab/range)
-"avM" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "avN" = (
 /obj/machinery/light{
 	dir = 8;
@@ -12894,18 +12727,6 @@
 "axp" = (
 /turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
-"axq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "axr" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -13052,21 +12873,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"axE" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "axF" = (
 /turf/closed/wall/r_wall,
 /area/crew_quarters/heads/hos)
@@ -13953,13 +13759,6 @@
 	pixel_y = 32
 	},
 /obj/effect/turf_decal/trimline/purple/filled/line,
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"azk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line,
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
 "azl" = (
@@ -15082,15 +14881,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aBe" = (
-/obj/effect/turf_decal/trimline/purple/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aBf" = (
 /obj/machinery/computer/secure_data,
 /turf/open/floor/carpet,
@@ -15141,18 +14931,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aBm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aBn" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 4
@@ -15180,21 +14958,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aBp" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
-"aBq" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aBr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -15220,12 +14983,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
-"aBs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "aBt" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -15570,13 +15327,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/department/science)
-"aBZ" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "aCa" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -16340,13 +16090,6 @@
 /obj/item/healthanalyzer,
 /turf/open/floor/plasteel/white,
 /area/science/explab)
-"aDq" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "aDr" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -17661,13 +17404,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"aFH" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aFI" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -17692,12 +17428,6 @@
 "aFL" = (
 /turf/open/floor/plating/asteroid/basalt,
 /area/asteroid/nearstation)
-"aFM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aFN" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
@@ -18703,25 +18433,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aHC" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aHD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aHE" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
@@ -18731,16 +18445,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/courtroom)
-"aHG" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aHH" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -19566,15 +19270,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/art)
-"aIT" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aIU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 4
@@ -19824,17 +19519,6 @@
 /obj/structure/sign/warning/vacuum/external,
 /turf/closed/wall/r_wall,
 /area/quartermaster/storage)
-"aJu" = (
-/obj/machinery/conveyor{
-	dir = 1;
-	id = "QMLoad"
-	},
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor";
-	name = "Supply Dock Loading Door"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "aJv" = (
 /obj/machinery/door/airlock/external{
 	name = "Supply Dock Airlock";
@@ -19846,16 +19530,6 @@
 "aJw" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/sign/warning/vacuum/external,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
-"aJx" = (
-/obj/machinery/door/poddoor{
-	id = "QMLoaddoor2";
-	name = "Supply Dock Loading Door"
-	},
-/obj/machinery/conveyor{
-	id = "QMLoad2"
-	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
 "aJy" = (
@@ -20004,16 +19678,6 @@
 /obj/item/storage/box/lights,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"aJO" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aJP" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
@@ -20489,34 +20153,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"aKH" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aKI" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -20618,13 +20254,6 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
-/area/security/brig)
-"aKP" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
 /area/security/brig)
 "aKQ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
@@ -21555,15 +21184,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aMw" = (
-/obj/machinery/light/small{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aMx" = (
 /obj/item/radio/intercom{
 	desc = "Talk through this. It looks like it has been modified to not broadcast.";
@@ -21578,16 +21198,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"aMy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aMz" = (
@@ -21900,12 +21510,6 @@
 	},
 /obj/structure/rack,
 /obj/item/flashlight/seclite,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
-"aMZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "aNa" = (
@@ -22536,34 +22140,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"aOn" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aOo" = (
 /obj/structure/cable,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -23304,22 +22880,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain/private)
-"aPN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/item/radio/intercom{
-	dir = 4;
-	pixel_x = 27
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aPO" = (
 /obj/structure/closet/secure_closet/personal/cabinet,
 /obj/item/radio/intercom{
@@ -24100,12 +23660,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aRa" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "aRb" = (
 /obj/machinery/airalarm{
 	dir = 8;
@@ -24657,13 +24211,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
-"aSc" = (
-/obj/structure/closet/wardrobe/cargotech,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "aSd" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer3{
 	dir = 8
@@ -25689,25 +25236,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"aUf" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aUg" = (
 /obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"aUh" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "aUi" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /obj/machinery/camera/autoname{
@@ -26860,12 +26392,6 @@
 	icon_state = "yellowsiding"
 	},
 /area/quartermaster/office)
-"aWF" = (
-/obj/effect/turf_decal/caution{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/warehouse)
 "aWG" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 8
@@ -27163,28 +26689,6 @@
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
-"aXi" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aXj" = (
 /obj/item/reagent_containers/glass/bucket,
 /turf/open/floor/plasteel,
@@ -28091,14 +27595,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/wood,
 /area/crew_quarters/heads/captain)
-"aYW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aYX" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -28106,15 +27602,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"aYY" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
@@ -28131,18 +27618,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"aZa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aZb" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/tile/neutral,
@@ -28327,15 +27802,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/central)
-"aZv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "aZw" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -28722,24 +28188,6 @@
 /obj/effect/landmark/blobstart,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"bad" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "bae" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -31051,17 +30499,6 @@
 /obj/effect/turf_decal/tile,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
-"ber" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/conveyor{
-	backwards = 1;
-	forwards = 2;
-	id = "trashsort"
-	},
-/turf/open/floor/plating,
-/area/quartermaster/sorting)
 "bes" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/stripes/line{
@@ -31503,12 +30940,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"bfq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bfr" = (
 /obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -32674,15 +32105,6 @@
 /obj/item/storage/box/donkpockets,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bhG" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bhH" = (
 /obj/structure/sink/kitchen{
 	pixel_y = 28
@@ -32692,15 +32114,6 @@
 	},
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"bhI" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -33335,16 +32748,6 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"biY" = (
-/obj/machinery/deepfryer,
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "biZ" = (
@@ -34086,21 +33489,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"bkr" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bks" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
@@ -34417,18 +33805,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"bkU" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "bkV" = (
 /obj/effect/landmark/start/cook,
 /obj/structure/disposalpipe/segment{
@@ -34551,14 +33927,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/janitor)
-"blg" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "blh" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35202,13 +34570,6 @@
 	},
 /turf/open/floor/plasteel/grimy,
 /area/bridge)
-"bmq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bmr" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -35226,13 +34587,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bms" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
@@ -35283,13 +34637,6 @@
 /area/hallway/primary/central)
 "bmy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bmz" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
@@ -35473,16 +34820,6 @@
 	},
 /obj/machinery/light{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"bmU" = (
-/obj/structure/chair,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -35698,15 +35035,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/gateway)
-"bnl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bnm" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/effect/turf_decal/trimline/neutral/filled/line,
@@ -36145,12 +35473,6 @@
 "bnL" = (
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bnM" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bnN" = (
 /obj/structure/chair/stool,
 /obj/machinery/camera{
@@ -36162,18 +35484,6 @@
 	dir = 8
 	},
 /area/chapel/main)
-"bnO" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bnP" = (
 /obj/machinery/door/airlock/external{
 	name = "Departure Lounge Airlock"
@@ -36341,16 +35651,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"bog" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "boh" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -36601,16 +35901,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"boK" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "boL" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -36618,16 +35908,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "boM" = (
-/obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"boN" = (
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
@@ -36675,15 +35955,6 @@
 "boU" = (
 /turf/closed/wall,
 /area/hallway/primary/aft)
-"boV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "boW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -36703,16 +35974,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"boX" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "boY" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /turf/open/floor/plating,
@@ -36753,14 +36014,6 @@
 "bpe" = (
 /turf/closed/wall,
 /area/hallway/primary/starboard)
-"bpf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bpg" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -36776,19 +36029,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"bph" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bpi" = (
 /turf/closed/wall,
 /area/hallway/secondary/exit)
@@ -36833,26 +36073,6 @@
 	icon_state = "0-8"
 	},
 /turf/open/floor/plating,
-/area/hallway/secondary/exit/departure_lounge)
-"bpn" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants/random,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"bpo" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bpp" = (
 /obj/structure/cable{
@@ -36956,15 +36176,6 @@
 "bpC" = (
 /turf/closed/wall,
 /area/medical/morgue)
-"bpD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bpE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -36982,13 +36193,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"bpF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bpG" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 10
@@ -37135,15 +36339,6 @@
 /obj/structure/filingcabinet/security,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bpS" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bpT" = (
 /obj/machinery/door/window/brigdoor/westright{
 	name = "Holding Area";
@@ -37190,13 +36385,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
-"bpZ" = (
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bqa" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -37250,12 +36438,6 @@
 /obj/item/storage/box/disks{
 	pixel_x = 2;
 	pixel_y = 2
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
-"bqe" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -37631,13 +36813,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bqJ" = (
 /obj/effect/landmark/event_spawn,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"bqK" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bqL" = (
@@ -38025,12 +37200,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bru" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "brv" = (
 /obj/machinery/door/window/westleft{
 	name = "Monkey Enclosure";
@@ -38056,28 +37225,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
-"brz" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "brA" = (
 /turf/closed/wall,
 /area/library)
@@ -38418,16 +37565,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bsj" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/structure/chair,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bsk" = (
 /obj/effect/turf_decal/tile{
 	dir = 4
@@ -38623,12 +37760,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bsC" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
 "bsD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -39298,18 +38429,6 @@
 /obj/structure/bookcase/random/nonfiction,
 /turf/open/floor/wood,
 /area/library)
-"btX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "btY" = (
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -40039,21 +39158,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"bvr" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "bvs" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
@@ -40357,18 +39461,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bvS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bvT" = (
 /obj/machinery/light,
 /turf/open/floor/carpet,
@@ -40405,9 +39497,6 @@
 /obj/machinery/door/morgue{
 	name = "Study"
 	},
-/turf/open/floor/plasteel/cult,
-/area/library)
-"bvZ" = (
 /turf/open/floor/plasteel/cult,
 /area/library)
 "bwa" = (
@@ -40504,18 +39593,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
-"bwg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bwh" = (
 /obj/structure/reagent_dispensers/fueltank,
 /turf/open/floor/plating,
@@ -40571,12 +39648,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/green/filled/line,
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
-"bwr" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bws" = (
@@ -40707,12 +39778,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"bwC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bwD" = (
 /obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
@@ -40739,17 +39804,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/cryo)
-"bwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "bwH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -40848,16 +39902,6 @@
 "bwR" = (
 /turf/closed/wall,
 /area/medical/virology)
-"bwS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bwT" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/green/filled/line,
@@ -41031,42 +40075,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"bxn" = (
-/obj/machinery/door/firedoor,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"bxo" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "bxp" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -41280,25 +40288,6 @@
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bxP" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bxQ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -41862,13 +40851,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"byW" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "byX" = (
 /obj/structure/window/reinforced/spawner,
 /obj/effect/turf_decal/trimline/blue/filled/line,
@@ -42227,15 +41209,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bzH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bzI" = (
 /obj/effect/mapping_helpers/airlock/locked,
 /obj/machinery/door/airlock/vault{
@@ -42371,22 +41344,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"bzU" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bzV" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced{
@@ -42411,39 +41368,6 @@
 	},
 /turf/open/space/basic,
 /area/space)
-"bzZ" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bAa" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bAb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bAc" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced{
@@ -42727,14 +41651,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
-"bAy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "bAz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/trimline/green/filled/line{
@@ -42784,12 +41700,6 @@
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"bAE" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
@@ -42910,35 +41820,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bAR" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bAS" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bAT" = (
 /obj/structure/chair/comfy/black{
 	dir = 8
@@ -44005,13 +42886,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"bCV" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "bCW" = (
 /obj/structure/window/reinforced{
 	dir = 1;
@@ -44124,15 +42998,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bDg" = (
-/obj/structure/chair{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "bDh" = (
 /turf/closed/wall/r_wall,
 /area/medical/medbay/front_office)
@@ -44516,19 +43381,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/cmo)
-"bDJ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bDK" = (
 /turf/closed/wall,
 /area/maintenance/bar)
@@ -45109,16 +43961,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/ai)
-"bEK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bEL" = (
 /obj/item/electropack/shockcollar,
 /obj/item/assembly/signaler,
@@ -47741,24 +46583,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/patients_rooms/room_a)
-"bJH" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
 "bJI" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -48426,18 +47250,6 @@
 "bKV" = (
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"bKW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bKX" = (
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
@@ -48461,19 +47273,6 @@
 	dir = 6
 	},
 /obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bKZ" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
 "bLa" = (
@@ -48811,16 +47610,6 @@
 /obj/structure/grille,
 /turf/open/space/basic,
 /area/space/nearstation)
-"bLI" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bLJ" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -48833,16 +47622,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"bLL" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bLM" = (
 /turf/open/floor/carpet/orange,
 /area/quartermaster/qm/private)
@@ -49452,13 +48231,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"bMM" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bMN" = (
 /obj/machinery/ai_slipper{
 	uses = 10
@@ -49479,23 +48251,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat_interior)
-"bMQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"bMR" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bMS" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -49606,17 +48361,6 @@
 /obj/structure/window/reinforced/spawner,
 /turf/open/space,
 /area/space)
-"bNg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "bNh" = (
 /obj/machinery/airalarm{
 	dir = 4;
@@ -49958,18 +48702,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bNK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"bNL" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bNM" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -50035,22 +48767,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
-"bNU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bNV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bNW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -51163,37 +49879,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bPk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bPl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bPm" = (
 /obj/structure/rack,
 /obj/item/circuitboard/machine/telecomms/bus{
@@ -51621,15 +50306,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/transit_tube)
-"bPV" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bPW" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 1
@@ -51988,18 +50664,6 @@
 /obj/machinery/porta_turret/ai,
 /turf/open/floor/plating,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"bQM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bQN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
@@ -52029,22 +50693,6 @@
 	},
 /turf/open/floor/carpet,
 /area/bridge)
-"bQP" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bQQ" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -52341,22 +50989,10 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge/showroom/corporate)
-"bRr" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "bRs" = (
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"bRt" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
 "bRu" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -52501,32 +51137,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/cafeteria)
-"bRM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/item/radio/intercom{
-	dir = 1;
-	pixel_y = -29
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bRN" = (
 /obj/machinery/light{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"bRO" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/surgery)
 "bRP" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 6
@@ -52608,12 +51224,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"bRW" = (
-/obj/effect/turf_decal/trimline/neutral/filled/end{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "bRX" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -52684,12 +51294,6 @@
 "bSg" = (
 /obj/machinery/status_display/evac{
 	pixel_y = 31
-	},
-/turf/open/floor/plasteel/grimy,
-/area/tcommsat/computer)
-"bSh" = (
-/obj/structure/showcase/cyborg/old{
-	pixel_y = 20
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
@@ -52802,17 +51406,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/storage/primary)
-"bSu" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bSv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -52882,16 +51475,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"bSC" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "bSD" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -52914,18 +51497,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"bSF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "bSG" = (
 /obj/effect/spawner/structure/window,
 /turf/open/floor/plating,
@@ -53552,31 +52123,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"bTQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bTR" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-21"
@@ -54080,18 +52626,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"bUN" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bUO" = (
 /obj/structure/cable{
 	icon_state = "0-8"
@@ -54370,15 +52904,6 @@
 	},
 /turf/open/floor/plating,
 /area/storage/tech)
-"bVn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "bVo" = (
 /obj/machinery/light{
 	dir = 1;
@@ -55058,20 +53583,6 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/dorms)
-"bWx" = (
-/obj/machinery/light/small{
-	dir = 4;
-	light_color = "#d8b1b1"
-	},
-/obj/machinery/light_switch{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 8
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/dorms)
 "bWy" = (
 /obj/effect/turf_decal/trimline/green/filled/corner{
 	dir = 8
@@ -55392,16 +53903,6 @@
 /obj/machinery/telecomms/server/presets/medical,
 /turf/open/floor/circuit/telecomms/mainframe,
 /area/tcommsat/server)
-"bXh" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bXi" = (
 /obj/machinery/telecomms/bus/preset_two,
 /turf/open/floor/circuit/telecomms/mainframe,
@@ -56538,15 +55039,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bZn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "bZo" = (
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
@@ -56788,14 +55280,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/crew_quarters/heads/cmo)
-"bZJ" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "bZK" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -57066,13 +55550,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"cah" = (
-/obj/structure/chair/stool,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "cai" = (
 /obj/machinery/holopad,
 /obj/effect/turf_decal/bot,
@@ -57167,12 +55644,6 @@
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"cav" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "caw" = (
 /obj/machinery/light{
 	dir = 1
@@ -57243,13 +55714,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"caB" = (
-/obj/structure/urinal{
-	dir = 8;
-	pixel_x = 28
-	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
 "caC" = (
@@ -57688,13 +56152,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"cbh" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cbi" = (
 /obj/machinery/light,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
@@ -57715,15 +56172,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"cbk" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "cbl" = (
@@ -57987,28 +56435,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cbI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cbJ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
@@ -58561,18 +56987,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/delivery,
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"ccP" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ccQ" = (
@@ -61291,12 +59705,6 @@
 /obj/machinery/airalarm/directional/east,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"ciZ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
@@ -67612,18 +66020,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/cable,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cwt" = (
-/obj/machinery/door/poddoor{
-	id = "SecJusticeChamber";
-	name = "Justice Vent"
-	},
-/turf/open/floor/plating,
-/area/security/execution/education)
-"cwu" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "cwv" = (
 /obj/machinery/door/airlock/atmos{
 	name = "Atmospherics Maintenance";
@@ -68967,9 +67366,6 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating,
 /area/hallway/secondary/entry)
-"czu" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "czv" = (
 /obj/item/storage/toolbox/artistic,
 /turf/open/floor/plating,
@@ -69423,21 +67819,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/hallway/primary/aft)
-"cAn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "cAo" = (
 /obj/effect/turf_decal/stripes/red/line,
 /obj/effect/turf_decal/arrows/red,
@@ -69664,20 +68045,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cAE" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "cAF" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69708,18 +68075,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cAG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "cAH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69801,31 +68156,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cAK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cAL" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -69880,16 +68210,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cAN" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "cAO" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -70178,15 +68498,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"cBq" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "cBr" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -70221,41 +68532,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/tcommsat/computer)
-"cBv" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"cBw" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cBx" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel/grimy,
 /area/chapel/office)
-"cBy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cBz" = (
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/primary/starboard";
@@ -70271,12 +68553,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"cBA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -70329,19 +68605,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cBG" = (
-/obj/machinery/light{
-	dir = 4;
-	light_color = "#c1caff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -70539,30 +68802,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cCb" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cCc" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cCd" = (
 /obj/structure/chair{
 	dir = 4
@@ -70591,30 +68830,9 @@
 	},
 /turf/open/floor/carpet/royalblack,
 /area/crew_quarters/dorms)
-"cCf" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cCg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cCh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cCi" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -70627,14 +68845,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage)
-"cCk" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cCl" = (
 /obj/machinery/light,
 /obj/structure/extinguisher_cabinet{
@@ -70722,26 +68932,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cCr" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"cCs" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -71039,16 +69229,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"cCU" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "cCV" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/light/small{
@@ -71119,12 +69299,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"cDd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
 "cDe" = (
 /obj/machinery/firealarm{
 	dir = 8;
@@ -71146,25 +69320,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 5;
 	pixel_y = -32
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cDg" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"cDh" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
@@ -71219,12 +69374,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"cDo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -72232,18 +70381,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"cEX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/machinery/camera/autoname{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "cEY" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -72519,21 +70656,6 @@
 /obj/effect/landmark/xeno_spawn,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
-"cFA" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"cFB" = (
-/obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "cFC" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden/layer1{
@@ -73006,12 +71128,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"cGi" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "cGj" = (
 /obj/effect/landmark/event_spawn,
 /obj/effect/turf_decal/tile/neutral,
@@ -73239,19 +71355,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"cGB" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/light/small,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "cGC" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -73260,16 +71363,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"cGD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "cGE" = (
@@ -73312,12 +71405,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
-"cGH" = (
-/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "cGI" = (
 /obj/machinery/button/door{
 	id = "aux_base_shutters";
@@ -73732,29 +71819,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"cHu" = (
-/obj/machinery/door/firedoor,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cHv" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -73844,15 +71908,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/space/basic,
 /area/engine/engineering)
-"cHC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage_shared)
 "cHD" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74315,12 +72370,6 @@
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cIo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "cIp" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -74353,15 +72402,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cIr" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cIs" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -74459,27 +72499,9 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"cIE" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"cIF" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
 "cIG" = (
 /obj/effect/turf_decal/trimline/neutral/filled/corner{
 	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"cIH" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
@@ -74522,16 +72544,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"cIM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "cIN" = (
@@ -75107,18 +73119,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
-"cJS" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cJT" = (
 /obj/structure/reagent_dispensers/fueltank,
 /obj/effect/turf_decal/stripes/line{
@@ -75843,12 +73843,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"cLc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "cLd" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 5
@@ -75857,33 +73851,6 @@
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cLe" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cLf" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"cLg" = (
-/obj/machinery/atmospherics/pipe/manifold/yellow/visible{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cLh" = (
@@ -76084,12 +74051,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"cLA" = (
-/obj/machinery/turnstile{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "cLB" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -76182,15 +74143,6 @@
 	dir = 8
 	},
 /area/hallway/primary/aft)
-"cLK" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
 "cLL" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 4
@@ -76217,15 +74169,6 @@
 /turf/open/floor/plasteel/dark/corner{
 	dir = 8
 	},
-/area/hallway/primary/aft)
-"cLO" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cLP" = (
 /obj/effect/turf_decal/bot,
@@ -76296,14 +74239,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/engine/transit_tube)
-"cLW" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
 "cLX" = (
 /obj/structure/transit_tube/curved/flipped{
 	dir = 8
@@ -76318,18 +74253,6 @@
 /obj/effect/spawner/lootdrop/grille_or_trash,
 /turf/open/floor/plating,
 /area/maintenance/fore)
-"cLZ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cMa" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76789,34 +74712,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"cMP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cMQ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -76948,13 +74843,6 @@
 	},
 /turf/open/floor/carpet,
 /area/library/lounge)
-"cNa" = (
-/obj/effect/turf_decal/trimline/red/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cNb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -77848,16 +75736,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"cOO" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -79095,56 +76973,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"cRJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "cRK" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/meter,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /turf/open/floor/plasteel,
 /area/maintenance/disposal/incinerator)
-"cRL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "cRM" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Door"
@@ -79530,18 +77364,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"cSo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cSp" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 9
@@ -79646,13 +77468,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"cSy" = (
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "cSz" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -79680,12 +77495,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"cSB" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "cSC" = (
 /obj/machinery/vending/coffee,
 /turf/open/floor/plasteel,
@@ -80690,21 +78499,6 @@
 /obj/item/storage/belt/utility,
 /turf/open/floor/plating,
 /area/maintenance/aft)
-"cUZ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cVa" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1,
 /obj/structure/reagent_dispensers/peppertank{
@@ -82029,9 +79823,6 @@
 /obj/machinery/power/grounding_rod,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"cXW" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "cXX" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 1;
@@ -82208,19 +79999,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"dfH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dfW" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "dgb" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -82230,38 +80008,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"dgh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dhT" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "diH" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced{
@@ -82272,50 +80018,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"dmw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"dmF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"dnB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "doD" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"drN" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "dsE" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -82335,12 +80043,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"duY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "dwu" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -82350,90 +80052,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"dxi" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dyQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"dzF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"dAC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"dBn" = (
-/turf/open/floor/plasteel/dark,
-/area/science/circuit)
-"dBy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dCq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"dCL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/storage)
 "dEp" = (
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -82465,15 +80083,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"dFt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "dFG" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -82498,16 +80107,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"dJU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dPK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
@@ -82571,26 +80170,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"dWz" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"dXw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "dZP" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -82613,18 +80192,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"ecb" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "ect" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -82647,33 +80214,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"eeF" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ehb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ehe" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "ehl" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 4
@@ -82708,43 +80248,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"elZ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"eng" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"enm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"eor" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"eot" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "eqe" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -82794,38 +80297,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"etT" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"eum" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "evX" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"eyJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "ezo" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -82833,27 +80310,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/engineering)
-"eBy" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"eDp" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"eDw" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
 "eDP" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 8
@@ -82863,15 +80319,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"eFn" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "eFp" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -82879,14 +80326,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"eFR" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
+"eFG" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "eGt" = (
 /obj/effect/turf_decal/trimline/green/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -82894,22 +80343,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"eHp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "eHx" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -82944,13 +80377,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"eMX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "eNI" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -82985,24 +80411,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ePf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ePw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "eTx" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -83025,96 +80433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"eYT" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"fah" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"faL" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fbf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"fbg" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"ffU" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fhd" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fjA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "fjH" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -83139,21 +80457,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"fkp" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"fmA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "fow" = (
 /obj/effect/turf_decal/tile{
 	dir = 4
@@ -83164,14 +80467,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"fqz" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fqL" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -83182,12 +80477,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"frA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "fsj" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/structure/window/reinforced{
@@ -83201,44 +80490,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"fsz" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"fua" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"fuH" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fvi" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "fwg" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -83248,59 +80499,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"fxB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fxW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"fzX" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"fAL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "fDN" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -83308,19 +80506,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"fEh" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"fEs" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
 "fEH" = (
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 1
@@ -83328,27 +80513,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"fIe" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fJs" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "fKc" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 8
@@ -83358,63 +80522,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"fLq" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fMa" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fMb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"fMq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"fNq" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
-"fOG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "fOO" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -83425,31 +80538,6 @@
 /obj/effect/turf_decal/tile/blue,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"fPC" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "fQN" = (
 /obj/structure/closet/secure_closet/personal,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -83458,14 +80546,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
-"fQZ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "fSW" = (
 /obj/effect/spawner/structure/window/plasma/reinforced,
 /obj/structure/cable{
@@ -83473,29 +80553,6 @@
 	},
 /turf/open/floor/plating,
 /area/engine/engineering)
-"fTY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"fVC" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"fXb" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
 "fXq" = (
 /obj/structure/disposaloutlet{
 	dir = 8
@@ -83503,36 +80560,6 @@
 /obj/structure/disposalpipe/trunk,
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"fYk" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"fYP" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"fZf" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "fZL" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -83551,43 +80578,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"gbe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gbn" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"gdL" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"geu" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"gev" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ggi" = (
 /obj/machinery/light{
 	dir = 8;
@@ -83598,75 +80588,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"giI" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gjl" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"gjs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"gmv" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"gnP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "gqj" = (
 /obj/machinery/light/small{
 	dir = 4;
@@ -83691,55 +80612,12 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"grj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"gsS" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "guj" = (
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"gvF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"gyt" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gyO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "gyY" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -83754,34 +80632,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
-"gCs" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"gCt" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"gIr" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "gIA" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -83791,13 +80641,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"gLE" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "gMF" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
@@ -83807,19 +80650,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"gMN" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "gMV" = (
 /obj/effect/turf_decal/trimline/red/filled/line,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -83827,50 +80657,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"gOF" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"gQV" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"gRe" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"gRX" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"gSL" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
 "gTB" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 4
@@ -83901,53 +80687,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"gZv" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "haK" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hbf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hbw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hcn" = (
 /obj/machinery/atmospherics/pipe/simple/yellow/visible{
 	dir = 8
@@ -83957,75 +80702,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"hdz" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"hfX" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hge" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"hhZ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hne" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"hnu" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"hnx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hof" = (
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/line{
@@ -84036,22 +80712,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"hpB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hqw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "hwC" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -84062,68 +80722,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"hxZ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"hBb" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"hBn" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"hBF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"hBR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "hBS" = (
 /obj/machinery/deepfryer,
 /obj/effect/turf_decal/tile/bar{
@@ -84134,49 +80732,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"hCc" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"hDp" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"hDI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "hIv" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -84187,75 +80742,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"hIK" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"hIQ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hIR" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hJo" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"hKf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"hLF" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"hLO" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/virology)
 "hMI" = (
 /obj/effect/turf_decal/tile{
 	dir = 4
@@ -84266,19 +80752,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"hQh" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "hST" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue{
@@ -84292,12 +80765,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"hUm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "hVN" = (
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
@@ -84308,97 +80775,6 @@
 /obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"hWH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"hWN" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"hZd" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"ibP" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"icD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"icF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ihc" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "ihw" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/blue,
@@ -84410,15 +80786,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"ijW" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "ikz" = (
 /obj/structure/window/reinforced{
 	dir = 4
@@ -84430,66 +80797,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/sorting)
-"ilr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ilx" = (
-/obj/structure/closet/secure_closet/personal,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"imY" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"inf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"iow" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ioQ" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ipF" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "ipL" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
 	dir = 4
@@ -84508,79 +80815,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"irl" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "iup" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer3{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
-"ivm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ivT" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"iwD" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ixb" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ixl" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iyp" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "iyH" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iza" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
@@ -84590,81 +80833,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/gateway)
-"iBJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"iBN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iEh" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iEs" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"iEH" = (
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"iFg" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iGm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"iGy" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "iJE" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -84672,109 +80840,12 @@
 	},
 /turf/open/space/basic,
 /area/engine/engineering)
-"iJK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iJM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"iLI" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"iMB" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iME" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"iNd" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"iPe" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "iPN" = (
 /obj/effect/turf_decal/trimline/green/filled/line{
 	dir = 6
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
-"iPQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"iSF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "iVC" = (
 /obj/structure/window/reinforced/spawner,
 /obj/structure/window/reinforced{
@@ -84785,131 +80856,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"iWu" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"iWA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"iXT" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jbX" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jdI" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"jei" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jeu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jeK" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"jfS" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"jgJ" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"jjH" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"jkm" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"jkP" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "joZ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -84930,34 +80876,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"jtn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"jtx" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jtU" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "juo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -84968,44 +80886,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jvo" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"jvp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jza" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jzl" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"jzT" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "jCQ" = (
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -85013,83 +80893,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"jFn" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"jFJ" = (
-/obj/structure/cable/yellow{
-	icon_state = "0-8"
-	},
-/obj/machinery/power/rad_collector/anchored,
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"jFN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jGm" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"jGv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jGE" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"jJu" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jKq" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "jLE" = (
 /obj/machinery/light/small{
 	dir = 4
@@ -85099,28 +80902,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"jMn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"jMK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
 "jNI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -85133,92 +80914,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"jPg" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"jPn" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jPp" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"jPE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"jPS" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"jQW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"jRu" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jRE" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "jSU" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -85228,73 +80923,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
-"jUx" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
-/area/hallway/primary/aft)
-"jUX" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jXg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"jXp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"jYB" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kag" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"kau" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"kaB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "kcN" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/vr_sleeper{
@@ -85311,20 +80939,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"kdY" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"kfJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "khi" = (
 /obj/machinery/light{
 	dir = 4;
@@ -85336,21 +80950,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"khx" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"kin" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kkw" = (
 /obj/effect/turf_decal/tile/bar,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -85358,175 +80957,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"klf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kmR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"kno" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kpD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"ksP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"ktm" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"ktI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "kuT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 10
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"kwd" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"kwG" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kxi" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kzJ" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kzK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"kBv" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "kDs" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -85537,130 +80973,6 @@
 /obj/item/twohanded/required/kirbyplants/random,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"kDv" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"kDQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"kDS" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kEK" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kGk" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"kHg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"kHE" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"kJA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"kJG" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kJX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"kKc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"kKJ" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "kNb" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/effect/turf_decal/trimline/blue/filled/line{
@@ -85668,173 +80980,25 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
-"kNu" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kNH" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kNJ" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"kPe" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kPl" = (
-/obj/structure/urinal{
-	dir = 8;
-	pixel_x = 28
-	},
-/turf/open/floor/plasteel/freezer,
-/area/crew_quarters/toilet)
-"kQG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"kTg" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"kUz" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/gateway)
-"kVW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "kXQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"kYW" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"lbm" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"lbU" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"lce" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"lcf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"ldv" = (
-/obj/structure/cable{
+"lik" = (
+/obj/structure/cable/yellow{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable/yellow{
+	icon_state = "1-8"
 	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"let" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"leP" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"liQ" = (
-/turf/open/floor/plasteel/dark,
-/area/science/circuit)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "lkU" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -85851,56 +81015,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"llB" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"lnz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lnB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lou" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lpt" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "lpx" = (
 /obj/structure/table,
 /obj/item/reagent_containers/glass/beaker/large,
@@ -85909,16 +81023,6 @@
 /obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"lpI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/obj/machinery/vr_sleeper{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/locker)
-"lpL" = (
-/turf/open/floor/plasteel/dark,
-/area/science/circuit)
 "lqd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -85929,112 +81033,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/security/brig)
-"lrT" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"lss" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ltu" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"ltJ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ltP" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"lug" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"lzw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"lAu" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"lAF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lAP" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"lBj" = (
-/turf/open/floor/plasteel/cult,
-/area/library)
 "lCX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/cable{
@@ -86058,58 +81056,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"lEh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"lKh" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
-"lKk" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"lLj" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "lLo" = (
 /obj/machinery/door/poddoor{
 	id = "QMLoaddoor2";
@@ -86120,21 +81066,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"lLS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"lMc" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "lNj" = (
 /obj/machinery/conveyor{
 	dir = 1;
@@ -86146,29 +81077,6 @@
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
-"lNQ" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"lPG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"lQX" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
 "lRt" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
@@ -86178,15 +81086,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
-"lSu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "lTj" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
@@ -86201,18 +81100,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
-"lTR" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"lWy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "lWO" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -86223,69 +81110,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/engineering)
-"lYr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"lYR" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"maO" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mbG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mdb" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "mdU" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -86293,36 +81117,19 @@
 	},
 /turf/open/space/basic,
 /area/engine/engineering)
-"mes" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
+"mfy" = (
+/obj/structure/cable/yellow{
+	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mgT" = (
-/obj/structure/window/reinforced{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "1-4"
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mjv" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "mks" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 8
@@ -86332,36 +81139,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"mln" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"mmq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"mnC" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
 "mqh" = (
 /obj/structure/chair{
 	dir = 4
@@ -86382,13 +81159,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
-"mts" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "mtV" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -86398,195 +81168,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"muM" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/turret_protected/aisat/hallway)
-"mvo" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"mvq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mvN" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mwk" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mxS" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"mxW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mxY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mza" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"mAZ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"mBg" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mCp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mDJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"mEn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mEp" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mFd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mFO" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mGB" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"mMj" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "mNk" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -86595,56 +81176,6 @@
 /obj/effect/turf_decal/tile/yellow,
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"mNW" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mTV" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"mUQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"ndS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"neC" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
 "neT" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -86657,22 +81188,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"nfi" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"nfv" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "ngt" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -86680,22 +81195,6 @@
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"njs" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"nkc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "nkH" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -86704,15 +81203,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on/layer1{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nlu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
@@ -86751,61 +81241,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"nnI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nqu" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nrj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nrn" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nsK" = (
-/obj/effect/turf_decal/trimline/yellow/filled/corner{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"nsR" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ntq" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "ntW" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -86830,196 +81265,12 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"nvK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"nwy" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nzQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"nAB" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"nAF" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"nBd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nDn" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "nFt" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 1
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/foyer)
-"nGf" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"nGs" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/circuit)
-"nGC" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"nHk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nIA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"nJX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nKe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"nMT" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"nOP" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "nRc" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -87032,37 +81283,12 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"nSY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "nUG" = (
 /obj/effect/turf_decal/trimline/purple/filled/corner{
 	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"nVl" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"nXF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "nXH" = (
 /obj/machinery/light{
 	dir = 8;
@@ -87073,87 +81299,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"nXM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"nYh" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"nYJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/machinery/vr_sleeper{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"oad" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"oai" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oaG" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"obN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"ocr" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"ocA" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oeP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -87173,18 +81318,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"oiR" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "ojZ" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -87197,113 +81330,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"ong" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "onU" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"oop" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"opw" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oqT" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"ore" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"orS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "oxP" = (
 /obj/structure/showcase/cyborg/old{
 	pixel_y = 20
 	},
 /turf/open/floor/plasteel/grimy,
 /area/tcommsat/computer)
-"ozj" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"oAg" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oAX" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oBz" = (
-/obj/structure/closet/secure_closet/engineering_personal,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
 "oCd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -87326,66 +81364,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"oCS" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"oFM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"oHo" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"oIo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"oJk" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"oJp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oKi" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "oKO" = (
 /obj/machinery/light{
 	dir = 8;
@@ -87402,159 +81380,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"oLY" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oMh" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oQL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"oSv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oSL" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"oSY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"oVv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"oWI" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"oYz" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pad" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"pcz" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pfv" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pht" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"phw" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "phO" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -87565,56 +81390,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"pmc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pmd" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pnj" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
-"poC" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pqf" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
 "pqo" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -87630,63 +81405,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
-"prf" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ptp" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"puL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pws" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pxf" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "pza" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -87694,83 +81412,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"pAg" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"pBb" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pDj" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pDu" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pGh" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"pGQ" = (
-/obj/machinery/light{
-	dir = 8;
-	light_color = "#e8eaff"
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "pHw" = (
 /obj/effect/turf_decal/tile{
 	dir = 8
@@ -87780,148 +81421,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"pKs" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pLo" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"pMK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pNA" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"pPn" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pQe" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"pTa" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pTW" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pUf" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"pUV" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pVq" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"pVI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "pWd" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -87934,41 +81433,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"pWk" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"pXL" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "qae" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -87981,32 +81445,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"qag" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qai" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "qax" = (
 /obj/structure/disposalpipe/segment,
 /obj/effect/turf_decal/trimline/purple/filled/line{
@@ -88014,467 +81452,17 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/research)
-"qaH" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"qbQ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"qcn" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"qee" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"qfI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qil" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qiu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qmF" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"qou" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qoQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/machinery/camera/autoname{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"quq" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"qur" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"qvk" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"qvC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qxc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qAj" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"qBh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"qCl" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"qDa" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"qFo" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"qFC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"qLL" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"qML" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"qOp" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"qPX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "qUA" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"qVb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"raQ" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rcK" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"rcM" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/brig)
 "reY" = (
 /obj/effect/turf_decal/tile{
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/red,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"rfd" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"rfi" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rfK" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rfR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rga" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rgk" = (
-/obj/effect/turf_decal/tile/bar,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rjv" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rjC" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"rlr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rml" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rnR" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"rnY" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rpE" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rqB" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "rqY" = (
@@ -88483,181 +81471,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"rsJ" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rtm" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/science/circuit)
-"rtD" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"rus" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"rvX" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/security/prison)
-"rwZ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"rxT" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ryg" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ryJ" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"rAb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rBk" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rBB" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rFE" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"rFK" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rGd" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"rGm" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"rHQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "rIV" = (
 /obj/structure/closet/wardrobe/cargotech,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
@@ -88665,244 +81478,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"rKH" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"rLf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"rNy" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rPu" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"rRK" = (
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "rUI" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"rVD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rXa" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"rXW" = (
-/obj/effect/turf_decal/caution{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "rYm" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sbg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"sda" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"sej" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sfW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sgV" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"shr" = (
-/obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"skC" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"skW" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"skY" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"spN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"spU" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"spW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
@@ -88920,107 +81502,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"srf" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sug" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"suQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"swC" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/trimline/red/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"sxv" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"syz" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"syW" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"szh" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sAu" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"sCj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "sDf" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
@@ -89033,154 +81514,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"sEg" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"sFe" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sGf" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sIx" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"sIH" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/break_room)
-"sKt" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/light,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"sLu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"sNl" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sPB" = (
-/obj/effect/turf_decal/trimline/green/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hydroponics)
-"sQC" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"sSQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"sVe" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"sVq" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"sXb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"sXl" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"sZd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"tbM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tbT" = (
 /obj/machinery/power/emitter/anchored{
 	dir = 1;
@@ -89191,36 +81524,6 @@
 	},
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
-"tcG" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tdQ" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"teA" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"teF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "tfI" = (
 /obj/structure/chair/stool,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -89228,15 +81531,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/break_room)
-"tgv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "thv" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -89329,24 +81623,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"toy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"tpy" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "tpJ" = (
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -89362,18 +81638,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/command)
-"tqI" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "tsA" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -89396,223 +81660,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"tzm" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"tAf" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"tCW" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tDo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tDs" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"tDv" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tER" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tFj" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tFn" = (
-/obj/effect/turf_decal/trimline/green/filled/line,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"tMI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"tPr" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"tPW" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"tQj" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tRb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tSf" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"tTR" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"tUR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"tVa" = (
-/obj/machinery/porta_turret/ai,
-/turf/open/floor/plating,
-/area/ai_monitored/turret_protected/aisat/foyer)
-"tXU" = (
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"tXX" = (
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/prison)
-"tZa" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "uaq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -89622,15 +81669,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"uaF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ubl" = (
 /obj/structure/lattice/catwalk,
 /obj/structure/cable{
@@ -89638,13 +81676,6 @@
 	},
 /turf/open/space/basic,
 /area/engine/engineering)
-"uci" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "ucq" = (
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -89664,24 +81695,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/turret_protected/aisat/hallway)
-"ugN" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"uky" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "ulq" = (
 /obj/machinery/light{
 	dir = 4;
@@ -89702,16 +81715,6 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/toilet)
-"ung" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "unn" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
@@ -89749,15 +81752,6 @@
 	},
 /turf/open/floor/wood,
 /area/library)
-"usc" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "utM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -89770,12 +81764,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"uum" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "uwg" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral{
@@ -89783,65 +81771,6 @@
 	},
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"uxb" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/white/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"uxo" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"uzF" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"uDE" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"uET" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -89972,18 +81901,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"uRI" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "uSM" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -90049,12 +81966,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"uZm" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "uZH" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -90063,53 +81974,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"vcF" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"vdd" = (
-/obj/structure/chair/comfy/teal{
-	dir = 4
-	},
-/turf/open/floor/wood,
-/area/library)
-"vdw" = (
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"veJ" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vgm" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"vgI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vhh" = (
 /obj/effect/turf_decal/trimline/blue/filled/corner{
 	dir = 1
@@ -90117,9 +81981,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/corner,
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"vlw" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
 "voR" = (
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 1
@@ -90134,15 +81995,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"vpb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit)
 "vrE" = (
 /obj/machinery/light,
 /obj/effect/turf_decal/tile/neutral,
@@ -90160,27 +82012,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vud" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"vvS" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vwv" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /obj/machinery/light{
@@ -90210,22 +82041,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"vyQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"vzy" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "vBE" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -90244,19 +82059,6 @@
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
-"vDM" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "vDW" = (
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -90317,46 +82119,18 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
-"vGs" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"vHL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "vJb" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vJu" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
 "vKZ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"vLp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "vLQ" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -90367,35 +82141,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"vMw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"vOv" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"vPs" = (
-/obj/effect/turf_decal/tile{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "vPQ" = (
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 1
@@ -90427,117 +82172,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"wbD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wga" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wgc" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"whc" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"whJ" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wiI" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"wmc" = (
-/obj/effect/turf_decal/trimline/yellow/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/engine/engineering)
-"wmw" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/light/small{
-	dir = 1;
-	light_color = "#ffc1c1";
-	pixel_y = -5
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 10
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"wnq" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"wpg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wpD" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wrk" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"wrL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "wsH" = (
 /obj/machinery/atmospherics/pipe/manifold/yellow/visible{
 	dir = 1
@@ -90547,15 +82181,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"wtw" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
 "wtQ" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 4
@@ -90565,19 +82190,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"wvy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wvL" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
 "wwa" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -90607,66 +82219,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"wGp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"wHI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wHL" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"wJn" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"wMr" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "wNs" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -90689,56 +82241,14 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
-"wOD" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 8
+"wOj" = (
+/obj/structure/cable/yellow{
+	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"wOQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wPh" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 6
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"wPG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"wQY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
+/obj/effect/turf_decal/stripes/line,
+/obj/machinery/power/grounding_rod,
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "wUP" = (
 /obj/structure/window/reinforced/spawner/north,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
@@ -90749,28 +82259,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"wWM" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"wXX" = (
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"wYe" = (
-/obj/effect/turf_decal/tile{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/structure/chair{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "wZC" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -90782,128 +82270,15 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"wZU" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 6
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/blue/filled/corner,
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"wZY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "xag" = (
 /turf/closed/wall,
 /area/science/circuit)
-"xaF" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xaM" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xbp" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 5
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xbA" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
-"xcA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"xdW" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 "xfQ" = (
 /obj/effect/turf_decal/trimline/neutral/filled/end{
 	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"xho" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xhI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xjG" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -90914,62 +82289,6 @@
 "xmV" = (
 /turf/open/floor/plasteel/dark,
 /area/science/circuit)
-"xoX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"xpA" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/command)
-"xqi" = (
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
-"xsi" = (
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"xte" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xvg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xyH" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 10
@@ -90982,45 +82301,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/aisat)
-"xyI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xyK" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xCn" = (
-/obj/effect/turf_decal/trimline/purple/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/science/research)
-"xEk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"xFo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
 "xGE" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/trimline/neutral/filled/line{
@@ -91028,13 +82308,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/prison)
-"xGP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "xGR" = (
 /obj/machinery/door/firedoor,
 /obj/effect/turf_decal/tile/neutral,
@@ -91043,81 +82316,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xHG" = (
-/obj/structure/lattice/catwalk,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/space/basic,
-/area/engine/engineering)
-"xJT" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/ai_monitored/storage/satellite)
-"xKa" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xKO" = (
-/obj/machinery/cryopod{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/dorms)
-"xMz" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/central)
-"xNb" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/fitness/recreation)
-"xNh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xOR" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"xQo" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
 "xQx" = (
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
@@ -91130,142 +82328,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
-"xSy" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/purple/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"xSD" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xTY" = (
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xUa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"xUp" = (
-/obj/structure/cable/yellow{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 8
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
-"xVk" = (
-/turf/closed/wall/r_wall,
-/area/science/circuit)
-"xVl" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xVT" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
-	},
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
-"xWw" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3,
-/obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/yellow/line{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/red/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"xYq" = (
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "xYx" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -91276,59 +82338,6 @@
 /obj/machinery/light,
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"xZt" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"xZG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
-"ybo" = (
-/obj/structure/disposaloutlet{
-	dir = 8
-	},
-/obj/structure/disposalpipe/trunk,
-/turf/open/floor/engine,
-/area/science/xenobiology)
-"ybq" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"ydk" = (
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
-"yfg" = (
-/obj/machinery/power/rad_collector/anchored,
-/obj/structure/cable/yellow{
-	icon_state = "0-4"
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plating/airless,
-/area/engine/engineering)
 "yfq" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -91341,64 +82350,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/security/brig)
-"yfG" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/secondary/entry)
-"yga" = (
-/obj/machinery/atmospherics/pipe/simple/yellow/visible,
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"ygo" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 9
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ygV" = (
-/obj/structure/window/reinforced/spawner/north,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
-"ygZ" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/trimline/neutral/filled/line{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"yiX" = (
-/obj/structure/window/reinforced/spawner,
-/obj/structure/window/reinforced{
-	dir = 8;
-	layer = 2.9
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
-	dir = 5
-	},
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 10
-	},
-/turf/open/floor/plasteel/dark,
-/area/aisat)
 
 (1,1,1) = {"
 aaa
@@ -101589,9 +92540,9 @@ bIY
 bIY
 bIY
 byU
-fIe
+uRi
 bVp
-iza
+tnV
 bKd
 bIY
 bIY
@@ -101839,23 +92790,23 @@ aaa
 aaa
 aaa
 bxN
-fIe
-iEh
-iEh
-iEh
-iEh
-iEh
-iEh
+uRi
+ucq
+ucq
+ucq
+ucq
+ucq
+ucq
 bPK
 bRU
 bYA
-iEh
-iEh
-iEh
-iEh
-iEh
-iEh
-iza
+ucq
+ucq
+ucq
+ucq
+ucq
+ucq
+tnV
 bzY
 aab
 aab
@@ -102095,11 +93046,11 @@ aab
 aab
 aab
 bzS
-fIe
-hfX
-kDS
-kDS
-kDS
+uRi
+eia
+dQa
+dQa
+dQa
 dZP
 vwv
 bOa
@@ -102109,11 +93060,11 @@ caW
 dZP
 vwv
 dZP
-kDS
-kDS
-kDS
+dQa
+dQa
+dQa
 cAh
-yiX
+vTO
 bzY
 aab
 aav
@@ -102351,9 +93302,9 @@ aab
 aab
 aab
 bzS
-ltJ
-hfX
-kzJ
+ddh
+eia
+tln
 bBW
 bJg
 bJg
@@ -102369,9 +93320,9 @@ bBX
 bSd
 bSS
 bAc
-oSL
+eqX
 xyH
-yiX
+vTO
 bzY
 aav
 aab
@@ -102607,9 +93558,9 @@ aav
 aab
 aab
 bzS
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 bzV
 aav
 aaa
@@ -102629,7 +93580,7 @@ aab
 bAc
 diH
 xyH
-yiX
+vTO
 bBY
 aab
 aab
@@ -102863,9 +93814,9 @@ aab
 aav
 aab
 bzS
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 bzV
 aab
 aav
@@ -102887,7 +93838,7 @@ aab
 bAc
 diH
 xyH
-yiX
+vTO
 bzY
 aab
 aab
@@ -103119,9 +94070,9 @@ aab
 aab
 aav
 bzS
-ltJ
-hfX
-kzJ
+ddh
+eia
+tln
 bzV
 aab
 aab
@@ -103143,9 +94094,9 @@ aab
 aab
 aab
 bAc
-oSL
+eqX
 xyH
-yiX
+vTO
 bzY
 aab
 aab
@@ -103375,8 +94326,8 @@ aab
 aab
 aab
 bDC
-fIe
-hfX
+uRi
+eia
 bKY
 bzV
 aab
@@ -103403,7 +94354,7 @@ aab
 bAc
 diH
 xyH
-yiX
+vTO
 bzY
 aab
 aaa
@@ -103631,8 +94582,8 @@ aab
 aab
 aab
 bzS
-fIe
-hfX
+uRi
+eia
 bJF
 bBW
 aab
@@ -103647,7 +94598,7 @@ bBX
 bBX
 bNC
 bOg
-fNq
+cuS
 bBX
 bBX
 bBX
@@ -103661,7 +94612,7 @@ aab
 bAc
 cBd
 cBh
-iza
+tnV
 bzY
 aaa
 aaa
@@ -103887,8 +94838,8 @@ aac
 aab
 aab
 bzS
-ltJ
-tXU
+ddh
+vhh
 bKy
 bzV
 aav
@@ -103904,7 +94855,7 @@ aab
 bBX
 bNC
 bOg
-jtU
+cuT
 bBX
 aab
 aab
@@ -103918,8 +94869,8 @@ aab
 aab
 bAc
 clQ
-mEp
-iza
+eDP
+tnV
 bzY
 aaa
 aaa
@@ -104143,9 +95094,9 @@ aaa
 aac
 aab
 bzS
-fIe
-tXU
-sVq
+uRi
+vhh
+iVC
 bzV
 aab
 aav
@@ -104161,7 +95112,7 @@ aab
 bBX
 bNC
 bOg
-fNq
+cuS
 bBX
 aab
 aab
@@ -104176,8 +95127,8 @@ aab
 aab
 bYB
 diH
-mEp
-iza
+eDP
+tnV
 bJf
 aaa
 aac
@@ -104399,9 +95350,9 @@ aaa
 aaa
 aac
 bzS
-fIe
-tXU
-sVq
+uRi
+vhh
+iVC
 bBW
 aav
 aav
@@ -104434,8 +95385,8 @@ aav
 aav
 bYB
 diH
-mEp
-iza
+eDP
+tnV
 bJf
 aac
 aaa
@@ -104655,9 +95606,9 @@ aaa
 aab
 aaa
 byU
-ltJ
-tXU
-sVq
+ddh
+vhh
+iVC
 bBW
 aab
 aab
@@ -104691,9 +95642,9 @@ aab
 aav
 aab
 bAc
-oSL
-mEp
-iza
+eqX
+eDP
+tnV
 bKd
 aaa
 aab
@@ -104912,8 +95863,8 @@ aaa
 aab
 bxN
 byV
-tXU
-sVq
+vhh
+iVC
 bBW
 aav
 aav
@@ -104932,7 +95883,7 @@ aab
 bBX
 bNC
 bOh
-fNq
+cuS
 bBX
 aab
 aab
@@ -104950,8 +95901,8 @@ bST
 aav
 bYB
 diH
-mEp
-iza
+eDP
+tnV
 bJf
 aab
 aab
@@ -105168,8 +96119,8 @@ aaa
 aaa
 bwP
 bxO
-tXU
-sVq
+vhh
+iVC
 bzV
 aab
 aav
@@ -105189,7 +96140,7 @@ bBX
 bBX
 bNC
 bOg
-jtU
+cuT
 bBX
 aab
 aab
@@ -105208,8 +96159,8 @@ bBX
 bST
 bAc
 diH
-mEp
-iza
+eDP
+tnV
 bzX
 aab
 aaa
@@ -105424,7 +96375,7 @@ aaa
 aaa
 aaa
 bwP
-fah
+uKM
 byX
 bzV
 aab
@@ -105446,7 +96397,7 @@ bBX
 bME
 bNC
 bOg
-fNq
+cuS
 bBX
 aab
 bBX
@@ -105465,7 +96416,7 @@ bUP
 bST
 aab
 bAc
-gyt
+vFP
 byX
 cdz
 aab
@@ -105681,7 +96632,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byX
 bzW
 aav
@@ -105722,7 +96673,7 @@ bUP
 bST
 aab
 cbC
-fah
+uKM
 byX
 cdz
 aab
@@ -105938,7 +96889,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byX
 bzX
 aab
@@ -105962,7 +96913,7 @@ bOx
 bOj
 cuW
 can
-tVa
+bQL
 bLJ
 bSf
 bZG
@@ -105979,7 +96930,7 @@ bUP
 bST
 aab
 cbC
-gyt
+vFP
 byX
 cdz
 aab
@@ -106195,7 +97146,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byX
 bzX
 aab
@@ -106236,7 +97187,7 @@ bUP
 bST
 aab
 cbC
-gyt
+vFP
 byX
 cdz
 aab
@@ -106452,7 +97403,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byX
 bzX
 aab
@@ -106493,7 +97444,7 @@ bUP
 bST
 aab
 cbC
-gyt
+vFP
 byX
 cdz
 aab
@@ -106709,7 +97660,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byX
 bzX
 aab
@@ -106750,7 +97701,7 @@ bUP
 bST
 aab
 cbC
-fah
+uKM
 byX
 cdz
 aab
@@ -107223,7 +98174,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byZ
 bzX
 aab
@@ -107480,7 +98431,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byZ
 bzX
 aab
@@ -107737,7 +98688,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byZ
 bzX
 aab
@@ -107994,7 +98945,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byZ
 bzX
 aab
@@ -108018,7 +98969,7 @@ bPs
 bOj
 cDe
 cBc
-tVa
+bQL
 bLJ
 bSl
 bTc
@@ -108251,7 +99202,7 @@ aaa
 aaa
 aaa
 bwP
-gyt
+vFP
 byZ
 bzW
 aav
@@ -108290,8 +99241,8 @@ bUS
 bSV
 bZP
 bZO
-iEh
-iEh
+ucq
+ucq
 cCW
 byX
 cdz
@@ -108508,7 +99459,7 @@ aaa
 aaa
 aaa
 bwP
-fah
+uKM
 byZ
 bzY
 aab
@@ -108530,7 +99481,7 @@ bBX
 bME
 bPv
 bOt
-fbg
+ufs
 bBX
 aab
 bBX
@@ -108767,7 +99718,7 @@ aaa
 bwP
 bxS
 bzb
-iza
+tnV
 bzY
 aab
 aav
@@ -108805,9 +99756,9 @@ bBX
 bBX
 bST
 caY
-gyt
+vFP
 cCX
-sVq
+iVC
 bzX
 aab
 aaa
@@ -109024,8 +99975,8 @@ aaa
 aab
 bxT
 bzT
-pmd
-iza
+uLR
+tnV
 bBY
 aav
 aav
@@ -109044,7 +99995,7 @@ aab
 bBX
 bPv
 bOp
-fbg
+ufs
 bBX
 aab
 aab
@@ -109061,9 +100012,9 @@ bST
 bST
 aav
 cap
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 cbE
 aab
 aab
@@ -109282,8 +100233,8 @@ aab
 aaa
 bxT
 vxz
-pmd
-iza
+uLR
+tnV
 bBY
 aab
 aab
@@ -109317,9 +100268,9 @@ aab
 aav
 aab
 bzS
-ltJ
-hfX
-kzJ
+ddh
+eia
+tln
 cbE
 aaa
 aab
@@ -109539,9 +100490,9 @@ aab
 aaa
 aaa
 bAc
-pPn
-pmd
-iza
+fsj
+uLR
+tnV
 bBY
 aav
 aav
@@ -109573,9 +100524,9 @@ aav
 aav
 aav
 bDC
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 cbE
 aaa
 aaa
@@ -109797,9 +100748,9 @@ aaa
 aaa
 aab
 bAc
-pPn
-pmd
-iza
+fsj
+uLR
+tnV
 bzY
 aab
 aav
@@ -109815,7 +100766,7 @@ aab
 bBX
 bPv
 bOo
-fbg
+ufs
 bBX
 aab
 aab
@@ -109829,9 +100780,9 @@ aab
 aab
 aab
 bDC
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 caZ
 aac
 aac
@@ -110056,7 +101007,7 @@ aab
 aab
 bAc
 vxz
-pmd
+uLR
 bKH
 bzY
 aav
@@ -110086,8 +101037,8 @@ aab
 aab
 bzS
 cnO
-hfX
-kzJ
+eia
+tln
 bzV
 aaa
 aaa
@@ -110313,7 +101264,7 @@ aab
 aab
 aab
 bAc
-pPn
+fsj
 bFX
 bKa
 bBY
@@ -110329,7 +101280,7 @@ bBX
 bBX
 bPv
 bOo
-fbg
+ufs
 bBX
 bBX
 bBX
@@ -110343,7 +101294,7 @@ aaa
 bzS
 cCT
 cBn
-kzJ
+tln
 bzV
 aab
 aaa
@@ -110571,9 +101522,9 @@ aab
 aab
 aab
 bAc
-pPn
-pmd
-iza
+fsj
+uLR
+tnV
 bzY
 aab
 aab
@@ -110597,9 +101548,9 @@ aaa
 aaa
 aaa
 bxN
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 bzV
 aab
 aab
@@ -110830,8 +101781,8 @@ aab
 aab
 bAc
 vxz
-pmd
-iza
+uLR
+tnV
 bzY
 aab
 aaa
@@ -110853,9 +101804,9 @@ aaa
 aaa
 aaa
 bxN
-ltJ
-hfX
-kzJ
+ddh
+eia
+tln
 bzV
 aab
 aab
@@ -111087,9 +102038,9 @@ aab
 aab
 aab
 bAc
-pPn
-pmd
-iza
+fsj
+uLR
+tnV
 bzY
 aaa
 aac
@@ -111109,9 +102060,9 @@ aac
 aaa
 aaa
 bxN
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 bzV
 aab
 aab
@@ -111345,9 +102296,9 @@ aab
 aab
 aab
 bAc
-pPn
-pmd
-iza
+fsj
+uLR
+tnV
 bJf
 aac
 aaa
@@ -111365,9 +102316,9 @@ aab
 aac
 aaa
 bxN
-fIe
-hfX
-kzJ
+uRi
+eia
+tln
 bzV
 aab
 aaa
@@ -111604,8 +102555,8 @@ aab
 aab
 bAc
 vxz
-pmd
-iza
+uLR
+tnV
 bKd
 bIY
 chv
@@ -111621,9 +102572,9 @@ bBX
 bSc
 bTe
 bzS
-ltJ
-hfX
-kzJ
+ddh
+eia
+tln
 bBW
 aav
 aac
@@ -111861,25 +102812,25 @@ aaa
 aaa
 aaa
 bxT
-pPn
-pmd
-iEh
-iEh
+fsj
+uLR
+ucq
+ucq
 bMG
-tdQ
+iyH
 bNY
 bRT
 bPQ
 bXM
 cuV
-tdQ
+iyH
 cve
-tdQ
-iEh
-iEh
-iEh
-hfX
-kzJ
+iyH
+ucq
+ucq
+ucq
+eia
+tln
 bzV
 aav
 aab
@@ -112119,23 +103070,23 @@ aaa
 aaa
 aaa
 bxT
-pPn
-kDS
-kDS
+fsj
+dQa
+dQa
 bML
-oLY
-oLY
+vWi
+vWi
 bPH
 bQT
 bOw
 caX
-oLY
+vWi
 cvf
-kDS
-kDS
-kDS
-kDS
-kzJ
+dQa
+dQa
+dQa
+dQa
+tln
 bzV
 aab
 aav
@@ -117162,15 +108113,15 @@ aaQ
 aaQ
 acy
 aaQ
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
-lTR
+uFf
+uFf
+uFf
+uFf
+uFf
+uFf
+uFf
+uFf
+uFf
 aaQ
 aaQ
 any
@@ -117404,7 +108355,7 @@ aaN
 aab
 aaa
 aaa
-aeT
+aaT
 aaX
 abb
 agk
@@ -117419,7 +108370,7 @@ abH
 agn
 acz
 abe
-lTR
+uFf
 adS
 aeL
 afG
@@ -117677,9 +108628,9 @@ adQ
 acA
 acX
 adt
-rtm
+adT
 aeM
-rtm
+adT
 ago
 ahk
 aie
@@ -117696,7 +108647,7 @@ aqc
 aqc
 avE
 awv
-kHg
+dWs
 axl
 aaQ
 azx
@@ -117933,7 +108884,7 @@ aaQ
 aaQ
 acB
 aaQ
-lTR
+uFf
 aut
 aeN
 adU
@@ -117953,7 +108904,7 @@ avO
 atW
 ayR
 aPu
-kHg
+dWs
 aCU
 aaV
 azy
@@ -118190,9 +109141,9 @@ aaA
 abp
 acC
 acY
-lTR
+uFf
 aid
-lpL
+xmV
 afH
 wNs
 ahm
@@ -118447,13 +109398,13 @@ aaA
 abp
 acD
 boY
-lTR
+uFf
 adW
-lpL
+xmV
 gyY
 aoa
 gyY
-lpL
+xmV
 ajc
 abd
 alE
@@ -118704,12 +109655,12 @@ aaA
 abp
 acD
 abc
-lTR
+uFf
 adX
 aeO
-lpL
+xmV
 wNs
-lpL
+xmV
 aih
 ajd
 abd
@@ -118724,7 +109675,7 @@ avU
 aqd
 azd
 aww
-kHg
+dWs
 abt
 aaV
 azB
@@ -118961,7 +109912,7 @@ aaA
 abp
 acD
 cOv
-lTR
+uFf
 adY
 aeP
 coc
@@ -118981,7 +109932,7 @@ avL
 aqd
 azd
 aww
-kHg
+dWs
 aUi
 aaQ
 aaQ
@@ -119238,7 +110189,7 @@ abJ
 abJ
 azf
 aww
-kHg
+dWs
 abt
 any
 azC
@@ -119495,7 +110446,7 @@ arn
 bJo
 azd
 awz
-kHg
+dWs
 aCU
 any
 azD
@@ -120009,7 +110960,7 @@ aro
 abJ
 azd
 aww
-kHg
+dWs
 aFN
 any
 azF
@@ -120266,7 +111217,7 @@ asV
 abJ
 aCi
 awB
-kHg
+dWs
 axl
 any
 azG
@@ -120523,7 +111474,7 @@ atM
 abJ
 bdT
 aww
-kHg
+dWs
 axL
 axL
 axL
@@ -121037,7 +111988,7 @@ atN
 auP
 azh
 awC
-kHg
+dWs
 axN
 ayE
 azI
@@ -121294,7 +112245,7 @@ arr
 abJ
 azd
 awz
-kHg
+dWs
 axO
 ayF
 azJ
@@ -121551,7 +112502,7 @@ atO
 abJ
 azi
 awz
-kHg
+dWs
 axL
 ayG
 ayN
@@ -122065,7 +113016,7 @@ apY
 abJ
 azd
 awz
-kHg
+dWs
 axL
 ayI
 azK
@@ -122322,7 +113273,7 @@ abJ
 abJ
 azd
 awz
-kHg
+dWs
 axP
 ayJ
 azL
@@ -122445,7 +113396,7 @@ clH
 clH
 cdL
 cpn
-tTR
+crM
 cqk
 cqk
 cth
@@ -122702,7 +113653,7 @@ cmB
 cnr
 cBo
 cpo
-tTR
+crM
 cqk
 cqk
 cti
@@ -122959,7 +113910,7 @@ cVi
 cdd
 cdN
 cpp
-tTR
+crM
 cqk
 cqk
 cth
@@ -123093,7 +114044,7 @@ atT
 auR
 azQ
 awE
-kHg
+dWs
 axQ
 ayM
 azN
@@ -123221,7 +114172,7 @@ cqk
 csh
 ctj
 cub
-nVl
+cwZ
 cvF
 cqg
 cqg
@@ -123350,7 +114301,7 @@ atS
 auS
 azS
 awz
-kHg
+dWs
 axN
 ayN
 azO
@@ -123454,31 +114405,31 @@ cKF
 cKH
 boU
 cCz
-fvi
-fvi
+uIi
+uIi
 uYv
-yfG
-yfG
-yfG
-yfG
-yfG
+dgb
+dgb
+dgb
+dgb
+dgb
 bkT
 bQg
-yfG
-yfG
-yfG
-yfG
+dgb
+dgb
+dgb
+dgb
 cCK
-yfG
+dgb
 cHc
-yfG
+dgb
 uYv
 cEM
 cHw
 cER
 cth
 cub
-gIr
+cxa
 cvH
 cwj
 cqg
@@ -123607,7 +114558,7 @@ avA
 auQ
 azZ
 awF
-kHg
+dWs
 axR
 aTE
 azO
@@ -123640,7 +114591,7 @@ aTH
 aTH
 boB
 bam
-gjl
+tpJ
 bcs
 bdz
 beK
@@ -123712,7 +114663,7 @@ cKE
 boU
 cCA
 cML
-skW
+cfS
 lCX
 upC
 etb
@@ -123864,7 +114815,7 @@ afU
 afU
 aAo
 awG
-kHg
+dWs
 axL
 axL
 azP
@@ -123968,25 +114919,25 @@ cKt
 cKI
 boU
 cBI
-hWN
-tSf
-dJU
-ePw
-tqI
-ePw
-ePw
+thv
+cCg
+uKJ
+cfj
+cfO
+cfj
+cfj
 crf
-ePw
+cfj
 cjw
-ePw
+cfj
 cnv
-ePw
-tqI
+cfj
+cfO
 cSN
 cHb
-ePw
-ePw
-dJU
+cfj
+cfj
+uKJ
 cEO
 cHy
 cET
@@ -124122,12 +115073,12 @@ auT
 duB
 awH
 aCb
-rtD
+qax
 aDz
 aFW
 aHr
-rtD
-rtD
+qax
+qax
 aJQ
 aKK
 aNn
@@ -124154,7 +115105,7 @@ aTJ
 aTJ
 brk
 bao
-gjl
+tpJ
 bcs
 bdB
 beK
@@ -124226,7 +115177,7 @@ cKJ
 boU
 cWR
 cMQ
-wrL
+uRw
 boU
 cqg
 cqg
@@ -124387,7 +115338,7 @@ aBU
 axn
 aEs
 aEn
-kHg
+dWs
 aPf
 aaQ
 cMl
@@ -124482,8 +115433,8 @@ cKt
 cKK
 boU
 cgm
-hWN
-wrL
+thv
+uRw
 boU
 cPF
 chI
@@ -124506,7 +115457,7 @@ cqk
 cqk
 ctn
 cuf
-nVl
+cwZ
 cvG
 aab
 aab
@@ -124668,7 +115619,7 @@ aTL
 aTJ
 brk
 bam
-gjl
+tpJ
 bct
 bdD
 beK
@@ -124721,7 +115672,7 @@ cVB
 boU
 cLG
 bOU
-iGm
+ely
 boU
 bRf
 bSo
@@ -124740,7 +115691,7 @@ cKL
 boU
 cCC
 cQV
-wrL
+uRw
 boU
 bYa
 ced
@@ -124763,7 +115714,7 @@ baC
 ctd
 cto
 cuf
-nVl
+cwZ
 cvG
 cvG
 cvG
@@ -124978,7 +115929,7 @@ bJs
 boU
 cLH
 bOU
-iGm
+ely
 boU
 bRg
 bRK
@@ -125018,9 +115969,9 @@ cla
 cqq
 cqg
 cqg
-hdz
+ctM
 cuf
-nVl
+cwZ
 cvJ
 cwl
 cwO
@@ -125235,7 +116186,7 @@ bJs
 boU
 cLI
 bOV
-iGm
+ely
 boU
 bDb
 boU
@@ -125277,7 +116228,7 @@ crm
 cqg
 cXa
 cuf
-nVl
+cwZ
 cvG
 cvG
 cvG
@@ -125423,7 +116374,7 @@ cXq
 aJF
 ngt
 nmx
-xEk
+vFo
 apg
 aab
 aab
@@ -125439,7 +116390,7 @@ aTK
 aTJ
 brr
 bam
-gjl
+tpJ
 bcl
 bdq
 beC
@@ -125494,24 +116445,24 @@ cWN
 bOU
 qUA
 uYv
-fvi
+uIi
 bSp
 bTl
 bUk
 bZm
 cCx
-fvi
-fvi
+uIi
+uIi
 nkH
-fvi
-fvi
+uIi
+uIi
 cMK
-pBb
-fvi
+cfP
+uIi
 uYv
 cHr
-hWN
-mwk
+thv
+voS
 boU
 cdB
 cRW
@@ -125534,7 +116485,7 @@ bYa
 cqg
 ctW
 cuf
-nVl
+cwZ
 cvG
 aab
 aab
@@ -125680,7 +116631,7 @@ cXq
 aJF
 ngt
 nmx
-xEk
+vFo
 bym
 aab
 aab
@@ -125749,24 +116700,24 @@ bLS
 boU
 bVo
 cCm
-jGv
+dFe
 cfi
-jGv
-skW
+dFe
+cfS
 cju
 czN
 cCL
-skW
-jGv
-skW
+cfS
+dFe
+cfS
 cEL
-skW
-jGv
+cfS
+dFe
 cEN
-jGv
+dFe
 cHd
 lCX
-skW
+cfS
 cRI
 cCE
 boU
@@ -125789,9 +116740,9 @@ cla
 cqt
 crn
 cqg
-hdz
+ctM
 cuf
-nVl
+cwZ
 cvF
 cqg
 cwN
@@ -126007,22 +116958,22 @@ boU
 cBI
 bOX
 cCa
-dJU
-klf
-klf
+uKJ
+ean
+ean
 bWZ
-klf
-klf
-klf
-klf
-klf
-klf
+ean
+ean
+ean
+ean
+ean
+ean
 ulq
 cUG
-klf
+ean
 cFf
 sDf
-dJU
+uKJ
 cBR
 bOX
 cHv
@@ -126048,7 +116999,7 @@ cUl
 cqg
 cXb
 cuf
-gIr
+cxa
 cvH
 cwm
 cvH
@@ -126194,7 +117145,7 @@ aIb
 aJF
 ngt
 nmx
-xEk
+vFo
 cye
 aab
 aab
@@ -126263,7 +117214,7 @@ cRh
 boU
 cBI
 bOX
-qoQ
+cqm
 bQz
 bQz
 bQz
@@ -126303,7 +117254,7 @@ ceG
 cqt
 cRy
 cqg
-hdz
+ctM
 cug
 cyh
 cvK
@@ -126520,16 +117471,16 @@ cTt
 boU
 cBN
 bOX
-mwk
+voS
 bQz
 cUy
 bRh
 cFn
-kDv
+wtQ
 cKA
-kDv
-kDv
-kDv
+wtQ
+wtQ
+wtQ
 cLb
 cLL
 bQz
@@ -126539,7 +117490,7 @@ bZQ
 car
 cFF
 cFO
-gCt
+evX
 bYJ
 cdB
 bYa
@@ -126686,26 +117637,26 @@ anR
 arG
 auk
 bXs
-tZa
-tZa
+dEp
+dEp
 axC
 gVP
-hCc
-hCc
+fKc
+fKc
 aDv
 aEk
 aGJ
 aHA
 aXd
-tZa
-tZa
-tZa
-tZa
+dEp
+dEp
+dEp
+dEp
 aPg
 aPj
 gVP
-hCc
-hCc
+fKc
+fKc
 aKy
 nmx
 cNB
@@ -126724,7 +117675,7 @@ aXa
 aWY
 btl
 bam
-gjl
+tpJ
 bcw
 bdK
 beT
@@ -126777,7 +117728,7 @@ cRh
 boU
 cBI
 bOX
-wrL
+uRw
 bQA
 cmx
 bRh
@@ -126788,7 +117739,7 @@ cWp
 cJx
 cJx
 cJx
-rGm
+xQx
 bQz
 cWQ
 bZg
@@ -126796,7 +117747,7 @@ bZg
 bZg
 cJI
 cNb
-gCt
+evX
 bYJ
 cdB
 bYa
@@ -126965,7 +117916,7 @@ aCM
 aJH
 aJM
 aPW
-xEk
+vFo
 apg
 aab
 aab
@@ -126992,7 +117943,7 @@ cIB
 bjz
 bkk
 bkL
-kUz
+tlP
 biQ
 bmk
 bne
@@ -127009,7 +117960,7 @@ cPo
 bsN
 bte
 btT
-hLO
+fZN
 bwi
 bwR
 byh
@@ -127034,7 +117985,7 @@ cPB
 boU
 cBI
 bOX
-wrL
+uRw
 bQA
 cUz
 bRh
@@ -127203,26 +118154,26 @@ avG
 aYm
 axi
 pqo
-tDo
+ect
 aJX
-tDo
-tDo
-tDo
+ect
+ect
+ect
 lkU
 aDQ
 aDF
 bku
 pqo
 lkU
-tDo
-tDo
-tDo
-tDo
-tDo
-tDo
+ect
+ect
+ect
+ect
+ect
+ect
 aLw
-gmv
-xEk
+uWN
+vFo
 apg
 aab
 aab
@@ -127238,7 +118189,7 @@ aXc
 aYf
 btE
 cGt
-gjl
+tpJ
 bcw
 bdM
 beV
@@ -127249,7 +118200,7 @@ cIC
 bjA
 bkl
 bkM
-kUz
+tlP
 blP
 bml
 bnf
@@ -127291,7 +118242,7 @@ bFI
 boU
 cIy
 bOX
-wrL
+uRw
 bQA
 cmx
 bRh
@@ -127478,8 +118429,8 @@ apk
 aHX
 apk
 bPB
-gmv
-xEk
+uWN
+vFo
 apg
 aab
 aab
@@ -127506,7 +118457,7 @@ cIB
 bjB
 bkm
 bkN
-kUz
+tlP
 biQ
 bmm
 bre
@@ -127548,7 +118499,7 @@ boU
 cFZ
 cBI
 bOX
-wrL
+uRw
 bQA
 bRh
 bRh
@@ -127559,7 +118510,7 @@ cJx
 cJx
 cJx
 cWs
-rGm
+xQx
 bQz
 bZj
 cJB
@@ -127735,8 +118686,8 @@ aEv
 aHY
 aFl
 aJD
-gmv
-xEk
+uWN
+vFo
 apg
 aab
 aab
@@ -127785,7 +118736,7 @@ bwT
 bwR
 byk
 bAp
-hLO
+fZN
 bBz
 bFc
 bwR
@@ -127816,7 +118767,7 @@ cJx
 cWq
 cJx
 cJx
-rGm
+xQx
 bQz
 cjU
 cJA
@@ -127992,8 +118943,8 @@ aHu
 aHY
 aFl
 aJD
-gmv
-xEk
+uWN
+vFo
 apg
 aab
 aab
@@ -128009,7 +118960,7 @@ aWY
 aWY
 buq
 bam
-gjl
+tpJ
 bcw
 bdQ
 cJK
@@ -128062,21 +119013,21 @@ boU
 cGb
 cBI
 bOX
-wrL
+uRw
 bQz
 cUB
 bRh
 cFG
-hnu
-hnu
-hnu
+fZL
+fZL
+fZL
 cWr
-hnu
-hnu
+fZL
+fZL
 cMy
 cFI
-gRX
-gRX
+cfq
+cfq
 cJC
 cJG
 cFK
@@ -128249,8 +119200,8 @@ aHv
 aHY
 aFl
 aJD
-gmv
-xEk
+uWN
+vFo
 apg
 aab
 aab
@@ -128266,7 +119217,7 @@ cEU
 aWY
 buu
 ban
-gjl
+tpJ
 bcw
 bht
 beY
@@ -128319,7 +119270,7 @@ bMs
 boU
 cIz
 bOX
-wrL
+uRw
 bQA
 cUC
 bRh
@@ -128506,7 +119457,7 @@ aGO
 aGO
 aGO
 aKv
-gmv
+uWN
 vrE
 apg
 aab
@@ -128523,7 +119474,7 @@ aOW
 aSt
 brk
 bam
-gjl
+tpJ
 bcw
 bdR
 bfa
@@ -128576,7 +119527,7 @@ cVD
 boU
 cgm
 bOX
-wrL
+uRw
 bQA
 cUC
 bRh
@@ -128595,7 +119546,7 @@ cnQ
 fwg
 cFM
 cFV
-ilx
+fQN
 bYJ
 cVK
 chI
@@ -128764,7 +119715,7 @@ aHZ
 aIR
 aLt
 aPc
-xEk
+vFo
 apg
 aOl
 aPa
@@ -128833,7 +119784,7 @@ bFI
 boU
 cBI
 bOX
-wrL
+uRw
 bQA
 cUC
 bRh
@@ -128852,7 +119803,7 @@ cEV
 cEV
 cEV
 cFW
-ilx
+fQN
 bYJ
 cdB
 chI
@@ -129028,7 +119979,7 @@ aZd
 uSM
 aQm
 bvQ
-sGf
+joZ
 uSM
 uSM
 bEb
@@ -129048,7 +119999,7 @@ cQx
 utM
 utM
 iqD
-sGf
+joZ
 uSM
 bqS
 bMu
@@ -129090,7 +120041,7 @@ bKj
 bNb
 cBO
 bOZ
-wrL
+uRw
 bQz
 cUC
 bRN
@@ -129278,9 +120229,9 @@ aIQ
 aIR
 aJD
 aXg
-tPr
-tPr
-tPr
+oCd
+oCd
+oCd
 aZT
 aZU
 bkc
@@ -129309,7 +120260,7 @@ blq
 aQO
 bmr
 bAr
-nrn
+kXQ
 bTr
 aRZ
 cRb
@@ -129347,7 +120298,7 @@ bIt
 boU
 cBI
 bOX
-mwk
+voS
 bQB
 bQB
 bQB
@@ -129366,7 +120317,7 @@ cQH
 cFY
 kcN
 cQH
-ilx
+fQN
 bYJ
 cVL
 bYN
@@ -129545,28 +120496,28 @@ bkA
 xGR
 aVO
 biO
-pcz
-pcz
-pcz
-pcz
+uLi
+uLi
+uLi
+uLi
 bsp
 blr
-pcz
-pcz
-pcz
-pcz
+uLi
+uLi
+uLi
+uLi
 bmv
 cQE
-pcz
-pcz
-pcz
-pcz
+uLi
+uLi
+uLi
+uLi
 bSv
 xGR
-pcz
+uLi
 bDV
 bnn
-nrn
+kXQ
 bON
 aRZ
 boR
@@ -129604,7 +120555,7 @@ bFI
 boU
 cBI
 bOX
-wrL
+uRw
 bQB
 bRl
 bWv
@@ -129798,7 +120749,7 @@ axa
 axa
 bap
 aPY
-shr
+vtT
 aRH
 aRH
 aRH
@@ -129823,7 +120774,7 @@ bgp
 bgp
 bRS
 aPY
-nrn
+kXQ
 aOz
 aRZ
 boR
@@ -129861,7 +120812,7 @@ bFI
 boU
 cWO
 bOX
-wrL
+uRw
 bQB
 coD
 bRP
@@ -130036,16 +120987,16 @@ axw
 aye
 aIw
 aWt
-wOD
+uVs
 aMq
-rVD
-rVD
+dwu
+dwu
 pWd
-rVD
+dwu
 aZj
-wOD
-wOD
-wOD
+uVs
+uVs
+uVs
 aQX
 aqG
 aKL
@@ -130080,7 +121031,7 @@ bPX
 bgp
 cJa
 aPY
-nrn
+kXQ
 aOy
 aRZ
 boR
@@ -130118,7 +121069,7 @@ bFH
 boU
 cBM
 bPa
-wrL
+uRw
 bQB
 bRn
 gqj
@@ -130312,7 +121263,7 @@ aKO
 axa
 cHZ
 aPY
-rgk
+kkw
 aRI
 aSF
 aTT
@@ -130337,7 +121288,7 @@ bgr
 bii
 bgn
 aPY
-nBd
+dFG
 aRZ
 aRZ
 bpt
@@ -130375,7 +121326,7 @@ aaA
 boU
 cBK
 bOX
-wrL
+uRw
 bQB
 bQB
 bQB
@@ -130569,7 +121520,7 @@ cND
 axa
 bap
 aPY
-rgk
+kkw
 aRJ
 aSG
 aSG
@@ -130594,7 +121545,7 @@ bko
 blT
 bDW
 bno
-nBd
+dFG
 aRZ
 cAs
 bpr
@@ -130632,7 +121583,7 @@ aaA
 boU
 cBI
 bOX
-qoQ
+cqm
 bQB
 cph
 cCe
@@ -130817,7 +121768,7 @@ aqG
 aqG
 aPp
 aIe
-phw
+mtV
 aqG
 aKO
 aLy
@@ -130889,7 +121840,7 @@ aaA
 boU
 cBL
 bOX
-wrL
+uRw
 bQB
 cpR
 cEZ
@@ -131146,7 +122097,7 @@ aaA
 boU
 cBI
 bOX
-wrL
+uRw
 bQB
 cpX
 cFc
@@ -131334,13 +122285,13 @@ aIf
 aKX
 aqG
 aNv
-rcM
-rcM
-rcM
+rUI
+rUI
+rUI
 axa
 btt
 aPY
-rgk
+kkw
 aRI
 aSG
 aTW
@@ -131365,7 +122316,7 @@ bjH
 bii
 bgn
 aPY
-nBd
+dFG
 aRZ
 boU
 boU
@@ -131623,18 +122574,18 @@ bgp
 bnu
 bAs
 vJb
-sGf
-fvi
+joZ
+uIi
 bTt
-fvi
-fvi
+uIi
+uIi
 cec
-pBb
+cfP
 cPl
-fvi
-fvi
-fvi
-fvi
+uIi
+uIi
+uIi
+uIi
 bVI
 neT
 cBm
@@ -131647,20 +122598,20 @@ hST
 neT
 neT
 neT
-fvi
+uIi
 bZR
-pBb
-fvi
+cfP
+uIi
 cjv
-fvi
+uIi
 nkH
 cBF
-fvi
-fvi
-fvi
+uIi
+uIi
+uIi
 cBQ
 bOX
-wrL
+uRw
 bQB
 bRl
 bWN
@@ -131854,7 +122805,7 @@ aZN
 axa
 bbt
 aPY
-uci
+txO
 aRH
 aSK
 aTX
@@ -131884,17 +122835,17 @@ bqz
 wEY
 bsB
 wEY
-pws
+dQT
 wEY
-pws
+dQT
 cPm
-pws
+dQT
 wEY
 cAB
 wEY
-pws
+dQT
 wEY
-pws
+dQT
 bQQ
 cAm
 cuX
@@ -132102,7 +123053,7 @@ aCV
 aqG
 aQn
 aIh
-phw
+mtV
 aqG
 aXP
 aXQ
@@ -132111,7 +123062,7 @@ aYP
 axa
 cCB
 aPY
-uci
+txO
 aRM
 aSL
 aZV
@@ -132138,40 +123089,40 @@ cGC
 bns
 bNM
 xGR
-lnB
-lnB
+eFp
+eFp
 khi
-lnB
-lnB
+eFp
+eFp
 bUo
 clK
-lnB
+eFp
 khi
 bAQ
-lnB
-xTY
+eFp
+eTx
 cSG
-xTY
+eTx
 ihw
 cEw
 byf
 bBC
 cGd
 ihw
-xTY
-xTY
+eTx
+eTx
 cIR
 sDf
-klf
-klf
-klf
+ean
+ean
+ean
 cBB
-klf
-klf
+ean
+ean
 ulq
 clB
 cBH
-klf
+ean
 bVV
 bOY
 bVk
@@ -132368,7 +123319,7 @@ aLA
 axa
 bap
 aPY
-uci
+txO
 aRN
 aSM
 aTZ
@@ -132393,7 +123344,7 @@ blx
 bii
 bgn
 bns
-nBd
+dFG
 aRZ
 boU
 boU
@@ -132431,7 +123382,7 @@ boU
 boU
 cTW
 bOX
-wrL
+uRw
 bQB
 bQB
 bQB
@@ -132625,7 +123576,7 @@ aNo
 axa
 bap
 aPY
-uci
+txO
 aRN
 aSN
 aUa
@@ -132650,7 +123601,7 @@ blv
 bii
 bgn
 bns
-nBd
+dFG
 aRZ
 czI
 bpw
@@ -132668,7 +123619,7 @@ bws
 bxt
 bzf
 bsV
-lKh
+doD
 bBE
 bCU
 mqh
@@ -132690,13 +123641,13 @@ cBS
 bOX
 qUA
 bQC
-hDI
+vKZ
 ggi
 bZT
 bSw
 bWQ
 eqk
-hDI
+vKZ
 ggi
 cbQ
 bZU
@@ -132713,7 +123664,7 @@ cSF
 cUb
 cSK
 cUc
-hDI
+vKZ
 chT
 czC
 bSw
@@ -132873,7 +123824,7 @@ aGd
 aGX
 cDE
 aIe
-phw
+mtV
 aqG
 aKS
 aLB
@@ -132907,7 +123858,7 @@ bkX
 bii
 bGO
 bnt
-nBd
+dFG
 aRZ
 boZ
 cAg
@@ -132925,7 +123876,7 @@ btG
 btG
 bzg
 bzq
-lKh
+doD
 bBw
 bCm
 bCm
@@ -132975,8 +123926,8 @@ csZ
 czC
 bSw
 eqk
-hDI
-hDI
+vKZ
+vKZ
 cmb
 cmW
 brT
@@ -133120,7 +124071,7 @@ aqG
 aqG
 cXc
 aAl
-phw
+mtV
 aqG
 aDa
 aEJ
@@ -133139,7 +124090,7 @@ aqG
 axa
 bap
 aPY
-shr
+vtT
 aRN
 aSP
 aUc
@@ -133387,7 +124338,7 @@ aGf
 aqG
 aPp
 aIj
-sXb
+fMb
 aJW
 bRj
 aLC
@@ -133439,7 +124390,7 @@ bwk
 lpx
 bzl
 bsV
-lKh
+doD
 bBH
 bCo
 bDm
@@ -133466,30 +124417,30 @@ bSw
 bYo
 bVc
 bYO
-gQV
-gQV
-gQV
-gQV
-gQV
+fDN
+fDN
+fDN
+fDN
+fDN
 cFg
 ccv
 cEY
 bZS
 cTP
 cSt
-gQV
+fDN
 cGk
-gQV
+fDN
 cGl
-gQV
+fDN
 bUy
 cay
 cft
-fMq
+ccn
 cGp
-fMq
-fMq
-fMq
+ccn
+ccn
+ccn
 cyF
 cmb
 cmX
@@ -133634,7 +124585,7 @@ aqG
 aqG
 aFh
 aAl
-phw
+mtV
 aqG
 aqG
 aDH
@@ -133678,7 +124629,7 @@ bly
 bii
 bgn
 bns
-nBd
+dFG
 aRZ
 boZ
 bDx
@@ -133696,7 +124647,7 @@ bwl
 bxa
 bzp
 bsQ
-lKh
+doD
 bBH
 bCW
 bDo
@@ -133716,7 +124667,7 @@ bCD
 boU
 cBS
 bOU
-tSf
+cCg
 bQC
 bSx
 bSE
@@ -133741,7 +124692,7 @@ bWB
 bWB
 bTw
 bVc
-ehe
+cfu
 cNW
 bRh
 bRh
@@ -133882,22 +124833,22 @@ aoC
 asS
 aNf
 yfq
-rVD
-rVD
+dwu
+dwu
 pWd
-rVD
-rVD
+dwu
+dwu
 aCk
 yfq
 aFk
 aAl
 aIU
 aYZ
-rVD
-rVD
-rVD
-rVD
-rVD
+dwu
+dwu
+dwu
+dwu
+dwu
 cLx
 aQQ
 aIl
@@ -133935,7 +124886,7 @@ blx
 bii
 bgn
 bns
-nBd
+dFG
 aRZ
 czK
 bpx
@@ -133973,7 +124924,7 @@ bCD
 boU
 cBS
 bOU
-wrL
+uRw
 boU
 bQB
 bQB
@@ -133998,7 +124949,7 @@ cdE
 bWB
 bTw
 bVc
-ehe
+cfu
 bQz
 cnU
 bQz
@@ -134123,7 +125074,7 @@ aab
 aab
 aab
 acS
-cwt
+cuL
 adF
 ael
 afk
@@ -134158,7 +125109,7 @@ ayi
 cLy
 cdt
 cEt
-sXb
+fMb
 aqJ
 cDx
 aqG
@@ -134210,14 +125161,14 @@ bwn
 bxc
 bzF
 bsQ
-eBy
+dIv
 bCc
 bCX
 bDE
 bEk
 bGk
 bCq
-eBy
+dIv
 bGU
 bJe
 bIy
@@ -134230,7 +125181,7 @@ bMx
 boU
 cBV
 bOU
-wrL
+uRw
 boU
 eVg
 eVg
@@ -134380,7 +125331,7 @@ aab
 aab
 aab
 acS
-cwt
+cuL
 adG
 aem
 afl
@@ -134415,7 +125366,7 @@ hIv
 cLz
 aQR
 aIn
-sXb
+fMb
 aqJ
 aBk
 aLF
@@ -134449,7 +125400,7 @@ bjH
 bgp
 bFQ
 bns
-nBd
+dFG
 aRZ
 boZ
 bpx
@@ -134474,7 +125425,7 @@ bDh
 bEE
 bDh
 bCq
-eBy
+dIv
 cOi
 bJy
 bJC
@@ -134487,7 +125438,7 @@ cPC
 boU
 cBW
 bOV
-mwk
+voS
 boU
 bRu
 bRX
@@ -134637,7 +125588,7 @@ aab
 aab
 aab
 acS
-cwt
+cuL
 cif
 aen
 afm
@@ -134683,7 +125634,7 @@ bbv
 aQb
 aSA
 aRR
-sPB
+ebs
 cAw
 aVm
 aWk
@@ -134706,7 +125657,7 @@ blz
 bgw
 bGg
 bHj
-nBd
+dFG
 aRZ
 boZ
 bpx
@@ -134929,7 +125880,7 @@ aGg
 aqG
 cDW
 aIp
-sXb
+fMb
 azm
 aKV
 aLE
@@ -134940,10 +125891,10 @@ bbw
 aPY
 eGt
 aRR
-sPB
+ebs
 czO
 aVm
-sPB
+ebs
 aXl
 aYq
 aYq
@@ -134963,7 +125914,7 @@ blA
 blW
 bJT
 bnv
-nBd
+dFG
 aRZ
 boZ
 bpx
@@ -135001,7 +125952,7 @@ bCD
 boU
 cBS
 bPg
-qoQ
+cqm
 boU
 bRw
 bRw
@@ -135210,11 +126161,11 @@ aYs
 aZo
 bfn
 aVo
-xVT
-xVT
-xVT
-xVT
-iLI
+gMF
+gMF
+gMF
+gMF
+ehl
 bki
 bgw
 bgw
@@ -135258,7 +126209,7 @@ bCD
 boU
 cBS
 bPg
-wrL
+uRw
 boU
 bRx
 bRx
@@ -135273,9 +126224,9 @@ bXz
 bXz
 bWB
 bZw
-kPl
-kPl
-kPl
+umI
+umI
+umI
 bWB
 cXf
 bWB
@@ -135454,10 +126405,10 @@ bby
 aQe
 eGt
 aRU
-sPB
+ebs
 cAw
 aVn
-sPB
+ebs
 aXn
 aSX
 aSX
@@ -135468,11 +126419,11 @@ cNJ
 aRO
 bgw
 bhH
-xVT
-xVT
-xVT
-iLI
-oiR
+gMF
+gMF
+gMF
+ehl
+nRc
 blB
 aPb
 bmB
@@ -135502,7 +126453,7 @@ bDl
 bEg
 bFd
 bCs
-eBy
+dIv
 bGZ
 bJe
 bIy
@@ -135515,7 +126466,7 @@ cVC
 boU
 cBU
 bPg
-wrL
+uRw
 boU
 bQB
 bQB
@@ -135668,14 +126619,14 @@ aby
 bsn
 adI
 acT
-gSL
-gSL
-gSL
+uaq
+uaq
+uaq
 aqM
-gSL
-gSL
+uaq
+uaq
 aqt
-gSL
+uaq
 apz
 aoh
 att
@@ -135711,10 +126662,10 @@ bbz
 aQf
 eGt
 aRR
-sPB
+ebs
 cAx
 aVm
-sPB
+ebs
 aXn
 aYq
 aYq
@@ -135724,17 +126675,17 @@ aYq
 bfo
 aRR
 bgB
-xVT
-xVT
+gMF
+gMF
 biX
-xVT
-iLI
+gMF
+ehl
 tjc
 blB
 aPb
 bmC
 bnx
-nBd
+dFG
 aRZ
 boZ
 bpx
@@ -135772,7 +126723,7 @@ bCD
 boU
 cBY
 bPg
-wrL
+uRw
 boU
 bRy
 bRy
@@ -135806,7 +126757,7 @@ cks
 cjM
 czV
 cfv
-hZd
+ceU
 cCp
 cpH
 cku
@@ -135918,7 +126869,7 @@ abr
 aaa
 aaa
 aaa
-aeT
+aaT
 abX
 acq
 acU
@@ -135968,10 +126919,10 @@ bbW
 aQg
 eGt
 aRR
-sPB
+ebs
 cAw
 aVm
-sPB
+ebs
 aXo
 aYt
 aZk
@@ -135981,12 +126932,12 @@ aSX
 cAw
 bft
 vDt
-xVT
+gMF
 blF
 hBS
 hBS
-iLI
-oiR
+ehl
+nRc
 blC
 aTh
 bmD
@@ -136070,10 +127021,10 @@ cDP
 cJZ
 cKd
 cBp
-dCL
+cCj
 cHg
 cNy
-dCL
+cCj
 jSU
 cHE
 jSU
@@ -136185,12 +127136,12 @@ acT
 akM
 fjH
 aSU
-tXX
-tXX
+xGE
+xGE
 amO
 fjH
 anZ
-tXX
+xGE
 aqA
 atV
 aqL
@@ -136238,11 +127189,11 @@ aSX
 cAw
 bfu
 bhJ
-xVT
+gMF
 biq
 biZ
 bjS
-iLI
+ehl
 bkV
 blD
 aTh
@@ -136273,7 +127224,7 @@ bDn
 bEj
 bCl
 bFM
-eBy
+dIv
 bHb
 bJe
 bIy
@@ -136286,7 +127237,7 @@ bMx
 boU
 cBS
 bPg
-mwk
+voS
 boU
 bRA
 bRA
@@ -136322,8 +127273,8 @@ ciV
 cfv
 cNs
 csw
-pUf
-pUf
+ctB
+ctB
 cKb
 cSe
 cso
@@ -136495,12 +127446,12 @@ aYq
 cAw
 bgy
 vDt
-xVT
-xVT
+gMF
+gMF
 bjh
 bjT
-iLI
-oiR
+ehl
+nRc
 blD
 aTh
 bmF
@@ -136543,7 +127494,7 @@ bCD
 boU
 cBS
 bPg
-wrL
+uRw
 boU
 aaA
 aaA
@@ -136577,23 +127528,23 @@ cjO
 cjN
 ciV
 cfv
-hZd
+ceU
 coJ
 cyd
 cyd
 cAr
 fjJ
 cnR
-qbQ
-qbQ
+col
+col
 cNz
-qbQ
-qbQ
-qbQ
-qbQ
-qbQ
-qbQ
-qbQ
+col
+col
+col
+col
+col
+col
+col
 cLv
 cmZ
 cVW
@@ -136737,7 +127688,7 @@ aNy
 axa
 bcy
 aPY
-nBd
+dFG
 aRO
 aSS
 cAS
@@ -136752,17 +127703,17 @@ aSX
 cAw
 aRR
 bhK
-xVT
-xVT
+gMF
+gMF
 bjb
 bjU
-iLI
+ehl
 tjc
 blB
 aPo
 bmG
 bnB
-uci
+txO
 aRZ
 boZ
 bpx
@@ -136776,7 +127727,7 @@ cEu
 btS
 bvh
 bvM
-eBy
+dIv
 bxk
 byy
 bzw
@@ -136787,7 +127738,7 @@ bDI
 bBI
 bBI
 bBI
-eBy
+dIv
 bHb
 bCl
 bIx
@@ -136800,7 +127751,7 @@ bCD
 boU
 cBS
 bPg
-wrL
+uRw
 boU
 bRB
 bRB
@@ -136994,7 +127945,7 @@ aHL
 aHM
 cWH
 aQh
-nBd
+dFG
 aRO
 aSW
 aUk
@@ -137009,7 +127960,7 @@ bbR
 bfp
 aRO
 bhL
-xVT
+gMF
 bir
 bjV
 bks
@@ -137019,7 +127970,7 @@ blB
 aPo
 bmH
 bnC
-uci
+txO
 aRZ
 boZ
 bpx
@@ -137057,7 +128008,7 @@ bCD
 boU
 cBU
 bPg
-wrL
+uRw
 boU
 bRB
 aaA
@@ -137091,7 +128042,7 @@ cfv
 cfv
 cfv
 cfv
-hZd
+ceU
 coJ
 cAr
 cAr
@@ -137314,7 +128265,7 @@ bCD
 boU
 cBS
 bPg
-wrL
+uRw
 boU
 bRB
 aaA
@@ -137348,7 +128299,7 @@ cmJ
 cNm
 tkG
 tkG
-nsK
+cgs
 cty
 cBe
 cJo
@@ -137357,13 +128308,13 @@ cYh
 cxt
 cmZ
 iJE
-jjH
+ePb
 cws
-yfg
+cxw
 tsA
-yfg
+cxw
 tsA
-yfg
+cxw
 rqY
 cwU
 cwU
@@ -137533,7 +128484,7 @@ aTa
 aRZ
 bgn
 bns
-uci
+txO
 aRZ
 cOQ
 bpx
@@ -137571,7 +128522,7 @@ bMy
 boU
 cBV
 bPg
-wrL
+uRw
 boU
 bRB
 bRB
@@ -137595,7 +128546,7 @@ cWm
 cXO
 bXe
 cdO
-nsK
+cgs
 cgt
 chf
 chY
@@ -137604,8 +128555,8 @@ cNk
 cmA
 ciX
 cjb
-kpD
-kpD
+cmn
+cmn
 ctz
 cDp
 cKf
@@ -137613,7 +128564,7 @@ cru
 cnR
 cyc
 cmZ
-jfS
+ubl
 cHA
 cwS
 cyu
@@ -137622,8 +128573,8 @@ czy
 cwS
 cyu
 guj
-jjH
-jjH
+ePb
+ePb
 mdU
 cwU
 cmZ
@@ -137828,7 +128779,7 @@ bCD
 boU
 cBW
 bPi
-mwk
+voS
 boU
 ccG
 bRB
@@ -137870,18 +128821,18 @@ crv
 cmZ
 cmZ
 cmZ
-jfS
+ubl
 cvS
 cCS
 cyz
 cCS
-cyz
+lik
 cCS
 cyz
 cCS
 cKg
 cwT
-jfS
+ubl
 cwU
 cmZ
 cmZ
@@ -138047,7 +128998,7 @@ aTa
 aRZ
 bgn
 bns
-uci
+txO
 aRZ
 czP
 bpA
@@ -138085,7 +129036,7 @@ bCD
 boU
 cod
 bPg
-wrL
+uRw
 bDb
 ccK
 bRB
@@ -138127,7 +129078,7 @@ crw
 cLq
 ctA
 cuq
-jfS
+ubl
 cvT
 cwR
 cwS
@@ -138279,7 +129230,7 @@ aHM
 aHM
 bih
 aPY
-nBd
+dFG
 aRV
 aRZ
 aUp
@@ -138304,7 +129255,7 @@ cKk
 blY
 cKm
 cKn
-uci
+txO
 aRZ
 bpc
 bpA
@@ -138342,7 +129293,7 @@ cVC
 boU
 cBS
 bPg
-wrL
+uRw
 bDb
 cdj
 bRB
@@ -138384,7 +129335,7 @@ cLr
 cOJ
 cON
 cuq
-jfS
+ubl
 cwp
 cwS
 cwT
@@ -138536,7 +129487,7 @@ aND
 aOy
 bgn
 aPY
-nBd
+dFG
 aRW
 aRZ
 aUq
@@ -138561,7 +129512,7 @@ bit
 bit
 bvp
 bns
-uci
+txO
 aRZ
 bpc
 bpA
@@ -138599,7 +129550,7 @@ bCD
 boU
 cBU
 bPg
-wrL
+uRw
 bDb
 cep
 bRB
@@ -138622,7 +129573,7 @@ bDR
 bFE
 bGb
 cei
-oBz
+ceQ
 bYV
 cgw
 cJY
@@ -138641,7 +129592,7 @@ cNu
 cOK
 hof
 cuq
-jfS
+ubl
 cwp
 cwS
 cwT
@@ -138793,7 +129744,7 @@ aND
 aOz
 bgn
 aPY
-nBd
+dFG
 cla
 cla
 aZu
@@ -138818,7 +129769,7 @@ blH
 bit
 cWM
 bnt
-uci
+txO
 aRZ
 bpc
 bpA
@@ -138856,7 +129807,7 @@ bCD
 boU
 cGq
 bPg
-wrL
+uRw
 bDb
 ceX
 bRB
@@ -138879,7 +129830,7 @@ bDS
 cpI
 bGc
 cej
-oBz
+ceQ
 cfE
 bYq
 chj
@@ -138898,8 +129849,8 @@ cOG
 cOL
 hof
 cuq
-jfS
-cwp
+ubl
+eFG
 cwS
 cwU
 cwS
@@ -138907,7 +129858,7 @@ cYj
 cwS
 cwU
 cwS
-cWG
+wOj
 cwT
 tjO
 cwT
@@ -139075,7 +130026,7 @@ bka
 bit
 cIt
 bns
-uci
+txO
 aRZ
 bpc
 bpA
@@ -139113,7 +130064,7 @@ bCE
 boU
 cBS
 bPg
-wrL
+uRw
 bDb
 cBs
 bRB
@@ -139155,7 +130106,7 @@ cOH
 cOM
 hof
 cuq
-jfS
+ubl
 cwp
 cwS
 cwT
@@ -139307,7 +130258,7 @@ aND
 aND
 cMA
 aPY
-nBd
+dFG
 cla
 aTd
 aUu
@@ -139332,7 +130283,7 @@ blI
 bit
 bgn
 bns
-shr
+vtT
 aRZ
 bpd
 bpB
@@ -139370,7 +130321,7 @@ bpc
 boU
 cBS
 bPg
-wrL
+uRw
 bDb
 ccK
 bRB
@@ -139412,7 +130363,7 @@ cOI
 crw
 cOP
 cuq
-jfS
+ubl
 cwp
 cwS
 cwT
@@ -139564,7 +130515,7 @@ cGW
 aND
 bgn
 aPY
-nBd
+dFG
 cla
 aTe
 aVu
@@ -139589,7 +130540,7 @@ blJ
 bit
 bgn
 bns
-uci
+txO
 aRZ
 czR
 bpA
@@ -139907,7 +130858,7 @@ cNf
 cdi
 cdP
 cel
-hZd
+ceU
 cqh
 bYq
 chg
@@ -139926,15 +130877,15 @@ crB
 cmZ
 cmZ
 cmZ
-jfS
+ubl
 cwr
-xUp
+cxp
 czc
-xUp
-czc
-xUp
+cxp
+mfy
+cxp
 cAt
-xUp
+cxp
 cXV
 cwT
 cHA
@@ -140080,76 +131031,76 @@ biu
 aQl
 boF
 nXH
-puL
-puL
-puL
+ePe
+ePe
+ePe
 jCQ
 jCQ
 bBK
 bsr
-puL
+ePe
 bvC
-puL
-puL
+ePe
+ePe
 nXH
 rYm
 rYm
-puL
+ePe
 bya
 byJ
 bsA
 bCb
 nXH
-puL
+ePe
 bLo
 bns
 vJb
 uSM
-lYr
-lYr
-lYr
-lYr
-lYr
-lYr
+tvc
+tvc
+tvc
+tvc
+tvc
+tvc
 cmE
 bUt
 cWz
-mvo
+uPt
 oKO
-mvo
+uPt
 cAD
 abN
 bVw
 bxv
 cIL
 oKO
-mvo
+uPt
 cIN
-mvo
+uPt
 cBt
 uwg
 cBa
-lYr
-lYr
+tvc
+tvc
 haK
 haK
-lYr
+tvc
 ceN
-lYr
-lYr
-lYr
+tvc
+tvc
+tvc
 cOC
 cBZ
 bPj
 cHs
 uwg
 cTY
-lYr
-lYr
+tvc
+tvc
 cCw
-lYr
-lYr
-lYr
+tvc
+tvc
+tvc
 cHt
 bXe
 nuO
@@ -140164,7 +131115,7 @@ nuO
 cCN
 cdP
 cem
-hZd
+ceU
 bYq
 bYq
 cii
@@ -140173,10 +131124,10 @@ clI
 cjT
 ckD
 cns
-qFo
+coj
 coP
 cNt
-qFo
+coj
 cpP
 cqK
 crC
@@ -140366,48 +131317,48 @@ bsq
 bNn
 bvR
 bNl
-wGp
-wGp
+vGr
+vGr
 cAu
 cAA
-wGp
-wGp
-wGp
-wGp
+vGr
+vGr
+vGr
+vGr
 cAC
 bPA
 cAF
 bPz
-wGp
-wGp
-wGp
-wGp
-wGp
+vGr
+vGr
+vGr
+vGr
+vGr
 cAH
 cAI
-wGp
+vGr
 cAJ
-nIA
-nIA
+eHx
+eHx
 cAL
-nIA
-nIA
-nIA
-nIA
-nIA
-nIA
+eHx
+eHx
+eHx
+eHx
+eHx
+eHx
 cAM
 cEP
-nIA
+eHx
 cAO
-nIA
-nIA
+eHx
+eHx
 coF
 cAP
 cHD
-nIA
-nIA
-nIA
+eHx
+eHx
+eHx
 cIc
 bXJ
 bYr
@@ -140441,13 +131392,13 @@ csD
 ctE
 csD
 ezo
-jjH
+ePb
 cxv
-jFJ
+czo
 cwS
-jFJ
+czo
 cwS
-jFJ
+czo
 cwS
 cwU
 cwU
@@ -140592,42 +131543,42 @@ bLO
 aND
 bjm
 aZc
-jkm
-jkm
+uQf
+uQf
 aTn
-rsJ
+mks
 bFf
 brb
 brd
 bcp
-rsJ
-rsJ
+mks
+mks
 cGQ
-jkm
+uQf
 bRk
-jkm
-jkm
+uQf
+uQf
 cQO
-uDE
-jkm
-jkm
+bxY
+uQf
+uQf
 bBg
-jkm
-jkm
-jkm
-jkm
-jkm
-uDE
+uQf
+uQf
+uQf
+uQf
+uQf
+bxY
 bTs
 bVb
 bsf
 byi
 bTp
 cSM
-gCs
-sZd
+chC
+gIA
 byR
-sZd
+gIA
 bQN
 bwJ
 bwJ
@@ -140642,29 +131593,29 @@ fOO
 cIQ
 dsE
 hwC
-sZd
+gIA
 cBz
-sZd
-gCs
+gIA
+chC
 bMo
 cBD
-sZd
-sZd
-sZd
-sZd
+gIA
+gIA
+gIA
+gIA
 cTT
 cTX
 cEQ
-gCs
+chC
 hwC
 cTZ
-sZd
+gIA
 bYG
 dsE
 cvO
 cCy
-sZd
-sZd
+gIA
+gIA
 bXe
 mNk
 clO
@@ -140687,12 +131638,12 @@ cSv
 cjT
 cTF
 cnR
-sAu
-qbQ
+cok
+col
 cWB
-qbQ
+col
 cKZ
-sAu
+cok
 ctw
 cjS
 ctF
@@ -141650,7 +132601,7 @@ cAf
 bpi
 bQc
 bHi
-vpb
+tkv
 brB
 bsa
 bsE
@@ -141719,7 +132670,7 @@ cTH
 coS
 cnd
 cKO
-kYW
+dSS
 cqO
 crF
 csG
@@ -141907,7 +132858,7 @@ aRj
 bpi
 bQb
 bFn
-vpb
+tkv
 brB
 bsa
 bsF
@@ -141967,12 +132918,12 @@ cdx
 ceZ
 cgA
 chr
-yga
+cjg
 cTB
-yga
+cjg
 cmt
 ckI
-yga
+cjg
 coT
 cpT
 cKP
@@ -142233,7 +133184,7 @@ cng
 coY
 cpU
 cKQ
-oCS
+gTB
 cqP
 crI
 csG
@@ -142435,7 +133386,7 @@ bxC
 bsE
 bzK
 brA
-lBj
+eIr
 bCG
 brA
 bEt
@@ -142678,7 +133629,7 @@ aRj
 bpi
 cMW
 bHi
-vpb
+tkv
 brA
 bsc
 bsE
@@ -142692,7 +133643,7 @@ bxD
 bDt
 bzL
 brA
-lBj
+eIr
 bCH
 brA
 bEq
@@ -143004,7 +133955,7 @@ cNp
 cnf
 cof
 cKQ
-oCS
+gTB
 coW
 ciw
 csH
@@ -143192,7 +134143,7 @@ bix
 bpi
 bQb
 bHi
-vpb
+tkv
 brB
 bsa
 bsH
@@ -143261,7 +134212,7 @@ cnY
 cnf
 cpV
 cKQ
-oCS
+gTB
 coW
 cix
 csG
@@ -143425,8 +134376,8 @@ aUG
 cyJ
 aWL
 aYF
-rXW
-rXW
+aWD
+aWD
 baS
 cQo
 bce
@@ -143449,7 +134400,7 @@ aRj
 bpi
 bQb
 bFn
-vpb
+tkv
 brB
 bsa
 bsH
@@ -143518,7 +134469,7 @@ cmu
 cnf
 csx
 cKQ
-oCS
+gTB
 coX
 crG
 csI
@@ -143706,7 +134657,7 @@ aQz
 bpi
 bQf
 bJS
-vpb
+tkv
 brB
 bsa
 bsH
@@ -143963,7 +134914,7 @@ ccA
 bpi
 bQb
 bFn
-vpb
+tkv
 brA
 bse
 bsH
@@ -145060,7 +136011,7 @@ cdx
 cdx
 cvj
 cKQ
-kYW
+dSS
 cgB
 crR
 ctH
@@ -145251,12 +136202,12 @@ bqB
 bnL
 brE
 bsh
-rqB
-rqB
+pHw
+pHw
 bua
 blZ
 bvv
-lBj
+eIr
 brA
 aaA
 aaA
@@ -145317,7 +136268,7 @@ cdy
 cdy
 cdy
 cKQ
-kYW
+dSS
 cqV
 crS
 csN
@@ -145831,7 +136782,7 @@ cXh
 cpc
 cpc
 cKQ
-kYW
+dSS
 cqV
 crU
 cdy
@@ -146088,7 +137039,7 @@ cMg
 cpd
 cpc
 cKT
-kYW
+dSS
 cqV
 crV
 cdy
@@ -146345,7 +137296,7 @@ coe
 cpc
 cpc
 cKT
-kYW
+dSS
 cqV
 cOf
 cdy
@@ -146602,7 +137553,7 @@ cXi
 cpc
 cpc
 cKQ
-kYW
+dSS
 cqV
 crU
 ccS
@@ -146786,7 +137737,7 @@ bma
 jqb
 bnL
 bot
-qcn
+eec
 bpl
 bip
 bqH
@@ -146795,7 +137746,7 @@ brG
 fow
 bsL
 bnL
-qcn
+eec
 bma
 aaa
 aaa
@@ -146859,7 +137810,7 @@ coH
 cpQ
 cdy
 cKU
-kYW
+dSS
 cqV
 crV
 cgF
@@ -147043,7 +137994,7 @@ bma
 jqb
 bnL
 bot
-qcn
+eec
 bpm
 bpQ
 bnL
@@ -147052,7 +138003,7 @@ bpm
 fow
 bsL
 bnL
-qcn
+eec
 bma
 aaa
 aaa
@@ -147116,7 +138067,7 @@ cdy
 cdy
 cdy
 cKQ
-kYW
+dSS
 cqX
 crU
 cgF
@@ -147309,7 +138260,7 @@ blZ
 bsk
 bsL
 bnL
-qcn
+eec
 bma
 aaa
 aaa
@@ -147559,9 +138510,9 @@ bnL
 bot
 boL
 kDs
-rqB
-rqB
-rqB
+pHw
+pHw
+pHw
 kDs
 bsl
 bsL
@@ -147887,7 +138838,7 @@ cdx
 cdx
 cvj
 cKX
-kYW
+dSS
 cra
 crX
 csP


### PR DESCRIPTION

## About The Pull Request

I fixed a lot of misc things but here's what I remember:

- Viro now has a grinder, a dropper, some other misc junk they were missing

- chem has the beakers they were missing

- cryo actually starts with cryomix

- Tesla wires have been rewired so that the emitters are on the output side of the SMESes (as box does it)

- Roundstart nanite lab was removed and converted to circuitry (99% sure kevin said roundstart nanite labs were not kosher)

- VR sleepers added around holodeck

- I couldn't figure out why but apparently the Holodeck console still isn't spawning, I tried deleting and replacing it but there's definitely one on the map so I dunno why it isnt spawning in.

## Why It's Good For The Game

hopefully helps make people not complain every time this map is picked

## Changelog
:cl:
fix: uncorks some of Lambda's rooms.
/:cl:
