### PR TITLE
Ports text formatted round timer from skyrat.

### DIFF
--- a/code/controllers/subsystem/time_track.dm
+++ b/code/controllers/subsystem/time_track.dm
@@ -23,7 +23,7 @@ SUBSYSTEM_DEF(time_track)
 	var/time_dilation_text
 
 /datum/controller/subsystem/time_track/fire()
-	stat_time_text = "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]\n\nRound Time: [WORLDTIME2TEXT("hh:mm:ss")]\n\nStation Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]\n\n[time_dilation_text]"
+	stat_time_text = "Server Time: [time2text(world.timeofday, "YYYY-MM-DD hh:mm:ss")]\n\nRound Time: [DisplayTimeText(world.time - SSticker.round_start_time, 1)] \n\nStation Time: [STATION_TIME_TIMESTAMP("hh:mm:ss", world.time)]\n\n[time_dilation_text]"
 
 	if(++last_measurement == measurement_delay)
 		last_measurement = 0


### PR DESCRIPTION
## About The Pull Request
Title. Credits to hugmeorelse for the original commit.

## Why It's Good For The Game
It nicely displays how much time has actually passed since the start of the round and not since the start of the server. I set the second arg of the call to 1 so it rounds decimals too.

## Changelog
:cl: hugmeorelse
tweak: Changed the round timer. This time it rounds decimals.
/:cl:
