### PR TITLE
The Neo-Russian Rifleman's Primer - a book that makes you pump shotguns and work rifle bolts faster

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -221,6 +221,7 @@
 #define TRAIT_NO_INTERNALS		"no-internals"
 #define TRAIT_NO_ALCOHOL		"alcohol_intolerance"
 #define TRAIT_MUTATION_STASIS			"mutation_stasis" //Prevents processed genetics mutations from processing.
+#define TRAIT_FAST_PUMP				"fast_pump"	
 
 // common trait sources
 #define TRAIT_GENERIC "generic"
@@ -246,6 +247,7 @@
 #define BLOODSUCKER_TRAIT "bloodsucker"
 #define SHOES_TRAIT "shoes" //inherited from your sweet kicks
 #define GLOVE_TRAIT "glove" //inherited by your cool gloves
+#define BOOK_TRAIT "granter (book)" // knowledge is power
 
 // unique trait sources, still defines
 #define STATUE_MUTE "statue"

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -85,7 +85,7 @@
 	granted_trait = TRAIT_FAST_PUMP
 	traitname = "riflery"
 	icon_state = "book1"
-	remarks = list("One smooth motion...", "Palm the bolt...", "Push up, rotate back, push forward, down...", "Don't slap yourself with the bolt...", "Wait, what's this about pumping?")
+	remarks = list("One smooth motion...", "Palm the bolt...", "Push up, rotate back, push forward, down...", "Don't slap yourself with the bolt...", "Wait, what's this about pumping?", "Who just scribbled \"Z\" and \"LMB\" on this page?")
 
 ///ACTION BUTTONS///
 

--- a/code/game/objects/items/granters.dm
+++ b/code/game/objects/items/granters.dm
@@ -57,6 +57,35 @@
 			on_reading_finished(user)
 		reading = FALSE
 	return TRUE
+///TRAITS///
+
+/obj/item/book/granter/trait
+	var/granted_trait
+	var/traitname = "being cool"
+
+/obj/item/book/granter/trait/already_known(mob/user)
+	if(!granted_trait)
+		return TRUE
+	if(HAS_TRAIT(user, granted_trait))
+		to_chat(user, "<span class ='notice'>You already have all the insight you need about [traitname].")
+		return TRUE
+	return FALSE
+
+/obj/item/book/granter/trait/on_reading_start(mob/user)
+	to_chat(user, "<span class='notice'>You start reading about [traitname]...</span>")
+
+/obj/item/book/granter/trait/on_reading_finished(mob/user)
+	to_chat(user, "<span class='notice'>You feel like you've got a good handle on [traitname]!</span>")
+	ADD_TRAIT(user, granted_trait, BOOK_TRAIT)
+
+/obj/item/book/granter/trait/rifleman
+	name = "\proper the Neo-Russian Rifleman\'s Primer"
+	desc = "A book with stains of vodka and...blood? The back is hard to read, but says something about bolt-actions. Or pump-actions. Both, maybe."
+	oneuse = FALSE
+	granted_trait = TRAIT_FAST_PUMP
+	traitname = "riflery"
+	icon_state = "book1"
+	remarks = list("One smooth motion...", "Palm the bolt...", "Push up, rotate back, push forward, down...", "Don't slap yourself with the bolt...", "Wait, what's this about pumping?")
 
 ///ACTION BUTTONS///
 

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -41,7 +41,10 @@
 		to_chat(user, "<span class='warning'>You're too exhausted for that.</span>")//CIT CHANGE - ditto
 		return//CIT CHANGE - ditto
 	pump(user, TRUE)
-	recentpump = world.time + 10
+	if(HAS_TRAIT(user, TRAIT_FAST_PUMP))
+		recentpump = world.time + 2
+	else
+		recentpump = world.time + 10
 	if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
 		user.adjustStaminaLossBuffered(2) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
 	return

--- a/code/modules/projectiles/guns/ballistic/shotgun.dm
+++ b/code/modules/projectiles/guns/ballistic/shotgun.dm
@@ -45,8 +45,8 @@
 		recentpump = world.time + 2
 	else
 		recentpump = world.time + 10
-	if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
-		user.adjustStaminaLossBuffered(2) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
+		if(istype(user))//CIT CHANGE - makes pumping shotguns cost a lil bit of stamina.
+			user.adjustStaminaLossBuffered(2) //CIT CHANGE - DITTO. make this scale inversely to the strength stat when stats/skills are added
 	return
 
 /obj/item/gun/ballistic/shotgun/blow_up(mob/user)
@@ -93,7 +93,7 @@
 	fire_delay = 7
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/riot
 	sawn_desc = "Come with me if you want to live."
-	unique_reskin = list("Tatical" = "riotshotgun",
+	unique_reskin = list("Tactical" = "riotshotgun",
 						"Wood Stock" = "wood_riotshotgun"
 						)
 
@@ -215,7 +215,7 @@
 	fire_delay = 5
 	mag_type = /obj/item/ammo_box/magazine/internal/shot/com
 	w_class = WEIGHT_CLASS_HUGE
-	unique_reskin = list("Tatical" = "cshotgun",
+	unique_reskin = list("Tactical" = "cshotgun",
 						"Slick" = "cshotgun_slick"
 						)
 

--- a/code/modules/uplink/uplink_items/uplink_devices.dm
+++ b/code/modules/uplink/uplink_items/uplink_devices.dm
@@ -188,6 +188,16 @@
 	item = /obj/item/healthanalyzer/rad_laser
 	cost = 3
 
+/datum/uplink_item/device_tools/riflery_primer
+	name = "Riflery Primer"
+	desc = "An old book with blood and vodka stains on it. Freshly pulled from a dusty crate in some old warehouse, \
+			this primer of questionable worth and value is rumored to increase your rifle-bolt-working and/or shotgun \
+			racking fivefold. Then again, the techniques here only work on bolt-actions and pump-actions..."
+	item = /obj/item/book/granter/trait/rifleman
+	cost = 3
+	restricted_roles = list("Operative") // i want it to be surplusable but i also want it to be mostly nukie only, please advise
+	surplus = 90
+
 /datum/uplink_item/device_tools/stimpack
 	name = "Stimpack"
 	desc = "Stimpacks, the tool of many great heroes, make you nearly immune to stuns and knockdowns for about \


### PR DESCRIPTION
## About The Pull Request
Adds the Neo-Russian Rifleman's Primer, a trait granter book that lets you pump shotguns and work Mosin bolts much faster. Primarily for nuclear operatives who got shafted on TC/want to suffer with the Moist Nugget/etc., it's also possible to show up in a surplus crate. Maybe. Hopefully.
Has literally no effect on things that aren't shotguns/Mosins (because those are shotguns codewise).

also slaps in the code for trait-granting books

## Why It's Good For The Game
god don't you love mashing Z to make a bangstick actually go
## Changelog
:cl:
add: Nuclear operatives can now purchase the Rifleman's Primer for insights on using their bolt-actions better. Traitors might also be able to get it - but only in surplus crates.
/:cl: