### PR TITLE
Cybernetic arm implant balance pass (namely: shields)

### DIFF
--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -241,6 +241,8 @@
 #define COMSIG_ITEM_ALT_AFTERATTACK "item_alt_afterattack"		//from base of obj/item/altafterattack(): (atom/target, mob/user, proximity, params)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (mob/user)
+	// relocated, tell inventory procs if those called this that the item isn't available anymore.
+	#define COMPONENT_DROPPED_RELOCATION 1
 #define COMSIG_ITEM_PICKUP "item_pickup"						//from base of obj/item/pickup(): (/mob/taker)
 #define COMSIG_ITEM_ATTACK_ZONE "item_attack_zone"				//from base of mob/living/carbon/attacked_by(): (mob/living/carbon/target, mob/living/user, hit_zone)
 #define COMSIG_ITEM_IMBUE_SOUL "item_imbue_soul" 				//return a truthy value to prevent ensouling, checked in /obj/effect/proc_holder/spell/targeted/lichdom/cast(): (mob/user)

--- a/code/__DEFINES/misc/return_values.dm
+++ b/code/__DEFINES/misc/return_values.dm
@@ -1,0 +1,3 @@
+// obj/item/dropped
+/// dropped() relocated this item, return FALSE for doUnEquip.
+#define ITEM_RELOCATED_BY_DROPPED			"relocated_by_dropped"

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -392,7 +392,8 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 	if(item_flags & DROPDEL)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
-	SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user)
+	if(SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user) & COMPONENT_DROPPED_RELOCATION)
+		return ITEM_RELOCATED_BY_DROPPED
 	user.update_equipment_speed_mods()
 
 // called just as an item is picked up (loc is not yet changed)

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -389,6 +389,8 @@ obj/item/shield/riot/bullet_proof
 			recharge_timerid = null
 
 /obj/item/shield/riot/implant/proc/recharge()
+	if(obj_integrity == max_integrity)
+		return
 	obj_integrity = max_integrity
 	if(ismob(loc.loc))		//cyberimplant.user
 		to_chat(loc, "<span class='notice'>[src] has recharged its reinforcement matrix and is ready for use!</span>")

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -357,20 +357,41 @@ obj/item/shield/riot/bullet_proof
 	block_chance = 50
 
 /obj/item/shield/riot/implant
-	name = "riot tower shield"
-	desc = "A massive shield that can block a lot of attacks and can take a lot of abuse before breaking." //It cant break unless it is removed from the implant
+	name = "telescoping shield implant"
+	desc = "A compact, arm-mounted telescopic shield. While nigh-indestructible when powered by a host user, it will eventually overload from damage. Recharges while inside its implant."
 	item_state = "metal"
 	icon_state = "metal"
-	block_chance = 30 //May be big but hard to move around to block.
+	block_chance = 50
 	slowdown = 1
 	shield_flags = SHIELD_FLAGS_DEFAULT
 	item_flags = SLOWS_WHILE_IN_HAND
+	var/recharge_timerid
+	var/recharge_delay = 15 SECONDS
 
-/obj/item/shield/riot/implant/run_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(attack_type & ATTACK_TYPE_PROJECTILE)
-		final_block_chance = 60 //Massive shield
-	return ..()
+/// Entirely overriden take_damage.
+/obj/item/shield/riot/implant/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
+	obj_integrity -= damage_amount
+	if(obj_integrity < 0)
+		obj_integrity = 0
+	if(obj_integrity == 0)
+		if(ismob(loc))
+			var/mob/living/L = loc
+			L.visible_message("<span class='boldwarning'>[src] overloads from the damage sustained!</span>")
+			L.dropItemToGround(src)			//implant component catch hook will grab it.
 
+/obj/item/shield/riot/implant/Moved()
+	. = ..()
+	if(istype(loc, /obj/item/organ/cyberimp/arm/shield))
+		recharge_timerid = addtimer(CALLBACK(src, .proc/recharge), recharge_delay, flags = TIMER_STOPPABLE)
+	else		//extending
+		if(recharge_timerid)
+			deltimer(recharge_timerid)
+			recharge_timerid = null
+
+/obj/item/shield/riot/implant/proc/recharge()
+	obj_integrity = max_integrity
+	if(ismob(loc.loc))		//cyberimplant.user
+		to_chat(loc, "<span class='notice'>[src] has recharged its reinforcement matrix and is ready for use!</span>")
 
 /obj/item/shield/energy
 	name = "energy combat shield"

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -165,6 +165,7 @@
 	attack_verb = list("shoved", "bashed")
 	var/cooldown = 0 //shield bash cooldown. based on world.time
 	var/repair_material = /obj/item/stack/sheet/mineral/titanium
+	var/can_shatter = TRUE
 	shield_flags = SHIELD_FLAGS_DEFAULT | SHIELD_TRANSPARENT
 	max_integrity = 75
 
@@ -214,7 +215,7 @@
 	new /obj/item/shard((get_turf(src)))
 
 /obj/item/shield/riot/on_shield_block(mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
-	if(obj_integrity <= damage)
+	if(can_shatter && (obj_integrity <= damage))
 		var/turf/T = get_turf(owner)
 		T.visible_message("<span class='warning'>[attack_text] destroys [src]!</span>")
 		shatter(owner)
@@ -366,6 +367,7 @@ obj/item/shield/riot/bullet_proof
 	shield_flags = SHIELD_FLAGS_DEFAULT
 	max_integrity = 60
 	obj_integrity = 60
+	can_shatter = FALSE
 	item_flags = SLOWS_WHILE_IN_HAND
 	var/recharge_timerid
 	var/recharge_delay = 15 SECONDS

--- a/code/game/objects/items/shields.dm
+++ b/code/game/objects/items/shields.dm
@@ -364,11 +364,13 @@ obj/item/shield/riot/bullet_proof
 	block_chance = 50
 	slowdown = 1
 	shield_flags = SHIELD_FLAGS_DEFAULT
+	max_integrity = 60
+	obj_integrity = 60
 	item_flags = SLOWS_WHILE_IN_HAND
 	var/recharge_timerid
 	var/recharge_delay = 15 SECONDS
 
-/// Entirely overriden take_damage.
+/// Entirely overriden take_damage. This shouldn't exist outside of an implant (other than maybe christmas).
 /obj/item/shield/riot/implant/take_damage(damage_amount, damage_type = BRUTE, damage_flag = 0, sound_effect = 1, attack_dir, armour_penetration = 0)
 	obj_integrity -= damage_amount
 	if(obj_integrity < 0)
@@ -376,6 +378,7 @@ obj/item/shield/riot/bullet_proof
 	if(obj_integrity == 0)
 		if(ismob(loc))
 			var/mob/living/L = loc
+			playsound(src, 'sound/effects/glassbr3.ogg', 100)
 			L.visible_message("<span class='boldwarning'>[src] overloads from the damage sustained!</span>")
 			L.dropItemToGround(src)			//implant component catch hook will grab it.
 

--- a/code/modules/assembly/flash.dm
+++ b/code/modules/assembly/flash.dm
@@ -229,6 +229,7 @@
 	var/flashcd = 20
 	var/overheat = 0
 	var/obj/item/organ/cyberimp/arm/flash/I = null
+	var/active_light_strength = 7
 
 /obj/item/assembly/flash/armimplant/burn_out()
 	if(I && I.owner)
@@ -248,6 +249,12 @@
 	update_icon(1)
 	return TRUE
 
+/obj/item/assembly/flash/armimplant/Moved(oldLoc, dir)
+	. = ..()
+	if(!ismob(loc))
+		set_light(0)
+	else
+		set_light(7)
 
 /obj/item/assembly/flash/armimplant/proc/cooldown()
 	overheat = FALSE

--- a/code/modules/mob/inventory.dm
+++ b/code/modules/mob/inventory.dm
@@ -333,7 +333,8 @@
 				I.moveToNullspace()
 			else
 				I.forceMove(newloc)
-		I.dropped(src)
+		if(I.dropped(src) == ITEM_RELOCATED_BY_DROPPED)
+			return FALSE
 	return TRUE
 
 //Outdated but still in use apparently. This should at least be a human proc.

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -272,7 +272,7 @@
 	contents = newlist(/obj/item/shield/riot/implant)
 
 /obj/item/organ/cyberimp/arm/shield/Extend(obj/item/I)
-	if(item.obj_integrity == 0)				//that's how the shield recharge works
+	if(I.obj_integrity == 0)				//that's how the shield recharge works
 		to_chat(owner, "<span class='warning'>[I] is still too unstable to extend. Give it some time!</span>")
 		return FALSE
 	return ..()

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -20,7 +20,27 @@
 
 	update_icon()
 	SetSlotFromZone()
-	items_list = contents.Copy()
+	for(var/obj/item/I in contents)
+		add_item(I)
+
+/obj/item/organ/cyberimp/arm/proc/add_item(obj/item/I)
+	if(I in items_list)
+		return
+	I.forceMove(src)
+	items_list += I
+	// ayy only dropped signal for performance, we can't possibly have shitcode that doesn't call it when removing items from a mob, right?
+	// .. right??!
+	RegisterSignal(I, COMSIG_ITEM_DROPPED, .proc/magnetic_catch)
+
+/obj/item/organ/cyberimp/arm/proc/magnetic_catch(datum/source, mob/user)
+	var/obj/item/I = source			//if someone is misusing the signal, just runtime
+	if(I in items_list)
+		if(I in contents)		//already in us somehow? i probably shouldn't catch this so it's easier to spot bugs but eh..
+			return
+		I.visible_message("<span class='notice'>[I] snaps back into [src]!</span>")
+		I.forceMove(contents)
+		if(I == holder)
+			holder = null
 
 /obj/item/organ/cyberimp/arm/proc/SetSlotFromZone()
 	switch(zone)
@@ -62,7 +82,7 @@
 	. = ..()
 	if(. & EMP_PROTECT_SELF)
 		return
-	if(prob(15/severity) && owner)
+	if(owner)
 		to_chat(owner, "<span class='warning'>[src] is hit by EMP!</span>")
 		// give the owner an idea about why his implant is glitching
 		Retract()
@@ -75,28 +95,19 @@
 		"<span class='notice'>[holder] snaps back into your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm.</span>",
 		"<span class='italics'>You hear a short mechanical noise.</span>")
 
-	if(istype(holder, /obj/item/assembly/flash/armimplant))
-		var/obj/item/assembly/flash/F = holder
-		F.set_light(0)
-
 	owner.transferItemToLoc(holder, src, TRUE)
 	holder = null
 	playsound(get_turf(owner), 'sound/mecha/mechmove03.ogg', 50, 1)
 
-/obj/item/organ/cyberimp/arm/proc/Extend(var/obj/item/item)
+/obj/item/organ/cyberimp/arm/proc/Extend(obj/item/item)
 	if(!(item in src))
 		return
 
 	holder = item
 
-	ADD_TRAIT(holder, TRAIT_NODROP, HAND_REPLACEMENT_TRAIT)
 	holder.resistance_flags = INDESTRUCTIBLE | LAVA_PROOF | FIRE_PROOF | UNACIDABLE | ACID_PROOF
 	holder.slot_flags = null
 	holder.set_custom_materials(null)
-
-	if(istype(holder, /obj/item/assembly/flash/armimplant))
-		var/obj/item/assembly/flash/F = holder
-		F.set_light(7)
 
 	var/obj/item/arm_item = owner.get_active_held_item()
 
@@ -223,21 +234,6 @@
 	icon_state = "arm_taser"
 	contents = newlist(/obj/item/gun/energy/e_gun/advtaser/mounted)
 
-/obj/item/organ/cyberimp/arm/gun/emp_act(severity)
-	. = ..()
-	if(. & EMP_PROTECT_SELF)
-		return
-	if(prob(30/severity) && owner && !(organ_flags & ORGAN_FAILING))
-		Retract()
-		owner.visible_message("<span class='danger'>A loud bang comes from [owner]\'s [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm!</span>")
-		playsound(get_turf(owner), 'sound/weapons/flashbang.ogg', 100, 1)
-		to_chat(owner, "<span class='userdanger'>You feel an explosion erupt inside your [zone == BODY_ZONE_R_ARM ? "right" : "left"] arm as your implant breaks!</span>")
-		owner.adjust_fire_stacks(20)
-		owner.IgniteMob()
-		owner.adjustFireLoss(25)
-		crit_fail = 1
-		organ_flags |= ORGAN_FAILING
-
 /obj/item/organ/cyberimp/arm/flash
 	name = "integrated high-intensity photon projector" //Why not
 	desc = "An integrated projector mounted onto a user's arm that is able to be used as a powerful flash."
@@ -274,6 +270,12 @@
 	name = "arm-mounted riot shield"
 	desc = "A deployable riot shield to help deal with civil unrest."
 	contents = newlist(/obj/item/shield/riot/implant)
+
+/obj/item/organ/cyberimp/arm/shield/Extend(obj/item/I)
+	if(item.obj_integrity == 0)				//that's how the shield recharge works
+		to_chat(owner, "<span class='warning'>[I] is still too unstable to extend. Give it some time!</span>")
+		return FALSE
+	return ..()
 
 /obj/item/organ/cyberimp/arm/shield/emag_act()
 	. = ..()

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -33,6 +33,7 @@
 	RegisterSignal(I, COMSIG_ITEM_DROPPED, .proc/magnetic_catch)
 
 /obj/item/organ/cyberimp/arm/proc/magnetic_catch(datum/source, mob/user)
+	. = COMPONENT_DROPPED_RELOCATION
 	var/obj/item/I = source			//if someone is misusing the signal, just runtime
 	if(I in items_list)
 		if(I in contents)		//already in us somehow? i probably shouldn't catch this so it's easier to spot bugs but eh..

--- a/code/modules/surgery/organs/augments_arms.dm
+++ b/code/modules/surgery/organs/augments_arms.dm
@@ -39,7 +39,7 @@
 		if(I in contents)		//already in us somehow? i probably shouldn't catch this so it's easier to spot bugs but eh..
 			return
 		I.visible_message("<span class='notice'>[I] snaps back into [src]!</span>")
-		I.forceMove(contents)
+		I.forceMove(src)
 		if(I == holder)
 			holder = null
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -124,6 +124,7 @@
 #include "code\__DEFINES\dcs\helpers.dm"
 #include "code\__DEFINES\dcs\signals.dm"
 #include "code\__DEFINES\flags\shields.dm"
+#include "code\__DEFINES\misc\return_values.dm"
 #include "code\__HELPERS\_cit_helpers.dm"
 #include "code\__HELPERS\_lists.dm"
 #include "code\__HELPERS\_logging.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

All implants:
Always retracts when EMP'd. I don't know why it was a prob(15) on the strongest EMPs, that's barely anything.
No longer nodrop. Items are instead component hooked to retract if dropped or otherwise removed from the user.

Gun implants:
No longer literally explodes when EMP'd. This is already an adminspawn meme and tasers are nowhere as strong as before. No reason to make them unusable.

Shield implant:
No longer indestructible in that they will need to recharge for 15 seconds after being damaged to the point of breaking. Obviously can't be extended while damaged. Won't knock down the user when ""broken"" temporarily.
Nerfed to 60 integrity from 75. This is 3 laser shots or a bit more than half a shotgun blast.
Rebalanced to be flat 50% block chance instead of 60% projectile and 30% melee. What was the justification for this? Really don't see the need to make them super strong in ranged. 
No longer nodrop. See: all implants. Already damn strong enough with them being able to block lasers and not being able to break.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Cybernetic arm implants given a balancing pass. Gun ones don't blow up on EMPs, all of them now retract on EMPs. Shields now work differently and can overload.
tweak: Cybernetic implants are no longer nodrop, instead having a magnetic catch system so they snap back when dropped/removed from the user.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
