### PR TITLE
Kilo station improvements

### DIFF
--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -39,10 +39,6 @@
 /obj/structure/table,
 /obj/item/paper_bin,
 /obj/item/pen,
-/obj/item/mmi/posibrain{
-	pixel_x = 5;
-	pixel_y = 8
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "aae" = (
@@ -57,7 +53,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/poddoor/shutters/radiation/preopen{
 	id = "engsm";
 	name = "Radiation Chamber Shutters"
@@ -165,6 +160,10 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
+/mob/living/simple_animal/bot/cleanbot{
+	auto_patrol = 1;
+	name = "Sir Cleansworth"
+	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
 "aau" = (
@@ -263,17 +262,6 @@
 /area/ai_monitored/turret_protected/ai)
 "aaE" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aaF" = (
@@ -287,7 +275,6 @@
 	dir = 5
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
 "aaG" = (
@@ -593,9 +580,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "abd" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -636,10 +620,6 @@
 /turf/open/floor/plasteel/dark,
 /area/lawoffice)
 "abg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -732,6 +712,9 @@
 	freerange = 1;
 	name = "Station Intercom (Command)";
 	pixel_y = -28
+	},
+/obj/structure/window/reinforced{
+	dir = 8
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
@@ -873,7 +856,6 @@
 	pixel_x = 24
 	},
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
 "abD" = (
@@ -953,9 +935,6 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai)
 "abM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -1132,7 +1111,6 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "acg" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/engine,
@@ -1352,7 +1330,6 @@
 /turf/open/space,
 /area/space/nearstation)
 "acz" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -1363,7 +1340,9 @@
 /turf/open/floor/engine,
 /area/ai_monitored/storage/satellite)
 "acB" = (
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/ai_monitored/storage/satellite)
 "acC" = (
@@ -1642,7 +1621,6 @@
 /obj/machinery/light_switch{
 	pixel_y = -24
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
@@ -1661,7 +1639,7 @@
 	dir = 4
 	},
 /turf/open/floor/engine,
-/area/ai_monitored/turret_protected/aisat_interior)
+/area/space)
 "acY" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -1828,26 +1806,18 @@
 	id = "prisonblast";
 	name = "Prison Blast Door"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "adm" = (
 /obj/structure/chair/office{
 	dir = 4
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/ai_monitored/storage/satellite)
 "adn" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -1890,7 +1860,7 @@
 /turf/open/floor/circuit/green{
 	luminosity = 2
 	},
-/area/ai_monitored/turret_protected/ai)
+/area/space)
 "adr" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 4
@@ -1912,7 +1882,6 @@
 	id = "xeno_blastdoor";
 	name = "Xenobiology Containment Blast Door"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "adt" = (
@@ -1943,10 +1912,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/courtroom)
 "adv" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -1998,6 +1963,9 @@
 "adz" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
+	},
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/storage/satellite)
@@ -2086,10 +2054,10 @@
 	pixel_y = 26
 	},
 /obj/structure/cable{
-	icon_state = "0-4"
+	icon_state = "0-8"
 	},
 /obj/structure/cable{
-	icon_state = "0-8"
+	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/foyer)
@@ -2186,6 +2154,9 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/engine,
 /area/ai_monitored/storage/satellite)
 "adO" = (
@@ -2212,9 +2183,12 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/aisat/foyer)
 "adT" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/r_wall/rust,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/effect/spawner/structure/window/reinforced,
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/turf/open/floor/plating,
+/area/science/xenobiology)
 "adU" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -2236,7 +2210,6 @@
 	pixel_y = 24;
 	req_one_access_txt = "2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "adW" = (
@@ -2348,7 +2321,6 @@
 	pixel_y = -24;
 	req_one_access_txt = "2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "aed" = (
@@ -2395,16 +2367,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aej" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -2441,7 +2403,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/medical/cryo)
 "aeo" = (
@@ -2687,7 +2648,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/medical/cryo)
 "aeQ" = (
@@ -2800,16 +2760,6 @@
 /turf/open/floor/plating,
 /area/security/warden)
 "aeY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -3012,16 +2962,6 @@
 /turf/closed/wall,
 /area/maintenance/port/aft)
 "afn" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -3510,13 +3450,16 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "afX" = (
-/obj/structure/grille/broken,
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg1"
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/area/maintenance/starboard/fore)
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/heads/cmo)
 "afY" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
@@ -3626,6 +3569,9 @@
 	name = "xenobiology camera";
 	network = list("ss13","rd","xeno")
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "agg" = (
@@ -3650,6 +3596,9 @@
 	external_pressure_bound = 120;
 	name = "server vent"
 	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "agi" = (
@@ -3666,6 +3615,9 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
 "agj" = (
@@ -3943,10 +3895,11 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/fore)
 "agF" = (
-/obj/structure/grille,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating,
-/area/maintenance/starboard/fore)
+/obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
+	dir = 4
+	},
+/turf/open/floor/plasteel/showroomfloor,
+/area/medical/medbay/central)
 "agG" = (
 /obj/docking_port/stationary{
 	dir = 2;
@@ -4581,7 +4534,6 @@
 	pixel_x = -26
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ahI" = (
@@ -4662,16 +4614,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4680,16 +4622,6 @@
 "ahQ" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -4803,7 +4735,6 @@
 /turf/open/floor/plating,
 /area/security/brig)
 "ahY" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -4816,37 +4747,21 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ahZ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aia" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aib" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aic" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -4939,16 +4854,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -4958,9 +4863,7 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aij" = (
-/obj/structure/flora/grass/jungle,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -5127,10 +5030,6 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "aix" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -5159,16 +5058,6 @@
 /area/security/main)
 "aiz" = (
 /obj/machinery/computer/secure_data,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/security/main)
 "aiA" = (
@@ -5322,16 +5211,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/landmark/start/security_officer,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -5399,16 +5278,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "aiR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aiS" = (
@@ -5436,28 +5305,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
-"aiU" = (
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel/dark,
-/area/hallway/primary/fore)
-"aiV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/fore)
-"aiW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/fore)
 "aiX" = (
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -5471,12 +5318,6 @@
 /area/ai_monitored/turret_protected/aisat_interior)
 "aiY" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5541,12 +5382,6 @@
 /area/ai_monitored/turret_protected/aisat/foyer)
 "ajc" = (
 /obj/structure/chair,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -5582,19 +5417,8 @@
 /turf/open/floor/plasteel,
 /area/security/main)
 "ajg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/blood/gibs/limb,
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/fore)
-"ajh" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
@@ -5607,13 +5431,13 @@
 	},
 /area/maintenance/port/fore)
 "ajj" = (
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
+/obj/machinery/atmospherics/components/unary/vent_pump/on,
+/obj/effect/turf_decal/box,
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
-/area/maintenance/fore)
+/turf/open/floor/plasteel,
+/area/hallway/primary/fore)
 "ajk" = (
 /obj/effect/turf_decal/tile/brown{
 	dir = 1
@@ -5690,16 +5514,6 @@
 	color = "#c45c57";
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/landmark/start/head_of_security,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -5746,17 +5560,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/xenobiology)
-"ajs" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/fore)
 "ajt" = (
 /turf/closed/wall,
 /area/crew_quarters/kitchen)
@@ -5915,16 +5718,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "ajJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -5942,15 +5735,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/bridge)
-"ajL" = (
-/obj/machinery/door/poddoor/preopen{
-	id = "Biohazard";
-	name = "Emergency Research Blast Door"
-	},
-/obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
-/turf/open/floor/plasteel/dark,
-/area/science/research)
 "ajM" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/item/shard,
@@ -6061,7 +5845,6 @@
 /area/hallway/primary/fore)
 "ajX" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ajY" = (
@@ -6114,10 +5897,10 @@
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
 "akd" = (
-/obj/structure/flora/tree/jungle/small,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/structure/flora/ausbushes/ppflowers,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "ake" = (
@@ -6323,7 +6106,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "akz" = (
@@ -6379,7 +6161,6 @@
 "akF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "akG" = (
@@ -6405,12 +6186,6 @@
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
 "akI" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/decal/cleanable/blood/gibs/old,
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
@@ -6613,6 +6388,7 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -6766,7 +6542,6 @@
 	pixel_x = 28
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "all" = (
@@ -6961,9 +6736,6 @@
 "alw" = (
 /obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "alx" = (
@@ -7031,29 +6803,12 @@
 /obj/machinery/status_display/evac{
 	pixel_y = 32
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"alA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/fore)
 "alB" = (
 /turf/closed/wall/r_wall,
 /area/science/xenobiology)
 "alC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -7113,13 +6868,6 @@
 /obj/vehicle/ridden/secway,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
-"alH" = (
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/fore)
 "alI" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating{
@@ -7281,8 +7029,22 @@
 	},
 /area/maintenance/fore)
 "alV" = (
-/turf/closed/wall/r_wall/rust,
-/area/ai_monitored/turret_protected/aisat_interior)
+/obj/structure/closet/crate/wooden/toy,
+/obj/effect/turf_decal/bot,
+/obj/machinery/airalarm{
+	dir = 4;
+	pixel_x = -23
+	},
+/obj/machinery/newscaster{
+	pixel_y = 30
+	},
+/obj/effect/decal/cleanable/cobweb,
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/theatre)
 "alW" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating,
@@ -8493,31 +8255,12 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard)
 "anX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "anY" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -9079,7 +8822,6 @@
 /turf/open/floor/wood,
 /area/lawoffice)
 "aoT" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/box/corners{
 	dir = 4
@@ -9537,7 +9279,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "apI" = (
@@ -9713,28 +9454,22 @@
 /turf/closed/wall/rust,
 /area/maintenance/central)
 "apY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/table/wood,
+/obj/structure/mirror{
+	pixel_x = -26
 	},
+/obj/item/reagent_containers/food/snacks/pie/cream,
+/obj/item/clothing/under/costume/lobster,
+/obj/item/clothing/head/lobsterhat,
+/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8;
-	icon_state = "intact"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/theatre)
 "apZ" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/structure/cable{
@@ -10276,18 +10011,18 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "aqQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/table/wood,
+/obj/item/storage/crayons,
+/obj/item/storage/crayons,
+/obj/item/bikehorn/rubberducky,
+/obj/structure/sign/poster/contraband/clown{
+	pixel_x = -30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/bridge)
+/turf/open/floor/plasteel/dark,
+/area/crew_quarters/theatre)
 "aqR" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -10726,7 +10461,6 @@
 /obj/structure/sign/warning/electricshock{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -10773,10 +10507,16 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "arD" = (
-/obj/effect/turf_decal/bot,
-/obj/effect/decal/cleanable/blood/old,
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/structure/sign/departments/science{
+	pixel_x = 32
+	},
 /turf/open/floor/plasteel,
-/area/crew_quarters/heads/hop)
+/area/hallway/primary/starboard)
 "arE" = (
 /obj/structure/table,
 /obj/item/clipboard,
@@ -11104,28 +10844,17 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "arW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/plasteel,
 /area/bridge)
 "arX" = (
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
+/obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel,
-/area/bridge)
+/area/hallway/primary/starboard)
 "arY" = (
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
@@ -11191,16 +10920,6 @@
 	},
 /area/maintenance/port/fore)
 "asd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -11226,7 +10945,7 @@
 	icon_state = "4-8"
 	},
 /turf/open/floor/engine,
-/area/ai_monitored/turret_protected/aisat/foyer)
+/area/space)
 "asg" = (
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-22"
@@ -11404,7 +11123,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "asw" = (
@@ -11977,6 +11695,7 @@
 	dir = 4;
 	name = "chapel camera"
 	},
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
@@ -12075,15 +11794,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "atF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L14"
@@ -12344,18 +12056,7 @@
 	},
 /area/maintenance/starboard/fore)
 "aua" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
-/obj/effect/turf_decal/box,
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aub" = (
@@ -12538,16 +12239,6 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "auo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -12634,9 +12325,20 @@
 /turf/closed/wall/r_wall,
 /area/bridge)
 "auz" = (
-/obj/structure/sign/warning/vacuum/external,
-/turf/closed/wall/rust,
-/area/maintenance/starboard)
+/obj/effect/turf_decal/tile/purple,
+/obj/effect/turf_decal/tile/purple{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
+	},
+/obj/machinery/light{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "auA" = (
 /obj/structure/cable{
 	icon_state = "2-8"
@@ -12738,12 +12440,12 @@
 	},
 /area/maintenance/solars/starboard/fore)
 "auK" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
-	dir = 8
+	dir = 1
 	},
+/obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
-/area/security/courtroom)
+/area/hallway/primary/port)
 "auL" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
 /obj/effect/turf_decal/box/corners{
@@ -12757,16 +12459,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "auM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
@@ -12910,11 +12602,21 @@
 /obj/item/folder/blue,
 /obj/item/melee/chainofcommand,
 /obj/item/toy/figure/captain,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "ave" = (
 /obj/structure/table/wood,
 /obj/machinery/computer/security/wooden_tv,
+/obj/structure/window/reinforced{
+	dir = 1
+	},
+/obj/structure/window/reinforced{
+	dir = 8
+	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "avf" = (
@@ -12982,7 +12684,6 @@
 "avj" = (
 /obj/structure/table/wood,
 /obj/item/storage/fancy/donut_box,
-/obj/item/card/id/captains_spare,
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/captain)
 "avk" = (
@@ -13023,10 +12724,6 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "avo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -13055,9 +12752,6 @@
 /turf/closed/wall,
 /area/maintenance/aft)
 "avr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/box/corners,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
@@ -13411,12 +13105,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "avQ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -13426,12 +13114,6 @@
 /turf/open/floor/plasteel,
 /area/bridge)
 "avR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -13490,35 +13172,16 @@
 /obj/structure/chair{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
 /obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "avX" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -13677,7 +13340,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "awl" = (
@@ -13734,10 +13396,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 8
-	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -13764,16 +13422,6 @@
 /turf/open/floor/plating,
 /area/storage/primary)
 "awr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -13783,10 +13431,6 @@
 /obj/machinery/status_display/ai{
 	pixel_x = -32;
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -13915,9 +13559,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -14015,9 +13656,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -14036,20 +13674,6 @@
 /obj/machinery/status_display/ai{
 	pixel_x = 32;
 	pixel_y = 32
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "mainframe floor"
-	},
-/area/tcommsat/server)
-"awM" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -14227,6 +13851,7 @@
 /obj/item/lighter,
 /obj/item/clothing/mask/cigarette/cigar/cohiba,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/suit_storage_unit/ce,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/chief)
 "axi" = (
@@ -14692,7 +14317,6 @@
 	name = "Containment Chamber Blast Door"
 	},
 /obj/machinery/atmospherics/pipe/simple/general/hidden,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -14832,7 +14456,6 @@
 /area/medical/morgue)
 "ayi" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ayj" = (
@@ -14844,16 +14467,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "ayk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -14917,7 +14530,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "ayr" = (
@@ -15156,7 +14768,6 @@
 /obj/structure/sign/warning/biohazard{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -15217,7 +14828,6 @@
 	dir = 1;
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "ayP" = (
@@ -15447,7 +15057,6 @@
 /obj/structure/sign/departments/evac{
 	pixel_y = 32
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "azc" = (
@@ -15639,9 +15248,6 @@
 /turf/open/floor/plasteel/dark,
 /area/ai_monitored/security/armory)
 "azp" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -15842,11 +15448,10 @@
 	},
 /area/maintenance/starboard)
 "azE" = (
-/obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
 	dir = 6
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "azF" = (
 /obj/structure/flora/junglebush/c,
@@ -16179,9 +15784,6 @@
 /turf/open/floor/plating,
 /area/medical/chemistry)
 "aAd" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "External Gas to Loop"
@@ -16190,7 +15792,7 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aAe" = (
 /obj/machinery/door/firedoor,
@@ -16211,10 +15813,6 @@
 	dir = 4;
 	pixel_x = -22
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -16227,7 +15825,6 @@
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -16249,7 +15846,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -16258,10 +15854,6 @@
 "aAk" = (
 /obj/structure/cable{
 	icon_state = "4-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -16277,10 +15869,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "0-8"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -16407,7 +15995,6 @@
 /turf/open/floor/grass,
 /area/chapel/main)
 "aAz" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -16430,9 +16017,11 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/robotics/lab)
 "aAD" = (
-/obj/structure/flora/tree/jungle/small,
-/turf/open/floor/grass,
-/area/chapel/main)
+/obj/effect/turf_decal/tile/neutral,
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
+/turf/open/floor/plasteel,
+/area/hallway/primary/starboard)
 "aAE" = (
 /obj/machinery/light/small{
 	dir = 8
@@ -16553,16 +16142,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "aAO" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
 	},
@@ -16638,7 +16217,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Docking Hallway"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "aAV" = (
@@ -17012,7 +16590,6 @@
 /area/engine/engineering)
 "aBw" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "aBx" = (
@@ -17022,10 +16599,6 @@
 /turf/open/floor/engine,
 /area/engine/engineering)
 "aBy" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fernybush,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -17160,20 +16733,9 @@
 /obj/structure/sign/departments/security{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "aBN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -17187,7 +16749,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aBP" = (
@@ -17324,10 +16885,6 @@
 /obj/item/radio/intercom{
 	pixel_x = -28
 	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -17335,7 +16892,6 @@
 /area/tcommsat/server)
 "aCe" = (
 /obj/structure/cable,
-/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -17407,10 +16963,6 @@
 	dir = 8;
 	name = "telecomms camera";
 	network = list("ss13","tcomms")
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
@@ -17490,7 +17042,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Security Hallway"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "aCr" = (
@@ -17563,16 +17114,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "aCy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -17827,10 +17368,7 @@
 /area/medical/cryo)
 "aCN" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -18126,7 +17664,6 @@
 "aDh" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/grass,
 /area/chapel/main)
@@ -18191,7 +17728,6 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "aDs" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/engine,
 /area/security/nuke_storage)
@@ -18305,6 +17841,7 @@
 /obj/machinery/atmospherics/miner/nitrogen{
 	max_ext_kpa = 2500
 	},
+/obj/machinery/portable_atmospherics/canister/nitrogen,
 /turf/open/floor/engine/n2{
 	initial_gas_mix = "n2=1000;TEMP=293.15"
 	},
@@ -18321,6 +17858,7 @@
 /obj/machinery/atmospherics/miner/oxygen{
 	max_ext_kpa = 2500
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
 /turf/open/floor/engine/o2{
 	initial_gas_mix = "o2=1000;TEMP=293.15"
 	},
@@ -18799,18 +18337,13 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/turf/open/floor/plasteel/dark/corner{
+	dir = 8
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/dark,
-/area/chapel/main)
+/area/hallway/primary/port)
 "aEv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -18951,7 +18484,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aEG" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -18981,7 +18513,6 @@
 /turf/open/floor/engine,
 /area/security/nuke_storage)
 "aEI" = (
-/obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -19343,6 +18874,7 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide{
 	max_ext_kpa = 2500
 	},
+/obj/machinery/portable_atmospherics/canister/carbon_dioxide,
 /turf/open/floor/engine/co2{
 	initial_gas_mix = "co2=1000;TEMP=293.15"
 	},
@@ -19351,6 +18883,7 @@
 /obj/machinery/atmospherics/miner/toxins{
 	max_ext_kpa = 2500
 	},
+/obj/machinery/portable_atmospherics/canister/toxins,
 /turf/open/floor/engine/plasma{
 	initial_gas_mix = "plasma=1000;TEMP=293.15"
 	},
@@ -19359,6 +18892,7 @@
 /obj/machinery/atmospherics/miner/n2o{
 	max_ext_kpa = 2500
 	},
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine/n2o{
 	initial_gas_mix = "n2o=1000;TEMP=293.15"
 	},
@@ -19682,14 +19216,18 @@
 	},
 /area/maintenance/port/fore)
 "aFY" = (
+/obj/machinery/air_sensor{
+	pixel_x = -32;
+	pixel_y = -32
+	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /obj/machinery/igniter{
 	id = "Incinerator"
-	},
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 8
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -19719,16 +19257,17 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/hor)
 "aGb" = (
-/obj/machinery/power/turbine{
-	luminosity = 2
-	},
-/obj/structure/cable,
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
-"aGc" = (
 /obj/machinery/door/poddoor/incinerator_atmos_main,
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
+"aGc" = (
+/obj/machinery/door/window{
+	dir = 1;
+	name = "Captain's Desk";
+	req_access_txt = "20"
+	},
+/turf/open/floor/carpet,
+/area/crew_quarters/heads/captain)
 "aGd" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
@@ -20096,7 +19635,6 @@
 /area/medical/genetics/cloning)
 "aGG" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aGH" = (
@@ -20419,7 +19957,6 @@
 /area/security/brig)
 "aHq" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aHr" = (
@@ -20866,7 +20403,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "aHV" = (
@@ -21126,9 +20662,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-16"
-	},
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
@@ -21264,9 +20797,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
 	},
 /obj/machinery/button/door{
 	id = "transittube_ai";
@@ -21525,16 +21055,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "aIY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/light{
 	dir = 8
@@ -21728,7 +21248,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aJs" = (
@@ -21755,7 +21274,6 @@
 /area/engine/atmos)
 "aJu" = (
 /obj/machinery/computer/med_data,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -21768,20 +21286,11 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aJv" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/showroomfloor,
-/area/medical/medbay/central)
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood,
+/area/crew_quarters/locker)
 "aJw" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
@@ -22135,9 +21644,6 @@
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "applebush"
 	},
 /turf/open/floor/plasteel/dark/corner{
 	dir = 1
@@ -22665,16 +22171,6 @@
 	},
 /area/maintenance/port)
 "aKN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
@@ -22964,9 +22460,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/loading_area{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "aLk" = (
@@ -22988,13 +22481,6 @@
 /obj/structure/chair{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aLn" = (
@@ -23016,16 +22502,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aLo" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -23396,11 +22872,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
 "aMa" = (
-/obj/effect/turf_decal/loading_area,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/visible{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "aMb" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -23622,7 +23097,6 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/power/apc{
 	areastring = "/area/science/mixing/chamber";
 	dir = 4;
@@ -23820,9 +23294,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
@@ -24180,21 +23651,10 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "aNi" = (
-/obj/machinery/power/compressor{
-	comp_id = "incineratorturbine";
-	dir = 1;
+/obj/machinery/power/turbine{
 	luminosity = 2
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
 /obj/structure/cable,
-/obj/machinery/camera{
-	c_tag = "Turbine Chamber";
-	dir = 4;
-	name = "turbine camera";
-	network = list("turbine")
-	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
 "aNj" = (
@@ -24295,7 +23755,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aNr" = (
@@ -24695,12 +24154,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
-"aOa" = (
-/obj/structure/flora/junglebush/b,
-/turf/open/floor/grass,
-/area/medical/genetics)
 "aOb" = (
-/obj/structure/flora/junglebush/large,
 /turf/open/floor/grass,
 /area/medical/genetics)
 "aOc" = (
@@ -24756,10 +24210,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "aOh" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 8
@@ -24822,10 +24272,6 @@
 /area/medical/genetics)
 "aOn" = (
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/components/binary/valve{
 	dir = 8
 	},
@@ -24833,14 +24279,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing/chamber)
 "aOo" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/purple,
 /obj/machinery/atmospherics/pipe/manifold/general/visible{
 	dir = 4
 	},
@@ -25266,22 +24704,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/cmo)
-"aOS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/fore)
 "aOT" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -25300,16 +24722,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "aOU" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/sorting/mail{
@@ -25353,16 +24765,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/heads/cmo)
 "aOY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 4;
 	name = "bar sorting disposal pipe";
@@ -25490,19 +24892,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/research)
 "aPk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25529,7 +24918,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 9
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing/chamber)
 "aPn" = (
@@ -25639,16 +25027,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "aPv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -25678,18 +25056,10 @@
 /turf/open/floor/plating,
 /area/medical/storage)
 "aPz" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
-/obj/effect/turf_decal/box,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -25792,16 +25162,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
 "aPH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /obj/structure/disposalpipe/segment{
@@ -25998,12 +25358,8 @@
 /area/medical/storage)
 "aPV" = (
 /obj/structure/table/glass,
-/obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/item/paper_bin{
@@ -26215,23 +25571,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
-"aQm" = (
-/obj/structure/closet/crate/wooden/toy,
-/obj/effect/turf_decal/bot,
-/obj/machinery/airalarm{
-	dir = 4;
-	pixel_x = -23
-	},
-/obj/machinery/newscaster{
-	pixel_y = 30
-	},
-/obj/effect/decal/cleanable/cobweb,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/theatre)
 "aQn" = (
 /obj/structure/closet/secure_closet/medical3,
 /obj/item/storage/belt/medical,
@@ -26368,10 +25707,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar/atrium)
 "aQy" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
 "aQz" = (
@@ -26629,9 +25964,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/structure/disposalpipe/segment{
@@ -26642,16 +25974,14 @@
 	},
 /area/maintenance/central)
 "aRc" = (
-/obj/structure/cable{
-	icon_state = "0-8"
+/obj/machinery/door/airlock/maintenance{
+	name = "backstage maintenance";
+	req_access_txt = "46"
 	},
-/obj/effect/decal/cleanable/dirt,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
+/turf/open/floor/plasteel/dark,
 /area/maintenance/central)
 "aRd" = (
 /obj/machinery/computer/med_data{
@@ -26700,16 +26030,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/storage)
 "aRh" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 5
 	},
@@ -26722,6 +26042,9 @@
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
@@ -27099,16 +26422,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/checkpoint/science/research)
 "aRB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -27151,16 +26464,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/storage)
 "aRE" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -27420,7 +26723,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aRZ" = (
@@ -27629,7 +26931,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
 "aSm" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
 	},
@@ -27641,23 +26942,6 @@
 	},
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
-"aSn" = (
-/obj/structure/table/wood,
-/obj/structure/mirror{
-	pixel_x = -26
-	},
-/obj/item/reagent_containers/food/snacks/pie/cream,
-/obj/item/clothing/under/costume/lobster,
-/obj/item/clothing/head/lobsterhat,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/theatre)
 "aSo" = (
 /obj/machinery/navbeacon{
 	codes_txt = "delivery;dir=4";
@@ -27811,25 +27095,21 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/chemistry)
 "aSx" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/chair,
+/obj/machinery/light{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/clipboard,
-/obj/item/storage/firstaid/regular,
+/obj/effect/landmark/start/assistant,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aSy" = (
 /obj/structure/table,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/item/stack/medical/gauze,
 /obj/item/stack/medical/ointment,
 /obj/item/stack/medical/bruise_pack{
 	pixel_x = 4
 	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "aSz" = (
@@ -27910,10 +27190,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/lab)
 "aSE" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/medbay/central)
@@ -28098,16 +27374,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/mixing)
 "aST" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -28146,11 +27412,12 @@
 	},
 /area/maintenance/starboard)
 "aSW" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
-/obj/item/crowbar/red,
-/obj/item/healthanalyzer,
-/turf/open/floor/plasteel/dark,
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "cmoprivacy";
+	name = "Office Privacy Shutters"
+	},
+/turf/open/floor/plating,
 /area/medical/medbay/central)
 "aSX" = (
 /obj/machinery/status_display/evac,
@@ -28267,7 +27534,6 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "aTi" = (
-/obj/structure/flora/junglebush/large,
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/medical/virology)
@@ -28725,9 +27991,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -28904,7 +28167,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "aUc" = (
-/obj/effect/turf_decal/loading_area,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
@@ -29330,9 +28592,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-18"
-	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/storage)
 "aUG" = (
@@ -29711,7 +28970,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "aVc" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -29750,9 +29008,6 @@
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-18"
 	},
 /obj/machinery/light_switch{
 	pixel_x = -24;
@@ -29872,16 +29127,12 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/science/storage)
 "aVm" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -29956,9 +29207,7 @@
 /area/crew_quarters/kitchen)
 "aVr" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -30142,7 +29391,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -30154,7 +29402,6 @@
 	pixel_x = -6;
 	pixel_y = 8
 	},
-/obj/item/restraints/handcuffs,
 /obj/item/pen,
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
@@ -30226,7 +29473,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/janitor)
 "aVN" = (
 /obj/structure/chair{
@@ -30649,10 +29896,7 @@
 /area/security/checkpoint/medical)
 "aWs" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -30666,10 +29910,6 @@
 /turf/open/floor/grass,
 /area/hallway/secondary/exit/departure_lounge)
 "aWt" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -30893,22 +30133,18 @@
 "aWQ" = (
 /obj/machinery/door/firedoor,
 /obj/effect/decal/cleanable/blood/old,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "aWR" = (
 /turf/closed/wall,
 /area/science/xenobiology)
 "aWS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/newscaster{
+	pixel_x = 30
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
+/turf/open/floor/wood,
+/area/crew_quarters/locker)
 "aWT" = (
 /obj/structure/closet/secure_closet/chemical,
 /obj/structure/window/reinforced{
@@ -31070,7 +30306,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/storage)
 "aXi" = (
@@ -31122,6 +30357,8 @@
 	pixel_y = 4
 	},
 /obj/item/stock_parts/cell/high,
+/obj/item/clothing/glasses/science,
+/obj/item/clothing/glasses/science,
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aXo" = (
@@ -31232,11 +30469,6 @@
 	dir = 4
 	},
 /obj/item/folder,
-/obj/item/nanite_scanner{
-	pixel_x = -4;
-	pixel_y = 4
-	},
-/obj/item/nanite_remote,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -31303,7 +30535,6 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/science/robotics/mechbay)
 "aXD" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -31325,17 +30556,18 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "aXE" = (
-/obj/machinery/nanite_chamber,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Cabin_4Privacy";
+	name = "Cabin 4 Privacy Shutter"
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/research)
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/locker)
 "aXF" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/computer/nanite_chamber_control,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -31351,6 +30583,12 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
+/obj/structure/table/reinforced,
+/obj/item/multitool{
+	pixel_x = -4;
+	pixel_y = 3
+	},
+/obj/item/integrated_electronics/analyzer,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aXG" = (
@@ -31428,11 +30666,6 @@
 /area/tcommsat/server)
 "aXN" = (
 /obj/machinery/igniter/incinerator_toxmix,
-/mob/living/simple_animal/chicken{
-	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 1, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0);
-	desc = "A timeless classic.";
-	name = "Kentucky"
-	},
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "aXO" = (
@@ -31531,13 +30764,9 @@
 /area/maintenance/starboard/fore)
 "aXX" = (
 /obj/structure/chair/office/light{
-	dir = 1;
-	pixel_y = 3
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/box/red,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -31886,7 +31115,6 @@
 	id = "emmd";
 	name = "Emergency Medical Lockdown Shutters"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
@@ -32013,20 +31241,9 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/chemistry)
 "aYM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "aYN" = (
-/obj/machinery/nanite_program_hub,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -32038,6 +31255,8 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/obj/structure/table/reinforced,
+/obj/item/stack/sheet/metal/ten,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aYO" = (
@@ -32064,14 +31283,16 @@
 /turf/open/floor/plasteel/grimy,
 /area/crew_quarters/bar)
 "aYR" = (
-/obj/machinery/computer/nanite_cloud_controller,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
+/obj/effect/spawner/structure/window/reinforced,
+/obj/machinery/door/poddoor/shutters/preopen{
+	id = "Cabin_3Privacy";
+	name = "Cabin 3 Privacy Shutter"
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/research)
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/plating,
+/area/crew_quarters/locker)
 "aYS" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32086,7 +31307,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aYT" = (
-/obj/machinery/nanite_programmer,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -32097,6 +31317,9 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
+	},
+/obj/machinery/modular_computer/console/preset/civilian{
+	dir = 8
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/research)
@@ -32137,10 +31360,20 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "aYZ" = (
-/obj/effect/turf_decal/box,
-/obj/effect/decal/cleanable/blood/old,
-/turf/open/floor/engine,
-/area/ai_monitored/turret_protected/ai_upload)
+/obj/structure/cable{
+	icon_state = "2-8"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
+/turf/open/floor/plating/airless{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/maintenance/port/aft)
 "aZa" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
@@ -32204,24 +31437,31 @@
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aZf" = (
-/obj/machinery/door/airlock/maintenance{
-	name = "backstage maintenance";
-	req_access_txt = "46"
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/central)
+/turf/open/floor/plasteel/showroomfloor,
+/area/crew_quarters/theatre)
 "aZg" = (
-/obj/structure/filingcabinet/chestdrawer,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
+/turf/open/floor/plasteel,
+/area/hallway/primary/central)
 "aZh" = (
 /obj/machinery/porta_turret/ai,
 /obj/machinery/light/small{
@@ -32238,25 +31478,10 @@
 /turf/closed/wall,
 /area/science/lab)
 "aZj" = (
-/obj/structure/table,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/clipboard,
-/obj/item/reagent_containers/glass/beaker/large{
-	pixel_x = -6
-	},
-/obj/item/reagent_containers/glass/beaker{
-	pixel_x = 6
-	},
-/obj/item/clothing/glasses/science,
-/obj/item/clothing/glasses/science,
-/obj/structure/extinguisher_cabinet{
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/dark,
-/area/science/lab)
+/obj/effect/turf_decal/bot,
+/obj/machinery/holopad,
+/turf/open/floor/plasteel,
+/area/hallway/secondary/exit/departure_lounge)
 "aZk" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/neutral{
@@ -32268,9 +31493,6 @@
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/glass/fifty,
 /obj/item/clothing/glasses/welding,
-/obj/item/radio/intercom{
-	pixel_x = 28
-	},
 /turf/open/floor/plasteel/dark,
 /area/science/lab)
 "aZl" = (
@@ -32649,7 +31871,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "aZP" = (
@@ -33001,7 +32222,6 @@
 /obj/structure/sign/warning/vacuum{
 	pixel_x = 32
 	},
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "bar" = (
@@ -33117,9 +32337,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "baz" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -33346,16 +32563,6 @@
 /turf/open/floor/circuit/green/telecomms/mainframe,
 /area/science/server)
 "baQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -33722,7 +32929,6 @@
 /area/science/mixing)
 "bbt" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/engine/vacuum,
 /area/science/mixing/chamber)
 "bbv" = (
@@ -33762,16 +32968,6 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "bbz" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -33852,8 +33048,6 @@
 /turf/open/floor/engine,
 /area/ai_monitored/turret_protected/ai_upload)
 "bbH" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple,
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -33919,15 +33113,8 @@
 	dir = 4
 	},
 /obj/item/clipboard,
-/obj/item/nanite_remote{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/item/nanite_scanner{
-	pixel_x = 4
 	},
 /obj/machinery/light{
 	dir = 1
@@ -34072,7 +33259,6 @@
 /turf/closed/wall/r_wall,
 /area/science/mixing/chamber)
 "bbY" = (
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -34432,8 +33618,12 @@
 	},
 /area/maintenance/port)
 "bcD" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/mixing)
+/obj/effect/turf_decal/box,
+/obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hallway/primary/aft)
 "bcE" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable{
@@ -34767,7 +33957,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bcY" = (
 /obj/structure/grille/broken,
@@ -34805,7 +33995,6 @@
 /area/crew_quarters/kitchen)
 "bda" = (
 /obj/machinery/door/firedoor/heavy,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/science/mixing/chamber)
 "bdb" = (
@@ -34855,7 +34044,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "bdg" = (
@@ -35360,12 +34548,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard)
 "bdO" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -35482,7 +34664,6 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "bdV" = (
@@ -35855,7 +35036,6 @@
 	pixel_x = -32;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/fore)
 "bev" = (
@@ -35934,7 +35114,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "beC" = (
@@ -35977,7 +35156,6 @@
 "beF" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/medical/medbay/central)
 "beG" = (
@@ -36398,6 +35576,7 @@
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/shieldwallgen/xenobiologyaccess,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -36747,7 +35926,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "bfT" = (
@@ -36802,7 +35980,6 @@
 "bfX" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "bfY" = (
@@ -36824,6 +36001,9 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/components/unary/thermomachine/freezer/on{
 	name = "euthanization chamber freezer"
+	},
+/obj/structure/cable{
+	icon_state = "4-8"
 	},
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
@@ -36926,7 +36106,6 @@
 	pixel_x = 32;
 	pixel_y = -8
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "bgi" = (
@@ -37305,16 +36484,6 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "bgK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -37393,10 +36562,6 @@
 /turf/open/floor/grass,
 /area/medical/virology)
 "bgP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -37412,7 +36577,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bgQ" = (
 /obj/structure/cable{
@@ -38090,16 +37255,6 @@
 /turf/open/floor/plating,
 /area/quartermaster/office)
 "bhY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bhZ" = (
@@ -38153,16 +37308,6 @@
 	},
 /area/maintenance/port)
 "bie" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -38458,16 +37603,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/science/research)
 "biC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -38782,16 +37917,6 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/supply)
 "biX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -38850,7 +37975,6 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/loading_area,
-/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -38866,7 +37990,6 @@
 	},
 /obj/effect/turf_decal/loading_area,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bjd" = (
@@ -39030,16 +38153,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/miningoffice)
 "bjp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
@@ -39084,16 +38197,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
 "bjt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -39113,7 +38216,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/tank/internals/oxygen/yellow,
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningoffice)
 "bjv" = (
@@ -39124,7 +38226,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/tank/internals/oxygen/yellow,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -39176,7 +38277,6 @@
 	dir = 1;
 	pixel_y = 3
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -39197,7 +38297,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -39369,16 +38468,6 @@
 /turf/open/floor/plating,
 /area/maintenance/central)
 "bjN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -39424,21 +38513,11 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -39679,16 +38758,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/office)
 "bks" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bkt" = (
@@ -39787,16 +38856,6 @@
 /area/quartermaster/sorting)
 "bkA" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -39821,7 +38880,6 @@
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/arrows,
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -39930,7 +38988,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/tank/internals/oxygen/yellow,
 /obj/machinery/light,
 /obj/machinery/requests_console{
 	department = "Mining";
@@ -40125,16 +39182,6 @@
 /turf/open/floor/plating,
 /area/maintenance/port)
 "blb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -40208,16 +39255,6 @@
 /turf/open/floor/plasteel/dark,
 /area/quartermaster/miningoffice)
 "bli" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -40227,16 +39264,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "blj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -40331,16 +39358,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/medical/virology)
 "blq" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -40348,16 +39365,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "blr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
@@ -40435,16 +39442,6 @@
 /area/quartermaster/storage)
 "blz" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
@@ -40474,36 +39471,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/showroomfloor,
 /area/library)
-"blC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/storage)
 "blD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -40582,16 +39550,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/qm)
 "blK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
@@ -40600,16 +39558,6 @@
 /area/quartermaster/storage)
 "blL" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -40840,7 +39788,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bmf" = (
 /obj/effect/turf_decal/tile/brown{
@@ -41214,7 +40162,6 @@
 	},
 /obj/effect/turf_decal/arrows,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
 /obj/machinery/firealarm{
 	dir = 4;
 	pixel_x = -24
@@ -41231,7 +40178,7 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bmF" = (
 /obj/machinery/status_display/evac,
@@ -41246,7 +40193,7 @@
 /obj/machinery/plantgenes{
 	pixel_y = 5
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bmH" = (
 /obj/effect/turf_decal/tile/red{
@@ -41274,16 +40221,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bmJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
@@ -41403,7 +40340,7 @@
 /area/crew_quarters/kitchen)
 "bmU" = (
 /obj/structure/lattice,
-/turf/closed/wall/r_wall/rust,
+/turf/closed/wall/r_wall,
 /area/security/prison)
 "bmV" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -41508,7 +40445,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 6
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -41667,10 +40603,6 @@
 /area/crew_quarters/locker)
 "bnq" = (
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
-/obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -41766,17 +40698,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/library)
-"bny" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "bnz" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -41832,31 +40753,7 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
-"bnD" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
-/obj/structure/extinguisher_cabinet{
-	pixel_x = -26
-	},
-/turf/open/floor/plasteel/dark,
-/area/hydroponics)
 "bnE" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	name = "kitchen sorting disposal pipe";
 	sortType = 20
@@ -41898,9 +40795,7 @@
 /area/bridge)
 "bnH" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -41973,20 +40868,6 @@
 /obj/item/toy/figure/chef,
 /turf/open/floor/plating,
 /area/crew_quarters/kitchen)
-"bnM" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/structure/sign/departments/science{
-	pixel_x = 32
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bnN" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 1
@@ -42035,11 +40916,7 @@
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bnR" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -42047,17 +40924,6 @@
 	dir = 8
 	},
 /turf/open/floor/grass,
-/area/hydroponics)
-"bnS" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 8
-	},
-/obj/structure/sign/poster/official/fruit_bowl{
-	pixel_x = -32
-	},
-/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bnT" = (
 /obj/structure/flora/grass/jungle/b,
@@ -42152,10 +41018,7 @@
 /area/security/courtroom)
 "boa" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -42165,24 +41028,12 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "bob" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
 /obj/structure/window/reinforced,
 /turf/open/floor/grass,
-/area/hydroponics)
-"boc" = (
-/obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bod" = (
 /obj/effect/turf_decal/tile/brown{
@@ -42267,10 +41118,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "boh" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -42941,12 +41789,9 @@
 /area/crew_quarters/kitchen)
 "bpi" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/junglebush/b,
 /obj/item/radio/intercom{
 	pixel_y = -28
 	},
-/obj/effect/decal/remains/human,
-/obj/effect/decal/cleanable/blood/old,
 /turf/open/floor/grass,
 /area/hydroponics)
 "bpj" = (
@@ -43159,10 +42004,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -43180,10 +42021,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -43223,10 +42060,6 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -43234,9 +42067,6 @@
 	dir = 8
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bpE" = (
@@ -43272,7 +42102,7 @@
 /area/quartermaster/storage)
 "bpF" = (
 /obj/structure/sign/departments/cargo,
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/hallway/primary/starboard)
 "bpG" = (
 /obj/effect/turf_decal/tile/neutral,
@@ -43366,16 +42196,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "bpN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
@@ -43454,24 +42274,6 @@
 /obj/structure/sign/departments/botany,
 /turf/closed/wall,
 /area/hallway/primary/starboard)
-"bpW" = (
-/obj/effect/turf_decal/tile/purple,
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/purple,
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bpX" = (
 /obj/machinery/door/poddoor/preopen{
 	id = "brigfrontdoor";
@@ -43480,7 +42282,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_y = 28
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -43528,7 +42329,7 @@
 /area/bridge)
 "bqb" = (
 /obj/structure/sign/departments/custodian,
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/maintenance/central)
 "bqc" = (
 /obj/effect/turf_decal/bot,
@@ -43551,10 +42352,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bqe" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -43577,9 +42374,6 @@
 /turf/open/floor/plasteel/dark,
 /area/teleporter)
 "bqg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
@@ -43601,7 +42395,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 22
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "bqj" = (
 /obj/effect/turf_decal/tile/red,
@@ -43652,8 +42446,13 @@
 /area/crew_quarters/kitchen)
 "bqm" = (
 /obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/supply/hidden,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
-/area/bridge)
+/area/security/warden)
 "bqn" = (
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
@@ -43676,16 +42475,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "bqp" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 9
 	},
@@ -43707,17 +42496,15 @@
 	},
 /area/maintenance/central)
 "bqs" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
+/obj/structure/cable{
+	icon_state = "4-8"
+	},
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
-/area/bridge)
+/area/security/main)
 "bqt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
 	},
@@ -43808,8 +42595,6 @@
 "bqA" = (
 /obj/structure/table,
 /obj/item/folder/white,
-/obj/item/restraints/handcuffs,
-/obj/item/wirerod,
 /obj/item/pen,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -43981,16 +42766,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
@@ -44091,16 +42866,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bqT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -44111,18 +42876,17 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bqU" = (
-/obj/structure/table/wood,
-/obj/item/clothing/gloves/color/rainbow/clown,
-/obj/item/storage/crayons,
-/obj/item/storage/crayons,
-/obj/item/bikehorn/rubberducky,
-/obj/structure/sign/poster/contraband/clown{
-	pixel_x = -30
+/obj/effect/turf_decal/tile/red,
+/obj/effect/turf_decal/tile/red{
+	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/dark,
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/theatre)
 "bqV" = (
 /obj/effect/turf_decal/bot,
@@ -44300,16 +43064,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard)
 "bri" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
@@ -44361,7 +43115,9 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister,
-/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bro" = (
@@ -44370,7 +43126,9 @@
 	},
 /obj/machinery/portable_atmospherics/canister,
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "brp" = (
@@ -44487,7 +43245,6 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "brA" = (
@@ -44665,22 +43422,7 @@
 /area/crew_quarters/bar/atrium)
 "brN" = (
 /obj/machinery/hydroponics/constructable,
-/obj/effect/turf_decal/bot,
-/obj/machinery/light{
-	dir = 4
-	},
-/obj/machinery/firealarm{
-	dir = 8;
-	pixel_x = 28
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "brO" = (
 /obj/machinery/hydroponics/constructable,
@@ -44689,7 +43431,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/hydroponics)
 "brP" = (
 /obj/structure/table,
@@ -44953,19 +43695,10 @@
 	},
 /area/maintenance/central/secondary)
 "bsm" = (
-/turf/closed/wall/rust,
-/area/chapel/office)
+/obj/machinery/status_display/evac,
+/turf/open/floor/plasteel,
+/area/engine/supermatter)
 "bsn" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -45024,9 +43757,6 @@
 /area/lawoffice)
 "bss" = (
 /obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
 /obj/structure/cable{
@@ -45049,16 +43779,6 @@
 	},
 /area/hallway/primary/port)
 "bst" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -45083,16 +43803,6 @@
 /turf/open/floor/plasteel/dark/corner,
 /area/hallway/primary/port)
 "bsv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail/flip{
 	dir = 2;
 	name = "cargo sorting disposal pipe";
@@ -45186,12 +43896,6 @@
 /turf/open/floor/plasteel,
 /area/security/courtroom)
 "bsC" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -45205,13 +43909,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "bsE" = (
-/turf/open/floor/plasteel,
-/area/bridge)
-"bsF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/bridge)
 "bsG" = (
@@ -45334,10 +44031,7 @@
 /area/library)
 "bsN" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 8
 	},
@@ -45348,10 +44042,7 @@
 /turf/open/floor/grass,
 /area/crew_quarters/heads/hop)
 "bsO" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -45359,11 +44050,7 @@
 /turf/open/floor/grass,
 /area/crew_quarters/heads/hop)
 "bsP" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -45534,12 +44221,6 @@
 	id = "QMLoad";
 	name = "off ramp";
 	pixel_y = 5
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -45755,7 +44436,6 @@
 "btt" = (
 /obj/machinery/door/firedoor,
 /obj/structure/disposalpipe/segment,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "btu" = (
@@ -45896,8 +44576,6 @@
 "btH" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/fullgrass,
-/obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -45913,10 +44591,7 @@
 /area/crew_quarters/bar)
 "btI" = (
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -46038,17 +44713,7 @@
 /obj/structure/bookcase/random/reference,
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
-"btU" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/bar)
 "btV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -46112,11 +44777,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	pixel_x = 8;
-	pixel_y = 3
-	},
 /obj/machinery/light_switch{
 	pixel_x = 24;
 	pixel_y = 40
@@ -46127,17 +44787,6 @@
 	pixel_x = 24;
 	pixel_y = 24;
 	req_access_txt = "25"
-	},
-/turf/open/floor/plasteel/dark,
-/area/crew_quarters/bar)
-"bub" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-02";
-	pixel_y = 3
 	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
@@ -46255,12 +44904,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "buk" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -46331,10 +44974,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "bur" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
@@ -47069,7 +45708,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/starboard)
 "bvC" = (
@@ -47184,7 +45822,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "bvL" = (
@@ -47255,16 +45892,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/toilet/restrooms)
 "bvQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -47313,10 +45940,6 @@
 /turf/open/floor/plasteel/dark,
 /area/library)
 "bvV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-16"
 	},
@@ -47385,7 +46008,6 @@
 /area/crew_quarters/heads/captain)
 "bwc" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "bwd" = (
@@ -47409,9 +46031,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-16"
 	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
@@ -47688,16 +46307,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "bwF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
 	},
@@ -47879,10 +46488,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/chapel/main)
-"bwU" = (
-/obj/structure/flora/grass/jungle,
-/turf/open/floor/grass,
-/area/chapel/main)
 "bwV" = (
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
@@ -47917,11 +46522,13 @@
 /turf/open/floor/plasteel/dark,
 /area/security/checkpoint/supply)
 "bwY" = (
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel{
 	dir = 8
 	},
 /area/chapel/main)
 "bwZ" = (
+/obj/structure/chair/stool,
 /turf/open/floor/plasteel/chapel,
 /area/chapel/main)
 "bxa" = (
@@ -48016,10 +46623,7 @@
 /area/chapel/main)
 "bxh" = (
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -48141,10 +46745,7 @@
 /area/quartermaster/storage)
 "bxt" = (
 /obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -48479,10 +47080,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/virology)
 "bxW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -48549,9 +47146,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-22"
 	},
 /obj/machinery/light,
 /obj/machinery/airalarm{
@@ -48829,16 +47423,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "byv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -48919,7 +47503,6 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/door/firedoor,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -49759,6 +48342,9 @@
 /obj/machinery/newscaster/security_unit{
 	pixel_x = 28
 	},
+/obj/structure/window/reinforced{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/captain)
 "bzQ" = (
@@ -50499,12 +49085,6 @@
 	name = "on ramp";
 	pixel_y = 6
 	},
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bAV" = (
@@ -50560,7 +49140,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
-/obj/effect/decal/cleanable/blood/old,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -50598,14 +49177,10 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bBc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/turf/open/floor/plasteel/dark/corner,
+/turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bBd" = (
 /obj/machinery/vending/tool,
@@ -50631,19 +49206,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
-"bBf" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bBg" = (
@@ -50697,7 +49259,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "bBk" = (
@@ -51120,16 +49681,6 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "bBS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -51192,16 +49743,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bBV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
 	},
@@ -51209,16 +49750,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bBW" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -51267,16 +49798,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bCa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -51617,14 +50138,11 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "bCG" = (
-/obj/effect/turf_decal/loading_area{
-	dir = 1
-	},
 /obj/machinery/atmospherics/components/binary/pump{
 	dir = 1;
 	name = "External Gas to Loop"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/engine,
 /area/engine/engineering)
 "bCH" = (
 /obj/effect/turf_decal/tile/blue{
@@ -52514,19 +51032,6 @@
 	luminosity = 2
 	},
 /area/storage/tech)
-"bEa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/closet/emcloset/anchored,
-/obj/machinery/light/small{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/port/aft)
 "bEb" = (
 /obj/structure/cable{
 	icon_state = "0-4"
@@ -52838,16 +51343,6 @@
 	},
 /area/maintenance/port/aft)
 "bEA" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -52857,16 +51352,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
@@ -52874,32 +51359,12 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bEC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bED" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 8
@@ -52922,16 +51387,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bEG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -53202,7 +51657,9 @@
 	dir = 1
 	},
 /obj/machinery/portable_atmospherics/canister/nitrogen,
-/obj/effect/turf_decal/box,
+/obj/effect/turf_decal/bot{
+	dir = 1
+	},
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bFi" = (
@@ -53308,6 +51765,9 @@
 	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/light/small{
+	dir = 4
+	},
 /turf/open/floor/plating{
 	icon_state = "platingdmg3"
 	},
@@ -54287,10 +52747,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "bGS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -54321,15 +52777,6 @@
 	},
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
-"bGW" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bGX" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -54625,21 +53072,6 @@
 /obj/item/bedsheet/brown,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"bHv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "bHw" = (
 /obj/structure/table,
 /obj/effect/turf_decal/tile/red{
@@ -54678,16 +53110,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bHy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/box,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
@@ -54952,16 +53374,6 @@
 	},
 /area/hallway/primary/central)
 "bHP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
@@ -54974,9 +53386,6 @@
 "bHS" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/security/processing)
 "bHT" = (
@@ -55510,16 +53919,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bIO" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
 /turf/open/floor/plasteel,
@@ -55530,12 +53929,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/security/processing)
@@ -55808,13 +54201,7 @@
 	pixel_x = 6
 	},
 /obj/item/pen,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -55826,12 +54213,6 @@
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
 	},
 /obj/item/storage/toolbox/mechanical{
 	pixel_x = 2;
@@ -55891,16 +54272,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/locker)
 "bJs" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
@@ -56249,13 +54620,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bJT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
@@ -56276,7 +54640,7 @@
 	dir = 1
 	},
 /turf/open/floor/wood{
-	icon_state = "wood-broken6"
+	icon_state = "wood-broken5"
 	},
 /area/crew_quarters/locker)
 "bJV" = (
@@ -56312,9 +54676,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/aft)
 "bJY" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/structure/table/wood,
+/obj/item/folder/red,
+/obj/item/lighter,
 /obj/machinery/button/door{
 	id = "Cabin_2";
 	name = "Cabin 2 Privacy Lock";
@@ -56322,14 +54686,7 @@
 	pixel_y = 24;
 	specialfunctions = 4
 	},
-/obj/machinery/airalarm{
-	dir = 8;
-	pixel_x = 24
-	},
-/obj/effect/landmark/start/assistant,
-/turf/open/floor/wood{
-	icon_state = "wood-broken3"
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bJZ" = (
 /obj/machinery/light/small{
@@ -56338,9 +54695,7 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken"
-	},
+/turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bKa" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -56369,56 +54724,32 @@
 	},
 /turf/open/floor/wood,
 /area/crew_quarters/locker)
-"bKc" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/machinery/button/door{
-	id = "Cabin_4Privacy";
-	name = "Cabin 4 Privacy Toggle";
-	pixel_x = -24;
-	pixel_y = -24
-	},
-/turf/open/floor/wood{
-	icon_state = "wood-broken4"
-	},
-/area/crew_quarters/locker)
 "bKd" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/newscaster{
-	pixel_x = -30
-	},
-/obj/machinery/button/door{
-	id = "Cabin_3Privacy";
-	name = "Cabin 3 Privacy Toggle";
-	pixel_x = -24;
-	pixel_y = -24
-	},
 /turf/open/floor/wood{
-	icon_state = "wood-broken5"
+	icon_state = "wood-broken6"
 	},
-/area/crew_quarters/locker)
-"bKe" = (
-/obj/structure/dresser,
-/turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bKf" = (
 /obj/structure/sign/poster/contraband/revolver,
 /turf/closed/wall,
 /area/crew_quarters/locker)
 "bKg" = (
-/obj/structure/table/wood,
-/obj/item/folder/red,
-/obj/item/lighter,
-/turf/open/floor/wood,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
 /area/crew_quarters/locker)
 "bKh" = (
-/obj/structure/closet/secure_closet/personal/cabinet,
-/obj/machinery/newscaster{
-	pixel_x = 30
+/obj/structure/bed,
+/obj/item/bedsheet/black,
+/obj/effect/decal/cleanable/cobweb/cobweb2,
+/obj/machinery/airalarm{
+	dir = 8;
+	pixel_x = 24
 	},
-/turf/open/floor/wood,
+/obj/effect/landmark/start/assistant,
+/turf/open/floor/wood{
+	icon_state = "wood-broken3"
+	},
 /area/crew_quarters/locker)
 "bKi" = (
 /obj/effect/turf_decal/tile/blue{
@@ -56438,12 +54769,19 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/locker)
 "bKk" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Cabin_4Privacy";
-	name = "Cabin 4 Privacy Shutter"
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/newscaster{
+	pixel_x = -30
 	},
-/turf/open/floor/plating,
+/obj/machinery/button/door{
+	id = "Cabin_4Privacy";
+	name = "Cabin 4 Privacy Toggle";
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken4"
+	},
 /area/crew_quarters/locker)
 "bKl" = (
 /obj/structure/flora/rock/pile,
@@ -56845,9 +55183,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "bKP" = (
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -56944,9 +55279,6 @@
 /area/crew_quarters/toilet/restrooms)
 "bKU" = (
 /obj/effect/turf_decal/box,
-//obj/structure/toilet/secret/low_loot{
-	dir = 8
-	},
 /obj/structure/mirror{
 	pixel_x = -28
 	},
@@ -57282,18 +55614,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"bLr" = (
-/obj/effect/turf_decal/tile/yellow{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/yellow,
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/storage/primary)
 "bLs" = (
 /obj/structure/table,
 /obj/effect/decal/cleanable/cobweb,
@@ -57334,16 +55654,6 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "bLt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -57351,7 +55661,8 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bLu" = (
-/turf/closed/wall/rust,
+/obj/structure/dresser,
+/turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bLv" = (
 /obj/effect/turf_decal/tile/purple{
@@ -57542,16 +55853,6 @@
 /turf/open/floor/grass,
 /area/security/prison)
 "bLI" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57608,11 +55909,6 @@
 	name = "Prison Intercom (General)";
 	pixel_y = 22;
 	prison_radio = 1
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-17";
-	pixel_x = -8;
-	pixel_y = 3
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
@@ -57673,16 +55969,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness/recreation)
 "bLS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -57761,16 +56047,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "bLY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -57778,16 +56054,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bLZ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -57947,16 +56213,6 @@
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bMm" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -58045,7 +56301,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -58057,12 +56312,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -58466,10 +56715,6 @@
 /turf/open/floor/mech_bay_recharge_floor,
 /area/maintenance/port/aft)
 "bMY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bMZ" = (
@@ -58570,9 +56815,7 @@
 "bNi" = (
 /obj/structure/flora/grass/jungle/b,
 /obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -58613,9 +56856,6 @@
 "bNn" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
@@ -58758,7 +56998,6 @@
 	dir = 8;
 	pixel_y = -24
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -58836,8 +57075,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
 "bNH" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
 /obj/structure/flora/ausbushes/ppflowers,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
@@ -59196,10 +57433,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -59214,9 +57447,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
@@ -59280,7 +57510,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/storage/primary)
@@ -59454,16 +57683,6 @@
 /turf/closed/wall/rust,
 /area/maintenance/starboard/aft)
 "bOD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
@@ -59471,48 +57690,18 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bOE" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOG" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -59524,17 +57713,6 @@
 /turf/closed/wall,
 /area/janitor)
 "bOI" = (
-/obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -59542,16 +57720,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bOJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -59559,16 +57727,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOK" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -59592,16 +57750,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "bOM" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/effect/decal/cleanable/dirt,
@@ -59627,16 +57775,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/main)
 "bOP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bOQ" = (
@@ -59669,16 +57807,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bOS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -59755,21 +57883,11 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bOY" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
+/obj/structure/disposalpipe/segment{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/disposalpipe/segment{
-	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
@@ -59857,10 +57975,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bPh" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/ywflowers,
-/obj/structure/flora/ausbushes/fernybush,
 /turf/open/floor/grass,
 /area/security/prison)
 "bPi" = (
@@ -59984,7 +58098,7 @@
 /area/hallway/primary/central)
 "bPp" = (
 /obj/machinery/status_display/shuttle,
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/security/courtroom)
 "bPq" = (
 /obj/machinery/door/airlock/maintenance{
@@ -60133,7 +58247,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 10
 	},
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/maintenance/starboard/aft)
 "bPA" = (
 /obj/effect/turf_decal/tile/red,
@@ -60157,16 +58271,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "bPB" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -60269,16 +58373,6 @@
 	},
 /area/hallway/secondary/entry)
 "bPL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/sorting/mail{
 	dir = 8;
 	name = "HoP sorting disposal pipe";
@@ -60369,10 +58463,6 @@
 	},
 /area/maintenance/port/aft)
 "bPR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -60516,16 +58606,6 @@
 	},
 /area/space/nearstation)
 "bQd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment{
@@ -60572,15 +58652,6 @@
 /area/hallway/primary/starboard)
 "bQh" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
@@ -60616,7 +58687,6 @@
 /obj/machinery/door/airlock/public/glass{
 	name = "Engineering Hallway"
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "bQl" = (
@@ -60750,16 +58820,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "bQv" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
 	},
@@ -60820,10 +58880,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -60841,9 +58897,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -60869,9 +58922,6 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 8
 	},
@@ -61305,10 +59355,6 @@
 "bRf" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/red,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-02";
-	pixel_y = 3
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -61361,16 +59407,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bRj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -61518,19 +59554,6 @@
 	},
 /obj/effect/turf_decal/bot,
 /obj/machinery/holopad,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
-"bRt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bRu" = (
@@ -61849,16 +59872,6 @@
 	},
 /area/maintenance/aft)
 "bRU" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61871,16 +59884,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bRV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61926,16 +59929,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bRZ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61955,16 +59948,6 @@
 /turf/open/floor/engine,
 /area/storage/tech)
 "bSb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -61975,16 +59958,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bSc" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 4
 	},
@@ -61996,9 +59969,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bSd" = (
-/turf/closed/wall/rust,
-/area/hallway/secondary/entry)
 "bSe" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/delivery,
@@ -62104,9 +60074,6 @@
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -62120,17 +60087,11 @@
 	},
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/disposalpipe/junction/flip,
 /turf/open/floor/plasteel,
 /area/storage/primary)
 "bSn" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/fullgrass,
 /obj/structure/flora/ausbushes/brflowers,
-/obj/structure/flora/ausbushes/leafybush,
 /obj/structure/window/reinforced,
 /obj/structure/window/reinforced{
 	dir = 1
@@ -62450,19 +60411,9 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
-"bSQ" = (
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/turf/closed/wall,
-/area/hallway/secondary/exit/departure_lounge)
 "bSR" = (
 /obj/machinery/shower{
 	dir = 8;
@@ -62591,7 +60542,6 @@
 /obj/structure/sign/departments/engineering{
 	pixel_x = 32
 	},
-/obj/effect/turf_decal/delivery,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
@@ -62656,16 +60606,6 @@
 /turf/open/floor/engine,
 /area/storage/tech)
 "bTe" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/airalarm{
 	dir = 4;
@@ -62787,12 +60727,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bTr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/power/apc{
 	areastring = "/area/hallway/secondary/entry";
 	dir = 0;
@@ -62875,16 +60809,6 @@
 /turf/closed/wall/rust,
 /area/hallway/secondary/exit/departure_lounge)
 "bTy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -62903,9 +60827,6 @@
 /obj/machinery/airalarm{
 	dir = 4;
 	pixel_x = -22
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
@@ -63272,9 +61193,6 @@
 /turf/closed/wall,
 /area/hallway/secondary/entry)
 "bUa" = (
-/obj/structure/bed,
-/obj/item/bedsheet/black,
-/obj/effect/landmark/start/assistant,
 /turf/open/floor/wood,
 /area/crew_quarters/locker)
 "bUb" = (
@@ -63340,15 +61258,6 @@
 /area/hallway/secondary/entry)
 "bUg" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
@@ -63418,9 +61327,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
-"bUl" = (
-/turf/closed/wall,
-/area/security/vacantoffice)
 "bUm" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/public/glass{
@@ -63466,7 +61372,7 @@
 	dir = 10
 	},
 /turf/open/floor/plasteel,
-/area/security/warden)
+/area/space)
 "bUs" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/command/glass{
@@ -63698,6 +61604,7 @@
 /area/security/processing)
 "bUQ" = (
 /obj/machinery/light/floor,
+/obj/machinery/portable_atmospherics/canister/air,
 /turf/open/floor/engine/air,
 /area/engine/atmos)
 "bUR" = (
@@ -63777,16 +61684,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bVa" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/junction/flip{
 	dir = 8
 	},
@@ -64290,13 +62187,6 @@
 	},
 /area/maintenance/central/secondary)
 "bVL" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
@@ -64308,10 +62198,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8;
-	icon_state = "intact"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -65329,10 +63215,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"bXo" = (
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bXp" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -65388,16 +63270,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bXu" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/box/corners{
 	dir = 1
 	},
@@ -65441,20 +63313,6 @@
 /obj/structure/sign/departments/evac,
 /turf/closed/wall,
 /area/hallway/secondary/exit/departure_lounge)
-"bXy" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/dirt,
-/turf/open/floor/plasteel,
-/area/hallway/secondary/exit/departure_lounge)
 "bXz" = (
 /obj/effect/turf_decal/bot,
 /obj/effect/decal/cleanable/cobweb/cobweb2,
@@ -65484,16 +63342,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bXC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -65518,16 +63366,6 @@
 /area/hallway/secondary/exit/departure_lounge)
 "bXE" = (
 /obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -65611,7 +63449,6 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
@@ -66138,12 +63975,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bYw" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -66485,31 +64316,6 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
-"bYS" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plasteel,
-/area/security/brig)
 "bYT" = (
 /obj/machinery/power/apc/highcap/five_k{
 	areastring = "/area/security/prison";
@@ -66585,13 +64391,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "bYZ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-10"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "bZa" = (
@@ -66730,10 +64529,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bZk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/entry)
 "bZl" = (
@@ -66835,16 +64630,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "bZr" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
@@ -66956,20 +64741,8 @@
 	dir = 1
 	},
 /area/hallway/primary/starboard)
-"bZA" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/turf/open/floor/plasteel,
-/area/hallway/primary/starboard)
 "bZB" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -66984,16 +64757,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/secondary/exit/departure_lounge)
 "bZD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -67078,24 +64841,14 @@
 	},
 /area/hallway/primary/starboard)
 "bZJ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 4
 	},
 /obj/structure/cable{
 	icon_state = "2-4"
+	},
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 4
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -67143,24 +64896,14 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "bZN" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 5
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/machinery/atmospherics/pipe/simple/supply/hidden{
+	dir = 5
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
@@ -67201,16 +64944,6 @@
 /turf/open/floor/plasteel/dark,
 /area/janitor)
 "bZR" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 5
 	},
@@ -67369,16 +65102,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cad" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 4
 	},
@@ -67454,15 +65177,8 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cak" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
 	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
@@ -67482,16 +65198,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "cal" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -67564,16 +65270,6 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/primary)
 "car" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -67622,10 +65318,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cau" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -67746,7 +65438,6 @@
 /obj/machinery/door/firedoor,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "caE" = (
@@ -68022,10 +65713,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/central)
 "cbb" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/structure/cable{
@@ -68236,9 +65923,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 10
 	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
 "cbw" = (
@@ -68304,7 +65988,6 @@
 /area/maintenance/starboard)
 "cbA" = (
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cbB" = (
@@ -68406,16 +66089,6 @@
 	},
 /area/hallway/primary/port)
 "cbH" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1{
 	dir = 1
 	},
@@ -68430,24 +66103,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel/dark/corner,
-/area/hallway/primary/port)
-"cbJ" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/structure/cable{
-	icon_state = "1-4"
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
-/turf/open/floor/plasteel/dark/corner{
-	dir = 8
-	},
 /area/hallway/primary/port)
 "cbM" = (
 /obj/effect/turf_decal/tile/neutral{
@@ -68548,10 +66203,6 @@
 	},
 /area/maintenance/port/aft)
 "cbT" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 9
 	},
@@ -68723,10 +66374,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cci" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -68741,10 +66388,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
-	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8;
-	icon_state = "intact"
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -68992,10 +66635,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "ccM" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -69042,9 +66681,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "ccR" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -69101,7 +66737,6 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "ccX" = (
@@ -69217,28 +66852,14 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cdg" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/plaque{
 	icon_state = "L6"
 	},
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
-	dir = 8;
-	icon_state = "intact"
+/obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
+	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
@@ -69254,20 +66875,9 @@
 /area/maintenance/aft)
 "cdi" = (
 /obj/structure/flora/grass/jungle/b,
-/obj/structure/flora/ausbushes/sparsegrass,
 /turf/open/floor/grass,
 /area/security/prison)
 "cdj" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/item/beacon,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -69664,9 +67274,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
-"cdY" = (
-/turf/closed/wall/r_wall/rust,
-/area/maintenance/central)
 "cdZ" = (
 /turf/closed/wall/r_wall,
 /area/maintenance/central)
@@ -69706,7 +67313,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/locker)
 "ced" = (
@@ -69798,6 +67404,7 @@
 	pixel_x = 4;
 	req_access_txt = "16"
 	},
+/obj/item/toy/talking/AI,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
 "ceg" = (
@@ -69952,6 +67559,7 @@
 	pixel_x = -3;
 	req_access_txt = "16"
 	},
+/obj/item/toy/talking/AI,
 /turf/open/floor/circuit/red,
 /area/ai_monitored/turret_protected/ai)
 "cep" = (
@@ -70031,12 +67639,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "ceu" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 8
 	},
@@ -70066,12 +67668,6 @@
 /turf/open/floor/circuit/red/telecomms,
 /area/tcommsat/server)
 "cex" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden/layer1{
 	dir = 8
 	},
@@ -70088,12 +67684,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cey" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -70195,9 +67785,6 @@
 /area/ai_monitored/turret_protected/ai)
 "ceF" = (
 /turf/closed/wall/r_wall,
-/area/ai_monitored/turret_protected/aisat/atmos)
-"ceG" = (
-/turf/closed/wall/r_wall/rust,
 /area/ai_monitored/turret_protected/aisat/atmos)
 "ceH" = (
 /obj/effect/turf_decal/tile/yellow{
@@ -70970,9 +68557,6 @@
 "cfY" = (
 /turf/closed/wall/r_wall,
 /area/ai_monitored/storage/satellite)
-"cga" = (
-/turf/closed/wall/r_wall/rust,
-/area/ai_monitored/storage/satellite)
 "cgb" = (
 /obj/structure/closet/emcloset,
 /obj/effect/decal/cleanable/dirt,
@@ -71002,7 +68586,7 @@
 "cgg" = (
 /obj/structure/sign/warning/docking,
 /turf/closed/wall/rust,
-/area/hallway/secondary/entry)
+/area/hallway/secondary/exit/departure_lounge)
 "cgi" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -71190,9 +68774,6 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
-	},
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-05"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -71470,16 +69051,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/fore)
 "cgV" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 10
 	},
@@ -71651,10 +69222,6 @@
 /turf/closed/wall,
 /area/maintenance/fore)
 "chk" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -71700,10 +69267,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/brig)
 "chm" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -72172,9 +69735,6 @@
 /obj/structure/lattice/catwalk,
 /turf/open/floor/plating/airless,
 /area/solar/port/aft)
-"chV" = (
-/turf/closed/wall/rust,
-/area/ai_monitored/turret_protected/aisat_interior)
 "chW" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/hatch{
@@ -72805,7 +70365,6 @@
 	name = "Engine Access Shutters"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1{
 	dir = 8
 	},
@@ -73236,21 +70795,6 @@
 /obj/structure/sign/warning/securearea,
 /turf/closed/wall,
 /area/engine/gravity_generator)
-"cjC" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "cjD" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -73270,33 +70814,6 @@
 	icon_state = "panelscorched"
 	},
 /area/maintenance/starboard/aft)
-"cjF" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/machinery/status_display/ai{
-	pixel_y = 32
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
-"cjG" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/cobweb/cobweb2,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "cjH" = (
 /obj/machinery/door/firedoor,
 /obj/machinery/door/airlock/engineering{
@@ -73312,7 +70829,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/engineering)
 "cjI" = (
-/obj/effect/turf_decal/box,
 /obj/machinery/shower{
 	dir = 4;
 	name = "emergency shower"
@@ -73535,7 +71051,6 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
-/obj/effect/turf_decal/box,
 /obj/machinery/shower{
 	dir = 4;
 	name = "emergency shower"
@@ -74089,16 +71604,6 @@
 	icon_state = "platingdmg1"
 	},
 /area/engine/engineering)
-"clg" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "clh" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on/layer1,
 /turf/open/floor/plasteel,
@@ -74413,14 +71918,6 @@
 	luminosity = 2
 	},
 /area/engine/gravity_generator)
-"clF" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/decal/cleanable/greenglow,
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "clG" = (
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
@@ -74533,37 +72030,11 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/solars/port/aft)
-"clP" = (
-/obj/effect/turf_decal/box/corners{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/turf/open/floor/plasteel/dark,
-/area/engine/gravity_generator)
 "clQ" = (
 /obj/machinery/gravity_generator/main/station,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/decal/cleanable/greenglow,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "clR" = (
-/obj/effect/turf_decal/box/corners,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "clS" = (
@@ -74596,7 +72067,6 @@
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
-/obj/effect/turf_decal/tile/neutral,
 /turf/open/floor/plasteel,
 /area/security/processing)
 "clY" = (
@@ -74665,9 +72135,6 @@
 /area/engine/atmos)
 "cmc" = (
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -74923,7 +72390,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cmt" = (
@@ -75058,16 +72524,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cmD" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /turf/open/floor/plasteel,
@@ -75087,7 +72543,6 @@
 	dir = 8
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cmF" = (
@@ -75187,7 +72642,6 @@
 	},
 /obj/machinery/light/small,
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/engine/gravity_generator)
 "cmR" = (
@@ -75448,7 +72902,6 @@
 	dir = 4;
 	pixel_x = -26
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "cnn" = (
@@ -76060,6 +73513,10 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
+/mob/living/simple_animal/bot/cleanbot{
+	auto_patrol = 1;
+	name = "\imprper Cleaner Bot"
+	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "coI" = (
@@ -76244,16 +73701,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cpd" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
@@ -76553,16 +74000,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/atmos)
 "cpu" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer1,
 /obj/item/beacon,
@@ -76673,7 +74110,7 @@
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
-/turf/open/floor/plasteel/dark,
+/turf/open/floor/plasteel,
 /area/engine/engineering)
 "cpF" = (
 /obj/structure/flora/rock/pile,
@@ -76782,16 +74219,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/aft)
 "cpP" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
@@ -76799,16 +74226,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "cpQ" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/item/beacon,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -78380,16 +75797,6 @@
 /obj/structure/cable{
 	icon_state = "4-8"
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 1
 	},
@@ -79516,7 +76923,6 @@
 	id = "xeno_blastdoor";
 	name = "Xenobiology Containment Blast Door"
 	},
-/obj/effect/turf_decal/caution/stand_clear,
 /obj/structure/disposalpipe/junction{
 	dir = 4
 	},
@@ -81324,16 +78730,6 @@
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/cable{
 	icon_state = "2-8"
 	},
@@ -81662,10 +79058,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
 "cyY" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/port/fore)
@@ -82334,7 +79726,6 @@
 	name = "Emergency Research Blast Door"
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "cAY" = (
@@ -82465,7 +79856,6 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/item/gun/energy/e_gun/advtaser,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "cBp" = (
@@ -82665,12 +80055,19 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/central)
 "cBW" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/shutters/preopen{
-	id = "Cabin_3Privacy";
-	name = "Cabin 3 Privacy Shutter"
+/obj/structure/closet/secure_closet/personal/cabinet,
+/obj/machinery/newscaster{
+	pixel_x = -30
 	},
-/turf/open/floor/plating,
+/obj/machinery/button/door{
+	id = "Cabin_3Privacy";
+	name = "Cabin 3 Privacy Toggle";
+	pixel_x = -24;
+	pixel_y = -24
+	},
+/turf/open/floor/wood{
+	icon_state = "wood-broken5"
+	},
 /area/crew_quarters/locker)
 "cBX" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -82705,6 +80102,9 @@
 	},
 /obj/structure/flora/grass/jungle/b,
 /obj/machinery/light,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating/asteroid/airless{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -82718,6 +80118,9 @@
 	},
 /obj/structure/flora/ausbushes/palebush,
 /obj/machinery/light/small,
+/obj/structure/cable{
+	icon_state = "1-8"
+	},
 /turf/open/floor/plating/asteroid/airless{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -82933,7 +80336,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/barricade/wooden/crude,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -83150,9 +80552,6 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/fore)
 "cDr" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/item/twohanded/required/kirbyplants{
 	icon_state = "plant-02";
 	pixel_y = 3
@@ -83570,16 +80969,6 @@
 "cEk" = (
 /obj/structure/bookcase/random/nonfiction,
 /obj/effect/decal/cleanable/cobweb,
-/turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/fore)
-"cEl" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/blood/old,
-/obj/effect/decal/remains/human,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "cEm" = (
@@ -84065,7 +81454,6 @@
 	dir = 4
 	},
 /obj/machinery/door/firedoor,
-/obj/effect/turf_decal/caution/stand_clear,
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/aft)
 "cFC" = (
@@ -84097,7 +81485,6 @@
 /obj/machinery/door/airlock/maintenance{
 	req_access_txt = "12"
 	},
-/obj/structure/barricade/wooden/crude,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
 "cFJ" = (
@@ -84332,11 +81719,7 @@
 /turf/open/floor/engine/vacuum,
 /area/science/test_area)
 "cGz" = (
-/obj/structure/flora/grass/jungle,
-/obj/structure/flora/ausbushes/grassybush,
-/obj/structure/flora/ausbushes/genericbush,
 /obj/structure/flora/ausbushes/ppflowers,
-/obj/structure/flora/ausbushes/sunnybush,
 /obj/structure/window/reinforced{
 	dir = 4
 	},
@@ -84694,20 +82077,6 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
-"cHC" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/structure/disposalpipe/segment,
-/turf/open/floor/plasteel,
-/area/hallway/primary/aft)
 "cHD" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 6
@@ -84833,16 +82202,6 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/heads/chief)
 "cHS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/effect/landmark/event_spawn,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -84895,9 +82254,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -84922,15 +82278,6 @@
 	icon_state = "platingdmg3"
 	},
 /area/maintenance/aft)
-"cIe" = (
-/obj/machinery/door/airlock/research{
-	glass = 1;
-	name = "Slime Euthanization Chamber";
-	opacity = 0;
-	req_access_txt = "55"
-	},
-/turf/open/floor/plasteel/dark,
-/area/maintenance/starboard/fore)
 "cIf" = (
 /obj/machinery/atmospherics/components/unary/outlet_injector/on{
 	dir = 4
@@ -85091,16 +82438,6 @@
 /turf/open/floor/plasteel/dark,
 /area/storage/tcom)
 "cIw" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
@@ -85259,9 +82596,6 @@
 	dir = 1
 	},
 /obj/machinery/light,
-/obj/item/twohanded/required/kirbyplants{
-	icon_state = "plant-21"
-	},
 /obj/structure/sign/warning/electricshock{
 	pixel_y = -32
 	},
@@ -85681,16 +83015,6 @@
 /turf/open/floor/plasteel/dark,
 /area/engine/break_room)
 "cKa" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -85709,16 +83033,6 @@
 /turf/open/floor/plasteel,
 /area/engine/break_room)
 "cKb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden/layer1,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
@@ -86540,7 +83854,6 @@
 /turf/open/floor/plating,
 /area/maintenance/department/electrical)
 "cMG" = (
-/obj/structure/girder,
 /obj/effect/decal/cleanable/dirt,
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/plating{
@@ -87036,15 +84349,6 @@
 /area/science/mixing/chamber)
 "cOW" = (
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -87066,12 +84370,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/prison)
 "cPb" = (
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel,
 /area/bridge)
@@ -87264,9 +84562,6 @@
 	icon_state = "wood-broken"
 	},
 /area/security/vacantoffice)
-"dis" = (
-/turf/closed/wall/r_wall/rust,
-/area/bridge)
 "dlg" = (
 /obj/machinery/light,
 /turf/open/floor/wood,
@@ -87333,16 +84628,6 @@
 /obj/item/twohanded/required/kirbyplants/dead,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"elZ" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/rust,
-/area/crew_quarters/bar)
-"emD" = (
-/turf/closed/wall/rust,
-/area/quartermaster/miningoffice)
-"erN" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/starboard)
 "esR" = (
 /obj/effect/decal/cleanable/cobweb,
 /turf/open/floor/wood{
@@ -87350,10 +84635,6 @@
 	},
 /area/maintenance/port/fore)
 "evx" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
 /turf/open/floor/engine{
 	initial_gas_mix = "n2=100;TEMP=80";
 	name = "mainframe floor"
@@ -87376,9 +84657,6 @@
 /obj/effect/turf_decal/tile/red,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"ezp" = (
-/turf/closed/wall/rust,
-/area/hydroponics)
 "eBN" = (
 /obj/structure/window/reinforced{
 	dir = 8
@@ -87419,9 +84697,6 @@
 /obj/machinery/status_display/evac,
 /turf/closed/wall/rust,
 /area/security/prison)
-"eVT" = (
-/turf/closed/wall/rust,
-/area/science/explab)
 "fcv" = (
 /obj/structure/sign/warning/fire{
 	pixel_x = 32
@@ -87441,9 +84716,6 @@
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
-"fAH" = (
-/turf/closed/wall/r_wall/rust,
-/area/security/main)
 "fXq" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -87535,9 +84807,6 @@
 	},
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"gMU" = (
-/turf/closed/wall/r_wall/rust,
-/area/ai_monitored/turret_protected/ai_upload)
 "gPA" = (
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
@@ -87549,21 +84818,9 @@
 /obj/effect/decal/cleanable/generic,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"hqv" = (
-/turf/closed/wall/rust,
-/area/crew_quarters/kitchen)
-"hvb" = (
-/turf/closed/wall/r_wall/rust,
-/area/tcommsat/computer)
 "hxn" = (
 /turf/open/space/basic,
 /area/hallway/secondary/entry)
-"hzY" = (
-/turf/closed/wall/rust,
-/area/gateway)
-"hAb" = (
-/turf/closed/wall/r_wall/rust,
-/area/security/courtroom)
 "hDh" = (
 /obj/effect/decal/cleanable/cobweb/cobweb2,
 /obj/structure/closet/cardboard,
@@ -87574,16 +84831,6 @@
 /turf/closed/wall/r_wall/rust,
 /area/security/prison)
 "ice" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -87595,26 +84842,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
-"ieA" = (
-/obj/effect/decal/cleanable/dirt,
-/mob/living/simple_animal/hostile/cat_butcherer,
-/turf/open/floor/plating{
-	icon_state = "platingdmg3"
-	},
-/area/maintenance/fore)
-"iiA" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "mainframe floor"
-	},
-/area/tcommsat/server)
 "ikw" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Cell 4";
@@ -87627,13 +84854,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"ivg" = (
-/obj/structure/lattice/catwalk,
-/turf/open/space/basic,
-/area/space)
-"iwR" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/server)
 "iBL" = (
 /obj/machinery/camera{
 	c_tag = "Laser Room Starboard";
@@ -87670,9 +84890,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"iRL" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/aft)
 "iSg" = (
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
@@ -87682,9 +84899,6 @@
 /mob/living/simple_animal/hostile/retaliate/ghost,
 /turf/open/floor/plasteel/dark,
 /area/maintenance/starboard/fore)
-"iYW" = (
-/turf/closed/wall/r_wall/rust,
-/area/crew_quarters/heads/captain)
 "iZo" = (
 /turf/closed/wall/r_wall/rust,
 /area/medical/virology)
@@ -87738,9 +84952,6 @@
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
-"jxc" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/fore)
 "jAT" = (
 /obj/structure/lattice/catwalk,
 /obj/machinery/light,
@@ -87748,21 +84959,6 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/hallway/secondary/entry)
-"jCp" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
-	},
-/turf/open/floor/engine{
-	initial_gas_mix = "n2=100;TEMP=80";
-	name = "mainframe floor"
-	},
-/area/tcommsat/server)
-"jDv" = (
-/turf/closed/wall/rust,
-/area/quartermaster/storage)
 "jHJ" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 9
@@ -87906,15 +85102,20 @@
 /turf/closed/wall/rust,
 /area/hallway/secondary/exit/departure_lounge)
 "ktv" = (
-/obj/machinery/air_sensor{
-	pixel_x = -32;
-	pixel_y = -32
+/obj/machinery/power/compressor{
+	comp_id = "incineratorturbine";
+	dir = 1;
+	luminosity = 2
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
+/obj/structure/cable,
+/obj/machinery/camera{
+	c_tag = "Turbine Chamber";
+	dir = 4;
+	name = "turbine camera";
+	network = list("turbine")
 	},
 /turf/open/floor/engine/vacuum,
 /area/maintenance/disposal/incinerator)
@@ -87951,7 +85152,7 @@
 /area/maintenance/port/fore)
 "llm" = (
 /obj/structure/sign/poster/ripped,
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/crew_quarters/fitness/recreation)
 "lKu" = (
 /obj/structure/table/wood,
@@ -87961,12 +85162,9 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/port/fore)
-"lSJ" = (
-/turf/open/floor/engine/vacuum,
-/area/maintenance/disposal/incinerator)
 "lVk" = (
 /obj/machinery/status_display/evac,
-/turf/closed/wall/rust,
+/turf/closed/wall,
 /area/security/warden)
 "mbs" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/simple,
@@ -87986,16 +85184,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
 "mIt" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment,
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=SE CPH";
@@ -88038,13 +85226,6 @@
 /obj/effect/decal/cleanable/dirt,
 /turf/closed/mineral/random/labormineral,
 /area/space/nearstation)
-"mPm" = (
-/turf/closed/wall/rust,
-/area/security/checkpoint/supply)
-"nDw" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/rust,
-/area/crew_quarters/heads/hor)
 "nJw" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/firedoor,
@@ -88057,15 +85238,6 @@
 "nNA" = (
 /turf/closed/wall/rust,
 /area/bridge)
-"nNV" = (
-/turf/closed/wall/rust,
-/area/science/lab)
-"nSz" = (
-/turf/closed/wall/rust,
-/area/medical/cryo)
-"nVt" = (
-/turf/closed/wall/rust,
-/area/storage/tech)
 "nXu" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -88134,9 +85306,6 @@
 	icon_state = "wood-broken4"
 	},
 /area/maintenance/port/fore)
-"pQf" = (
-/turf/closed/wall/r_wall/rust,
-/area/science/xenobiology)
 "qfZ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
@@ -88150,23 +85319,7 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"qtv" = (
-/turf/closed/wall/r_wall/rust,
-/area/tcommsat/server)
-"qtS" = (
-/turf/closed/wall/rust,
-/area/medical/genetics/cloning)
 "qvS" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=W CPH";
 	dir = 8;
@@ -88275,35 +85428,12 @@
 /obj/structure/sign/warning,
 /turf/closed/wall/rust,
 /area/space/nearstation)
-"sPG" = (
-/turf/closed/wall/rust,
-/area/crew_quarters/heads/hor)
-"tgw" = (
-/obj/structure/sign/warning/electricshock,
-/turf/closed/wall/r_wall/rust,
-/area/security/prison)
-"tqw" = (
-/turf/closed/wall/rust,
-/area/lawoffice)
-"tyb" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/central)
 "tCi" = (
 /obj/effect/decal/cleanable/glass,
 /turf/open/floor/wood{
 	icon_state = "wood-broken3"
 	},
 /area/maintenance/port/fore)
-"tEC" = (
-/turf/closed/wall/rust,
-/area/crew_quarters/bar)
-"tGU" = (
-/obj/structure/sign/warning/securearea,
-/turf/closed/wall/rust,
-/area/gateway)
-"tYn" = (
-/turf/closed/wall/rust,
-/area/janitor)
 "uda" = (
 /turf/closed/wall/rust,
 /area/security/warden)
@@ -88335,16 +85465,6 @@
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/port)
 "unX" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 8
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/neutral{
-	dir = 4
-	},
 /obj/machinery/navbeacon{
 	codes_txt = "patrol;next_patrol=E CPH";
 	dir = 8;
@@ -88373,9 +85493,6 @@
 "uRM" = (
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"uWo" = (
-/turf/closed/wall/rust,
-/area/security/checkpoint/medical)
 "vle" = (
 /obj/structure/festivus,
 /turf/open/floor/wood,
@@ -88389,9 +85506,6 @@
 /obj/item/instrument/guitar,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
-"whw" = (
-/turf/closed/wall/rust,
-/area/medical/surgery)
 "whZ" = (
 /obj/effect/turf_decal/tile/green{
 	dir = 8
@@ -88409,24 +85523,6 @@
 /obj/machinery/atmospherics/components/unary/vent_pump/on,
 /turf/open/floor/wood,
 /area/security/vacantoffice)
-"wmX" = (
-/turf/closed/wall/rust,
-/area/quartermaster/qm)
-"wvq" = (
-/turf/closed/wall/rust,
-/area/security/courtroom)
-"wCy" = (
-/turf/closed/wall/rust,
-/area/hallway/primary/port)
-"wDP" = (
-/turf/closed/wall/rust,
-/area/crew_quarters/fitness/recreation)
-"wQL" = (
-/turf/closed/wall/rust,
-/area/security/execution/education)
-"xei" = (
-/turf/closed/wall/r_wall/rust,
-/area/teleporter)
 "xqv" = (
 /obj/structure/table/wood,
 /obj/item/reagent_containers/food/drinks/drinkingglass{
@@ -88436,9 +85532,6 @@
 /obj/item/reagent_containers/food/drinks/drinkingglass,
 /turf/open/floor/wood,
 /area/maintenance/port/fore)
-"xqL" = (
-/turf/closed/wall/rust,
-/area/quartermaster/office)
 "xse" = (
 /obj/machinery/cryopod,
 /obj/effect/decal/cleanable/dirt,
@@ -88447,10 +85540,6 @@
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
-"xBI" = (
-/obj/machinery/status_display/evac,
-/turf/closed/wall/rust,
-/area/chapel/office)
 "xJY" = (
 /obj/structure/rack,
 /obj/item/storage/backpack,
@@ -98953,7 +96042,7 @@ bmU
 ruL
 ruL
 ruL
-hNk
+aav
 aeu
 aeu
 aap
@@ -99206,11 +96295,11 @@ cqG
 cov
 cpx
 bLM
-hNk
+aav
 mmZ
 ewj
 qfZ
-hNk
+aav
 aeu
 aeu
 aeU
@@ -99463,11 +96552,11 @@ cIA
 coD
 cqt
 aeu
-hNk
+aav
 xse
 nXu
 qPY
-hNk
+aav
 aeu
 aeu
 aUz
@@ -99718,14 +96807,14 @@ cqI
 cqP
 afm
 bVx
-hNk
-hNk
-hNk
+aav
+aav
+aav
 cxV
 ydo
 eBN
-tgw
-hNk
+asO
+aav
 aeu
 aeu
 aeu
@@ -99975,7 +97064,7 @@ bGl
 bGV
 bIi
 cpv
-hNk
+aav
 awn
 bTz
 czR
@@ -99983,7 +97072,7 @@ cFN
 cIm
 cJC
 aav
-hNk
+aav
 aeu
 aeu
 aeU
@@ -100240,7 +97329,7 @@ bNi
 bPa
 caX
 cJG
-hNk
+aav
 aeu
 aeU
 aUz
@@ -100746,7 +97835,7 @@ ajd
 cof
 ajd
 ajd
-hNk
+aav
 btd
 bVV
 bMe
@@ -100754,7 +97843,7 @@ bNH
 bTu
 ciF
 cIQ
-hNk
+aav
 aeu
 aUz
 aeU
@@ -101003,7 +98092,7 @@ ajd
 bHc
 bIo
 ajd
-hNk
+aav
 bLN
 bMQ
 bPk
@@ -101011,7 +98100,7 @@ bRa
 bSR
 bTF
 bVm
-hNk
+aav
 aeu
 aeu
 coy
@@ -101773,7 +98862,7 @@ ajd
 ajd
 ajd
 ajd
-hNk
+aav
 bKv
 bLX
 eQS
@@ -102031,7 +99120,7 @@ ajd
 aeu
 aeu
 aav
-hNk
+aav
 bJB
 abp
 abp
@@ -102545,7 +99634,7 @@ coA
 bHj
 adf
 aeu
-hNk
+aav
 bJF
 bJN
 cuS
@@ -102802,7 +99891,7 @@ coA
 bHo
 aeE
 agK
-hNk
+aav
 bLj
 bYc
 cDG
@@ -102810,7 +99899,7 @@ aaG
 aez
 cIj
 aeB
-wQL
+cZm
 aez
 aez
 cko
@@ -105381,13 +102470,13 @@ bSW
 bUd
 bVO
 aey
-fAH
-fAH
+aey
+aey
 aey
 aey
 byu
 aey
-fAH
+aey
 aey
 aey
 clr
@@ -105611,7 +102700,7 @@ amA
 amR
 amA
 cFW
-wDP
+awD
 bKD
 bLg
 bLm
@@ -105901,7 +102990,7 @@ ahZ
 aiL
 aiL
 aiL
-cDB
+bqs
 ajS
 bOO
 bBG
@@ -106392,7 +103481,7 @@ bxE
 byS
 bGI
 bMg
-wDP
+awD
 bDt
 bDV
 bFn
@@ -106639,7 +103728,7 @@ csG
 bid
 bjx
 csQ
-wDP
+awD
 bKn
 bLc
 bMi
@@ -106649,7 +103738,7 @@ bLT
 bEK
 bGT
 bMx
-wDP
+awD
 afz
 adZ
 ajd
@@ -106664,7 +103753,7 @@ aej
 aeY
 afn
 aeY
-aeY
+bqm
 ahg
 bXO
 bYO
@@ -106867,7 +103956,7 @@ apF
 aqP
 asb
 aNG
-aOa
+aOb
 akd
 aOC
 aOm
@@ -106896,8 +103985,8 @@ aqu
 bif
 bjz
 csR
-wDP
-wDP
+awD
+awD
 bLo
 bLp
 btz
@@ -107133,7 +104222,7 @@ abo
 agk
 agI
 agL
-abl
+afX
 ahc
 aPx
 aPx
@@ -107371,7 +104460,7 @@ aeu
 cwp
 cwq
 cyL
-aiV
+alw
 cyY
 adv
 alw
@@ -107628,10 +104717,10 @@ aeu
 cwp
 abu
 cyM
-aiW
+cyY
 cyZ
 czl
-alA
+cyY
 czp
 bgN
 cwp
@@ -107915,8 +105004,8 @@ aQJ
 aTc
 aUL
 aWr
-uWo
-whw
+aQI
+aQN
 bxr
 aQN
 aQN
@@ -108142,10 +105231,10 @@ cwq
 cyE
 ahL
 cyO
-ajh
-ajs
+cyY
+alw
 akI
-alH
+cyY
 czr
 ans
 czK
@@ -108172,7 +105261,7 @@ aQI
 aQJ
 aQf
 aQJ
-uWo
+aQI
 baB
 bcS
 bek
@@ -108185,7 +105274,7 @@ aUJ
 aUJ
 afe
 brD
-bLn
+brD
 bvO
 bKF
 bza
@@ -108419,8 +105508,8 @@ aCL
 aPh
 aGp
 aNW
-aJv
-aQk
+aJC
+agF
 aSE
 aQy
 aWt
@@ -108455,7 +105544,7 @@ cBT
 aef
 aef
 lVk
-uda
+aef
 aef
 ani
 anm
@@ -108703,11 +105792,11 @@ btD
 bvP
 bxQ
 bzg
-bLu
-bLu
 bIV
 bIV
-csS
+bIV
+bIV
+bIV
 bFp
 aah
 bHz
@@ -108932,7 +106021,7 @@ aBq
 aCP
 aEo
 aGt
-nSz
+aNQ
 aJB
 aQo
 aTO
@@ -108955,17 +106044,17 @@ aoV
 bxV
 aoV
 afe
-bLu
+bIV
 bFb
 akv
 bzZ
 bKL
-bLu
+bIV
 bJQ
-bKc
+bLu
 bKk
-cBv
-bFp
+aXE
+aYZ
 aah
 bHA
 aaA
@@ -108980,7 +106069,7 @@ cqg
 ajw
 agV
 bXT
-bYS
+bYQ
 bYm
 ama
 aiQ
@@ -109188,8 +106277,8 @@ aNH
 aVH
 aNO
 aso
-qtS
-qtS
+aNL
+aNL
 aQd
 aQC
 aNn
@@ -109220,11 +106309,11 @@ bzh
 aoL
 bJU
 bUa
-bKk
-csS
+aJv
+aXE
 cCa
-uda
-uda
+aef
+aef
 bJC
 aef
 aef
@@ -109235,7 +106324,7 @@ bWr
 coN
 cqh
 bVW
-uda
+aef
 ayi
 aJr
 ayi
@@ -109477,8 +106566,8 @@ bzi
 bIV
 bIV
 bIV
-bLu
-cBI
+bIV
+bIV
 bFp
 aah
 bHC
@@ -109735,8 +106824,8 @@ bIV
 bJS
 bKd
 cBW
-cBv
-bFp
+aYR
+aYZ
 aah
 bHA
 aff
@@ -109990,14 +107079,14 @@ bAL
 bzh
 apV
 bJZ
-bKe
-cBW
-cBy
+bUa
+bLu
+aYR
 cCb
-uda
+aef
 aef
 lVk
-uda
+aef
 uda
 bXr
 bNq
@@ -110245,11 +107334,11 @@ bGA
 bJp
 bAQ
 bIV
-bLu
+bIV
 bIV
 bKf
 bIV
-csN
+bIV
 bFq
 aah
 bHD
@@ -110506,7 +107595,7 @@ arf
 bKb
 bKg
 bLu
-cBw
+bIV
 bFq
 aah
 bHu
@@ -110762,8 +107851,8 @@ bzp
 bIV
 bJY
 bKh
+aWS
 bIV
-afz
 ayy
 agX
 agX
@@ -111017,10 +108106,10 @@ bKC
 bAy
 bzu
 bIV
-bLu
 bIV
 bIV
-bEa
+bIV
+ajd
 bFr
 bBI
 bHH
@@ -111227,7 +108316,7 @@ aeu
 aWG
 aWG
 aWG
-bsm
+aWG
 aWG
 aWG
 cAN
@@ -111260,8 +108349,8 @@ aSg
 aAc
 aSg
 bAN
-aPf
-aPf
+bAN
+bAN
 bAN
 bAN
 bAN
@@ -111481,7 +108570,7 @@ aaa
 aeu
 aeu
 aeu
-bsm
+aWG
 acE
 cgY
 cAi
@@ -111764,7 +108853,7 @@ aJQ
 aLn
 aMN
 aOD
-aiU
+bdf
 aYx
 aSe
 aYx
@@ -111784,7 +108873,7 @@ boU
 bfS
 bss
 btV
-bZH
+aEu
 bxW
 bzx
 bKq
@@ -111995,7 +109084,7 @@ aeu
 aeu
 aeu
 aeu
-bsm
+aWG
 aWG
 czG
 cAk
@@ -112020,7 +109109,7 @@ aMX
 aJR
 aOP
 aAO
-anY
+aNy
 aHq
 aYM
 aST
@@ -112037,7 +109126,7 @@ bmJ
 bmJ
 bqp
 bri
-bmJ
+auK
 bfX
 bst
 bvQ
@@ -112253,8 +109342,8 @@ aeu
 aeu
 aeu
 aeu
-bsm
-bsm
+aWG
+aWG
 aWG
 aWG
 aWG
@@ -112265,7 +109354,7 @@ bsZ
 aWG
 aWG
 avY
-bsm
+aWG
 beG
 bwC
 bxe
@@ -112275,7 +109364,7 @@ bwY
 aGM
 bxJ
 ahF
-aOS
+aPk
 aBN
 aOF
 bdU
@@ -112321,7 +109410,7 @@ arq
 bEo
 bEF
 bGX
-bBf
+bYZ
 aKC
 all
 alX
@@ -112522,7 +109611,7 @@ bta
 btC
 atL
 avK
-xBI
+btg
 aob
 azS
 aAu
@@ -112532,7 +109621,7 @@ bwZ
 bxF
 bxJ
 ahF
-aOS
+aPk
 aJi
 aOG
 btE
@@ -112542,7 +109631,7 @@ btE
 aPK
 aLU
 btE
-cJc
+buC
 buC
 aRF
 aSP
@@ -112575,14 +109664,14 @@ ajd
 bRP
 bBr
 cdj
-bBf
+bYZ
 bEG
-bBf
-bBf
+bYZ
+bYZ
 bVa
-cHC
+bUZ
 cHS
-cHC
+bUZ
 aKN
 cfp
 baF
@@ -112768,7 +109857,7 @@ aeu
 aeu
 aeu
 adH
-ajj
+alc
 ajz
 adQ
 cAF
@@ -112779,7 +109868,7 @@ aWG
 aWG
 bvT
 avL
-bsm
+aWG
 btA
 cBh
 btA
@@ -112789,12 +109878,12 @@ bxu
 bwP
 btA
 bsx
-aOS
+aPk
 aaJ
-tEC
-tEC
+btE
+btE
 bvi
-bub
+aTe
 buu
 bvf
 aTe
@@ -112805,14 +109894,14 @@ bvn
 bfv
 bvU
 bvu
-cJc
+buC
 blx
 bnx
 boY
 buC
 bsy
 aoh
-tqw
+aoh
 bCn
 aoh
 aoA
@@ -112822,8 +109911,8 @@ cbC
 cbH
 cbM
 cbP
-aer
-aer
+ajd
+ajd
 czw
 bWQ
 czU
@@ -112835,7 +109924,7 @@ cCh
 cCh
 cCo
 bGY
-bHv
+bYw
 bVc
 cbc
 cch
@@ -113048,7 +110137,7 @@ btA
 ahF
 aOT
 cfa
-tEC
+btE
 aTB
 btT
 buc
@@ -113080,7 +110169,7 @@ aYM
 aYM
 cbM
 cbw
-aer
+ajd
 ajd
 ajd
 czW
@@ -113092,7 +110181,7 @@ bBk
 aaY
 aaY
 bGZ
-bBf
+bYZ
 bVd
 bHU
 aMA
@@ -113299,15 +110388,15 @@ azW
 bwR
 bye
 bxi
-aEu
+aEx
 bxH
 bxJ
 ahF
-aOS
+aPk
 cfa
 btF
 aqg
-btU
+aqg
 buy
 buJ
 bvq
@@ -113323,7 +110412,7 @@ bjH
 blB
 bAS
 buC
-cJc
+buC
 bps
 aoh
 aok
@@ -113337,7 +110426,7 @@ cbI
 cbN
 aYM
 cbR
-cbJ
+cbw
 ajd
 bKA
 bBG
@@ -113349,7 +110438,7 @@ aci
 bWc
 aaY
 bHk
-bBf
+bYZ
 bVd
 bXV
 ccj
@@ -113846,9 +110935,9 @@ aoS
 aoX
 adc
 aoh
-wCy
-wCy
-wCy
+boC
+boC
+boC
 bvJ
 bwc
 bBj
@@ -113863,7 +110952,7 @@ ack
 bWe
 bBk
 bHk
-bBf
+bYZ
 cFA
 axF
 axF
@@ -114056,7 +111145,7 @@ adQ
 cAr
 cAy
 cAC
-adQ
+adH
 bsf
 cCI
 cBc
@@ -114067,14 +111156,14 @@ cBc
 btA
 bwK
 btB
-bwU
+btB
 bxD
-aAD
+btB
 aEx
 bxJ
 aIl
 ahF
-aOS
+aPk
 cfa
 btF
 aRM
@@ -114105,7 +111194,7 @@ asF
 asF
 aos
 bEd
-wvq
+asF
 bGq
 bOP
 bIt
@@ -114120,7 +111209,7 @@ acl
 bCd
 bBk
 bHk
-bBf
+bYZ
 cHk
 bFa
 bGf
@@ -114317,7 +111406,7 @@ adH
 anb
 anU
 apG
-adQ
+adH
 aoc
 atO
 awh
@@ -114352,7 +111441,7 @@ bpH
 bsh
 buC
 boW
-wvq
+asF
 adu
 bwk
 byi
@@ -114588,7 +111677,7 @@ aEC
 bxJ
 aIo
 ahF
-aOS
+aPk
 cfa
 btE
 aXm
@@ -114602,14 +111691,14 @@ btE
 btE
 bey
 btE
-tEC
-cJc
-cJc
+btE
+buC
+buC
 buC
 buC
 buC
 bpn
-wvq
+asF
 aow
 arB
 atc
@@ -114634,7 +111723,7 @@ bws
 aaY
 aaY
 bHk
-bBf
+bYZ
 cac
 bFa
 cnz
@@ -114845,7 +111934,7 @@ btA
 btA
 ago
 aaZ
-aOS
+aPk
 cfa
 btH
 aXp
@@ -114853,7 +111942,7 @@ btY
 bvk
 bvE
 bvH
-aWS
+aTe
 buA
 bbk
 bcW
@@ -114866,7 +111955,7 @@ bqr
 brs
 bsk
 btO
-wvq
+asF
 asY
 ask
 aaV
@@ -114891,7 +111980,7 @@ bUz
 bWg
 axF
 bYn
-bBf
+bYZ
 cae
 bVo
 cck
@@ -115090,7 +112179,7 @@ cCM
 cCR
 bsf
 ajv
-adQ
+adH
 cDc
 cCU
 cDh
@@ -115102,7 +112191,7 @@ aaI
 aGN
 cDq
 aJS
-aOS
+aPk
 cfa
 btI
 aXr
@@ -115121,14 +112210,14 @@ aLD
 bpn
 asF
 asF
-wvq
+asF
 asF
 asF
 asF
 asu
 auI
 atf
-auK
+byi
 avW
 ccR
 apa
@@ -115320,7 +112409,7 @@ aeu
 ceF
 ceF
 ceF
-ceG
+ceF
 ceF
 ceF
 ceF
@@ -115341,10 +112430,10 @@ aeU
 aUz
 aeu
 adH
-adQ
 adH
 adH
-adQ
+adH
+adH
 adH
 cCU
 cDy
@@ -115361,7 +112450,7 @@ ago
 aBO
 aNq
 aRY
-elZ
+btK
 btE
 buf
 aSh
@@ -115395,8 +112484,8 @@ auP
 bQx
 bOP
 bRh
-tyb
-iRL
+bOU
+axF
 cag
 cbh
 bRX
@@ -115435,10 +112524,10 @@ aFH
 aFN
 cwz
 aaa
-acm
 aaa
 aaa
 acm
+aaa
 aaa
 aaa
 aaa
@@ -115567,20 +112656,20 @@ aeu
 aeu
 asZ
 asZ
-aAg
 asZ
 asZ
-aAg
-aAg
 asZ
 asZ
-ceG
+asZ
+asZ
+asZ
+ceF
 ceF
 akN
 aac
 adr
 adA
-ceG
+ceF
 ceF
 ceF
 ceF
@@ -115616,7 +112705,7 @@ cdD
 cdD
 ago
 aJT
-aOS
+aPk
 aMU
 aOI
 btE
@@ -115624,8 +112713,8 @@ btE
 btE
 aOy
 btE
-tEC
-tEC
+btE
+btE
 bbr
 aTe
 aTe
@@ -115693,9 +112782,9 @@ aIL
 aFI
 aFW
 aFI
-aFI
 cko
 cko
+aaa
 aaa
 aaa
 aaa
@@ -115821,16 +112910,16 @@ aUz
 aeu
 aeu
 aeu
-aAg
-asZ
-asZ
-asZ
-aAg
 asZ
 asZ
 asZ
 asZ
-aAg
+asZ
+asZ
+asZ
+asZ
+asZ
+asZ
 ceF
 axB
 acn
@@ -115882,7 +112971,7 @@ aPQ
 aTu
 bpq
 aXa
-tEC
+btE
 btE
 aTL
 aOy
@@ -115919,7 +113008,7 @@ bCe
 bVg
 bCe
 bHl
-bBf
+bYZ
 cHj
 bFa
 bFS
@@ -115949,10 +113038,10 @@ aFO
 cwc
 aFO
 cwA
-lSJ
 aFI
 aFI
 aFI
+aaa
 aaa
 aaa
 aaa
@@ -116079,14 +113168,14 @@ aeu
 aeu
 asZ
 asZ
-aAg
-aAg
+asZ
+asZ
 asZ
 asZ
 cef
 asZ
 asZ
-aAg
+asZ
 asZ
 ceF
 acJ
@@ -116157,7 +113246,7 @@ asF
 asF
 arn
 arn
-hAb
+arn
 arn
 aur
 arn
@@ -116169,14 +113258,14 @@ bOP
 bJy
 aCq
 cbA
-bBf
+bYZ
 byv
-bBE
-bBf
-bBf
-bBf
-bBf
-bBf
+bcD
+bYZ
+bYZ
+bYZ
+bYZ
+bYZ
 cHk
 bFa
 bFa
@@ -116209,7 +113298,7 @@ aFY
 ktv
 aNi
 aGb
-aGc
+aaa
 aaa
 aaa
 aaa
@@ -116387,14 +113476,14 @@ aEH
 ceZ
 aIs
 aiA
-aOS
+aPk
 cgq
 aXu
 aox
 aMi
 aMc
 aTz
-apX
+aox
 arA
 akM
 aox
@@ -116463,10 +113552,10 @@ aFU
 cwd
 jHJ
 cwH
-cwH
 aFI
 aFI
 aFI
+aaa
 aaa
 aaa
 aaa
@@ -116591,7 +113680,7 @@ aeu
 aeu
 aeu
 asZ
-aAg
+asZ
 asZ
 aam
 aaF
@@ -116602,7 +113691,7 @@ ceD
 cel
 abR
 atB
-adT
+chX
 aHw
 ace
 acM
@@ -116721,9 +113810,9 @@ aJl
 aFI
 aFI
 aFI
-aFI
 cko
 cko
+aaa
 aaa
 aaa
 aaa
@@ -116847,7 +113936,7 @@ aaa
 aeU
 ciQ
 aeu
-aAg
+asZ
 asZ
 aak
 aan
@@ -116863,7 +113952,7 @@ adg
 ace
 acp
 acW
-alV
+adg
 adG
 adR
 adU
@@ -116902,7 +113991,7 @@ ago
 aIz
 ajW
 ajJ
-aOS
+aPk
 fXq
 aIV
 aox
@@ -116920,13 +114009,13 @@ cBV
 aox
 atT
 atT
-dis
-dis
-dis
-dis
+atT
+atT
+atT
+atT
 ajK
 atT
-dis
+atT
 atj
 apN
 awj
@@ -117190,7 +114279,7 @@ asA
 apf
 atr
 auG
-arD
+ark
 bsP
 bQx
 bOF
@@ -117362,7 +114451,7 @@ aeU
 anH
 aeu
 asZ
-aAg
+asZ
 aal
 aaw
 aaU
@@ -117417,7 +114506,7 @@ aIB
 aba
 cgw
 aRk
-apY
+aNy
 oPf
 aLV
 aHz
@@ -117426,8 +114515,8 @@ arl
 arl
 byV
 bzc
-gMU
-gMU
+arl
+arl
 bfJ
 abk
 aqb
@@ -117436,8 +114525,8 @@ atT
 aqz
 aoW
 bqe
-aqQ
-aqQ
+bsE
+bsE
 avQ
 byn
 bzI
@@ -117630,7 +114719,7 @@ cdH
 ceB
 abZ
 atB
-adT
+chX
 aZh
 acz
 ada
@@ -117663,15 +114752,15 @@ ciZ
 ahh
 ahh
 ahh
-qtv
-qtv
-qtv
-qtv
-qtv
+ahh
+ahh
+ahh
+ahh
+ahh
 cfM
 cfM
-hvb
-hvb
+cfM
+cfM
 cfM
 aRl
 bVL
@@ -117709,7 +114798,7 @@ atG
 bQx
 bOF
 bYW
-nVt
+bCM
 bDp
 bQn
 bSf
@@ -117877,7 +114966,7 @@ aeu
 aeu
 aeu
 asZ
-aAg
+asZ
 apn
 ceE
 cfJ
@@ -117887,10 +114976,10 @@ abC
 abL
 aca
 asZ
-alV
+adg
 azv
 chB
-chV
+azv
 adg
 ciN
 ciM
@@ -117917,7 +115006,7 @@ aoM
 adH
 adH
 ahh
-qtv
+ahh
 awo
 cdn
 cdJ
@@ -117933,7 +115022,7 @@ cfM
 aRm
 cci
 aKP
-gMU
+arl
 arl
 arl
 byN
@@ -117959,7 +115048,7 @@ atj
 atj
 bHI
 atj
-nNA
+atj
 atT
 atT
 atT
@@ -118133,15 +115222,15 @@ aeu
 aeu
 aeu
 aeu
-aAg
 asZ
 asZ
 asZ
-aAg
+asZ
+asZ
 asZ
 ceo
 asZ
-aAg
+asZ
 asZ
 asZ
 cfY
@@ -118192,10 +115281,10 @@ cdg
 aQh
 bwp
 ciX
-gMU
+arl
 byq
 aXz
-aYZ
+aZc
 bbU
 bzm
 bzc
@@ -118392,14 +115481,14 @@ aeu
 aeu
 aeu
 asZ
-aAg
-aAg
 asZ
 asZ
-aAg
 asZ
 asZ
-aAg
+asZ
+asZ
+asZ
+asZ
 asZ
 cfY
 acj
@@ -118408,7 +115497,7 @@ adm
 adz
 adN
 ciB
-cga
+cfY
 acm
 aeo
 aaa
@@ -118650,15 +115739,15 @@ aeu
 aeu
 aeu
 asZ
-aAg
-aAg
 asZ
 asZ
-aAg
 asZ
-aAg
 asZ
-cga
+asZ
+asZ
+asZ
+asZ
+cfY
 cfY
 cde
 chG
@@ -118687,7 +115776,7 @@ adH
 adQ
 abX
 cBc
-qtv
+ahh
 cew
 awI
 cdq
@@ -118916,11 +116005,11 @@ aeu
 aeu
 aeu
 cfY
-cga
 cfY
 cfY
 cfY
-cga
+cfY
+cfY
 cfY
 acm
 acm
@@ -118937,21 +116026,21 @@ aeu
 adQ
 cCr
 cED
-ieA
+anJ
 ale
 alT
 cEW
 aoZ
 cFg
 agC
-qtv
+ahh
 atU
-jCp
+awJ
 awJ
 awJ
 aAj
 cff
-iiA
+awJ
 cfE
 cfR
 cge
@@ -118963,7 +116052,7 @@ chm
 aLg
 arl
 arl
-gMU
+arl
 bAw
 aXH
 aZl
@@ -118977,8 +116066,8 @@ awg
 blT
 bnI
 bpe
-bqm
-bsF
+bsE
+bsE
 bur
 atj
 aHU
@@ -118986,9 +116075,9 @@ auc
 atj
 atj
 aug
-nNA
-nNA
-nNA
+atj
+atj
+atj
 atT
 atT
 bIz
@@ -119220,7 +116309,7 @@ atF
 aLk
 aLV
 aLW
-gMU
+arl
 arl
 byM
 aZn
@@ -119234,10 +116323,10 @@ aqh
 aqk
 att
 aqG
-bqs
+bsE
 arY
 auM
-arX
+bsE
 byt
 afT
 atj
@@ -119249,7 +116338,7 @@ arw
 avF
 aus
 bIJ
-bOY
+aZg
 bKZ
 bmP
 bNZ
@@ -119460,7 +116549,7 @@ cFh
 cFj
 ahh
 ahh
-awM
+evx
 cdC
 ceJ
 aAl
@@ -119493,7 +116582,7 @@ atD
 aqG
 bqt
 cOW
-cOW
+cPb
 cPb
 byw
 ard
@@ -119719,13 +116808,13 @@ cAF
 ahh
 ahh
 ahh
-qtv
 ahh
-qtv
-qtv
+ahh
+ahh
+ahh
 ahh
 cfM
-hvb
+cfM
 cfM
 cfM
 cgz
@@ -119983,13 +117072,13 @@ cvM
 awE
 aEN
 aGQ
-hzY
-jxc
+aUa
+ago
 avw
 aRB
 aJi
 aLE
-apX
+aox
 aOk
 aox
 aox
@@ -120252,8 +117341,8 @@ akw
 aox
 aox
 aox
-apX
-apX
+aox
+aox
 aox
 aox
 aox
@@ -120277,7 +117366,7 @@ bqf
 cjy
 aus
 bIJ
-bOY
+aZg
 bLi
 bmc
 bmc
@@ -120497,7 +117586,7 @@ cvO
 cvU
 aEQ
 aGS
-tGU
+cvW
 aJY
 awr
 aRX
@@ -120530,8 +117619,8 @@ aui
 aui
 avb
 aui
-xei
-xei
+aui
+aui
 aui
 bCH
 bQd
@@ -120759,10 +117848,10 @@ aKi
 cIw
 cKd
 aox
-aox
+aGh
 aRc
-bzN
-akM
+aGh
+aGh
 ajt
 ajt
 aZq
@@ -120770,7 +117859,7 @@ aZq
 ajt
 ajt
 aQO
-apX
+aox
 cCk
 bka
 blW
@@ -120795,11 +117884,11 @@ bOF
 bJy
 aCq
 cbA
-bBf
-bBf
-bBf
+bYZ
+bYZ
+bYZ
 bBE
-bBf
+bYZ
 bEN
 ane
 aBS
@@ -120999,7 +118088,7 @@ cIX
 khA
 cDT
 iSg
-cEl
+cEb
 cJD
 atV
 cEg
@@ -121013,13 +118102,13 @@ aES
 aHv
 aUa
 aKl
-aPz
+ajj
 aNl
 aGh
-aGh
+alV
 aZf
-aGh
-aGh
+apY
+aqQ
 ajt
 aBc
 bmH
@@ -121028,10 +118117,10 @@ bcZ
 ajt
 bgf
 aox
-apX
 aox
 aox
-cdY
+aox
+cdZ
 cdZ
 ahy
 asx
@@ -121273,9 +118362,9 @@ aHq
 aNq
 aZO
 aGh
-aQm
+bqU
 aRi
-aSn
+bqU
 bqU
 ajt
 aXV
@@ -121291,7 +118380,7 @@ blZ
 bpq
 bpg
 aYO
-iYW
+asx
 bwb
 arz
 bDc
@@ -121313,7 +118402,7 @@ bQy
 bBn
 axF
 bCr
-bBf
+bYZ
 cpW
 bYu
 aCc
@@ -121541,7 +118630,7 @@ bqc
 bdo
 bqz
 bgo
-apX
+aox
 bqb
 cba
 aIN
@@ -121552,10 +118641,10 @@ asx
 bwd
 bzA
 bLe
-auT
+aGc
 auT
 arF
-iYW
+asx
 bAb
 bQR
 aYO
@@ -121812,7 +118901,7 @@ byE
 bzP
 arV
 brU
-iYW
+asx
 bAp
 bQS
 aox
@@ -121827,7 +118916,7 @@ bBR
 bCl
 bCA
 bCr
-bBf
+bYZ
 csC
 bYw
 aIb
@@ -122056,9 +119145,9 @@ bdy
 ajt
 ajt
 blc
-hqv
-ezp
-ezp
+ajt
+aZd
+aZd
 aZd
 auj
 aZd
@@ -122066,10 +119155,10 @@ asx
 asx
 asx
 asx
-iYW
-iYW
 asx
-iYW
+asx
+asx
+asx
 bMu
 bRr
 aox
@@ -122310,7 +119399,7 @@ ajt
 boI
 ajt
 bqy
-hqv
+ajt
 bgr
 bhd
 biJ
@@ -122318,9 +119407,9 @@ bjn
 bmE
 bns
 bpk
-bnD
-bnS
-boc
+brN
+brN
+brN
 bwG
 bso
 bpi
@@ -122831,11 +119920,11 @@ boV
 bjn
 bmG
 bnK
-bny
+brN
 bqH
-bny
+brN
 buB
-bny
+brN
 bzt
 bAs
 bBQ
@@ -122855,7 +119944,7 @@ bQC
 bCx
 awq
 bUY
-bBf
+bYZ
 cud
 cyb
 btG
@@ -123088,11 +120177,11 @@ bqP
 bmF
 bcX
 bnN
-bny
+brN
 bqH
-bny
+brN
 buB
-bny
+brN
 bzC
 boS
 bCF
@@ -123105,7 +120194,7 @@ bZM
 bhY
 bIT
 bQI
-bLr
+bMt
 bMt
 bMt
 bMt
@@ -123345,9 +120434,9 @@ bpb
 bjn
 bme
 bnK
-bny
+brN
 bqH
-bny
+brN
 buB
 bwM
 byG
@@ -123355,7 +120444,7 @@ bof
 bFJ
 bFX
 bqQ
-ezp
+aZd
 aZd
 bBU
 bXv
@@ -123602,7 +120691,7 @@ bhd
 bol
 bmg
 bnO
-bny
+brN
 bqI
 bsR
 buD
@@ -123611,8 +120700,8 @@ bAl
 bAu
 bFV
 bGk
-ezp
-ezp
+aZd
+aZd
 bGh
 bZI
 bhY
@@ -123850,7 +120939,7 @@ bsb
 brq
 brF
 brG
-hqv
+ajt
 boQ
 boH
 bqo
@@ -124107,7 +121196,7 @@ brr
 aVd
 brJ
 brI
-hqv
+ajt
 ajt
 bmA
 bph
@@ -124126,7 +121215,7 @@ bob
 bRc
 bZy
 bZp
-bZA
+bZD
 bZD
 bZJ
 bZN
@@ -124328,14 +121417,14 @@ bfq
 iMq
 bbx
 alB
-afX
-agF
+arx
+arx
 alB
 alB
 alB
-pQf
-pQf
-pQf
+alB
+alB
+alB
 alB
 alB
 alB
@@ -124585,7 +121674,7 @@ aWJ
 ayv
 aWJ
 alB
-cIe
+bdp
 bhl
 alB
 bfq
@@ -124629,8 +121718,8 @@ bAX
 bnz
 bBZ
 bqS
-bGW
-bGW
+bZD
+aAD
 bqX
 brz
 buO
@@ -124672,7 +121761,7 @@ clM
 axW
 cnk
 coo
-axU
+ayn
 aLH
 aLx
 aLz
@@ -124837,7 +121926,7 @@ aeu
 aeu
 aeu
 aeu
-pQf
+alB
 bfs
 aWJ
 bft
@@ -125093,8 +122182,8 @@ alB
 alB
 alB
 alB
-pQf
-pQf
+alB
+alB
 bfM
 bfM
 bfM
@@ -125132,10 +122221,10 @@ bdf
 bpC
 bkG
 bbH
-bnM
-bpC
-bpC
-bpW
+bBc
+bBc
+bBc
+bBc
 bgP
 bBc
 bBp
@@ -125149,7 +122238,7 @@ bqY
 bvB
 buR
 bPx
-erN
+bnv
 bjX
 bkz
 bOv
@@ -125192,7 +122281,7 @@ aLF
 aag
 aag
 aag
-aLF
+bsm
 cuA
 cuW
 bYI
@@ -125356,7 +122445,7 @@ aeV
 bfl
 bfV
 aWR
-aWP
+adT
 adx
 aWR
 bgC
@@ -125382,17 +122471,17 @@ aXP
 bai
 aZS
 aZr
-ajL
-ajL
+cAX
+cAX
 cAX
 aJJ
 aRs
 aSB
 aTP
-aYd
-aYK
-aYK
-aYd
+arD
+arX
+arX
+auz
 bdO
 beO
 bpF
@@ -125406,14 +122495,14 @@ blf
 blf
 blg
 blf
-mPm
+blf
 blQ
 bAC
 bBL
 bkQ
 bjW
 bAv
-bOC
+bEg
 bGM
 bHP
 bJc
@@ -125623,7 +122712,7 @@ cqw
 bgM
 bgn
 bVA
-pQf
+alB
 ctJ
 cxP
 aWY
@@ -125633,7 +122722,7 @@ ayx
 bdc
 bdR
 aAZ
-eVT
+aZv
 aEE
 aFp
 aHJ
@@ -125647,12 +122736,12 @@ aYK
 aZL
 bch
 aYd
-aZg
-aZj
+aYK
+aYK
 aYd
 bhe
 cLt
-xqL
+bhI
 bhX
 bhs
 biM
@@ -125909,7 +122998,7 @@ aZQ
 aYd
 bdP
 beP
-xqL
+bhI
 bhy
 ats
 bko
@@ -125972,10 +123061,10 @@ ckk
 aEg
 cnu
 cnu
-cnd
+bOc
 cnd
 cnu
-cnd
+bOc
 cnu
 alm
 aaa
@@ -126406,9 +123495,9 @@ bgk
 aBd
 aZv
 aXw
-aXE
+dMc
 aXI
-aYR
+aXI
 beD
 bbj
 aNF
@@ -126430,7 +123519,7 @@ aKA
 bjh
 bjy
 bpw
-mPm
+blf
 bsV
 buS
 bxl
@@ -126484,13 +123573,13 @@ cmH
 cvE
 cmR
 cwe
-cnd
+krJ
 cwN
 cqQ
 csq
 cnu
 cuL
-cnd
+cnu
 acm
 aaa
 aaa
@@ -126655,7 +123744,7 @@ alB
 cOb
 cps
 cMW
-iwR
+aZF
 aZF
 ami
 aZF
@@ -126687,7 +123776,7 @@ bkr
 bmx
 bod
 bpx
-mPm
+blf
 blg
 bBo
 blg
@@ -126706,7 +123795,7 @@ bNM
 bOo
 cgd
 bNM
-tYn
+bNM
 aVM
 bNx
 bWx
@@ -126736,7 +123825,7 @@ cms
 cmE
 cmQ
 cju
-bOC
+bEg
 cnV
 cmh
 bOb
@@ -126955,7 +124044,7 @@ bIm
 bHR
 bNg
 bAF
-bOC
+bEg
 bQe
 bLZ
 bkE
@@ -127004,7 +124093,7 @@ cwZ
 cxi
 cnu
 cnu
-cnd
+cnu
 alm
 aaa
 aaa
@@ -127149,7 +124238,7 @@ alB
 alB
 alB
 alB
-pQf
+alB
 alB
 bfQ
 bfQ
@@ -127169,7 +124258,7 @@ alB
 cby
 cMP
 ajO
-iwR
+aZF
 aXf
 aeG
 aik
@@ -127184,8 +124273,8 @@ beE
 mIG
 aNM
 bgW
-nNV
-nNV
+aDI
+aDI
 biB
 aYg
 aDI
@@ -127255,11 +124344,11 @@ bEg
 cvG
 cvL
 cwm
-cnd
+bOc
 cpb
 crf
-cnd
-cnd
+cnu
+cnu
 cko
 aeu
 aeu
@@ -127450,7 +124539,7 @@ bbb
 bdz
 cby
 clA
-wmX
+aCb
 bjJ
 blJ
 biV
@@ -127470,7 +124559,7 @@ bCc
 bOw
 bAT
 bOC
-erN
+bnv
 bHT
 bJh
 bJK
@@ -127694,7 +124783,7 @@ aZY
 aJF
 aWX
 aVJ
-nDw
+anx
 bbM
 aNT
 aPo
@@ -127707,7 +124796,7 @@ bbb
 bdE
 cbz
 cLt
-wmX
+aCb
 bhO
 aqH
 biI
@@ -127720,7 +124809,7 @@ bkA
 bke
 blr
 bkY
-blC
+blD
 bls
 bPj
 bmo
@@ -127737,7 +124826,7 @@ bTk
 bXL
 bXx
 bPe
-bUt
+bWx
 hDh
 uRM
 uRM
@@ -127934,7 +125023,7 @@ alB
 alB
 alB
 alB
-pQf
+alB
 alB
 alB
 cng
@@ -127951,7 +125040,7 @@ aGa
 aKu
 aMe
 bfB
-sPG
+amV
 bfr
 bex
 aTU
@@ -127994,9 +125083,9 @@ bOG
 bQU
 bUs
 bTv
-krJ
-krJ
-krJ
+bOc
+bOc
+bOc
 bOc
 bWn
 bWx
@@ -128227,7 +125316,7 @@ big
 big
 bom
 aCb
-jDv
+bhQ
 bpB
 bkl
 bli
@@ -128247,7 +125336,7 @@ bQo
 bJM
 bPe
 bMF
-bRs
+aZj
 bQV
 bPe
 bTw
@@ -128273,9 +125362,9 @@ bUN
 cke
 aeu
 bzG
-cjC
-clg
-clP
+clR
+clR
+clR
 ctU
 bzG
 aeu
@@ -128530,7 +125619,7 @@ jAT
 aeu
 aeu
 bzG
-cjF
+clR
 clE
 clQ
 ctW
@@ -128787,8 +125876,8 @@ bUN
 aeu
 aeu
 bzG
-cjG
-clF
+clR
+clR
 clR
 ctX
 bzG
@@ -128997,7 +126086,7 @@ bhH
 bhW
 bmN
 boK
-emD
+bhH
 bhH
 bjV
 bkh
@@ -129020,7 +126109,7 @@ bLE
 bMN
 bON
 bQY
-bSQ
+bOc
 bPe
 bOc
 bWz
@@ -129538,7 +126627,7 @@ cmr
 aWs
 crl
 bXC
-bXo
+bON
 bYg
 bZk
 bTO
@@ -129739,7 +126828,7 @@ cME
 cMr
 cLs
 bkd
-ava
+bkd
 bkd
 bkd
 azD
@@ -130051,7 +127140,7 @@ bRV
 bNz
 bSn
 crl
-bRt
+bON
 bXw
 bWM
 bPe
@@ -130059,7 +127148,7 @@ bZC
 bPe
 bOc
 bSr
-bSd
+krJ
 cgg
 hxn
 hxn
@@ -130274,7 +127363,7 @@ aSM
 aUn
 baC
 aYp
-bcD
+awi
 bgi
 bkd
 bhH
@@ -130308,7 +127397,7 @@ bRZ
 cmr
 bRA
 crl
-bXy
+bON
 bXA
 bXN
 bTG
@@ -130565,7 +127654,7 @@ bSb
 cmr
 cGz
 cro
-bRt
+bON
 bXA
 cFE
 bTt
@@ -131043,7 +128132,7 @@ awi
 awi
 baC
 baC
-bcD
+awi
 aYs
 cdc
 cna
@@ -131554,7 +128643,7 @@ axO
 cOm
 cbj
 aio
-auz
+cbm
 aSZ
 cOo
 aVt
@@ -131603,13 +128692,13 @@ aeu
 aeu
 aUz
 acm
-cmJ
-ivg
-ivg
-cmJ
-ivg
-ivg
-cmJ
+acm
+acK
+acK
+acm
+acK
+acK
+acm
 acm
 aeU
 aeU
@@ -131804,14 +128893,14 @@ bkd
 aze
 aAG
 cbj
-cLt
+cbk
 aJn
 cLg
 aMq
 ava
 bkd
 bkd
-ava
+bkd
 avA
 avA
 bkd
@@ -132061,7 +129150,7 @@ bkd
 ava
 ava
 bkd
-ava
+bkd
 avA
 crw
 avA
@@ -132322,7 +129411,7 @@ bkd
 cLK
 cLK
 afJ
-ava
+bkd
 aeu
 alm
 acm
@@ -132575,7 +129664,7 @@ aeu
 aeu
 aeu
 aeu
-ava
+bkd
 agy
 cLR
 agy
@@ -132832,7 +129921,7 @@ aeu
 aeu
 aeu
 aeu
-beK
+bhq
 aaa
 aaa
 aaa

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -30297,6 +30297,7 @@
 /obj/item/radio/intercom{
 	pixel_y = 22
 	},
+/obj/item/mmi/posibrain,
 /turf/open/floor/plasteel/dark,
 /area/science/robotics/lab)
 "aXh" = (
@@ -30463,15 +30464,14 @@
 /turf/open/floor/plasteel/dark,
 /area/maintenance/central)
 "aXw" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/folder,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/computer/nanite_cloud_controller,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aXx" = (
@@ -30583,12 +30583,7 @@
 	name = "science camera";
 	network = list("ss13","rd")
 	},
-/obj/structure/table/reinforced,
-/obj/item/multitool{
-	pixel_x = -4;
-	pixel_y = 3
-	},
-/obj/item/integrated_electronics/analyzer,
+/obj/machinery/computer/nanite_chamber_control,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aXG" = (
@@ -31256,7 +31251,8 @@
 	dir = 1
 	},
 /obj/structure/table/reinforced,
-/obj/item/stack/sheet/metal/ten,
+/obj/item/nanite_scanner,
+/obj/item/nanite_remote,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "aYO" = (
@@ -35132,6 +35128,7 @@
 	dir = 4
 	},
 /obj/effect/landmark/event_spawn,
+/obj/machinery/nanite_program_hub,
 /turf/open/floor/plasteel/dark,
 /area/science/research)
 "beE" = (
@@ -85135,6 +85132,21 @@
 	icon_state = "wood-broken7"
 	},
 /area/maintenance/port/fore)
+"kRh" = (
+/obj/effect/turf_decal/tile/neutral{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/neutral{
+	dir = 8
+	},
+/obj/effect/turf_decal/bot,
+/obj/machinery/nanite_chamber,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "kSc" = (
 /obj/structure/sign/nanotrasen,
 /turf/closed/wall,
@@ -85399,6 +85411,14 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/hallway/secondary/entry)
+"sfp" = (
+/obj/effect/turf_decal/tile/neutral,
+/obj/effect/turf_decal/tile/neutral{
+	dir = 4
+	},
+/obj/machinery/nanite_programmer,
+/turf/open/floor/plasteel/dark,
+/area/science/research)
 "swG" = (
 /obj/item/reagent_containers/food/drinks/drinkingglass{
 	pixel_x = 4;
@@ -123495,9 +123515,9 @@ bgk
 aBd
 aZv
 aXw
-dMc
+kRh
 aXI
-aXI
+sfp
 beD
 bbj
 aNF

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -35,6 +35,10 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
+"g" = (
+/obj/effect/turf_decal/stripes/corner,
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/supply)
 "h" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -58,6 +62,12 @@
 	dir = 8
 	},
 /turf/open/floor/mineral/plastitanium,
+/area/shuttle/supply)
+"k" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "l" = (
 /obj/effect/turf_decal/stripes/line{
@@ -199,6 +209,15 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
+"M" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
+	},
+/obj/effect/turf_decal/stripes/corner{
+	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/supply)
 
 (1,1,1) = {"
 a
@@ -233,11 +252,11 @@ a
 c
 o
 w
+k
 w
+o
 w
-w
-w
-w
+M
 e
 A
 D
@@ -265,7 +284,7 @@ w
 w
 w
 w
-w
+g
 x
 A
 D

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -3,50 +3,30 @@
 /turf/closed/wall/mineral/titanium,
 /area/shuttle/supply)
 "b" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "c" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "d" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "e" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "f" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -55,18 +35,7 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
-"g" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/supply)
 "h" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -90,21 +59,7 @@
 	},
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
-"k" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/supply)
 "l" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -126,10 +81,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "n" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
@@ -140,20 +91,12 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "o" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "p" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -176,10 +119,6 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "q" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -195,19 +134,6 @@
 	},
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/mineral/plastitanium,
-/area/shuttle/supply)
-"s" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/corner{
-	dir = 1
-	},
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "t" = (
 /obj/machinery/door/poddoor{
@@ -228,28 +154,15 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "v" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "w" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "x" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -260,10 +173,6 @@
 /turf/closed/wall/mineral/titanium/nodiagonal,
 /area/shuttle/supply)
 "z" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
@@ -323,12 +232,12 @@ C
 a
 c
 o
-g
-k
-g
-o
-g
-s
+w
+w
+w
+w
+w
+w
 e
 A
 D
@@ -336,13 +245,13 @@ D
 (4,1,1) = {"
 a
 c
-g
-g
-g
-g
-g
-g
-g
+w
+w
+w
+w
+w
+w
+w
 z
 A
 D
@@ -350,12 +259,12 @@ D
 (5,1,1) = {"
 a
 c
-g
-g
-g
-g
-g
-g
+w
+w
+w
+w
+w
+w
 w
 x
 A

--- a/_maps/shuttles/cargo_kilo.dmm
+++ b/_maps/shuttles/cargo_kilo.dmm
@@ -35,10 +35,6 @@
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
-"g" = (
-/obj/effect/turf_decal/stripes/corner,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/supply)
 "h" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
@@ -64,9 +60,7 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/supply)
 "k" = (
-/obj/effect/turf_decal/stripes/corner{
-	dir = 4
-	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
 "l" = (
@@ -209,12 +203,24 @@
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plating/airless,
 /area/shuttle/supply)
-"M" = (
+"K" = (
+/obj/effect/turf_decal/stripes/line{
+	dir = 8
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/supply)
+"Q" = (
 /obj/effect/turf_decal/stripes/corner{
 	dir = 4
 	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
+	},
+/turf/open/floor/mineral/titanium/yellow,
+/area/shuttle/supply)
+"Z" = (
+/obj/effect/turf_decal/stripes/corner{
+	dir = 4
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/supply)
@@ -251,12 +257,12 @@ C
 a
 c
 o
-w
-k
+K
+Z
 w
 o
-w
-M
+K
+Q
 e
 A
 D
@@ -284,7 +290,7 @@ w
 w
 w
 w
-g
+k
 x
 A
 D

--- a/_maps/shuttles/emergency_kilo.dmm
+++ b/_maps/shuttles/emergency_kilo.dmm
@@ -144,7 +144,6 @@
 	pixel_y = 4
 	},
 /obj/item/folder/blue,
-/obj/item/gun/energy/e_gun/mini,
 /turf/open/floor/mineral/titanium/blue,
 /area/shuttle/escape)
 "av" = (
@@ -172,10 +171,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "ax" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/structure/sign/warning/vacuum/external{
 	pixel_y = 32
 	},
@@ -288,10 +283,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "aM" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
@@ -301,10 +292,6 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "aN" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -725,10 +712,6 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "bB" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -790,14 +773,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/recharge_station,
 /turf/open/floor/plasteel/dark,
-/area/shuttle/escape)
-"bG" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "bH" = (
 /obj/structure/reagent_dispensers/watertank,
@@ -1057,19 +1032,11 @@
 /turf/open/floor/plasteel/dark,
 /area/shuttle/escape)
 "cj" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "ck" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
-	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
@@ -1079,27 +1046,15 @@
 /area/shuttle/escape)
 "cr" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "cs" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/escape)
 "cA" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -1159,10 +1114,6 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/escape)
 "Xo" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -1543,7 +1494,7 @@ bn
 bi
 ac
 cj
-bG
+cr
 bR
 cK
 cT

--- a/_maps/shuttles/ferry_kilo.dmm
+++ b/_maps/shuttles/ferry_kilo.dmm
@@ -70,10 +70,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 "m" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -115,10 +111,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 "r" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -126,10 +118,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/transport)
 "s" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/corner,
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1

--- a/_maps/shuttles/labour_kilo.dmm
+++ b/_maps/shuttles/labour_kilo.dmm
@@ -29,10 +29,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "f" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -47,10 +43,6 @@
 	req_access_txt = "1"
 	},
 /obj/machinery/light,
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -62,10 +54,6 @@
 	machinedir = 2;
 	pixel_x = 30;
 	pixel_y = 30
-	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -111,10 +99,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/labor)
 "l" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -127,10 +111,6 @@
 /obj/machinery/light{
 	dir = 1
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -141,17 +121,12 @@
 	machinedir = 1;
 	pixel_x = 30
 	},
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "o" = (
-/obj/effect/turf_decal/tile/neutral,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -164,10 +139,6 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "p" = (
-/obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
@@ -177,9 +148,6 @@
 	pixel_x = 25
 	},
 /obj/effect/turf_decal/tile/neutral,
-/obj/effect/turf_decal/tile/neutral{
-	dir = 1
-	},
 /obj/structure/chair/comfy/shuttle{
 	dir = 8
 	},
@@ -189,31 +157,12 @@
 /turf/open/floor/mineral/plastitanium/red,
 /area/shuttle/labor)
 "r" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/structure/closet/crate,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/labor)
-"s" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
-/obj/effect/turf_decal/loading_area{
-	dir = 4
-	},
-/obj/effect/turf_decal/stripes/line,
-/turf/open/floor/mineral/titanium/yellow,
-/area/shuttle/labor)
 "t" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/labor)
@@ -284,7 +233,7 @@ g
 a
 m
 p
-s
+t
 w
 y
 "}

--- a/_maps/shuttles/mining_kilo.dmm
+++ b/_maps/shuttles/mining_kilo.dmm
@@ -15,7 +15,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
 "d" = (
-/obj/effect/turf_decal/bot,
 /obj/machinery/computer/shuttle/mining,
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
@@ -31,10 +30,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
 "f" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -48,10 +43,6 @@
 /turf/open/floor/mineral/plastitanium,
 /area/shuttle/mining)
 "h" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -61,20 +52,12 @@
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/mining)
 "i" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /turf/open/floor/mineral/titanium/yellow,
 /area/shuttle/mining)
 "j" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -114,10 +97,6 @@
 /turf/open/floor/plating,
 /area/shuttle/mining)
 "m" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 4
@@ -134,10 +113,6 @@
 /turf/open/floor/plating/airless,
 /area/shuttle/mining)
 "p" = (
-/obj/effect/turf_decal/tile/brown,
-/obj/effect/turf_decal/tile/brown{
-	dir = 1
-	},
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/atmospherics/pipe/simple/general/hidden{
 	icon_state = "pipe11-2";


### PR DESCRIPTION
## About The Pull Request
This is no fixing this, this is a lost war before the first battle.
removed:Removes the spare tasers that are in sec
removed:Removes the egun on the shuttle
removed:Removes 210000000 decals all over
removed:Removes 200 plant stacks for no reason that looked like trash
removed:Removed a bunch of blood/skeles
removed:Removed almost all rust from departments/halls
add:Added a few more clean bots
tweak:Shrink-ed turbine
balance:viro gets less sec gear
Likely did other things to
Expanded Dorms by 1 tile and added dressers
Expanded clown/mime room by 1
~~Cried a lot~~

## Why It's Good For The Game

Less lag from all the annoying decals all over that bug out all the time to stab your eyes
Less power gamer creep round start with DUEL TASER ACTION
Less horrable plant boxes that have no reason to have 12 different plants per tile
Less mess to clean
Less horrable rust walls all over that make no real logic to be their other then `Hahah meteor get it?`
Less "hey isnt vaild hunting against the rules?"
Less "Hey why do I get handcuffs and almost a spear and or stunprod?"
Less horrable map i.g
Why did we even port this

## Changelog
:cl:
del: Removes the spare tasers that are in sec
del: Removes the egun on the shuttle
del: Removes 210000000 decals all over
del: Removes 200 plant stacks for no reason that looked like trash
del: Removed a bunch of blood/skeles
del: Removed almost all rust from departments/halls
del: Removed the catdoc that kills people and drops free ID
add: More room in dorms/clown-mime room
balance: Viro gets less sec gear
add:Added a few more clean bots
tweak:Shrink-ed turbine
/:cl: