### PR TITLE
teg map hot no hot room plz

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
@@ -103,10 +103,6 @@
 /obj/structure/window/reinforced,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"dw" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space,
-/area/space/nearstation)
 "dZ" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -2631,7 +2627,7 @@ EN
 fq
 LS
 Hn
-dw
+tw
 yf
 Rh
 yf
@@ -2657,9 +2653,9 @@ XW
 ST
 Ok
 MP
-dw
-dw
-dw
+tw
+tw
+tw
 Rh
 Rh
 Rh

--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_teg.dmm
@@ -1170,7 +1170,8 @@
 /obj/machinery/atmospherics/components/unary/outlet_injector/atmos/engine_waste{
 	dir = 1
 	},
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/engine/engineering)
 "Hp" = (
 /obj/machinery/atmospherics/components/binary/pump{
@@ -1332,7 +1333,8 @@
 /area/engine/engineering)
 "LS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible,
-/turf/open/floor/plating/airless,
+/obj/structure/lattice/catwalk,
+/turf/open/space/basic,
 /area/engine/engineering)
 "Mf" = (
 /obj/structure/closet/secure_closet/engineering_personal,


### PR DESCRIPTION
## About The Pull Request

Replaces the flooring under the air injector to catwalks. The hot gas being injected from the output air injector was heating up the room by mistake.

## Why It's Good For The Game

A default setup TEG shouldn't involve throwing space heaters or HE pipe'd freezers to make it bearable.

## Changelog
:cl:
tweak: Made the TEG Engine not heat the room
/:cl: