### PR TITLE
Cargo Rework - MK *why did I ever lison to people that were just powergamers?*

### DIFF
--- a/code/modules/cargo/exports.dm
+++ b/code/modules/cargo/exports.dm
@@ -67,7 +67,7 @@ Credit dupes that require a lot of manual work shouldn't be removed, unless they
 	var/unit_name = ""				// Unit name. Only used in "Received [total_amount] [name]s [message]." message
 	var/message = ""
 	var/cost = 100					// Cost of item, in cargo credits. Must not alow for infinite price dupes, see above.
-	var/k_elasticity = 1/300			//coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity" - CIT EDIT 1/30 - > 0
+	var/k_elasticity = 1/100			//coefficient used in marginal price calculation that roughly corresponds to the inverse of price elasticity, or "quantity elasticity" - CIT EDIT 1/30 - > 100
 	var/list/export_types = list()	// Type of the exported object. If none, the export datum is considered base type.
 	var/include_subtypes = TRUE		// Set to FALSE to make the datum apply only to a strict type.
 	var/list/exclude_types = list()	// Types excluded from export

--- a/code/modules/cargo/exports/gear.dm
+++ b/code/modules/cargo/exports/gear.dm
@@ -1,5 +1,6 @@
 /datum/export/gear
 	include_subtypes = FALSE
+	k_elasticity = 0 //We always want clothing/gear
 
 //blanket
 /datum/export/gear/hat

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -111,7 +111,7 @@
 	include_subtypes = FALSE
 
 /datum/export/large/am_control_unit
-	cost = 4000
+	cost = 2000
 	unit_name = "antimatter control unit"
 	export_types = list(/obj/machinery/power/am_control_unit)
 
@@ -171,13 +171,13 @@
 	var/worth = 10
 	var/gases = C.air_contents.gases
 
-	worth += gases[/datum/gas/bz]*4
+	worth += gases[/datum/gas/bz]*2
 	worth += gases[/datum/gas/stimulum]*25
-	worth += gases[/datum/gas/hypernoblium]*1000
-	worth += gases[/datum/gas/miasma]*4
-	worth += gases[/datum/gas/tritium]*7
-	worth += gases[/datum/gas/pluoxium]*6
-	worth += gases[/datum/gas/nitryl]*30
+	worth += gases[/datum/gas/hypernoblium]*50
+	worth += gases[/datum/gas/miasma]*1
+	worth += gases[/datum/gas/tritium]*5
+	worth += gases[/datum/gas/pluoxium]*4
+	worth += gases[/datum/gas/nitryl]*35
 	return worth
 
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -171,13 +171,13 @@
 	var/worth = 10
 	var/gases = C.air_contents.gases
 
-	worth += gases[/datum/gas/bz]*2
+	worth += gases[/datum/gas/bz]*4
 	worth += gases[/datum/gas/stimulum]*25
-	worth += gases[/datum/gas/hypernoblium]*50
-	worth += gases[/datum/gas/miasma]*1
-	worth += gases[/datum/gas/tritium]*5
-	worth += gases[/datum/gas/pluoxium]*4
-	worth += gases[/datum/gas/nitryl]*35
+	worth += gases[/datum/gas/hypernoblium]*1000
+	worth += gases[/datum/gas/miasma]*4
+	worth += gases[/datum/gas/tritium]*7
+	worth += gases[/datum/gas/pluoxium]*6
+	worth += gases[/datum/gas/nitryl]*30
 	return worth
 
 

--- a/code/modules/cargo/exports/organs_robotics.dm
+++ b/code/modules/cargo/exports/organs_robotics.dm
@@ -2,15 +2,14 @@
 
 /datum/export/robotics
 	include_subtypes = FALSE
-	k_elasticity = 0 //ALWAYS worth selling upgrades
+	k_elasticity = 1/50
 
 /datum/export/implant
 	include_subtypes = FALSE
-	k_elasticity = 0 //ALWAYS worth selling upgrades
+	k_elasticity = 1/50
 
 /datum/export/organs
 	include_subtypes = TRUE
-	k_elasticity = 0 //ALWAYS worth selling orgains
 
 /datum/export/implant/autodoc
 	cost = 150
@@ -54,11 +53,6 @@
 	cost = 350
 	unit_name = "reviver implant"
 	export_types = list(/obj/item/organ/cyberimp/chest/reviver)
-
-/datum/export/implant/thrusters
-	cost = 150
-	unit_name = "thrusters set implant"
-	export_types = list(/obj/item/organ/cyberimp/chest/thrusters)
 
 /datum/export/implant/thrusters
 	cost = 150

--- a/code/modules/cargo/exports/tools.dm
+++ b/code/modules/cargo/exports/tools.dm
@@ -1,4 +1,7 @@
-/datum/export/toolbox
+/datum/export/tool
+	k_elasticity = 1/500 //Tool selling almost allways fine a target
+
+/datum/export/tool/toolbox
 	cost = 6
 	unit_name = "toolbox"
 	export_types = list(/obj/item/storage/toolbox)
@@ -29,93 +32,93 @@
 
 // Lights/Eletronic
 
-/datum/export/lights
+/datum/export/tool/lights
 	cost = 10
 	unit_name = "light fixer"
 	export_types = list(/obj/item/wallframe/light_fixture)
 	include_subtypes = TRUE
 
-/datum/export/apc_board
+/datum/export/tool/apc_board
 	cost = 5
 	unit_name = "apc electronics"
 	export_types = list(/obj/item/electronics/apc)
 	include_subtypes = TRUE
 
-/datum/export/apc_frame
+/datum/export/tool/apc_frame
 	cost = 3
 	unit_name = "apc frame"
 	export_types = list(/obj/item/wallframe/apc)
 	include_subtypes = TRUE
 
-/datum/export/floodlights
+/datum/export/tool/floodlights
 	cost = 15
 	unit_name = "floodlight fixer"
 	export_types = list(/obj/structure/floodlight_frame)
 	include_subtypes = TRUE
 
-/datum/export/bolbstubes
+/datum/export/tool/bolbstubes
 	cost = 1 //Time
 	unit_name = "light replacement"
 	export_types = list(/obj/item/light/tube, /obj/item/light/bulb)
 
-/datum/export/lightreplacer
+/datum/export/tool/lightreplacer
 	cost = 20
 	unit_name = "lightreplacer"
 	export_types = list(/obj/item/lightreplacer)
 
 // Basic tools
-/datum/export/basicmining
+/datum/export/tool/basicmining
 	cost = 30
 	unit_name = "basic mining tool"
 	export_types = list(/obj/item/pickaxe, /obj/item/pickaxe/mini, /obj/item/shovel, /obj/item/resonator)
 	include_subtypes = FALSE
 
-/datum/export/upgradedmining
+/datum/export/tool/upgradedmining
 	cost = 80
 	unit_name = "mining tool"
 	export_types = list(/obj/item/pickaxe/silver, /obj/item/pickaxe/drill, /obj/item/gun/energy/plasmacutter, /obj/item/resonator/upgraded)
 	include_subtypes = FALSE
 
-/datum/export/advdmining
+/datum/export/tool/advdmining
 	cost = 150
 	unit_name = "advanced mining tool"
 	export_types = list(/obj/item/pickaxe/diamond, /obj/item/pickaxe/drill/diamonddrill, /obj/item/pickaxe/drill/jackhammer, /obj/item/gun/energy/plasmacutter/adv)
 	include_subtypes = FALSE
 
-/datum/export/screwdriver
+/datum/export/tool/screwdriver
 	cost = 2
 	unit_name = "screwdriver"
 	export_types = list(/obj/item/screwdriver)
 	include_subtypes = FALSE
 
-/datum/export/wrench
+/datum/export/tool/wrench
 	cost = 2
 	unit_name = "wrench"
 	export_types = list(/obj/item/wrench)
 
-/datum/export/crowbar
+/datum/export/tool/crowbar
 	cost = 2
 	unit_name = "crowbar"
 	export_types = list(/obj/item/crowbar)
 
-/datum/export/wirecutters
+/datum/export/tool/wirecutters
 	cost = 2
 	unit_name = "pair"
 	message = "of wirecutters"
 	export_types = list(/obj/item/wirecutters)
 
-/datum/export/weldingtool
+/datum/export/tool/weldingtool
 	cost = 5
 	unit_name = "welding tool"
 	export_types = list(/obj/item/weldingtool)
 	include_subtypes = FALSE
 
-/datum/export/weldingtool/emergency
+/datum/export/tool/weldingtool/emergency
 	cost = 2
 	unit_name = "emergency welding tool"
 	export_types = list(/obj/item/weldingtool/mini)
 
-/datum/export/weldingtool/industrial
+/datum/export/tool/weldingtool/industrial
 	cost = 10
 	unit_name = "industrial welding tool"
 	export_types = list(/obj/item/weldingtool/largetank, /obj/item/weldingtool/hugetank)
@@ -131,23 +134,23 @@
 	unit_name = "pocket fire extinguisher"
 	export_types = list(/obj/item/extinguisher/mini)
 
-/datum/export/flashlight
+/datum/export/tool/flashlight
 	cost = 3
 	unit_name = "flashlight"
 	export_types = list(/obj/item/flashlight)
 	include_subtypes = FALSE
 
-/datum/export/flashlight/flare
+/datum/export/tool/flashlight/flare
 	cost = 2
 	unit_name = "flare"
 	export_types = list(/obj/item/flashlight/flare)
 
-/datum/export/flashlight/seclite
+/datum/export/tool/flashlight/seclite
 	cost = 5
 	unit_name = "seclite"
 	export_types = list(/obj/item/flashlight/seclite)
 
-/datum/export/analyzer
+/datum/export/tool/analyzer
 	cost = 5
 	unit_name = "analyzer"
 	export_types = list(/obj/item/analyzer)
@@ -163,32 +166,32 @@
 	export_types = list(/obj/item/radio)
 	exclude_types = list(/obj/item/radio/mech)
 
-/datum/export/rcd
+/datum/export/tool/rcd
 	cost = 100
 	unit_name = "rapid construction device"
 	export_types = list(/obj/item/construction/rcd)
 
-/datum/export/rcd_ammo
+/datum/export/tool/rcd_ammo
 	cost = 60
 	unit_name = "compressed matter cardridge"
 	export_types = list(/obj/item/rcd_ammo)
 
-/datum/export/rpd
+/datum/export/tool/rpd
 	cost = 100
 	unit_name = "rapid piping device"
 	export_types = list(/obj/item/pipe_dispenser)
 
-/datum/export/rld
+/datum/export/tool/rld
 	cost = 150
 	unit_name = "rapid light device"
 	export_types = list(/obj/item/construction/rld)
 
-/datum/export/rped
+/datum/export/tool/rped
 	cost = 100
 	unit_name = "rapid part exchange device"
 	export_types = list(/obj/item/storage/part_replacer)
 
-/datum/export/bsrped
+/datum/export/tool/bsrped
 	cost = 200
 	unit_name = "blue space part exchange device"
 	export_types = list(/obj/item/storage/part_replacer/bluespace)


### PR DESCRIPTION
## About The Pull Request

Most exports now have a fall off 
All most all exports that have fall off now fall off every 100

## Why It's Good For The Game

Takes the baby wheels off cargo now that they have, so many many options to sell stuff and help make cargo work with other departments

## Changelog
:cl:
add: Most organs now will have drop off - Even the black market has its limits!
add: Market drop off is now 3x closer, depression is reall
add: Miasma, ye that one, halfed it selling too.
add: Halfs most gasses that sell if not by 100 fold - Noable
add: Nryla now sells for a bit more.
add: Nerfs Anitmatter selling
add: Most tools need a lot to be sold before market gets fed up with them
add: Almost all clothing will always have a market as selling off 300 pares of gloves is really normal. Lots of people just like gloves
/:cl:
