### PR TITLE
Makes tactical component destroy() work properly.

### DIFF
--- a/code/datums/components/tactical.dm
+++ b/code/datums/components/tactical.dm
@@ -18,7 +18,7 @@
 	UnregisterSignal(parent, list(COMSIG_ITEM_EQUIPPED, COMSIG_ITEM_DROPPED))
 	unmodify()
 
-/datum/component/fantasy/Destroy()
+/datum/component/tactical/Destroy()
 	unmodify()
 	return ..()
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Bad copypasta made it fantasy instead of tactical.

## Why It's Good For The Game

errors are bad.

## Changelog
:cl:
fix: Makes tactical and fantasy components destroy properly
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
