### PR TITLE
Moves barkeeps cryo fluid to emag only in the Soda Dispender 

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -508,7 +508,6 @@
 	upgrade_reagents3 = list(
 		/datum/reagent/drug/mushroomhallucinogen,
 		/datum/reagent/consumable/nothing,
-		/datum/reagent/medicine/cryoxadone,
 		/datum/reagent/consumable/peachjuice
 	)
 	emagged_reagents = list(
@@ -516,7 +515,8 @@
 		/datum/reagent/consumable/ethanol/changelingsting,
 		/datum/reagent/consumable/ethanol/whiskey_cola,
 		/datum/reagent/toxin/mindbreaker,
-		/datum/reagent/toxin/staminatoxin
+		/datum/reagent/toxin/staminatoxin,
+		/datum/reagent/medicine/cryoxadone
 	)
 
 /obj/machinery/chem_dispenser/drinks/fullupgrade //fully ugpraded stock parts, emagged


### PR DESCRIPTION
## About The Pull Request

Bar keep dispenser has a lot of creep in it but thats - mostly - fine as theirs a lot of drinks, but having cryoxadone, that thing that needs stable plasma and heals people in the cold? Thats just a step to far for the 1 drink it makes. If you want doctor delight, you should worth with a doctor and get the needed cryoxadone rather then wait 15~ mins and get a endless amount.

## Why It's Good For The Game

Moves down an arguably "normal difficulty to make" into emag as it
 A) heals a bit in the cold
 B) Not even is a soda/juice
 C) Is used in *1* drink that is a healing drink - Like the hell
 D) maybe will help make barkeeps want to get more chems so that they can show off their skills and knowings on the more complicated drinks
## Changelog
:cl:
balance: cryoxadone is now emag locked Soda Dispender 
/:cl:
