### PR TITLE
Makes zipties white again

### DIFF
--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -163,7 +163,6 @@
 	color = pick(cable_colors)
 
 /obj/item/restraints/handcuffs/cable/attackby(obj/item/I, mob/user, params)
-	..()
 	if(istype(I, /obj/item/stack/rods))
 		var/obj/item/stack/rods/R = I
 		if (R.use(1))
@@ -203,7 +202,9 @@
 	custom_materials = null
 	breakouttime = 450 //Deciseconds = 45s
 	trashtype = /obj/item/restraints/handcuffs/cable/zipties/used
-	color = null
+
+/obj/item/restraints/handcuffs/cable/zipties/attack_self() //Zipties arent cable
+	return
 
 /obj/item/restraints/handcuffs/cable/zipties/used
 	desc = "A pair of broken zipties."

--- a/code/game/objects/items/handcuffs.dm
+++ b/code/game/objects/items/handcuffs.dm
@@ -197,6 +197,7 @@
 	name = "zipties"
 	desc = "Plastic, disposable zipties that can be used to restrain temporarily but are destroyed after use."
 	item_state = "zipties"
+	color = "white"
 	lefthand_file = 'icons/mob/inhands/equipment/security_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/security_righthand.dmi'
 	custom_materials = null

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -556,14 +556,14 @@ By design, d1 is the smallest direction and d2 is the highest
 		new_cable.update_icon()
 
 /obj/item/stack/cable_coil/attack_self(mob/user)
-	if(!use(15))
-		to_chat(user, "<span class='notice'>You dont have enough cable coil to make restraints out of them</span>")
+	if(amount < 15)
+		to_chat(user, "<span class='notice'>You don't have enough cable coil to make restraints out of them</span>")
 		return
 	to_chat(user, "<span class='notice'>You start making some cable restraints.</span>")
 	if(!do_after(user, 30, TRUE, user, TRUE))
-		to_chat(user, "<span class='notice'>You fail to make cable restraints, you need to stand still while doing so.</span>")
-		give(15)
+		to_chat(user, "<span class='notice'>You fail to make cable restraints, you need to be standing still to do it</span>")
 		return
+	use(15)
 	var/obj/item/restraints/handcuffs/cable/result = new(get_turf(user))
 	user.put_in_hands(result)
 	result.color = color 

--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -560,10 +560,9 @@ By design, d1 is the smallest direction and d2 is the highest
 		to_chat(user, "<span class='notice'>You don't have enough cable coil to make restraints out of them</span>")
 		return
 	to_chat(user, "<span class='notice'>You start making some cable restraints.</span>")
-	if(!do_after(user, 30, TRUE, user, TRUE))
+	if(!do_after(user, 30, TRUE, user, TRUE) || !use(15))
 		to_chat(user, "<span class='notice'>You fail to make cable restraints, you need to be standing still to do it</span>")
 		return
-	use(15)
 	var/obj/item/restraints/handcuffs/cable/result = new(get_turf(user))
 	user.put_in_hands(result)
 	result.color = color 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes zipties white, because my cabling PR fucked it up due to subtypes.
Also makes cabling not dissapear if you fail crafting it
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Zipties are supposed to be white
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix:Zipties are white again.
fix:Cabling shouldnt dissapear anymore if you fail crafting it
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
