### PR TITLE
Removing troublesome and filler uplink items.

### DIFF
--- a/code/modules/uplink/uplink_items/uplink_badass.dm
+++ b/code/modules/uplink/uplink_items/uplink_badass.dm
@@ -24,13 +24,6 @@
 			Radio headset does not include encryption key. No gun included."
 	item = /obj/item/storage/box/syndie_kit/centcom_costume
 
-/datum/uplink_item/badass/claymore
-	name = "Claymore"
-	cost = 8
-	player_minimum = 25
-	desc = "A claymore. We don't know why you'd do this."
-	item = /obj/item/claymore
-
 /datum/uplink_item/badass/costumes/clown
 	name = "Clown Costume"
 	desc = "Nothing is more terrifying than clowns with fully automatic weaponry."
@@ -84,11 +77,3 @@
 	limited_stock = 1
 	cant_discount = TRUE
 	include_modes = list(/datum/game_mode/nuclear, /datum/game_mode/nuclear/clown_ops)
-
-/datum/uplink_item/badass/shades
-	name = "Big Sunglasses"
-	desc = "Prevents flashes and looks badbass with some Smokes."
-	item = /obj/item/clothing/glasses/sunglasses/big
-	cost = 1
-	surplus = 5
-	illegal_tech = FALSE

--- a/code/modules/uplink/uplink_items/uplink_dangerous.dm
+++ b/code/modules/uplink/uplink_items/uplink_dangerous.dm
@@ -117,17 +117,6 @@
 /datum/uplink_item/dangerous/doublesword/get_discount()
 	return pick(4;0.8,2;0.65,1;0.5)
 
-/datum/uplink_item/dangerous/cxneb
-	name = "Dragon's Tooth Non-Eutactic Blade"
-	desc = "An illegal modification of a weapon that is functionally identical to the energy sword, \
-			the Non-Eutactic Blade (NEB) forges a hardlight blade on-demand, \
-	 		generating an extremely sharp, unbreakable edge that is guaranteed to satisfy your every need. \
-	 		This particular model has a polychromic hardlight generator, allowing you to murder in style! \
-	 		The illegal modifications bring this weapon up to par with the classic energy sword, and also gives it the energy sword's distinctive sounds."
-	item = /obj/item/melee/transforming/energy/sword/cx/traitor
-	cost = 8
-	exclude_modes = list(/datum/game_mode/nuclear/clown_ops)
-
 /datum/uplink_item/dangerous/sword
 	name = "Energy Sword"
 	desc = "The energy sword is an edged weapon with a blade of pure energy. The sword is small enough to be \

--- a/code/modules/uplink/uplink_items/uplink_roles.dm
+++ b/code/modules/uplink/uplink_items/uplink_roles.dm
@@ -64,14 +64,6 @@
 	restricted_roles = list("Clown")
 */
 
-/datum/uplink_item/role_restricted/clumsyDNA
-	name = "Clumsy Clown DNA"
-	desc = "A DNA injector that has been loaded with the clown gene that makes people clumsy.. \
-	Making someone clumsy will allow them to use clown firing pins as well as Reverse Revolvers. For a laugh try using this on the HOS to see how many times they shoot themselves in the foot!"
-	cost = 1
-	item = /obj/item/dnainjector/clumsymut
-	restricted_roles = list("Clown")
-
 /datum/uplink_item/role_restricted/haunted_magic_eightball
 	name = "Haunted Magic Eightball"
 	desc = "Most magic eightballs are toys with dice inside. Although identical in appearance to the harmless toys, this occult device reaches into the spirit world to find its answers. \
@@ -116,19 +108,11 @@
 	cost = 4
 	restricted_roles = list("Cook", "Botanist", "Clown", "Mime")
 
-/datum/uplink_item/role_restricted/strange_seeds
-	name = "Pack of strange seeds"
-	desc = "Mysterious seeds as strange as their name implies. Spooky."
-	item = /obj/item/seeds/random
-	cost = 2
-	restricted_roles = list("Botanist")
-	illegal_tech = FALSE
-
 /datum/uplink_item/role_restricted/strange_seeds_10pack
-	name = "Pack of strange seeds x10"
+	name = "Pack of strange seeds"
 	desc = "Mysterious seeds as strange as their name implies. Spooky. These come in bulk"
 	item = /obj/item/storage/box/strange_seeds_10pack
-	cost = 20
+	cost = 10
 	restricted_roles = list("Botanist")
 
 /datum/uplink_item/role_restricted/ez_clean_bundle


### PR DESCRIPTION
## About The Pull Request
Title. goodbye claymore, shades, single strange seed pack, clumsy clown DNA injector (clowns already have many items)...
And eutactic blades since they can still be combined one other to make a hyper eutactic blade unlike eswords for the double-esword, and are conceptually too similar to the original deal.

## Why It's Good For The Game
Removing some fillers from the uplink, Also strange seeds are a RNG roll and require some preparations so I'm fine with halving the price.

## Changelog
:cl:
del: Removed claymores, sunglasses, single strange seed, clumsy clown dna injectors and eutactic blades from the uplink
tweak: halved the cost of the x10 strange seeds pack uplink item from 20 to 10 tcs.
/:cl: