### PR TITLE
Buffs shoulder holsters

### DIFF
--- a/code/game/objects/items/storage/belt.dm
+++ b/code/game/objects/items/storage/belt.dm
@@ -695,7 +695,10 @@
 		/obj/item/gun/ballistic/revolver,
 		/obj/item/ammo_box,
 		/obj/item/toy/gun,
-		/obj/item/gun/energy/e_gun/mini
+		/obj/item/gun/energy/e_gun/mini,
+		/obj/item/gun/ballistic/automatic/magrifle/pistol,
+		/obj/item/gun/energy/disabler,
+		/obj/item/gun/energy/taser
 		))
 
 /obj/item/storage/belt/holster/full/PopulateContents()


### PR DESCRIPTION

## About The Pull Request

shoulder holsters now can hold
Mag pistols
Taser - NOT ADV
Disabler

## Why It's Good For The Game

Shoulder holsters are really weak and not all that well used when you can just get some jackboots and place your guns, or a tray that holds all the guns + 3 slots for mags/ammo
These are really rare when used outside the one role that gets it and antags stealing the .38 out of it.

## Changelog
:cl:
add: shoulder holster now hold tasers, disablers and  mag pistols, just like boots and other gun holders
/:cl: