### PR TITLE
Fixing empty new lines on IC assemblies examine.

### DIFF
--- a/code/modules/integrated_electronics/core/assemblies.dm
+++ b/code/modules/integrated_electronics/core/assemblies.dm
@@ -79,7 +79,9 @@
 
 	for(var/I in assembly_components)
 		var/obj/item/integrated_circuit/IC = I
-		. += IC.external_examine(user)
+		var/text = IC.external_examine(user)
+		if(text)
+			. += text
 	if(opened)
 		interact(user)
 

--- a/code/modules/integrated_electronics/core/integrated_circuit.dm
+++ b/code/modules/integrated_electronics/core/integrated_circuit.dm
@@ -36,7 +36,9 @@ a creative player the means to solve many problems.  Circuits are held inside an
 /obj/item/integrated_circuit/examine(mob/user)
 	interact(user)
 	. = ..()
-	. += external_examine(user)
+	var/text = external_examine(user)
+	if(text)
+		. += text
 
 // Can be called via electronic_assembly/attackby()
 /obj/item/integrated_circuit/proc/additem(var/obj/item/I, var/mob/living/user)
@@ -57,7 +59,7 @@ a creative player the means to solve many problems.  Circuits are held inside an
 		var/datum/integrated_io/activate/A = activators[k]
 		if(A.linked.len)
 			to_chat(user, "The '[A]' is connected to [A.get_linked_to_desc()].")
-	any_examine(user)
+	to_chat(user, any_examine(user))
 	interact(user)
 
 // This should be used when someone is examining from an 'outside' perspective, e.g. reading a screen or LED.


### PR DESCRIPTION
## About The Pull Request
Title. We want no null keys in the examine lists, unless it's on purpose.

## Why It's Good For The Game
Fixing an issue.

## Changelog
:cl:
fix: Fixing empty new lines on IC assemblies examine.
/:cl:
