### PR TITLE
Makes medical hardsuits a smig faster

### DIFF
--- a/code/modules/clothing/spacesuits/hardsuit.dm
+++ b/code/modules/clothing/spacesuits/hardsuit.dm
@@ -408,7 +408,6 @@
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/syndi/owl
 	mutantrace_variation = STYLE_DIGITIGRADE
 
-
 	//Wizard hardsuit
 /obj/item/clothing/head/helmet/space/hardsuit/wizard
 	name = "gem-encrusted hardsuit helmet"
@@ -473,6 +472,7 @@
 	name = "medical hardsuit"
 	desc = "A special suit that protects against hazardous, low pressure environments. Built with lightweight materials for easier movement."
 	item_state = "medical_hardsuit"
+	slowdown = 0.8
 	allowed = list(/obj/item/flashlight, /obj/item/tank/internals, /obj/item/storage/firstaid, /obj/item/healthanalyzer, /obj/item/stack/medical)
 	armor = list("melee" = 30, "bullet" = 5, "laser" = 10, "energy" = 5, "bomb" = 10, "bio" = 100, "rad" = 60, "fire" = 60, "acid" = 75)
 	helmettype = /obj/item/clothing/head/helmet/space/hardsuit/medical


### PR DESCRIPTION

## About The Pull Request

Medical hardsuits, the ones with the lowest amout of armor, no flash protection and almost always gotton in space/cargo, now are 20% faster then other hardsuits.

## Why It's Good For The Game
As a medical/paramedic rushing out to space can be hard if not right down impossable to get to a spaced body and back before 
A)Organ failers.
B) husking.
C) so much damage im basiclly forced to legit clone them as surgery would take to long.
This should help that if a medical/paramedic even goes through the work of getting the hardsuit or someone is nice and brings them back
Its a weak suit that by its own lore meant to be faster do to its use as a medical hardsuit rather then for combat/hazard work
## Changelog
:cl:
balance: Medical hardsuits are now lighter and move just a bit faster for you spacer!
/:cl:
