### PR TITLE
Fixing critter crates having an invalid icon state when opened.

### DIFF
--- a/code/game/objects/structures/crates_lockers/crates/critter.dm
+++ b/code/game/objects/structures/crates_lockers/crates/critter.dm
@@ -22,6 +22,9 @@
 
 	return ..()
 
+/obj/structure/closet/crate/critter/update_icon_state()
+	return
+
 /obj/structure/closet/crate/critter/closet_update_overlays(list/new_overlays)
 	. = new_overlays
 	if(opened)


### PR DESCRIPTION
## About The Pull Request
Title.

## Why It's Good For The Game
This will close #11936.

## Changelog
:cl:
fix: Fixed critter crates having an invalid icon state when opened.
/:cl:
