### PR TITLE
Ups Crab Meat from 1 to 4

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/crab.dm
+++ b/code/modules/mob/living/simple_animal/friendly/crab.dm
@@ -11,7 +11,7 @@
 	blood_volume = 350
 	speak_chance = 1
 	turns_per_move = 5
-	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/rawcrab = 1)
+	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/rawcrab = 4)
 	response_help  = "pets"
 	response_disarm = "gently pushes aside"
 	response_harm   = "stomps"


### PR DESCRIPTION
## About The Pull Request

Gives more crab meat,

## Why It's Good For The Game

Getting one meat from a somewhat rare animal is disappointing.

## Changelog
:cl:
tweak: crabs now give 4 meat instead of 1
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
