### PR TITLE
Game info verb for ghosts

### DIFF
--- a/code/game/gamemodes/dynamic/dynamic.dm
+++ b/code/game/gamemodes/dynamic/dynamic.dm
@@ -823,3 +823,11 @@ GLOBAL_VAR_INIT(dynamic_storyteller_type, /datum/dynamic_storyteller/classic)
 			return RULE_OF_THREE(40, 20, x) + 50
 		if (20 to INFINITY)
 			return rand(90, 100)
+
+/datum/game_mode/dynamic/ghost_info()
+	. = list()
+	. += "Current threat: [threat]"
+	. += "Target threat: [threat_level]"
+	. += "Storyteller: <b>[storyteller.name]</b><br/>"
+	. += "Parameters: centre = [GLOB.dynamic_curve_centre] ; width = [GLOB.dynamic_curve_width].<br/>"
+	. += "<i>On average, <b>[peaceful_percentage]</b>% of the rounds are more peaceful.</i><br/>"

--- a/code/game/gamemodes/game_mode.dm
+++ b/code/game/gamemodes/game_mode.dm
@@ -604,3 +604,7 @@
 /// Mode specific admin panel.
 /datum/game_mode/proc/admin_panel()
 	return
+
+/// Mode specific info for ghost game_info
+/datum/game_mode/proc/ghost_info()
+	return

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -942,6 +942,9 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 	set name = "Game info"
 	set desc = "Shows various info relating to the game mode, antagonists etc."
 	set category = "Ghost"
+	if(!started_as_observer && can_reenter_corpse)
+		to_chat(src, "You cannot see this info unless you are an observer or you've chosen Do Not Resuscitate!")
+		return
 	var/list/stuff = list("[SSticker.mode.name]")
 	stuff += "Antagonists:\n"
 	for(var/datum/antagonist/A in GLOB.antagonists)

--- a/code/modules/mob/dead/observer/observer.dm
+++ b/code/modules/mob/dead/observer/observer.dm
@@ -937,3 +937,17 @@ This is the proc mobs get to turn into a ghost. Forked from ghostize due to comp
 		spawners_menu = new(src)
 
 	spawners_menu.ui_interact(src)
+
+/mob/dead/observer/verb/game_info()
+	set name = "Game info"
+	set desc = "Shows various info relating to the game mode, antagonists etc."
+	set category = "Ghost"
+	var/list/stuff = list("[SSticker.mode.name]")
+	stuff += "Antagonists:\n"
+	for(var/datum/antagonist/A in GLOB.antagonists)
+		if(A.owner)
+			stuff += "[A.owner] the [A.name]"
+	var/ghost_info = SSticker.mode.ghost_info()
+	if(ghost_info)
+		stuff += ghost_info
+	to_chat(src,stuff.Join("\n"))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Ghosts can now hit a "game info" button that shows all the antagonists, what the current game mode is, and extra info on a mode-to-mode basis (e.g. dynamic will show storyteller, threat info)

## Why It's Good For The Game

Observer gang needs more good stuff

## Changelog
:cl:
add: Ghosts can see some extra info about the game
/:cl: