### PR TITLE
double barrel shotgun internal magazines multiload

### DIFF
--- a/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
+++ b/code/modules/projectiles/boxes_magazines/internal/shotgun.dm
@@ -36,6 +36,7 @@
 /obj/item/ammo_box/magazine/internal/shot/dual
 	name = "double-barrel shotgun internal magazine"
 	max_ammo = 2
+	multiload = 1
 
 /obj/item/ammo_box/magazine/internal/shot/dual/heck
 	name = "heckgun internal magazine"


### PR DESCRIPTION
## About The Pull Request
allows **double barrel shotguns and double barrel shotguns only** to be multiloaded. this requires that you have some sort of reloading method for this. perhaps in another PR.
## Why It's Good For The Game
one more difference between "i love having high capacity but fuck me is it a hassle to reload" and "i like reloading fast but this shotgun forces me to do so"
## Changelog
:cl:
balance: Double-barrel shotguns /and double-barrel shotguns only/ including subtypes can be multi-loaded (difference between speedloaders and sliding shells in one by one).
/:cl: