### PR TITLE
Lowers reagent selling from 0.3 to 0.01

### DIFF
--- a/code/__DEFINES/reagents.dm
+++ b/code/__DEFINES/reagents.dm
@@ -25,7 +25,7 @@
 //reagents_value defines, for cargo stuff.
 #define DEFAULT_REAGENTS_VALUE 1
 #define NO_REAGENTS_VALUE 0
-#define HARVEST_REAGENTS_VALUE 0.3
+#define HARVEST_REAGENTS_VALUE 0.01
 
 
 #define TOUCH			1	// splashing

--- a/code/modules/cargo/packs/medical.dm
+++ b/code/modules/cargo/packs/medical.dm
@@ -153,7 +153,7 @@
 /datum/supply_pack/medical/firstaidburns
 	name = "Burn Treatment Kit Crate"
 	desc = "Contains three first aid kits focused on healing severe burns."
-	cost = 1000
+	cost = 1300
 	contains = list(/obj/item/storage/firstaid/fire,
 					/obj/item/storage/firstaid/fire,
 					/obj/item/storage/firstaid/fire)


### PR DESCRIPTION

## About The Pull Request
Fixes a cargo explote with brun pack selling
Lowers reagent selling by like .29

## Why It's Good For The Game

Cargo getting 12 crops of 100 potancy omega weed is still to much for me to handle

## Changelog
:cl:
balance: Plant selling is worth even less, and burn packet now costs more
/:cl:
