### PR TITLE
[Fix] Light Icons

### DIFF
--- a/code/modules/power/lighting.dm
+++ b/code/modules/power/lighting.dm
@@ -313,7 +313,7 @@
 /obj/machinery/light/update_overlays()
 	. = ..()
 	if(on && status == LIGHT_OK)
-		var/mutable_appearance/glowybit = mutable_appearance(overlayicon, base_state, EMISSIVE_LAYER, EMISSIVE_PLANE)
+		var/mutable_appearance/glowybit = mutable_appearance(overlayicon, base_state, FLOAT_LAYER, FLOAT_PLANE)
 		glowybit.alpha = CLAMP(light_power*250, 30, 200)
 		. += glowybit
 


### PR DESCRIPTION
## About The Pull Request

https://github.com/Citadel-Station-13/Citadel-Station-13/issues/11808 Mentioned that light icons no longer show them being on. I checked the lighting and it looked fine. Curious, I changed the EMISSIVE_LAYER and EMISSIVE_PLANE to FLOAT instead.
This is when EMISSIVE is used.
![emissivelight](https://user-images.githubusercontent.com/55967837/79538784-043d7980-8053-11ea-93ee-9520671e7d08.png)
This is when FLOAT is used.
![floatlayer](https://user-images.githubusercontent.com/55967837/79538801-0bfd1e00-8053-11ea-9fe6-98fd97c104d7.png)
It can still be colored.
![yesitcolors](https://user-images.githubusercontent.com/55967837/79538815-191a0d00-8053-11ea-84d6-0eae295c7288.png)
It can still be turned off.
![theyturnoff](https://user-images.githubusercontent.com/55967837/79538837-1f0fee00-8053-11ea-96e4-7c313d8978c6.png)
It can still be broken.
![theybreakaswell](https://user-images.githubusercontent.com/55967837/79538854-28995600-8053-11ea-9454-c752ebe98b78.png)




## Why It's Good For The Game

Having lights have icons for being on is nice.

## Changelog
:cl:
fix: fixed light icons not be overlay'd.
/:cl:

