### PR TITLE
Fixes a runtime in livers.

### DIFF
--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -52,7 +52,7 @@
 
 /obj/item/organ/liver/applyOrganDamage(d, maximum = maxHealth)
 	. = ..()
-	if(!.)
+	if(!. || QDELETED(owner))
 		return
 	if(damage >= high_threshold)
 		var/move_calc = 1+((round(damage) - high_threshold)/(high_threshold/3))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

It's a runtime. It was showing up every single game. Annoying.

## Why It's Good For The Game

Runtimes are bad.

## Changelog
:cl:
fix: Disembodied livers no longer try to slow down the bodies they're in.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
