### PR TITLE
Takes out dinnerware cryoxadone and monkey cube

### DIFF
--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -20,10 +20,13 @@
 					/obj/item/reagent_containers/food/condiment/saltshaker = 5,
 					/obj/item/reagent_containers/food/condiment/peppermill = 5)
 	contraband = list(
+					/obj/item/reagent_containers/food/snacks/monkeycube = 1,
 					/obj/item/kitchen/knife/butcher = 2,
 					/obj/item/reagent_containers/syringe = 3)
 	premium = list(
-					/obj/item/reagent_containers/food/condiment/enzyme = 1)
+					/obj/item/reagent_containers/food/condiment/enzyme = 1,
+					/obj/item/reagent_containers/glass/bottle/cryoxadone = 2) // Bartender can literally make this with upgraded parts, or it gets stolen from medical.
+	
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/dinnerware
 	resistance_flags = FIRE_PROOF

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -20,12 +20,10 @@
 					/obj/item/reagent_containers/food/condiment/saltshaker = 5,
 					/obj/item/reagent_containers/food/condiment/peppermill = 5)
 	contraband = list(
-					/obj/item/reagent_containers/food/snacks/monkeycube = 1,
 					/obj/item/kitchen/knife/butcher = 2,
 					/obj/item/reagent_containers/syringe = 3)
 	premium = list(
-					/obj/item/reagent_containers/food/condiment/enzyme = 1,
-					/obj/item/reagent_containers/glass/bottle/cryoxadone = 2) // Bartender can literally make this with upgraded parts, or it gets stolen from medical.
+					/obj/item/reagent_containers/food/condiment/enzyme = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/dinnerware
 	resistance_flags = FIRE_PROOF

--- a/code/modules/vending/drinnerware.dm
+++ b/code/modules/vending/drinnerware.dm
@@ -26,7 +26,6 @@
 	premium = list(
 					/obj/item/reagent_containers/food/condiment/enzyme = 1,
 					/obj/item/reagent_containers/glass/bottle/cryoxadone = 2) // Bartender can literally make this with upgraded parts, or it gets stolen from medical.
-	
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/dinnerware
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION

## About The Pull Request

Dinner when hacked gave a monkey cube for no real reason other then more meat?
Dinner coin item was a bottle, that has legit plasma in it and can heal quickly clone damage or make synth meat, this was added for some reason

## Why It's Good For The Game

Removes some rather unfitting items from the dinnerware vender so that cook need to better counteract with the crew to get more meat/food items

## Changelog
:cl:
del: Removed cryoxadone bottles and monkey cube from cook venders
/:cl:
