### PR TITLE
Fixing robo limb burn damage being unfixable.

### DIFF
--- a/code/modules/power/cable.dm
+++ b/code/modules/power/cable.dm
@@ -533,7 +533,7 @@ By design, d1 is the smallest direction and d2 is the highest
 	if(affecting && affecting.status == BODYPART_ROBOTIC)
 		if(user == H)
 			user.visible_message("<span class='notice'>[user] starts to fix some of the wires in [H]'s [affecting.name].</span>", "<span class='notice'>You start fixing some of the wires in [H]'s [affecting.name].</span>")
-			if(!do_after(user, H, 50))
+			if(!do_mob(user, H, 50))
 				return
 		if(item_heal_robotic(H, user, 0, 15))
 			use(1)


### PR DESCRIPTION
## About The Pull Request
Title. it was using `do_mob` arguments on a `do_after` call.

## Why It's Good For The Game
This will close #12004.

## Changelog
:cl:
fix: Fixed robo limb burn damage being unfixable.
/:cl:
