### PR TITLE
Fixing Forensic scanners not reading blood DNA.

### DIFF
--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -397,13 +397,13 @@
 //returns the mob's dna info as a list, to be inserted in an object's blood_DNA list
 /mob/living/proc/get_blood_dna_list()
 	var/blood_id = get_blood_id()
-	if(!(blood_id in blood_reagent_types))
+	if(!(blood_id in GLOB.blood_reagent_types))
 		return
 	return list("ANIMAL DNA" = "Y-")
 
 /mob/living/carbon/get_blood_dna_list()
 	var/blood_id = get_blood_id()
-	if(!(blood_id in blood_reagent_types))
+	if(!(blood_id in GLOB.blood_reagent_types))
 		return
 	var/list/blood_dna = list()
 	if(dna)

--- a/code/game/atoms.dm
+++ b/code/game/atoms.dm
@@ -397,13 +397,13 @@
 //returns the mob's dna info as a list, to be inserted in an object's blood_DNA list
 /mob/living/proc/get_blood_dna_list()
 	var/blood_id = get_blood_id()
-	if(!(blood_id =="blood" || blood_id == "jellyblood"))
+	if(!(blood_id in blood_reagent_types))
 		return
 	return list("ANIMAL DNA" = "Y-")
 
 /mob/living/carbon/get_blood_dna_list()
 	var/blood_id = get_blood_id()
-	if(!(blood_id =="blood" || blood_id == "jellyblood"))
+	if(!(blood_id in blood_reagent_types))
 		return
 	var/list/blood_dna = list()
 	if(dna)


### PR DESCRIPTION
## About The Pull Request
Another thing that escaped me when I ported the reagent typepaths refactor.

## Why It's Good For The Game
This will close #11405. 

## Changelog
:cl:
fix: Forensic scanners can now detect blood DNA from... blood, and many other things again. Detectives rejoice.
/:cl:
