### PR TITLE
Removes the radioactive stuff from uranium 

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -59,7 +59,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	sheet_type = /obj/item/stack/sheet/mineral/diamond
 	value_per_unit = 0.25
 
-///Is slightly radioactive
+///Is cheap and dense 
 /datum/material/uranium
 	name = "uranium"
 	id = "uranium"
@@ -69,15 +69,6 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	value_per_unit = 0.05
 	armor_modifiers = list("melee" = 1.5, "bullet" = 1.4, "laser" = 0.5, "energy" = 0.5, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 1, "acid" = 1)
-
-/datum/material/uranium/on_applied(atom/source, amount, material_flags)
-	. = ..()
-	source.AddComponent(/datum/component/radioactive, amount / 20, source, 0) //half-life of 0 because we keep on going.
-
-/datum/material/uranium/on_removed(atom/source, material_flags)
-	. = ..()
-	qdel(source.GetComponent(/datum/component/radioactive))
-
 
 ///Adds firestacks on hit (Still needs support to turn into gas on destruction)
 /datum/material/plasma

--- a/code/game/turfs/simulated/wall/mineral_walls.dm
+++ b/code/game/turfs/simulated/wall/mineral_walls.dm
@@ -60,6 +60,15 @@
 	sheet_type = /obj/item/stack/sheet/mineral/uranium
 	canSmoothWith = list(/turf/closed/wall/mineral/uranium, /obj/structure/falsewall/uranium)
 
+//Radiates when being welded, other wise is safe
+/turf/closed/wall/mineral/uranium/attackby(obj/item/W, mob/user, params)
+	if(W.get_temperature() > 300)//If the temperature of the object is over 300, then ignite
+		log_game("uranium wall heated by [key_name(user)] in [AREACOORD(src)]")
+		radiate()
+		return
+	..()
+
+//We dont want this to get spammed to much
 /turf/closed/wall/mineral/uranium/proc/radiate()
 	if(!active)
 		if(world.time > last_event+15)
@@ -71,18 +80,6 @@
 			active = null
 			return
 	return
-
-/turf/closed/wall/mineral/uranium/attack_hand(mob/user)
-	radiate()
-	. = ..()
-
-/turf/closed/wall/mineral/uranium/attackby(obj/item/W, mob/user, params)
-	radiate()
-	..()
-
-/turf/closed/wall/mineral/uranium/Bumped(atom/movable/AM)
-	radiate()
-	..()
 
 /turf/closed/wall/mineral/plasma
 	name = "plasma wall"


### PR DESCRIPTION
## About The Pull Request

Makes items made from uranium no longer radioactive
sorry plux makers, you now need something a bit better then 4000 toolboxes

## Why It's Good For The Game
https://github.com/Skyrat-SS13/Skyrat13/pull/1597 sums it up p-well

Not even counting the abuse of this, its just a bad and adds nothing to the game that is worth having.

## Changelog
:cl:
del: uranium is no longer big bad evil rad man that it once was
/:cl:
