### PR TITLE
More useful gauze

### DIFF
--- a/code/game/objects/items/stacks/medical.dm
+++ b/code/game/objects/items/stacks/medical.dm
@@ -92,6 +92,7 @@
 	icon_state = "gauze"
 	var/stop_bleeding = 1800
 	var/heal_brute = 5
+	var/heal_tox = FALSE
 	self_delay = 10
 
 /obj/item/stack/medical/gauze/heal(mob/living/M, mob/user)
@@ -100,6 +101,9 @@
 		if(!H.bleedsuppress && H.bleed_rate) //so you can't stack bleed suppression
 			H.suppress_bloodloss(stop_bleeding)
 			to_chat(user, "<span class='notice'>You stop the bleeding of [M]!</span>")
+			H.adjustBruteLoss(-(heal_brute))
+			if(heal_tox)
+				H.adjustToxLoss(-5) //Heals 5 damage but is not safe for slimes...
 			return TRUE
 	to_chat(user, "<span class='notice'>You can not use \the [src] on [M]!</span>")
 
@@ -126,6 +130,13 @@
 	desc = "A roll of cloth roughly cut from something that can stop bleeding, but does not heal wounds."
 	stop_bleeding = 900
 	heal_brute = 0
+
+/obj/item/stack/medical/gauze/adv
+	name = "sterilized medical gauze"
+	desc = "A roll of elastic sterilized cloth that is extremely effective at stopping bleeding, heals minor wounds and cleans them."
+	singular_name = "sterilized medical gauze"
+	heal_tox = TRUE
+	self_delay = 5
 
 /obj/item/stack/medical/gauze/cyborg
 	custom_materials = null

--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -241,6 +241,13 @@
 	overdose_threshold = 50
 	value = 3
 
+/datum/reagent/medicine/silver_sulfadiazine/reaction_obj(obj/O, reac_volume)
+	if(istype(O, /obj/item/stack/medical/gauze))
+		var/obj/item/stack/medical/gauze/G = O
+		reac_volume = min((reac_volume / 10), G.amount)
+		new/obj/item/stack/medical/ointment(get_turf(G), reac_volume)
+		G.use(reac_volume)
+
 /datum/reagent/medicine/silver_sulfadiazine/reaction_mob(mob/living/M, method=TOUCH, reac_volume, show_message = 1)
 	if(iscarbon(M) && M.stat != DEAD)
 		if(method in list(INGEST, VAPOR, INJECT))
@@ -317,6 +324,12 @@
 			SEND_SIGNAL(M, COMSIG_ADD_MOOD_EVENT, "painful_medicine", /datum/mood_event/painful_medicine)
 	..()
 
+/datum/reagent/medicine/styptic_powder/reaction_obj(obj/O, reac_volume)
+	if(istype(O, /obj/item/stack/medical/gauze))
+		var/obj/item/stack/medical/gauze/G = O
+		reac_volume = min((reac_volume / 10), G.amount)
+		new/obj/item/stack/medical/bruise_pack(get_turf(G), reac_volume)
+		G.use(reac_volume)
 
 /datum/reagent/medicine/styptic_powder/on_mob_life(mob/living/carbon/M)
 	M.adjustBruteLoss(-2*REM, 0)

--- a/code/modules/reagents/chemistry/reagents/other_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/other_reagents.dm
@@ -1034,6 +1034,14 @@
 			// +20% success propability on each step, useful while operating in less-than-perfect conditions
 	..()
 
+/datum/reagent/space_cleaner/sterilizine/reaction_obj(obj/O, reac_volume)
+	if(istype(O, /obj/item/stack/medical/gauze))
+		var/obj/item/stack/medical/gauze/G = O
+		reac_volume = min((reac_volume / 10), G.amount)
+		new/obj/item/stack/medical/gauze/adv(get_turf(G), reac_volume)
+		G.use(reac_volume)
+
+
 /datum/reagent/iron
 	name = "Iron"
 	description = "Pure iron is a metal."


### PR DESCRIPTION
## About The Pull Request
Splashing silver sulfadiazine or styptic powder onto gauze will make them into brute packs or ointment and and splashing gauze with sterilizine will upgrade it!
Fixes the bug were the gauze would not heal you

## Why It's Good For The Game

Gauze atm just heals a small bit of damage and stops bleeding for like what 6 mins(?) and theirs no real way to restock on the packs and ointment outside of space/cargo... I dont want to add them to bio gene, so this is the best way without a crafting menu I can think of to 
A) make gauze useful
B) Allow medical to make some more packs and oinment
C) have it not be in a trash crafting menu

## Changelog
:cl:
add: Splashing gauze with 10  silver sulfadiazine will make a ointment pack, as well as splashing 10 of styptic powder to make a brute pack, and splashing gauze with sterilizine will upgrade it!
fix: gauze will now heal as it was meant to.
/:cl:
