### PR TITLE
Changes our cloning system into resleeving lite(tm), removes prescans.

### DIFF
--- a/code/game/machinery/cloning.dm
+++ b/code/game/machinery/cloning.dm
@@ -189,16 +189,6 @@
 	ADD_TRAIT(H, TRAIT_NOCRITDAMAGE, CLONING_POD_TRAIT)
 	H.Unconscious(80)
 
-	clonemind.transfer_to(H)
-
-	if(grab_ghost_when == CLONER_FRESH_CLONE)
-		H.grab_ghost()
-		to_chat(H, "<span class='notice'><b>Consciousness slowly creeps over you as your body regenerates.</b><br><i>So this is what cloning feels like?</i></span>")
-
-	if(grab_ghost_when == CLONER_MATURE_CLONE)
-		H.ghostize(TRUE)	//Only does anything if they were still in their old body and not already a ghost
-		to_chat(H.get_ghost(TRUE), "<span class='notice'>Your body is beginning to regenerate in a cloning pod. You will become conscious when it is complete.</span>")
-
 	if(H)
 		H.faction |= factions
 

--- a/code/game/machinery/computer/cloning.dm
+++ b/code/game/machinery/computer/cloning.dm
@@ -452,6 +452,10 @@
 		scantemp = "<font class='bad'>Unable to locate valid genetic data.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
 		return
+	if(mob_occupant.stat != DEAD)
+		scantemp = "<font class='bad'>Unable to scan living subject.</font>"
+		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)
+		return
 	if(mob_occupant.suiciding || mob_occupant.hellbound)
 		scantemp = "<font class='bad'>Subject's brain is not responding to scanning stimuli.</font>"
 		playsound(src, 'sound/machines/terminal_prompt_deny.ogg', 50, 0)


### PR DESCRIPTION


## About The Pull Request
Effectively, when you scan a body, and clone the mind remains wherever it was, (usually in the body you just scanned). This means that the cloning cycle will complete and dump out a catatonic version of the body you just scanned, forcing you to resleeve the old brain into the new body.

As a consequence of this, if you died while prescanned under this system, all that would happen is a catatonic version of you would pop out in medbay whilst your real body stays where it is, I've removed prescanning entirely since it no longer has any purpose in light of this.

## Why It's Good For The Game
Cloning is, and continues to be, ridiculously easy to pull off and bring dead people back into a round, and believe it or not, dying should have consequences. I mulled this over considering removing roundstart cloning entirely, however that comes with the problem that if someone is gibbed they lose their character and have to be revived via putting their brain in a monkeyman, so I felt this was the best of both worlds, one hand, you no longer pop out of the cloner immedietly ready to fight, on the other, you get to keep your character and create bodies to sleeve into.

I would really like to see this testmerged before it gets merged if it gets merged, since it's a pretty major change to medical play.
## Changelog
:cl:
tweak: Cloners now create catatonic bodies of those they scan, for the old body to be resleeved into.
del: prescans no longer exist, no free second chances if you get well and properly gibbed.
/:cl: