### PR TITLE
fixes cheetowalkers by making ashwalkers always spawn with a digitigrade leg type of "digitigrade"

### DIFF
--- a/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
+++ b/code/modules/mob/living/carbon/human/species_types/lizardpeople.dm
@@ -91,4 +91,9 @@
 	if((C.dna.features["spines"] != "None" ) && (C.dna.features["tail_lizard"] == "None")) //tbh, it's kinda ugly for them not to have a tail yet have floating spines
 		C.dna.features["tail_lizard"] = "Smooth"
 		C.update_body()
+	if(C.dna.features["legs"] != "digitigrade")
+		C.dna.features["legs"] = "digitigrade"
+		for(var/obj/item/bodypart/leggie in C.bodyparts)
+			if(leggie.body_zone == BODY_ZONE_L_LEG || leggie.body_zone == BODY_ZONE_R_LEG)
+				leggie.update_limb(FALSE, C)
 	return ..()


### PR DESCRIPTION
## About The Pull Request

![cheetowalker](https://user-images.githubusercontent.com/6356337/80559857-008fe800-89ad-11ea-81cb-148534eb323e.png)
This bug was originally introduced when the avian leg type was introduced. This PR fixes that by making ashwalkers actually have a leg type instead of defaulting to "plantigrade"

## Why It's Good For The Game
why ashwalkers cheetos

## Changelog
:cl: Bhijn
fix: Ashwalkers no longer spawn without leg sprites
/:cl:
