### PR TITLE
Identification components + chameleon clothing from uplink is now obfuscated

### DIFF
--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -60,7 +60,7 @@
 /// Delete on successful broad identification (so the main way we "uncover" how an object works, since this won't be on it to obfuscate it)
 #define ID_COMPONENT_DEL_ON_IDENTIFY						(1<<0)
 /// We've already been successfully deepscanned by a deconstructive analyzer
-#define ID_COMPONENT_DECONSTRUCTIVE_DEEPSCANNED				(1<<1)
+#define ID_COMPONENT_DECONSTRUCTOR_DEEPSCANNED				(1<<1)
 
 // /datum/component/identification/identification_effect_flags
 /// Block user from getting actions if they don't know how to use this. Triggered on equip.

--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -67,3 +67,9 @@
 // /datum/component/identification/identification_method_flags
 /// Can be identified in a deconstructive analyzer
 #define ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR			(1<<0)
+
+// Return values for /datum/component/deitnfication/check_knowledge()
+/// Has no knowledge, default
+#define ID_COMPONENT_KNONWLEDGE_NONE			0
+/// Has full knowledge
+#define ID_COMPONENT_KNOWLEDGE_FULL				1

--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -72,6 +72,6 @@
 
 // Return values for /datum/component/deitnfication/check_knowledge()
 /// Has no knowledge, default
-#define ID_COMPONENT_KNONWLEDGE_NONE			0
+#define ID_COMPONENT_KNOWLEDGE_NONE			0
 /// Has full knowledge
 #define ID_COMPONENT_KNOWLEDGE_FULL				1

--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -59,6 +59,8 @@
 // /datum/component/identification/identification_flags
 /// Delete on successful broad identification (so the main way we "uncover" how an object works, since this won't be on it to obfuscate it)
 #define ID_COMPONENT_DEL_ON_IDENTIFY						(1<<0)
+/// We've already been successfully deepscanned by a deconstructive analyzer
+#define ID_COMPONENT_DECONSTRUCTIVE_DEEPSCANNED				(1<<1)
 
 // /datum/component/identification/identification_effect_flags
 /// Block user from getting actions if they don't know how to use this. Triggered on equip.

--- a/code/__DEFINES/dcs/flags.dm
+++ b/code/__DEFINES/dcs/flags.dm
@@ -40,6 +40,7 @@
 #define CALTROP_BYPASS_SHOES 1
 #define CALTROP_IGNORE_WALKERS 2
 
+// Spellcasting
 #define SPELL_SKIP_ALL_REQS		(1<<0)
 #define SPELL_SKIP_CENTCOM		(1<<1)
 #define SPELL_SKIP_STAT			(1<<2)
@@ -53,3 +54,16 @@
 #define SPELL_CULT_ARMOR		(1<<10)
 #define SPELL_WIZARD_GARB		(SPELL_WIZARD_HAT|SPELL_WIZARD_ROBE)
 #define SPELL_CULT_GARB			(SPELL_CULT_HELMET|SPELL_CULT_ARMOR)
+
+//// Identification ////
+// /datum/component/identification/identification_flags
+/// Delete on successful broad identification (so the main way we "uncover" how an object works, since this won't be on it to obfuscate it)
+#define ID_COMPONENT_DEL_ON_IDENTIFY						(1<<0)
+
+// /datum/component/identification/identification_effect_flags
+/// Block user from getting actions if they don't know how to use this. Triggered on equip.
+#define ID_COMPONENT_EFFECT_NO_ACTIONS						(1<<0)
+
+// /datum/component/identification/identification_method_flags
+/// Can be identified in a deconstructive analyzer
+#define ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR			(1<<0)

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -255,6 +255,7 @@
 // THE FOLLOWING TWO BLOCKS SHOULD RETURN BLOCK FLAGS AS DEFINED IN __DEFINES/combat.dm!
 #define COMSIG_ITEM_CHECK_BLOCK "check_block"					//from base of obj/item/check_block(): (mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 #define COMSIG_ITEM_RUN_BLOCK "run_block"						//from base of obj/item/run_block(): (mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
+#define COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN "deconstructor_deepscan"			//Called by deconstructive analyzers deepscanning an item: (obj/machinery/rnd/destructive_analyzer/analyzer_machine, mob/user, list/information_list)
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -242,7 +242,7 @@
 #define COMSIG_ITEM_ALT_AFTERATTACK "item_alt_afterattack"		//from base of obj/item/altafterattack(): (atom/target, mob/user, proximity, params)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
 	// Do not grant actions on equip.
-	#define COMPONENT_NO_GRANT_ACTIONS
+	#define COMPONENT_NO_GRANT_ACTIONS		1
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (mob/user)
 	// relocated, tell inventory procs if those called this that the item isn't available anymore.
 	#define COMPONENT_DROPPED_RELOCATION 1

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -256,6 +256,8 @@
 #define COMSIG_ITEM_CHECK_BLOCK "check_block"					//from base of obj/item/check_block(): (mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 #define COMSIG_ITEM_RUN_BLOCK "run_block"						//from base of obj/item/run_block(): (mob/living/owner, atom/object, damage, attack_text, attack_type, armour_penetration, mob/attacker, def_zone, final_block_chance, list/block_return)
 #define COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN "deconstructor_deepscan"			//Called by deconstructive analyzers deepscanning an item: (obj/machinery/rnd/destructive_analyzer/analyzer_machine, mob/user, list/information_list)
+	// Uncovered information
+	#define COMPONENT_DEEPSCAN_UNCOVERED_INFORMATION		1
 
 // /obj/item/clothing signals
 #define COMSIG_SHOES_STEP_ACTION "shoes_step_action"			//from base of obj/item/clothing/shoes/proc/step_action(): ()

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -30,7 +30,7 @@
 #define COMSIG_PARENT_ATTACKBY "atom_attackby"			        //from base of atom/attackby(): (/obj/item, /mob/living, params)
 	#define COMPONENT_NO_AFTERATTACK 1								//Return this in response if you don't want afterattack to be called
 #define COMSIG_ATOM_HULK_ATTACK "hulk_attack"					//from base of atom/attack_hulk(): (/mob/living/carbon/human)
-#define COMSIG_PARENT_EXAMINE "atom_examine"                    //from base of atom/examine(): (/mob)
+#define COMSIG_PARENT_EXAMINE "atom_examine"                    //from base of atom/examine(): (/mob, list/examine_return_text)
 #define COMSIG_ATOM_GET_EXAMINE_NAME "atom_examine_name"		//from base of atom/get_examine_name(): (/mob, list/overrides)
 	//Positions for overrides list
 	#define EXAMINE_POSITION_ARTICLE 1

--- a/code/__DEFINES/dcs/signals.dm
+++ b/code/__DEFINES/dcs/signals.dm
@@ -241,6 +241,8 @@
 #define COMSIG_ITEM_AFTERATTACK "item_afterattack"				//from base of obj/item/afterattack(): (atom/target, mob/user, params)
 #define COMSIG_ITEM_ALT_AFTERATTACK "item_alt_afterattack"		//from base of obj/item/altafterattack(): (atom/target, mob/user, proximity, params)
 #define COMSIG_ITEM_EQUIPPED "item_equip"						//from base of obj/item/equipped(): (/mob/equipper, slot)
+	// Do not grant actions on equip.
+	#define COMPONENT_NO_GRANT_ACTIONS
 #define COMSIG_ITEM_DROPPED "item_drop"							//from base of obj/item/dropped(): (mob/user)
 	// relocated, tell inventory procs if those called this that the item isn't available anymore.
 	#define COMPONENT_DROPPED_RELOCATION 1

--- a/code/__DEFINES/research.dm
+++ b/code/__DEFINES/research.dm
@@ -60,7 +60,8 @@
 
 #define DESIGN_ID_IGNORE "IGNORE_THIS_DESIGN"
 
-#define RESEARCH_MATERIAL_RECLAMATION_ID "__materials"
+#define RESEARCH_MATERIAL_RECLAMATION_ID		"__materials"
+#define RESEARCH_DEEP_SCAN_ID					"__deepscan"
 
 //When adding new types, update the list below!
 #define TECHWEB_POINT_TYPE_GENERIC "General Research"

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -38,7 +38,7 @@
 		unregister += COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN
 	UnregisterSignal(parent, unregister)
 
-/datum/component/identification/proc/on_examine(mob/user, list/returnlist)
+/datum/component/identification/proc/on_examine(datum/source, mob/user, list/returnlist)
 	if(check_knowledge(user) != ID_COMPONENT_KNOWLEDGE_FULL)
 		return
 	if(!additional_examine_text)
@@ -54,7 +54,7 @@
 	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identification_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
 		RegisterWithParent()
 
-/datum/component/identification/proc/on_equip(mob/user)
+/datum/component/identification/proc/on_equip(datum/source, mob/user)
 	if(check_knowledge(user) == ID_COMPONENT_KNOWLEDGE_FULL)
 		return
 	if(identification_method_flags & ID_COMPONENT_EFFECT_NO_ACTIONS)
@@ -67,7 +67,7 @@
 	if(identification_flags & ID_COMPONENT_DEL_ON_IDENTIFY)
 		qdel(src)
 
-/datum/component/identification/proc/on_deconstructor_deepscan(obj/machinery/rnd/destructive_analyzer/analyzer, mob/user, list/information = list())
+/datum/component/identification/proc/on_deconstructor_deepscan(datum/source, obj/machinery/rnd/destructive_analyzer/analyzer, mob/user, list/information = list())
 	if((identification_method_flags & ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR) && !(identification_flags & ID_COMPONENT_DECONSTRUCTOR_DEEPSCANNED))
 		identification_flags |= ID_COMPONENT_DECONSTRUCTOR_DEEPSCANNED
 		on_identify(user)

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -79,5 +79,5 @@
 
 /datum/component/identification/syndicate/check_knowledge(mob/user)
 	. = ..()
-	if(user?.mind?.has_antag_datum(/datum/antagonist/traitor)
+	if(user?.mind?.has_antag_datum(/datum/antagonist/traitor))
 		. = max(., ID_COMPONENT_KNOWLEDGE_FULL)

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -28,7 +28,7 @@
 	if(identification_effect_flags & ID_COMPONENT_EFFECT_NO_ACTIONS)
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	if(identification_method_flags & ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR)
-		RegisteRsignal(parent, COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN, .proc/on_deconstructor_deepscan)
+		Registersignal(parent, COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN, .proc/on_deconstructor_deepscan)
 
 /datum/component/identification/UnregisterFromParent()
 	var/list/unregister = list(COMSIG_PARENT_EXAMINE)
@@ -49,11 +49,17 @@
 /datum/component/identification/vv_edit_var(var_name, var_value)
 	// since i care SOOO much about memory optimization, we only register signals we need to
 	// so when someone vv's us, we should probably make sure we have the ones we need to with an update.
-	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identifcation_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
+	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identification_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
 		UnregisterFromParent()
 	. = ..()
-	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identifcation_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
-		RegisterwithParent()
+	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identification_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
+		RegisterWithParent()
+
+/datum/component/identification/proc/on_equip(mob/user)
+	if(check_knowledge(user) == ID_COMPONENT_KNOWLEDGE_FULL)
+		return
+	if(identification_method_flags & ID_COMPONENT_EFFECT_NO_ACTIONS)
+		return COMPONENT_NO_GRANT_ACTIONS
 
 /datum/component/identification/proc/check_knowledge(mob/user)
 	return ID_COMPONENT_KNOWLEDGE_NONE

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -1,0 +1,39 @@
+/**
+  * Identification components
+  */
+/datum/component/identification
+	/// General flags for how we should work.
+	var/identification_flags = NONE
+	/// General flags for what we should do.
+	var/identification_effect_flags = NONE
+	/// General flags for how we can be identified.
+	var/identification_method_flags = NONE
+
+/datum/component/identification/Initialize(id_flags, id_effect_flags, id_method_flags)
+	if(!isobj(parent))
+		return COMPONENT_INCOMPATIBLE
+	. = ..()
+	if(. & COMPONENT_INCOMPATIBLE)
+		return
+	identification_flags = id_flags
+	identification_effect_flags = id_effect_flags
+	identification_method_flags = id_method_flags
+
+/datum/component/identification/RegisterWithParent()
+
+/datum/component/identification/UnregisterFromParent()
+
+/datum/component/identification/vv_edit_var(var_name, var_value)
+	// since i care SOOO much about memory optimization, we only register signals we need to
+	// so when someone vv's us, we should probably make sure we have the ones we need to with an update.
+	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identifcation_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
+		UnregisterFromParent()
+	. = ..()
+	if((var_value == NAMEOF(src, identification_flags)) || (var_value == NAMEOF(src, identifcation_effect_flags)) || (var_value == NAMEOF(src, identification_method_flags)))
+		RegisterwithParent()
+
+/datum/component/identification/proc/check_knowledge(mob/user)
+
+/datum/component/identification/proc/on_identify(mob/user)
+	if(identification_flags & ID_COMPONENT_DEL_ON_IDENTIFY)
+		qdel(src)

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -33,7 +33,18 @@
 		RegisterwithParent()
 
 /datum/component/identification/proc/check_knowledge(mob/user)
+	return ID_COMPONENT_KNOWLEDGE_NONE
 
 /datum/component/identification/proc/on_identify(mob/user)
 	if(identification_flags & ID_COMPONENT_DEL_ON_IDENTIFY)
 		qdel(src)
+
+/**
+  * Identification component subtype - Syndicate
+  *
+  * Checks if the user is a traitor.
+  */
+/datum/component/identification/syndicate/check_knowledge(mob/user)
+	. = ..()
+	if(user?.mind?.has_antag_datum(/datum/antagonist/traitor)
+		. = max(., ID_COMPONENT_KNOWLEDGE_FULL)

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -8,6 +8,8 @@
 	var/identification_effect_flags = NONE
 	/// General flags for how we can be identified.
 	var/identification_method_flags = NONE
+	/// If this is set, show this on examine to the examiner if they know how to use it.
+	var/additional_examine_text = "<span class='notice'>You seem to know more about this item than others..</span>"
 
 /datum/component/identification/Initialize(id_flags, id_effect_flags, id_method_flags)
 	if(!isobj(parent))
@@ -20,8 +22,19 @@
 	identification_method_flags = id_method_flags
 
 /datum/component/identification/RegisterWithParent()
+	RegisterSignal(parent, COMSIG_PARENT_EXAMINE, .proc/on_examine)
 
 /datum/component/identification/UnregisterFromParent()
+	var/list/unregister = list(COMSIG_PARENT_EXAMINE)
+
+	UnregisterSignal(parent, unregister)
+
+/datum/component/identification/proc/on_examine(mob/user, list/returnlist)
+	if(check_knowledge(user) != ID_COMPONENT_KNOWLEDGE_FULL)
+		return
+	if(!additional_examine_text)
+		return
+	returnlist += additional_examine_text
 
 /datum/component/identification/vv_edit_var(var_name, var_value)
 	// since i care SOOO much about memory optimization, we only register signals we need to

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -10,6 +10,8 @@
 	var/identification_method_flags = NONE
 	/// If this is set, show this on examine to the examiner if they know how to use it.
 	var/additional_examine_text = "<span class='notice'>You seem to know more about this item than others..</span>"
+	/// Added to deconstructive analyzer say on success if set
+	var/deconstructor_reveal_text = "item operation instructions"
 
 /datum/component/identification/Initialize(id_flags, id_effect_flags, id_method_flags)
 	if(!isobj(parent))
@@ -60,10 +62,12 @@
 	if(identification_flags & ID_COMPONENT_DEL_ON_IDENTIFY)
 		qdel(src)
 
-/datum/component/identification/proc/on_deconstructor_deepscan(obj/machinery/rnd/destructive_analyzer/analyzer, mob/user)
+/datum/component/identification/proc/on_deconstructor_deepscan(obj/machinery/rnd/destructive_analyzer/analyzer, mob/user, list/information = list())
 	if((identification_method_flags & ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR) && !(identification_flags & ID_COMPONENT_DECONSTRUCTOR_DEEPSCANNED))
 		identification_flags |= ID_COMPONENT_DECONSTRUCTOR_DEEPSCANNED
 		on_identify(user)
+		if(deconstructor_reveal_text)
+			information += deconstructor_reveal_text
 		return COMPONENT_DEEPSCAN_UNCOVERED_INFORMATION
 
 /**

--- a/code/datums/components/identification.dm
+++ b/code/datums/components/identification.dm
@@ -28,14 +28,13 @@
 	if(identification_effect_flags & ID_COMPONENT_EFFECT_NO_ACTIONS)
 		RegisterSignal(parent, COMSIG_ITEM_EQUIPPED, .proc/on_equip)
 	if(identification_method_flags & ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR)
-		Registersignal(parent, COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN, .proc/on_deconstructor_deepscan)
+		RegisterSignal(parent, COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN, .proc/on_deconstructor_deepscan)
 
 /datum/component/identification/UnregisterFromParent()
 	var/list/unregister = list(COMSIG_PARENT_EXAMINE)
 	if(identification_effect_flags & ID_COMPONENT_EFFECT_NO_ACTIONS)
 		unregister += COMSIG_ITEM_EQUIPPED
 	if(identification_method_flags & ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR)
-		unregister += COMSIG_ITEM_DECONSTRUCTOR_READ
 		unregister += COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN
 	UnregisterSignal(parent, unregister)
 

--- a/code/game/objects/items.dm
+++ b/code/game/objects/items.dm
@@ -434,11 +434,12 @@ GLOBAL_VAR_INIT(rpg_loot_items, FALSE)
 // for items that can be placed in multiple slots
 // note this isn't called during the initial dressing of a player
 /obj/item/proc/equipped(mob/user, slot)
-	SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
-	for(var/X in actions)
-		var/datum/action/A = X
-		if(item_action_slot_check(slot, user, A)) //some items only give their actions buttons when in a specific slot.
-			A.Grant(user)
+	. = SEND_SIGNAL(src, COMSIG_ITEM_EQUIPPED, user, slot)
+	if(!(. & COMPONENT_NO_GRANT_ACTIONS))
+		for(var/X in actions)
+			var/datum/action/A = X
+			if(item_action_slot_check(slot, user, A)) //some items only give their actions buttons when in a specific slot.
+				A.Grant(user)
 	item_flags |= IN_INVENTORY
 	user.update_equipment_speed_mods()
 

--- a/code/game/objects/items/cards_ids.dm
+++ b/code/game/objects/items/cards_ids.dm
@@ -258,6 +258,8 @@ update_label("John Doe", "Clowny")
 	chameleon_action.chameleon_type = /obj/item/card/id
 	chameleon_action.chameleon_name = "ID Card"
 	chameleon_action.initialize_disguises()
+	if(!anyone)
+		AddComponent(/datum/component/identification/syndicate, ID_COMPONENT_DEL_ON_IDENTIFY, ID_COMPONENT_EFFECT_NO_ACTIONS, NONE)		//no deconstructive analyzer usage.
 
 /obj/item/card/id/syndicate/afterattack(obj/item/O, mob/user, proximity)
 	if(!proximity)

--- a/code/game/objects/items/storage/uplink_kits.dm
+++ b/code/game/objects/items/storage/uplink_kits.dm
@@ -294,18 +294,18 @@
 	name = "chameleon kit"
 
 /obj/item/storage/box/syndie_kit/chameleon/PopulateContents()
-	new /obj/item/clothing/under/chameleon(src)
-	new /obj/item/clothing/suit/chameleon(src)
-	new /obj/item/clothing/gloves/chameleon(src)
-	new /obj/item/clothing/shoes/chameleon(src)
-	new /obj/item/clothing/glasses/chameleon(src)
-	new /obj/item/clothing/head/chameleon(src)
-	new /obj/item/clothing/mask/chameleon(src)
-	new /obj/item/storage/backpack/chameleon(src)
-	new /obj/item/radio/headset/chameleon(src)
-	new /obj/item/stamp/chameleon(src)
-	new /obj/item/pda/chameleon(src)
-	new /obj/item/clothing/neck/cloak/chameleon(src)
+	new /obj/item/clothing/under/chameleon/syndicate(src)
+	new /obj/item/clothing/suit/chameleon/syndicate(src)
+	new /obj/item/clothing/gloves/chameleon/insulated/syndicate(src)
+	new /obj/item/clothing/shoes/chameleon/syndicate(src)
+	new /obj/item/clothing/glasses/chameleon/syndicate(src)
+	new /obj/item/clothing/head/chameleon/syndicate(src)
+	new /obj/item/clothing/mask/chameleon/syndicate(src)
+	new /obj/item/storage/backpack/chameleon/syndicate(src)
+	new /obj/item/radio/headset/chameleon/syndicate(src)
+	new /obj/item/stamp/chameleon/syndicate(src)
+	new /obj/item/pda/chameleon/syndicate(src)
+	new /obj/item/clothing/neck/cloak/chameleon/syndicate(src)
 
 //5*(2*4) = 5*8 = 45, 45 damage if you hit one person with all 5 stars.
 //Not counting the damage it will do while embedded (2*4 = 8, at 15% chance)
@@ -510,4 +510,4 @@
 	new /obj/item/clothing/under/chameleon(src)
 	new /obj/item/storage/fancy/cigarettes/cigpack_syndicate(src)
 	new /obj/item/lighter(src)
-	
+

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -376,7 +376,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/gloves/chameleon)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
-CHAMELEON_CLOTHING_DEFINE(/obj/item/cltohing/gloves/chameleon/insulated)
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/gloves/chameleon/insulated)
 	siemens_coefficient = 0
 
 /obj/item/clothing/gloves/chameleon/Initialize()
@@ -532,7 +532,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/shoes/chameleon/noslip)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/storage/backpack/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/backpack/chameleon)
 	name = "backpack"
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -624,7 +624,7 @@ CHAMELEON_CLOTHING_DEFINE(/obj/item/pda/chameleon)
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/stamp/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/stamp/chameleon)
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
 /obj/item/stamp/chameleon/Initialize()

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -264,10 +264,10 @@
 
 // Forgive me for my sins...
 #define CHAMELEON_CLOTHING_DEFINE(path) \
-##path/syndicate/Initialize(mapload) \
-	. = ..() \
-	AddComponent(/datum/component/identification/syndicate, ID_COMPONENT_DEL_ON_IDENTIFY, ID_COMPONENT_EFFECT_NO_ACTIONS, ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR) \
-
+##path/syndicate/Initialize(mapload){\
+	. = ..();\
+	AddComponent(/datum/component/identification/syndicate, ID_COMPONENT_DEL_ON_IDENTIFY, ID_COMPONENT_EFFECT_NO_ACTIONS, ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR);\
+}\
 ##path
 
 CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/under/chameleon)

--- a/code/modules/clothing/chameleon.dm
+++ b/code/modules/clothing/chameleon.dm
@@ -262,7 +262,15 @@
 		return
 	random_look(owner)
 
-/obj/item/clothing/under/chameleon
+// Forgive me for my sins...
+#define CHAMELEON_CLOTHING_DEFINE(path) \
+##path/syndicate/Initialize(mapload) \
+	. = ..() \
+	AddComponent(/datum/component/identification/syndicate, ID_COMPONENT_DEL_ON_IDENTIFY, ID_COMPONENT_EFFECT_NO_ACTIONS, ID_COMPONENT_IDENTIFY_WITH_DECONSTRUCTOR) \
+
+##path
+
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/under/chameleon)
 //starts off as black
 	name = "black jumpsuit"
 	icon_state = "black"
@@ -300,7 +308,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/clothing/suit/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/suit/chameleon)
 	name = "armor"
 	desc = "A slim armored vest that protects against most types of damage."
 	icon_state = "armor"
@@ -329,7 +337,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/clothing/glasses/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/glasses/chameleon)
 	name = "Optical Meson Scanner"
 	desc = "Used by engineering and mining staff to see basic structural and terrain layouts through walls, regardless of lighting condition."
 	icon_state = "meson"
@@ -357,7 +365,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/clothing/gloves/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/gloves/chameleon)
 	desc = "These gloves will protect the wearer from electric shock."
 	name = "insulated gloves"
 	icon_state = "yellow"
@@ -367,6 +375,9 @@
 	armor = list("melee" = 10, "bullet" = 10, "laser" = 10, "energy" = 0, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 50, "acid" = 50)
 
 	var/datum/action/item_action/chameleon/change/chameleon_action
+
+CHAMELEON_CLOTHING_DEFINE(/obj/item/cltohing/gloves/chameleon/insulated)
+	siemens_coefficient = 0
 
 /obj/item/clothing/gloves/chameleon/Initialize()
 	. = ..()
@@ -386,7 +397,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/clothing/head/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/head/chameleon)
 	name = "grey cap"
 	desc = "It's a baseball hat in a tasteful grey colour."
 	icon_state = "greysoft"
@@ -429,7 +440,7 @@
 	var/datum/action/item_action/chameleon/drone/randomise/randomise_action = new(src)
 	randomise_action.UpdateButtonIcon()
 
-/obj/item/clothing/mask/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/mask/chameleon)
 	name = "gas mask"
 	desc = "A face-covering mask that can be connected to an air supply. While good for concealing your identity, it isn't good for blocking gas flow." //More accurate
 	icon_state = "gas_alt"
@@ -486,7 +497,7 @@
 /obj/item/clothing/mask/chameleon/drone/attack_self(mob/user)
 	to_chat(user, "<span class='notice'>[src] does not have a voice changer.</span>")
 
-/obj/item/clothing/shoes/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/shoes/chameleon)
 	name = "black shoes"
 	icon_state = "black"
 	desc = "A pair of black shoes."
@@ -511,7 +522,7 @@
 		return
 	chameleon_action.emp_randomise()
 
-/obj/item/clothing/shoes/chameleon/noslip
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/shoes/chameleon/noslip)
 	name = "black shoes"
 	icon_state = "black"
 	desc = "A pair of black shoes."
@@ -542,7 +553,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/storage/belt/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/storage/belt/chameleon)
 	name = "toolbelt"
 	desc = "Holds tools."
 	var/datum/action/item_action/chameleon/change/chameleon_action
@@ -570,7 +581,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/radio/headset/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/radio/headset/chameleon)
 	name = "radio headset"
 	var/datum/action/item_action/chameleon/change/chameleon_action
 
@@ -591,7 +602,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/pda/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/pda/chameleon)
 	name = "PDA"
 	var/datum/action/item_action/chameleon/change/pda/chameleon_action
 
@@ -627,7 +638,7 @@
 	. = ..()
 	chameleon_action.emp_randomise(INFINITY)
 
-/obj/item/clothing/neck/cloak/chameleon
+CHAMELEON_CLOTHING_DEFINE(/obj/item/clothing/neck/cloak/chameleon)
 	name = "black tie"
 	desc = "A neosilk clip-on tie."
 	icon = 'icons/obj/clothing/neck.dmi'

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -101,7 +101,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 	if(!istype(loaded_item) || !istype(linked_console))
 		return FALSE
 
-	if (id && id != RESEARCH_MATERIAL_RECLAMATION_ID)
+	if (id && id != RESEARCH_MATERIAL_RECLAMATION_ID && id != RESEARCH_DEEP_SCAN_ID)
 		var/datum/techweb_node/TN = SSresearch.techweb_node_by_id(id)
 		if(!istype(TN))
 			return FALSE
@@ -125,7 +125,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		if(destroy_item(loaded_item))
 			linked_console.stored_research.boost_with_path(SSresearch.techweb_node_by_id(TN.id), dpath)
 
-	else
+	else if(id == RESEARCH_MATERIAL_RECLAMATION_ID)
 		var/list/point_value = techweb_item_point_check(loaded_item)
 		if(linked_console.stored_research.deconstructed_items[loaded_item.type])
 			point_value = list()
@@ -143,6 +143,15 @@ Note: Must be placed within 3 tiles of the R&D Console
 		if(destroy_item(loaded_item))
 			linked_console.stored_research.add_point_list(point_value)
 			linked_console.stored_research.deconstructed_items[loaded_type] = point_value
+	else if(id == RESEARCH_DEEP_SCAN_ID)
+		var/list/return_list = list()
+		. = SEND_SIGNAL(loaded_item, COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN, src, user, return_list)
+		flick("d_analyzer_process", src)
+		if(. & COMPONENT_DEEPSCAN_UNCOVERED_INFORMATION)
+			say("New information uncovered from item deep scan[length(return_list)? " [english_list(return_list)]" : ""].")
+		else
+			say("Item deep scan uncovered no new information.")
+
 	return TRUE
 
 /obj/machinery/rnd/destructive_analyzer/proc/unload_item()

--- a/code/modules/research/destructive_analyzer.dm
+++ b/code/modules/research/destructive_analyzer.dm
@@ -148,7 +148,7 @@ Note: Must be placed within 3 tiles of the R&D Console
 		. = SEND_SIGNAL(loaded_item, COMSIG_ITEM_DECONSTRUCTOR_DEEPSCAN, src, user, return_list)
 		flick("d_analyzer_process", src)
 		if(. & COMPONENT_DEEPSCAN_UNCOVERED_INFORMATION)
-			say("New information uncovered from item deep scan[length(return_list)? " [english_list(return_list)]" : ""].")
+			say("New information uncovered from item deep scan[length(return_list)? ": [english_list(return_list)]" : ""].")
 		else
 			say("Item deep scan uncovered no new information.")
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -577,7 +577,6 @@ Nothing else in the console has ID requirements.
 
 		var/list/boostable_nodes = techweb_item_boost_check(linked_destroy.loaded_item)
 		for(var/id in boostable_nodes)
-			anything = TRUE
 			var/list/worth = boostable_nodes[id]
 			var/datum/techweb_node/N = SSresearch.techweb_node_by_id(id)
 
@@ -611,7 +610,6 @@ Nothing else in the console has ID requirements.
 		// point deconstruction and material reclamation use the same ID to prevent accidentally missing the points
 		var/list/point_values = techweb_item_point_check(linked_destroy.loaded_item)
 		if(point_values)
-			anything = TRUE
 			l += "<div class='statusDisplay'>[RDSCREEN_NOBREAK]"
 			if (stored_research.deconstructed_items[linked_destroy.loaded_item.type])
 				l += "<span class='linkOff'>Point Deconstruction</span>"
@@ -627,7 +625,6 @@ Nothing else in the console has ID requirements.
 			for (var/M in materials)
 				l += "* [CallMaterialName(M)] x [materials[M]]"
 			l += "</div>[RDSCREEN_NOBREAK]"
-			anything = TRUE
 
 		l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_DEEP_SCAN_ID]'>Nondestructive Deep Scan</A></div>"
 

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -575,7 +575,6 @@ Nothing else in the console has ID requirements.
 		l += "<table><tr><td>[icon2html(linked_destroy.loaded_item, usr)]</td><td><b>[linked_destroy.loaded_item.name]</b> <A href='?src=[REF(src)];eject_item=1'>Eject</A></td></tr></table>[RDSCREEN_NOBREAK]"
 		l += "Select a node to boost by deconstructing this item. This item can boost:"
 
-		var/anything = FALSE
 		var/list/boostable_nodes = techweb_item_boost_check(linked_destroy.loaded_item)
 		for(var/id in boostable_nodes)
 			anything = TRUE

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -630,7 +630,7 @@ Nothing else in the console has ID requirements.
 			l += "</div>[RDSCREEN_NOBREAK]"
 			anything = TRUE
 
-		l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_DEEP_SCAN_ID]'>Nondestructive Deep Scan</A></div>
+		l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_DEEP_SCAN_ID]'>Nondestructive Deep Scan</A></div>"
 
 		l += "</div>"
 	return l

--- a/code/modules/research/rdconsole.dm
+++ b/code/modules/research/rdconsole.dm
@@ -47,6 +47,9 @@ Nothing else in the console has ID requirements.
 
 	var/research_control = TRUE
 
+	/// Long action cooldown to prevent spam
+	var/last_long_action = 0
+
 /obj/machinery/computer/rdconsole/production
 	circuit = /obj/item/circuitboard/computer/rdconsole/production
 	research_control = FALSE
@@ -627,8 +630,7 @@ Nothing else in the console has ID requirements.
 			l += "</div>[RDSCREEN_NOBREAK]"
 			anything = TRUE
 
-		if (!anything)
-			l += "Nothing!"
+		l += "<div class='statusDisplay'><A href='?src=[REF(src)];deconstruct=[RESEARCH_DEEP_SCAN_ID]'>Nondestructive Deep Scan</A></div>
 
 		l += "</div>"
 	return l
@@ -915,6 +917,9 @@ Nothing else in the console has ID requirements.
 		screen = RDSCREEN_MENU
 		say("Ejecting Technology Disk")
 	if(ls["deconstruct"])
+		if((last_long_action + 1 SECONDS) > world.time)
+			return
+		last_long_action = world.time
 		if(QDELETED(linked_destroy))
 			say("No Destructive Analyzer Linked!")
 			return

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -389,6 +389,7 @@
 #include "code\datums\components\explodable.dm"
 #include "code\datums\components\footstep.dm"
 #include "code\datums\components\forced_gravity.dm"
+#include "code\datums\components\identification.dm"
 #include "code\datums\components\igniter.dm"
 #include "code\datums\components\infective.dm"
 #include "code\datums\components\jousting.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Adds identification components to set up systems where functionality of items or features are obfuscated unless the user knows how to use it.

Chameleon clothing from uplink is now obfuscated to non-traitors unless analyzed with a deconstructive analyzer

Chameleon gloves from uplink are now insulated.
Chameleon ID obfuscated too. **Those can not be analyzed with deconstructive analyzers.** This is to better match their old functions, aka not being usable/revealing at all unless you're a traitor. The chameleon action buttons were the change that revealed them, now it's no more.

deconstructive analyzers now have a deep scan mode.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Identification components might be useful in the future not just for obfuscating stuff like antag items.

Chameleon clothing: While I usually hate mechanically obfuscating antag gear and stuff I think it's reasonable to do it to this given them being useless as hell half the time. They're too weak and it's a bit hard to do a gimmick/have any stealth if any random joe who takes your gloves off instantly knows you're antag man.
Chameleon gloves from uplink are made insulated to make the kit worth a bit more.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Identification components added.
balance: Chameleon kits from uplinks now include insulated gloves. Included items are not usable by non-traitors until ran through a deconstructive analyzer on deep scan mode.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
