### PR TITLE
Makes warm donk pockets cooling after 7 minutes canon again.

### DIFF
--- a/code/game/objects/items/storage/storage.dm
+++ b/code/game/objects/items/storage/storage.dm
@@ -16,7 +16,7 @@
 	AddComponent(component_type)
 
 /obj/item/storage/AllowDrop()
-	return FALSE
+	return TRUE
 
 /obj/item/storage/contents_explosion(severity, target)
 	for(var/atom/A in contents)

--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -283,7 +283,7 @@ All foods are distributed among various categories. Use common sense.
 	S.create_reagents(S.volume, reagent_flags, reagent_value)
 	if(reagents)
 		reagents.trans_to(S, reagents.total_volume)
-	if(S.bonus_reagents && S.bonus_reagents.len)
+	if(cooking_efficiency && length(S.bonus_reagents))
 		for(var/r_id in S.bonus_reagents)
 			var/amount = S.bonus_reagents[r_id] * cooking_efficiency
 			if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)


### PR DESCRIPTION
## About The Pull Request
The donk pocket box doesn't lie anymore. This time it should be fairly foolproof short of admin trickeries.

## Why It's Good For The Game
When goof reintroduced warm donk pockets on tg approximately 5 years ago, they left out the cooling, probably knowing it would have been exploitable without checks against using the same chewed donk pockets over and over at 7 minutes intervals.

## Changelog
:cl:
add: Donk pockets now actually cool down after 7 minutes from heating.
/:cl:
