### PR TITLE
Nerfing the bonus reagents from higher tier microwaves.

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -285,7 +285,7 @@ All foods are distributed among various categories. Use common sense.
 		reagents.trans_to(S, reagents.total_volume)
 	if(S.bonus_reagents && S.bonus_reagents.len)
 		for(var/r_id in S.bonus_reagents)
-			var/amount = S.bonus_reagents[r_id] * cooking_efficiency
+			var/amount = round(S.bonus_reagents[r_id] * cooking_efficiency)
 			if(r_id == /datum/reagent/consumable/nutriment || r_id == /datum/reagent/consumable/nutriment/vitamin)
 				S.reagents.add_reagent(r_id, amount, tastes)
 			else

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -243,7 +243,7 @@
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 		return
 
-	if(prob(dirty * 5 - (5 / efficiency - 5)) //a clean unupgraded microwave has no risk of failure
+	if(prob(dirty * 5 / (5 * efficiency))) //a clean unupgraded microwave has no risk of failure
 		muck()
 		return
 	for(var/obj/O in ingredients)

--- a/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/microwave.dm
@@ -19,6 +19,7 @@
 	var/broken = 0 // 0, 1 or 2 // How broken is it???
 	var/max_n_of_items = 10
 	var/efficiency = 0
+	var/productivity = 0
 	var/datum/looping_sound/microwave/soundloop
 	var/list/ingredients = list() // may only contain /atom/movables
 
@@ -43,12 +44,14 @@
 	. = ..()
 
 /obj/machinery/microwave/RefreshParts()
-	efficiency = 0
+	efficiency = 0.6
+	productivity = 0
+	max_n_of_items = 5
 	for(var/obj/item/stock_parts/micro_laser/M in component_parts)
-		efficiency += M.rating
+		efficiency += M.rating * 0.4
+		productivity += M.rating
 	for(var/obj/item/stock_parts/matter_bin/M in component_parts)
-		max_n_of_items = 10 * M.rating
-		break
+		max_n_of_items += M.rating * 5
 
 /obj/machinery/microwave/examine(mob/user)
 	. = ..()
@@ -83,7 +86,7 @@
 	if(!(stat & (NOPOWER|BROKEN)))
 		. += "<span class='notice'>The status display reads:</span>"
 		. += "<span class='notice'>- Capacity: <b>[max_n_of_items]</b> items.<span>"
-		. += "<span class='notice'>- Cook time reduced by <b>[(efficiency - 1) * 25]%</b>.<span>"
+		. += "<span class='notice'>- Cook time reduced by <b>[(productivity - 1) * 25]%</b>.<span>"
 
 /obj/machinery/microwave/update_icon_state()
 	if(broken)
@@ -240,7 +243,7 @@
 		playsound(src, 'sound/machines/buzz-sigh.ogg', 50, 0)
 		return
 
-	if(prob(max((5 / efficiency) - 5, dirty * 5))) //a clean unupgraded microwave has no risk of failure
+	if(prob(dirty * 5 - (5 / efficiency - 5)) //a clean unupgraded microwave has no risk of failure
 		muck()
 		return
 	for(var/obj/O in ingredients)
@@ -285,7 +288,7 @@
 	update_icon()
 	loop(MICROWAVE_MUCK, 4)
 
-/obj/machinery/microwave/proc/loop(type, time, wait = max(12 - 2 * efficiency, 2)) // standard wait is 10
+/obj/machinery/microwave/proc/loop(type, time, wait = max(12 - 2 * productivity, 2)) // standard wait is 10
 	if(stat & (NOPOWER|BROKEN))
 		if(type == MICROWAVE_PRE)
 			pre_fail()


### PR DESCRIPTION
## About The Pull Request
Title. from 1/2/3/4 to 1/1.4/1.8/2.2, the resulting bonuses are also floored in `initialize_cooked_food`.
This doesn't impact microwaving speed.

## Why It's Good For The Game
It's very silly how food gets up 4 times the reagent bonuses from upgraded microwaves. When coupled with an upgraded food processor, it's possible to gain up to 16 times the resulting bonus reagents that would be gained from a basic counterpart.

## Changelog
:cl:
balance: nerfed upgraded microwaves' bonus reagents efficiency. This doesn't affect speed.
fix: fixed the logic that should have made higher tier microwaves less likely to be covered in muck from overuse and clown pranks.
/:cl:
