### PR TITLE
Quick fixing up of pubbystation things

### DIFF
--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -53150,6 +53150,9 @@
 	dir = 1;
 	pixel_y = -22
 	},
+/obj/structure/reflector/double/anchored{
+	dir = 9
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "dFJ" = (
@@ -56503,6 +56506,16 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
+"loL" = (
+/obj/machinery/atmospherics/components/trinary/filter/flipped/critical{
+	dir = 4;
+	filter_type = "n2"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
+/turf/open/floor/engine,
+/area/engine/engineering)
 "lqc" = (
 /obj/item/toy/gun,
 /obj/effect/decal/cleanable/oil,
@@ -58403,9 +58416,6 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "pCo" = (
-/obj/structure/reflector/single/anchored{
-	dir = 6
-	},
 /obj/machinery/light/small{
 	dir = 1
 	},
@@ -59921,10 +59931,10 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "tlV" = (
-/obj/structure/reflector/double/anchored{
-	dir = 9
+/obj/structure/reflector/single/anchored{
+	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plating,
 /area/engine/engineering)
 "tnP" = (
 /obj/machinery/seed_extractor,
@@ -94076,7 +94086,7 @@ bXk
 pCo
 wcs
 wcs
-tlV
+wcs
 eyj
 qkM
 miw
@@ -94330,7 +94340,7 @@ bZA
 cam
 mgz
 aac
-cbX
+tlV
 wcs
 wcs
 dEy
@@ -94592,7 +94602,7 @@ oHa
 eWi
 cbX
 aac
-vlC
+loL
 cgx
 qeY
 fyO

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -60782,19 +60782,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"vsG" = (
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/machinery/door/airlock/maintenance{
-	name = "Research Lab Maintenance";
-	req_one_access_txt = "7;29"
-	},
-/turf/open/floor/plating,
-/area/maintenance/department/engine)
 "vsJ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/tile/neutral{
@@ -94054,7 +94041,7 @@ jZG
 bpY
 bpY
 bpY
-vsG
+bNZ
 bva
 bva
 bva


### PR DESCRIPTION
## About The Pull Request

Makes the first filter automatically filter n2.
Moves the right reflectors over one tile.

EDIT: Also make a door a maint door instead of a research door for some reason, why wasn't that access fixed.

## Why It's Good For The Game

Adds consistency with the filters for the SM, and makes the emitter not break the light every round.

## Changelog
:cl:
tweak: Fixing up pubby's engine
/:cl:
