### PR TITLE
Removed that one ss13 slur the code.

### DIFF
--- a/strings/insult.json
+++ b/strings/insult.json
@@ -173,6 +173,6 @@
 		"jerk",
 		"bitch",
 		"cuck",
-		"ligger"
+		"moron"
     ]
 }

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -108,7 +108,6 @@
 
 	"lizards": [
 		"lizard",
-		"liz",
 		"kobold",
 		"hiss",
 		"hissed",

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -109,7 +109,8 @@
 	"lizards": [
 		"lizard",
 		"liz",
-		"kobold",		"hiss",
+		"kobold",
+		"hiss",
 		"hissed",
 		"hissing",
 		"wag",

--- a/strings/phobia.json
+++ b/strings/phobia.json
@@ -108,8 +108,8 @@
 
 	"lizards": [
 		"lizard",
-		"ligger",
-		"hiss",
+		"liz",
+		"kobold",		"hiss",
 		"hissed",
 		"hissing",
 		"wag",


### PR DESCRIPTION
## About The Pull Request
Outside the ss13 community, the term has different obscure meanings ranging from timberwork and plankts to music parties freeloaders, but within the community, it's a portmanteau derived from a racial slur.

## Why It's Good For The Game
ToS compliance.

## Changelog
No.