### PR TITLE
Fixes cybernetics not updating slowdowns when dropping shield

### DIFF
--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -393,7 +393,7 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 		qdel(src)
 	item_flags &= ~IN_INVENTORY
 	if(SEND_SIGNAL(src, COMSIG_ITEM_DROPPED,user) & COMPONENT_DROPPED_RELOCATION)
-		return ITEM_RELOCATED_BY_DROPPED
+		. = ITEM_RELOCATED_BY_DROPPED
 	user.update_equipment_speed_mods()
 
 // called just as an item is picked up (loc is not yet changed)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

the proc to update wasn't being called
it should be because even if the thing is relocated the mob still needs to update slowdowns
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

fix
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: cybernetic shields no longer keep slowing down after being dropped.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
