### PR TITLE
Xenomorph balancing pass

### DIFF
--- a/code/controllers/configuration/entries/game_options.dm
+++ b/code/controllers/configuration/entries/game_options.dm
@@ -217,7 +217,8 @@
 	config_entry_value = list(			//DEFAULTS
 	/mob/living/simple_animal = 1,
 	/mob/living/silicon/pai = 1,
-	/mob/living/carbon/alien/humanoid/hunter = -1,
+	/mob/living/carbon/alien/humanoid/sentinel = 0.25,
+	/mob/living/carbon/alien/humanoid/drone = 0.5,
 	/mob/living/carbon/alien/humanoid/royal/praetorian = 1,
 	/mob/living/carbon/alien/humanoid/royal/queen = 3
 	)

--- a/code/modules/mob/living/carbon/alien/alien.dm
+++ b/code/modules/mob/living/carbon/alien/alien.dm
@@ -12,6 +12,13 @@
 	bubble_icon = "alien"
 	type_of_meat = /obj/item/reagent_containers/food/snacks/meat/slab/xeno
 
+	/// How much brute damage without armor piercing they do against mobs in melee
+	var/meleeSlashHumanPower = 20
+	/// How much power they have for DefaultCombatKnockdown when attacking humans
+	var/meleeKnockdownPower = 100
+	/// How much brute damage they do to simple animals
+	var/meleeSlashSAPower = 35
+
 	var/obj/item/card/id/wear_id = null // Fix for station bounced radios -- Skie
 	var/has_fine_manipulation = 0
 	var/move_delay_add = 0 // movement delay to add

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/drone.dm
@@ -4,6 +4,7 @@
 	maxHealth = 125
 	health = 125
 	icon_state = "aliend"
+	meleeKnockdownPower = 80
 
 /mob/living/carbon/alien/humanoid/drone/Initialize()
 	AddAbility(new/obj/effect/proc_holder/alien/evolve(null))

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -4,6 +4,9 @@
 	maxHealth = 170
 	health = 170
 	icon_state = "alienh"
+	meleeKnockdownPower = 75
+	meleeSlashHumanPower = 20
+	meleeSlashSAPower = 45
 	var/obj/screen/leap_icon = null
 
 /mob/living/carbon/alien/humanoid/hunter/create_internal_organs()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/hunter
 	name = "alien hunter"
 	caste = "h"
-	maxHealth = 125
-	health = 125
+	maxHealth = 160
+	health = 160
 	icon_state = "alienh"
 	var/obj/screen/leap_icon = null
 
@@ -68,6 +68,7 @@
 			else
 				L.visible_message("<span class ='danger'>[src] pounces on [L]!</span>", "<span class ='userdanger'>[src] pounces on you!</span>")
 				L.DefaultCombatKnockdown(100)
+				L.Stagger(4 SECONDS)
 				sleep(2)//Runtime prevention (infinite bump() calls on hulks)
 				step_towards(src,L)
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/hunter.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/hunter
 	name = "alien hunter"
 	caste = "h"
-	maxHealth = 160
-	health = 160
+	maxHealth = 170
+	health = 170
 	icon_state = "alienh"
 	var/obj/screen/leap_icon = null
 

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -4,6 +4,7 @@
 	maxHealth = 140
 	health = 140
 	icon_state = "aliens"
+	meleeSlashHumanPower = 15
 
 /mob/living/carbon/alien/humanoid/sentinel/Initialize()
 	AddAbility(new /obj/effect/proc_holder/alien/sneak)

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/sentinel
 	name = "alien sentinel"
 	caste = "s"
-	maxHealth = 135
-	health = 135
+	maxHealth = 140
+	health = 140
 	icon_state = "aliens"
 
 /mob/living/carbon/alien/humanoid/sentinel/Initialize()

--- a/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/caste/sentinel.dm
@@ -1,8 +1,8 @@
 /mob/living/carbon/alien/humanoid/sentinel
 	name = "alien sentinel"
 	caste = "s"
-	maxHealth = 150
-	health = 150
+	maxHealth = 135
+	health = 135
 	icon_state = "aliens"
 
 /mob/living/carbon/alien/humanoid/sentinel/Initialize()

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid.dm
@@ -112,7 +112,6 @@
 		return A
 	return FALSE
 
-
 /mob/living/carbon/alien/humanoid/check_breath(datum/gas_mixture/breath)
 	if(breath && breath.total_moles() > 0 && !sneaking)
 		playsound(get_turf(src), pick('sound/voice/lowHiss2.ogg', 'sound/voice/lowHiss3.ogg', 'sound/voice/lowHiss4.ogg'), 50, 0, -5)

--- a/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/humanoid_defense.dm
@@ -1,4 +1,3 @@
-
 /mob/living/carbon/alien/humanoid/grabbedby(mob/living/carbon/user, supress_message = 0)
 	if(user == src && pulling && grab_state >= GRAB_AGGRESSIVE && !pulling.anchored && iscarbon(pulling))
 		devour_mob(pulling, devour_time = 60)

--- a/code/modules/mob/living/carbon/alien/humanoid/life.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/life.dm
@@ -1,5 +1,3 @@
-
-
 /mob/living/carbon/alien/humanoid/proc/adjust_body_temperature(current, loc_temp, boost)
 	var/temperature = current
 	var/difference = abs(current-loc_temp)	//get difference

--- a/code/modules/mob/living/carbon/alien/humanoid/queen.dm
+++ b/code/modules/mob/living/carbon/alien/humanoid/queen.dm
@@ -11,6 +11,10 @@
 	pressure_resistance = 200 //Because big, stompy xenos should not be blown around like paper.
 	butcher_results = list(/obj/item/reagent_containers/food/snacks/meat/slab/xeno = 20, /obj/item/stack/sheet/animalhide/xeno = 3)
 
+	meleeKnockdownPower = 125
+	meleeSlashHumanPower = 30
+	meleeSlashSAPower = 60
+
 	var/alt_inhands_file = 'icons/mob/alienqueen.dmi'
 
 /mob/living/carbon/alien/humanoid/royal/can_inject(mob/user, error_msg, target_zone, penetrate_thick = FALSE, bypass_immunity = FALSE)

--- a/code/modules/mob/living/carbon/alien/larva/larva.dm
+++ b/code/modules/mob/living/carbon/alien/larva/larva.dm
@@ -6,6 +6,7 @@
 	mob_size = MOB_SIZE_SMALL
 	density = FALSE
 	hud_type = /datum/hud/larva
+	mouse_opacity = MOUSE_OPACITY_OPAQUE
 
 	maxHealth = 25
 	health = 25

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -182,10 +182,7 @@
 					"<span class='userdanger'>[M] disarmed [src]!</span>")
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-			if(!lying)				//CITADEL EDIT
-				DefaultCombatKnockdown(100, TRUE, FALSE, 30, 25)
-			else
-				DefaultCombatKnockdown(100)
+			DefaultCombatKnockdown(100)
 			log_combat(M, src, "tackled")
 			visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
 				"<span class='userdanger'>[M] has tackled down [src]!</span>")

--- a/code/modules/mob/living/carbon/human/human_defense.dm
+++ b/code/modules/mob/living/carbon/human/human_defense.dm
@@ -155,7 +155,7 @@
 	if(M.a_intent == INTENT_HARM)
 		if (w_uniform)
 			w_uniform.add_fingerprint(M)
-		var/damage = prob(90) ? 20 : 0
+		var/damage = prob(90) ? M.meleeSlashHumanPower : 0
 		if(!damage)
 			playsound(loc, 'sound/weapons/slashmiss.ogg', 50, 1, -1)
 			visible_message("<span class='danger'>[M] has lunged at [src]!</span>", \
@@ -182,7 +182,7 @@
 					"<span class='userdanger'>[M] disarmed [src]!</span>")
 		else
 			playsound(loc, 'sound/weapons/pierce.ogg', 25, 1, -1)
-			DefaultCombatKnockdown(100)
+			DefaultCombatKnockdown(M.meleeKnockdownPower)
 			log_combat(M, src, "tackled")
 			visible_message("<span class='danger'>[M] has tackled down [src]!</span>", \
 				"<span class='userdanger'>[M] has tackled down [src]!</span>")

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -65,7 +65,7 @@
 		visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 				"<span class='userdanger'>[M] has slashed at [src]!</span>", null, COMBAT_MESSAGE_RANGE)
 		playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)
-		attack_threshold_check(damage)
+		attack_threshold_check(M.meleeSlashSAPower)
 		log_combat(M, src, "attacked")
 
 /mob/living/simple_animal/attack_larva(mob/living/carbon/alien/larva/L)

--- a/code/modules/mob/living/simple_animal/animal_defense.dm
+++ b/code/modules/mob/living/simple_animal/animal_defense.dm
@@ -61,7 +61,6 @@
 				"<span class='userdanger'>[M] [response_disarm] [name]!</span>", null, COMBAT_MESSAGE_RANGE)
 		log_combat(M, src, "disarmed")
 	else
-		var/damage = rand(15, 30)
 		visible_message("<span class='danger'>[M] has slashed at [src]!</span>", \
 				"<span class='userdanger'>[M] has slashed at [src]!</span>", null, COMBAT_MESSAGE_RANGE)
 		playsound(loc, 'sound/weapons/slice.ogg', 25, 1, -1)

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -1,8 +1,9 @@
 /obj/item/projectile/bullet/neurotoxin
 	name = "neurotoxin spit"
 	icon_state = "neurotoxin"
-	damage = 5
+	damage = 15
 	damage_type = TOX
+	var/stagger_duration = 3.5 SECONDS
 
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
@@ -10,5 +11,6 @@
 		nodamage = TRUE
 	else if(iscarbon(target))
 		var/mob/living/L = target
-		L.DefaultCombatKnockdown(100, TRUE, FALSE, 30, 25)
+		L.KnockToFloor(TRUE)
+		L.Stagger(stagger_duration)
 	return ..()

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -3,7 +3,7 @@
 	icon_state = "neurotoxin"
 	damage = 15
 	damage_type = TOX
-	var/stagger_duration = 3.5 SECONDS
+	var/stagger_duration = 5 SECONDS
 
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
@@ -11,6 +11,6 @@
 		nodamage = TRUE
 	else if(iscarbon(target))
 		var/mob/living/L = target
-		L.KnockToFloor(TRUE)
+		L.KnockToFloor()
 		L.Stagger(stagger_duration)
 	return ..()

--- a/code/modules/projectiles/projectile/special/neurotoxin.dm
+++ b/code/modules/projectiles/projectile/special/neurotoxin.dm
@@ -3,7 +3,7 @@
 	icon_state = "neurotoxin"
 	damage = 15
 	damage_type = TOX
-	var/stagger_duration = 5 SECONDS
+	var/stagger_duration = 8 SECONDS
 
 /obj/item/projectile/bullet/neurotoxin/on_hit(atom/target, blocked = FALSE)
 	if(isalien(target))
@@ -11,6 +11,6 @@
 		nodamage = TRUE
 	else if(iscarbon(target))
 		var/mob/living/L = target
-		L.KnockToFloor()
+		L.KnockToFloor(TRUE)
 		L.Stagger(stagger_duration)
 	return ..()

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -165,7 +165,7 @@
 
 	switch(animal_origin)
 		if(ALIEN_BODYPART,LARVA_BODYPART) //aliens take double burn //nothing can burn with so much snowflake code around
-			burn *= 2
+			burn *= 1.2
 
 	var/can_inflict = max_damage - get_damage()
 	if(can_inflict <= 0)

--- a/code/modules/surgery/bodyparts/bodyparts.dm
+++ b/code/modules/surgery/bodyparts/bodyparts.dm
@@ -164,7 +164,7 @@
 		return FALSE
 
 	switch(animal_origin)
-		if(ALIEN_BODYPART,LARVA_BODYPART) //aliens take double burn //nothing can burn with so much snowflake code around
+		if(ALIEN_BODYPART,LARVA_BODYPART) //aliens take some additional burn //nothing can burn with so much snowflake code around
 			burn *= 1.2
 
 	var/can_inflict = max_damage - get_damage()


### PR DESCRIPTION
tl;dr death to hardstuns and sanic speeds, some class separation, in return hp buffs some varied effects and royals hit harder in melee.

**This also nerfs the no-gravity meta, as now no-gravity actually makes some of them faster and better. Infact, there might be times when xenomorphs would WANT to take out gravity to gain their old speed and hinder the crew.**

<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Buffs: 
**Xenomorphs only take 1.2x burn damage instead of 2x**
Xenomorphs now stagger people on successful pounces, and neurotoxin does that too.
Neurotoxin now does 15 toxins damage instead of 5.
Hunter now has 170 HP, not accounting for burn damage multiplier, up from 125.
Neurotoxins now knocks people to the floor and staggers them for 8 seconds.

Nerfs:
Hunters no longer have super speed and run at a full sprint speed (10 tiles per second)
Sentinels run 0.25 delay slower than full sprint speed (around 8 tiles per second)
Drones run 0.5 delay slower than full sprint speed (around 6.66 tiles per second)
**Hunter tackles no longer hardstun.** Stamina damage/knockdown still applies.
**Neurotoxin no longer hardstuns, nor does stamina damage.** It still disarms, however.
Sentinel HP nerfed from 150HP to 140HP, without taking account for burn damage multiplier.
Alien larvae now have full tile melee hitboxes. Hide and don't get hit!

Misc balances/rebalances:
Aliens now hit for differing amounts of damage/knockdown. Note that knockdown is directly tied to how much stamina they drain on hit. They all still prioritize a disarm over knockdown, though.
Drones are worse at knocking people down. (100 --> 80)
Hunters are worse at knocking people down. (100 --> 75)
Sentinels are worse at slashing people (100 --> 15)
Hunters are better at attacking simpler animals (20 --> 45)
Non hunter aliens in general hit harder against simpler animals/mobs, as they generally use HP sinks rather than carbon crit/health system (20 --> 35)
Praetorians and queens are better at knocking people down and slashing people (100 --> 125 knockdown, 20 --> 30 slashforce, 20 --> 60 simple animal slashforce)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

**SILICONS STILL INCUR HARDSTUNS FROM XENO MELEE. Sorry, gamers. Make another PR.**

## Why It's Good For The Game

Hardstuns are unfun and something we've been trying to move away from, and so's trying to click a target moving at 20 tiles per second, faster than some people's laggy connections (allegedly) update their screens.
On the other side, it's pretty wacky for something to absolutely melt the moment you use anything burning on it yet not give much of a care to getting fire axed or something.
This rebalances xenomorphs to more of a medium-leaning threat, neither extremely glass-cannon-y while still relatively powerful (do not let them close distance in melee).
Gives the three xeno roles somre more separation too other than "super fast", "stunlock" and "wallspam".

Sentinels have been moved to a support role, instead of being able to chain-stunlock people solo. You can probably still kick someone's ass with the health buffs I guess, but gone are the days of chain-stunlocking with the neurotoxin spam. Stagger's pretty neat though, it works even without gravity too.

Drones: I probably hit them too hard here but we'll see. They're also a support/construction role, not a combat role. Like I said you can probably kick someone's ass but it's recommended to let the hunters do the melee'ing.

Royals: Been underwhelming without hardstun spam. Note that praetorian neurotoxins is ALSO nerfed here, and I don't knwo how to feel about that. That said, seeing them die to a few simple animals is a sham so here, have increased damage.

As for larvae: If the only way to kill one is spamming a tesla gun, I'd call that bad design. Hide better, abuse your full speed, projectile non-density, agility, and ability to hide under sprites. Don't get hit, you're supposed to be vulnerable.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Xenos have been given a balancing pass. See https://github.com/Citadel-Station-13/Citadel-Station-13/pull/11977 for details.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
