### PR TITLE
Makes objectives clean theirselves up properly

### DIFF
--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -23,8 +23,7 @@ GLOBAL_LIST_EMPTY(objectives)
 	GLOB.objectives -= src
 	if(owner)
 		for(var/datum/antagonist/A in owner.antag_datums)
-			if(locate(src) in A.objectives)
-				A.objectives -= src
+			A.objectives -= src
 	if(team)
 		team.objectives -= src
 	. = ..()

--- a/code/game/gamemodes/objective.dm
+++ b/code/game/gamemodes/objective.dm
@@ -19,6 +19,16 @@ GLOBAL_LIST_EMPTY(objectives)
 	if(text)
 		explanation_text = text
 
+/datum/objective/Destroy(force, ...)
+	GLOB.objectives -= src
+	if(owner)
+		for(var/datum/antagonist/A in owner.antag_datums)
+			if(locate(src) in A.objectives)
+				A.objectives -= src
+	if(team)
+		team.objectives -= src
+	. = ..()
+
 /datum/objective/proc/get_owners() // Combine owner and team into a single list.
 	. = (team && team.members) ? team.members.Copy() : list()
 	if(owner)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Objectives couldn't be deleted because nobody wrote their cleanup code.

## Why It's Good For The Game

Things... should maybe work actually.

## Changelog
:cl:
fix: Objectives now clean theirselves up instead of leaving null entries in lists everywhere.
/:cl: