### PR TITLE
organ/on_life tweaks.

### DIFF
--- a/code/modules/antagonists/abductor/equipment/gland.dm
+++ b/code/modules/antagonists/abductor/equipment/gland.dm
@@ -6,6 +6,7 @@
 	status = ORGAN_ROBOTIC
 	beating = TRUE
 	organ_flags = ORGAN_NO_SPOIL
+	no_pump = TRUE
 	var/true_name = "baseline placebo referencer"
 	var/cooldown_low = 300
 	var/cooldown_high = 300
@@ -92,6 +93,7 @@
 	update_gland_hud()
 
 /obj/item/organ/heart/gland/on_life()
+	. = ..()
 	if(!beating)
 		// alien glands are immune to stopping.
 		beating = TRUE

--- a/code/modules/mining/equipment/regenerative_core.dm
+++ b/code/modules/mining/equipment/regenerative_core.dm
@@ -65,7 +65,7 @@
 	qdel(src)
 
 /obj/item/organ/regenerative_core/on_life()
-	..()
+	. = ..()
 	if(owner.health < owner.crit_threshold)
 		ui_action_click()
 

--- a/code/modules/mob/living/brain/brain_item.dm
+++ b/code/modules/mob/living/brain/brain_item.dm
@@ -245,23 +245,17 @@
 	. = adjusted_amount
 */
 
-/obj/item/organ/brain/on_life()
-	if(damage >= BRAIN_DAMAGE_DEATH) //rip
-		to_chat(owner, "<span class='userdanger'>The last spark of life in your brain fizzles out...</span>")
-		owner.death()
-		brain_death = TRUE
-		return
-	..()
-
-/obj/item/organ/brain/on_death()
-	if(damage <= BRAIN_DAMAGE_DEATH) //rip
-		brain_death = FALSE
-	..()
-
-
 /obj/item/organ/brain/applyOrganDamage(var/d, var/maximum = maxHealth)
-	..()
-
+	. = ..()
+	if(!. || !owner)
+		return
+	if(damage >= BRAIN_DAMAGE_DEATH) //rip
+		if(owner.stat != DEAD)
+			to_chat(owner, "<span class='userdanger'>The last spark of life in your brain fizzles out...</span>")
+			owner.death()
+		brain_death = TRUE
+	else
+		brain_death = FALSE
 
 /obj/item/organ/brain/check_damage_thresholds(mob/M)
 	. = ..()

--- a/code/modules/mob/living/carbon/alien/organs.dm
+++ b/code/modules/mob/living/carbon/alien/organs.dm
@@ -77,6 +77,9 @@
 	alien_powers = list(/obj/effect/proc_holder/alien/transfer)
 
 /obj/item/organ/alien/plasmavessel/on_life()
+	. = ..()
+	if(!.)
+		return
 	//If there are alien weeds on the ground then heal if needed or give some plasma
 	if(locate(/obj/structure/alien/weeds) in owner.loc)
 		if(owner.health >= owner.maxHealth)

--- a/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
+++ b/code/modules/mob/living/carbon/alien/special/alien_embryo.dm
@@ -23,6 +23,8 @@
 
 /obj/item/organ/body_egg/alien_embryo/on_life()
 	. = ..()
+	if(!owner)
+		return
 	switch(stage)
 		if(2, 3)
 			if(prob(2))

--- a/code/modules/mob/living/carbon/human/species_types/dwarves.dm
+++ b/code/modules/mob/living/carbon/human/species_types/dwarves.dm
@@ -101,12 +101,11 @@ GLOBAL_LIST_INIT(dwarf_last, world.file2list("strings/names/dwarf_last.txt")) //
 
 /obj/item/organ/dwarfgland/on_life() //Primary loop to hook into to start delayed loops for other loops..
 	. = ..()
-	dwarf_cycle_ticker()
+	if(!owner || owner.stat == DEAD)
+		dwarf_cycle_ticker()
 
 //Handles the delayed tick cycle by just adding on increments per each on_life() tick
 /obj/item/organ/dwarfgland/proc/dwarf_cycle_ticker()
-	if(owner.stat == DEAD)
-		return //We make sure they are not dead, so they don't increment any tickers.
 	dwarf_eth_ticker++
 	dwarf_filth_ticker++
 

--- a/code/modules/surgery/organs/appendix.dm
+++ b/code/modules/surgery/organs/appendix.dm
@@ -12,12 +12,10 @@
 	var/inflamed
 
 /obj/item/organ/appendix/on_life()
-	..()
-	if(!(organ_flags & ORGAN_FAILING))
+	. = ..()
+	if(!.)
 		return
-	var/mob/living/carbon/M = owner
-	if(M)
-		M.adjustToxLoss(4, TRUE, TRUE)	//forced to ensure people don't use it to gain tox as slime person
+	owner.adjustToxLoss(4, TRUE, TRUE)	//forced to ensure people don't use it to gain tox as slime person
 
 /obj/item/organ/appendix/update_icon_state()
 	if(inflamed)

--- a/code/modules/surgery/organs/augments_chest.dm
+++ b/code/modules/surgery/organs/augments_chest.dm
@@ -16,7 +16,8 @@
 	slot = ORGAN_SLOT_STOMACH_AID
 
 /obj/item/organ/cyberimp/chest/nutriment/on_life()
-	if(synthesizing)
+	. = ..()
+	if(!. || synthesizing)
 		return
 
 	if(owner.nutrition <= hunger_threshold)
@@ -59,23 +60,25 @@
 	var/convalescence_time = 0
 
 /obj/item/organ/cyberimp/chest/reviver/on_life()
+	. = ..()
 	if(reviving)
-		var/do_heal = world.time < convalescence_time
+		var/do_heal = . && world.time < convalescence_time
 		if(revive_cost >= MAX_HEAL_COOLDOWN)
 			do_heal = FALSE
-		else if(owner.stat && owner.stat != DEAD)
+		else if(owner?.stat && owner.stat != DEAD)
 			do_heal = TRUE
 		else if(!do_heal)
 			convalescence_time = world.time + DEF_CONVALESCENCE_TIME
-		if(do_heal)
+		if(. && (do_heal || world.time < convalescence_time))
 			addtimer(CALLBACK(src, .proc/heal), 3 SECONDS)
 		else
 			cooldown = revive_cost + world.time
 			reviving = FALSE
-			to_chat(owner, "<span class='notice'>Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)].</span>")
+			if(owner)
+				to_chat(owner, "<span class='notice'>Your reviver implant shuts down and starts recharging. It will be ready again in [DisplayTimeText(revive_cost)].</span>")
 		return
 
-	if(cooldown > world.time || owner.stat == CONSCIOUS || owner.stat == DEAD || owner.suiciding)
+	if(!. || cooldown > world.time || owner.stat == CONSCIOUS || owner.stat == DEAD || owner.suiciding)
 		return
 
 	revive_cost = 0

--- a/code/modules/surgery/organs/augments_internal.dm
+++ b/code/modules/surgery/organs/augments_internal.dm
@@ -102,8 +102,8 @@
 	slot = ORGAN_SLOT_BRAIN_ANTISTUN
 
 /obj/item/organ/cyberimp/brain/anti_stun/on_life()
-	..()
-	if(crit_fail || !(organ_flags & ORGAN_FAILING))
+	. = ..()
+	if(!. || crit_fail)
 		return
 	owner.adjustStaminaLoss(-3.5, FALSE) //Citadel edit, makes it more useful in Stamina based combat
 	owner.HealAllImmobilityUpTo(STUN_SET_AMOUNT)

--- a/code/modules/surgery/organs/ears.dm
+++ b/code/modules/surgery/organs/ears.dm
@@ -29,22 +29,17 @@
 	var/damage_multiplier = 1
 
 /obj/item/organ/ears/on_life()
-	if(!iscarbon(owner))
-		return
-	..()
-	var/mob/living/carbon/C = owner
-	if((damage < maxHealth) && (organ_flags & ORGAN_FAILING))	//ear damage can be repaired from the failing condition
-		organ_flags &= ~ORGAN_FAILING
+	. = ..()
 	// genetic deafness prevents the body from using the ears, even if healthy
-	if(HAS_TRAIT(C, TRAIT_DEAF))
+	if(owner && HAS_TRAIT(owner, TRAIT_DEAF))
 		deaf = max(deaf, 1)
-	else if(!(organ_flags & ORGAN_FAILING)) // if this organ is failing, do not clear deaf stacks.
+	else if(.) // if this organ is failing, do not clear deaf stacks.
 		deaf = max(deaf - 1, 0)
 		if(prob(damage / 20) && (damage > low_threshold))
 			adjustEarDamage(0, 4)
-			SEND_SOUND(C, sound('sound/weapons/flash_ring.ogg'))
-			to_chat(C, "<span class='warning'>The ringing in your ears grows louder, blocking out any external noises for a moment.</span>")
-	else if((organ_flags & ORGAN_FAILING) && (deaf == 0))
+			SEND_SOUND(owner, sound('sound/weapons/flash_ring.ogg'))
+			to_chat(owner, "<span class='warning'>The ringing in your ears grows louder, blocking out any external noises for a moment.</span>")
+	else if(!. && !deaf)
 		deaf = 1	//stop being not deaf you deaf idiot
 
 /obj/item/organ/ears/proc/restoreEars()

--- a/code/modules/surgery/organs/eyes.dm
+++ b/code/modules/surgery/organs/eyes.dm
@@ -1,3 +1,7 @@
+#define BLURRY_VISION_ONE	1
+#define BLURRY_VISION_TWO	2
+#define BLIND_VISION_THREE	3
+
 /obj/item/organ/eyes
 	name = BODY_ZONE_PRECISE_EYES
 	icon_state = "eyeballs"
@@ -10,7 +14,7 @@
 	decay_factor = STANDARD_ORGAN_DECAY
 	maxHealth = 0.5 * STANDARD_ORGAN_THRESHOLD		//half the normal health max since we go blind at 30, a permanent blindness at 50 therefore makes sense unless medicine is administered
 	high_threshold = 0.3 * STANDARD_ORGAN_THRESHOLD	//threshold at 30
-	low_threshold = 0.15 * STANDARD_ORGAN_THRESHOLD	//threshold at 15
+	low_threshold = 0.2 * STANDARD_ORGAN_THRESHOLD	//threshold at 15
 
 	low_threshold_passed = "<span class='info'>Distant objects become somewhat less tangible.</span>"
 	high_threshold_passed = "<span class='info'>Everything starts to look a lot less clear.</span>"
@@ -27,14 +31,17 @@
 	var/flash_protect = 0
 	var/see_invisible = SEE_INVISIBLE_LIVING
 	var/lighting_alpha
-	var/damaged	= FALSE	//damaged indicates that our eyes are undergoing some level of negative effect
+	var/eye_damaged	= FALSE	//indicates that our eyes are undergoing some level of negative effect
 
 /obj/item/organ/eyes/Insert(mob/living/carbon/M, special = FALSE, drop_if_replaced = FALSE)
 	. = ..()
 	if(!.)
 		return
-	if(damage == initial(damage))
-		clear_eye_trauma()
+	switch(eye_damaged)
+		if(BLURRY_VISION_ONE, BLURRY_VISION_TWO)
+			owner.overlay_fullscreen("eye_damage", /obj/screen/fullscreen/impaired, eye_damaged)
+		if(BLIND_VISION_THREE)
+			owner.become_blind(EYE_DAMAGE)
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
 		old_eye_color = H.eye_color
@@ -48,46 +55,49 @@
 	owner.update_sight()
 
 /obj/item/organ/eyes/Remove(special = FALSE)
-	clear_eye_trauma()
 	. = ..()
 	var/mob/living/carbon/C = .
-	if(!QDELETED(C))
-		if(ishuman(C) && eye_color)
-			var/mob/living/carbon/human/H = C
-			H.eye_color = old_eye_color
-			if(!special)
-				H.dna.species.handle_body(H)
+	if(QDELETED(C))
+		return
+	switch(eye_damaged)
+		if(BLURRY_VISION_ONE, BLURRY_VISION_TWO)
+			C.clear_fullscreen("eye_damage")
+		if(BLIND_VISION_THREE)
+			C.cure_blind(EYE_DAMAGE)
+	if(ishuman(C) && eye_color)
+		var/mob/living/carbon/human/H = C
+		H.eye_color = old_eye_color
 		if(!special)
-			C.update_tint()
-			C.update_sight()
+			H.dna.species.handle_body(H)
+	if(!special)
+		C.update_tint()
+		C.update_sight()
 
-/obj/item/organ/eyes/on_life()
-	..()
-	var/mob/living/carbon/C = owner
-	//since we can repair fully damaged eyes, check if healing has occurred
-	if((organ_flags & ORGAN_FAILING) && (damage < maxHealth))
-		organ_flags &= ~ORGAN_FAILING
-		C.cure_blind(EYE_DAMAGE)
-	//various degrees of "oh fuck my eyes", from "point a laser at your eye" to "staring at the Sun" intensities
-	if(damage > 20)
-		damaged = TRUE
-		if(organ_flags & ORGAN_FAILING)
-			C.become_blind(EYE_DAMAGE)
-		else if(damage > 30)
-			C.overlay_fullscreen("eye_damage", /obj/screen/fullscreen/impaired, 2)
+
+/obj/item/organ/eyes/applyOrganDamage(d, maximum = maxHealth)
+	. = ..()
+	if(!.)
+		return
+	var/old_damaged = eye_damaged
+	switch(damage)
+		if(INFINITY to maxHealth)
+			eye_damaged = BLIND_VISION_THREE
+		if(maxHealth to high_threshold)
+			eye_damaged = BLURRY_VISION_TWO
+		if(high_threshold to low_threshold)
+			eye_damaged = BLURRY_VISION_ONE
 		else
-			C.overlay_fullscreen("eye_damage", /obj/screen/fullscreen/impaired, 1)
-	//called once since we don't want to keep clearing the screen of eye damage for people who are below 20 damage
-	else if(damaged)
-		damaged = FALSE
-		C.clear_fullscreen("eye_damage")
-	return
-
-/obj/item/organ/eyes/proc/clear_eye_trauma()
-	var/mob/living/carbon/C = owner
-	C.clear_fullscreen("eye_damage")
-	C.cure_blind(EYE_DAMAGE)
-	damaged = FALSE
+			eye_damaged = FALSE
+	if(eye_damaged == old_damaged || !owner)
+		return
+	if(old_damaged == BLIND_VISION_THREE)
+		owner.cure_blind(EYE_DAMAGE)
+	else if(eye_damaged == BLIND_VISION_THREE)
+		owner.become_blind(EYE_DAMAGE)
+	if(eye_damaged && eye_damaged != BLIND_VISION_THREE)
+		owner.overlay_fullscreen("eye_damage", /obj/screen/fullscreen/impaired, eye_damaged)
+	else
+		owner.clear_fullscreen("eye_damage")
 
 /obj/item/organ/eyes/night_vision
 	name = "shadow eyes"
@@ -383,3 +393,7 @@
 /obj/item/organ/eyes/ipc
 	name = "ipc eyes"
 	icon_state = "cybernetic_eyeballs"
+
+#undef BLURRY_VISION_ONE
+#undef BLURRY_VISION_TWO
+#undef BLIND_VISION_THREE

--- a/code/modules/surgery/organs/heart.dm
+++ b/code/modules/surgery/organs/heart.dm
@@ -15,6 +15,7 @@
 
 	// Heart attack code is in code/modules/mob/living/carbon/human/life.dm
 	var/beating = 1
+	var/no_pump = FALSE
 	var/icon_base = "heart"
 	attack_verb = list("beat", "thumped")
 	var/beat = BEAT_NONE//is this mob having a heatbeat sound played? if so, which?
@@ -66,27 +67,28 @@
 	return S
 
 /obj/item/organ/heart/on_life()
-	..()
+	. = ..()
+	if(!owner || no_pump)
+		return
 	if(owner.client && beating)
 		failed = FALSE
 		var/sound/slowbeat = sound('sound/health/slowbeat.ogg', repeat = TRUE)
 		var/sound/fastbeat = sound('sound/health/fastbeat.ogg', repeat = TRUE)
-		var/mob/living/carbon/H = owner
 
-		if(H.health <= H.crit_threshold && beat != BEAT_SLOW)
+		if(owner.health <= owner.crit_threshold && beat != BEAT_SLOW)
 			beat = BEAT_SLOW
-			H.playsound_local(get_turf(H), slowbeat,40,0, channel = CHANNEL_HEARTBEAT)
+			owner.playsound_local(get_turf(owner), slowbeat,40,0, channel = CHANNEL_HEARTBEAT)
 			to_chat(owner, "<span class = 'notice'>You feel your heart slow down...</span>")
-		if(beat == BEAT_SLOW && H.health > H.crit_threshold)
-			H.stop_sound_channel(CHANNEL_HEARTBEAT)
+		if(beat == BEAT_SLOW && owner.health > owner.crit_threshold)
+			owner.stop_sound_channel(CHANNEL_HEARTBEAT)
 			beat = BEAT_NONE
 
-		if(H.jitteriness)
-			if(H.health > HEALTH_THRESHOLD_FULLCRIT && (!beat || beat == BEAT_SLOW))
-				H.playsound_local(get_turf(H),fastbeat,40,0, channel = CHANNEL_HEARTBEAT)
+		if(owner.jitteriness)
+			if(owner.health > HEALTH_THRESHOLD_FULLCRIT && (!beat || beat == BEAT_SLOW))
+				owner.playsound_local(get_turf(owner),fastbeat,40,0, channel = CHANNEL_HEARTBEAT)
 				beat = BEAT_FAST
 		else if(beat == BEAT_FAST)
-			H.stop_sound_channel(CHANNEL_HEARTBEAT)
+			owner.stop_sound_channel(CHANNEL_HEARTBEAT)
 			beat = BEAT_NONE
 
 	if(organ_flags & ORGAN_FAILING)	//heart broke, stopped beating, death imminent
@@ -107,6 +109,7 @@ obj/item/organ/heart/slime
 	icon_state = "cursedheart-off"
 	icon_base = "cursedheart"
 	decay_factor = 0
+	no_pump = TRUE
 	actions_types = list(/datum/action/item_action/organ_action/cursed_heart)
 	var/last_pump = 0
 	var/add_colour = TRUE //So we're not constantly recreating colour datums
@@ -128,6 +131,9 @@ obj/item/organ/heart/slime
 		return ..()
 
 /obj/item/organ/heart/cursed/on_life()
+	. = ..()
+	if(!owner)
+		return
 	if(world.time > (last_pump + pump_delay))
 		if(ishuman(owner) && owner.client) //While this entire item exists to make people suffer, they can't control disconnects.
 			var/mob/living/carbon/human/H = owner
@@ -208,6 +214,8 @@ obj/item/organ/heart/slime
 
 obj/item/organ/heart/cybernetic/upgraded/on_life()
 	. = ..()
+	if(!.)
+		return
 	if(dose_available && owner.health <= owner.crit_threshold && !owner.reagents.has_reagent(rid))
 		owner.reagents.add_reagent(rid, ramount)
 		used_dose()
@@ -233,7 +241,7 @@ obj/item/organ/heart/cybernetic/upgraded/on_life()
 
 /obj/item/organ/heart/freedom/on_life()
 	. = ..()
-	if(owner.health < 5 && world.time > min_next_adrenaline)
+	if(. && owner.health < 5 && world.time > min_next_adrenaline)
 		min_next_adrenaline = world.time + rand(250, 600) //anywhere from 4.5 to 10 minutes
 		to_chat(owner, "<span class='userdanger'>You feel yourself dying, but you refuse to give up!</span>")
 		owner.heal_overall_damage(15, 15)

--- a/code/modules/surgery/organs/liver.dm
+++ b/code/modules/surgery/organs/liver.dm
@@ -25,25 +25,24 @@
 	var/cachedmoveCalc = 1
 
 /obj/item/organ/liver/on_life()
-	var/mob/living/carbon/C = owner
+	. = ..()
+	if(!.)//can't process reagents with a failing liver
+		return
 
-	if(istype(C))
-		if(!(organ_flags & ORGAN_FAILING))//can't process reagents with a failing liver
+	if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
+		//handle liver toxin filtration
+		for(var/datum/reagent/toxin/T in owner.reagents.reagent_list)
+			var/thisamount = owner.reagents.get_reagent_amount(T.type)
+			if (thisamount && thisamount <= toxTolerance)
+				owner.reagents.remove_reagent(T.type, 1)
+			else
+				damage += (thisamount*toxLethality)
 
-			if(filterToxins && !HAS_TRAIT(owner, TRAIT_TOXINLOVER))
-				//handle liver toxin filtration
-				for(var/datum/reagent/toxin/T in C.reagents.reagent_list)
-					var/thisamount = C.reagents.get_reagent_amount(T.type)
-					if (thisamount && thisamount <= toxTolerance)
-						C.reagents.remove_reagent(T.type, 1)
-					else
-						damage += (thisamount*toxLethality)
+	//metabolize reagents
+	owner.reagents.metabolize(owner, can_overdose=TRUE)
 
-			//metabolize reagents
-			C.reagents.metabolize(C, can_overdose=TRUE)
-
-			if(damage > 10 && prob(damage/3))//the higher the damage the higher the probability
-				to_chat(C, "<span class='warning'>You feel a dull pain in your abdomen.</span>")
+	if(damage > 10 && prob(damage/3))//the higher the damage the higher the probability
+		to_chat(owner, "<span class='warning'>You feel a dull pain in your abdomen.</span>")
 
 /obj/item/organ/liver/prepare_eat()
 	var/obj/S = ..()

--- a/code/modules/surgery/organs/lungs.dm
+++ b/code/modules/surgery/organs/lungs.dm
@@ -446,17 +446,17 @@
 			if(prob(20))
 				to_chat(H, "<span class='warning'>You feel [hot_message] in your [name]!</span>")
 
-
-/obj/item/organ/lungs/on_life()
-	..()
-	if((!failed) && ((organ_flags & ORGAN_FAILING)))
-		if(owner.stat == CONSCIOUS)
+/obj/item/organ/lungs/applyOrganDamage(d, maximum = maxHealth)
+	. = ..()
+	if(!.)
+		return
+	if(!failed && organ_flags & ORGAN_FAILING)
+		if(owner && owner.stat == CONSCIOUS)
 			owner.visible_message("<span class='danger'>[owner] grabs [owner.p_their()] throat, struggling for breath!</span>", \
 								"<span class='userdanger'>You suddenly feel like you can't breathe!</span>")
 		failed = TRUE
 	else if(!(organ_flags & ORGAN_FAILING))
 		failed = FALSE
-	return
 
 /obj/item/organ/lungs/prepare_eat()
 	var/obj/S = ..()
@@ -547,5 +547,6 @@
 	color = "#68e83a"
 
 /obj/item/organ/lungs/yamerol/on_life()
-	..()
-	damage += 2 //Yamerol lungs are temporary
+	. = ..()
+	if(.)
+		applyOrganDamage(2) //Yamerol lungs are temporary

--- a/code/modules/surgery/organs/organ_internal.dm
+++ b/code/modules/surgery/organs/organ_internal.dm
@@ -134,18 +134,19 @@
 	organ_flags &= ~ORGAN_FROZEN
 	return FALSE
 
-/obj/item/organ/proc/on_life()	//repair organ damage if the organ is not failing
-	if(organ_flags & ORGAN_FAILING)
-		return
+/obj/item/organ/proc/on_life()	//repair organ damage if the organ is not failing or synthetic
+	if(organ_flags & ORGAN_FAILING || !owner)
+		return FALSE
 	if(is_cold())
-		return
-	///Damage decrements by a percent of its maxhealth
-	var/healing_amount = -(maxHealth * healing_factor)
-	///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's health
-	healing_amount -= owner.satiety > 0 ? 4 * healing_factor * owner.satiety / MAX_SATIETY : 0
-	if(healing_amount)
-		applyOrganDamage(healing_amount) //to FERMI_TWEAK
-		//Make it so each threshold is stuck.
+		return FALSE
+	if(damage)
+		///Damage decrements by a percent of its maxhealth
+		var/healing_amount = -(maxHealth * healing_factor)
+		///Damage decrements again by a percent of its maxhealth, up to a total of 4 extra times depending on the owner's satiety
+		healing_amount -= owner.satiety > 0 ? 4 * healing_factor * owner.satiety / MAX_SATIETY : 0
+		if(healing_amount)
+			applyOrganDamage(healing_amount) //to FERMI_TWEAK
+	return TRUE
 
 /obj/item/organ/examine(mob/user)
 	. = ..()
@@ -205,9 +206,7 @@
 
 ///Adjusts an organ's damage by the amount "d", up to a maximum amount, which is by default max damage
 /obj/item/organ/proc/applyOrganDamage(var/d, var/maximum = maxHealth)	//use for damaging effects
-	if(!d) //Micro-optimization.
-		return FALSE
-	if(maximum < damage)
+	if(!d || maximum < damage) //Micro-optimization.
 		return FALSE
 	damage = clamp(damage + d, 0, maximum)
 	var/mess = check_damage_thresholds()

--- a/code/modules/surgery/organs/stomach.dm
+++ b/code/modules/surgery/organs/stomach.dm
@@ -17,33 +17,24 @@
 	low_threshold_cleared = "<span class='info'>The last bouts of pain in your stomach have died out.</span>"
 
 /obj/item/organ/stomach/on_life()
-	..()
-	var/datum/reagent/consumable/nutriment/Nutri
+	. = ..()
+	if(!owner)
+		return
 	if(ishuman(owner))
 		var/mob/living/carbon/human/H = owner
-		if(!(organ_flags & ORGAN_FAILING))
+		if(.)
 			H.dna.species.handle_digestion(H)
 		handle_disgust(H)
-		Nutri = locate(/datum/reagent/consumable/nutriment) in H.reagents.reagent_list
 
-		if(Nutri)
-			if(prob((damage/40) * Nutri.volume * Nutri.volume))
-				H.vomit(damage)
-				to_chat(H, "<span class='warning'>Your stomach reels in pain as you're incapable of holding down all that food!</span>")
-
-		else if(Nutri && damage > high_threshold)
-			if(prob((damage/10) * Nutri.volume * Nutri.volume))
-				H.vomit(damage)
-				to_chat(H, "<span class='warning'>Your stomach reels in pain as you're incapable of holding down all that food!</span>")
-
-
-	else if(iscarbon(owner))
-		var/mob/living/carbon/C = owner
-		Nutri = locate(/datum/reagent/consumable/nutriment) in C.reagents.reagent_list
-
-	if(damage < low_threshold)
+	if(!damage)
 		return
-
+	var/datum/reagent/consumable/nutriment/Nutri = locate(/datum/reagent/consumable/nutriment) in owner.reagents.reagent_list
+	if(!Nutri)
+		return
+	var/prob_divisor = damage > high_threshold ? 10 : 40
+	if(prob((damage/prob_divisor) * (Nutri.volume**2)))
+		owner.vomit(damage)
+		to_chat(owner, "<span class='warning'>Your stomach reels in pain as you're incapable of holding down all that food!</span>")
 
 /obj/item/organ/stomach/proc/handle_disgust(mob/living/carbon/human/H)
 	if(H.disgust)

--- a/modular_citadel/code/modules/arousal/genitals.dm
+++ b/modular_citadel/code/modules/arousal/genitals.dm
@@ -150,7 +150,8 @@
 		aroused_state = FALSE
 
 /obj/item/organ/genital/on_life()
-	if(!reagents || !owner)
+	. = ..()
+	if(!reagents || !.)
 		return
 	reagents.maximum_volume = fluid_max_volume
 	if(fluid_id && CHECK_BITFIELD(genital_flags, GENITAL_FUID_PRODUCTION))


### PR DESCRIPTION
## About The Pull Request
Mostly parent calls, early returns, using `applyOrganDamage` instead of `on_life` for certain non recurring organ damage effects such as blurry vision and blindness.

## Why It's Good For The Game
Code improvements. This will also close #12019.

## Changelog
:cl:
fix: fixed a few organs not healing over time provided they aren't failing, or still working otherwise.
code: see above.
/:cl:
