### PR TITLE
Fixes and tweaks for bloodsuckers

### DIFF
--- a/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
@@ -17,7 +17,7 @@
 		if(owner.current.stat == CONSCIOUS && !poweron_feed && !HAS_TRAIT(owner.current, TRAIT_FAKEDEATH)) // Deduct Blood
 			AddBloodVolume(passive_blood_drain) // -.1 currently
 		if(HandleHealing(1)) 		// Heal
-			if(notice_healing == FALSE && owner.current.blood_volume > 0)
+			if(!notice_healing && owner.current.blood_volume > 0)
 				to_chat(owner, "<span class='notice'>The power of your blood begins knitting your wounds...</span>")
 				notice_healing = TRUE
 		else if(notice_healing == TRUE)

--- a/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
@@ -14,7 +14,7 @@
 	set waitfor = FALSE // Don't make on_gain() wait for this function to finish. This lets this code run on the side.
 	var/notice_healing
 	while(owner && !AmFinalDeath()) // owner.has_antag_datum(ANTAG_DATUM_BLOODSUCKER) == src
-		if(owner.current.stat == CONSCIOUS && !poweron_feed && !HAS_TRAIT(owner.current, TRAIT_DEATHCOMA)) // Deduct Blood
+		if(owner.current.stat == CONSCIOUS && !poweron_feed && !HAS_TRAIT(owner.current, TRAIT_FAKEDEATH)) // Deduct Blood
 			AddBloodVolume(passive_blood_drain) // -.1 currently
 		if(HandleHealing(1)) 		// Heal
 			if(notice_healing == FALSE && owner.current.blood_volume > 0)
@@ -25,7 +25,7 @@
 		HandleStarving()  // Death
 		HandleDeath() // Standard Update
 		update_hud()// Daytime Sleep in Coffin
-		if(SSticker.mode.is_daylight() && !HAS_TRAIT_FROM(owner.current, TRAIT_DEATHCOMA, "bloodsucker"))
+		if(SSticker.mode.is_daylight() && !HAS_TRAIT_FROM(owner.current, TRAIT_FAKEDEATH, "bloodsucker"))
 			if(istype(owner.current.loc, /obj/structure/closet/crate/coffin))
 				Torpor_Begin()
 					// Wait before next pass
@@ -83,7 +83,7 @@
 	// NOTE: Mult of 0 is just a TEST to see if we are injured and need to go into Torpor!
 	//It is called from your coffin on close (by you only)
 	var/actual_regen = regen_rate + additional_regen
-	if(poweron_masquerade == TRUE || owner.current.AmStaked())
+	if(poweron_masquerade|| owner.current.AmStaked())
 		return FALSE
 	if(owner.current.reagents.has_reagent(/datum/reagent/consumable/garlic))
 		return FALSE
@@ -101,8 +101,8 @@
 		var/mob/living/carbon/C = owner.current
 		var/costMult = 1 // Coffin makes it cheaper
 		var/fireheal = 0 	// BURN: Heal in Coffin while Fakedeath, or when damage above maxhealth (you can never fully heal fire)
-		var/amInCoffinWhileTorpor = istype(C.loc, /obj/structure/closet/crate/coffin) && (mult == 0 || HAS_TRAIT(C, TRAIT_FAKEDEATH)) // Check for mult 0 OR death coma. (mult 0 means we're testing from coffin)
-		if(amInCoffinWhileTorpor)
+			// Check for mult 0 OR death coma. (mult 0 means we're testing from coffin)
+		if(istype(C.loc, /obj/structure/closet/crate/coffin) && (mult == 0 || HAS_TRAIT(C, TRAIT_FAKEDEATH)))
 			mult *= 4 // Increase multiplier if we're sleeping in a coffin.
 			fireheal = min(C.getFireLoss(), regen_rate) // NOTE: Burn damage ONLY heals in torpor.
 			C.ExtinguishMob()
@@ -112,6 +112,9 @@
 			CheckVampOrgans() // Heart, Eyes
 			if(check_limbs(costMult))
 				return TRUE
+		else if(owner.current.stat >= UNCONSCIOUS) //Faster regeneration and slight burn healing while unconcious
+			mult *= 2
+			fireheal = min(C.getFireLoss(), regen_rate * 0.2)
 
 		// BRUTE: Always Heal
 		var/bruteheal = min(C.getBruteLoss(), actual_regen)
@@ -120,8 +123,6 @@
 		if(bruteheal + fireheal + toxinheal > 0) 	// Just a check? Don't heal/spend, and return.
 			if(mult == 0)
 				return TRUE
-			if(owner.current.stat >= UNCONSCIOUS) //Faster regeneration while unconcious, so you dont have to wait all day
-				mult *= 2
 			// We have damage. Let's heal (one time)
 			C.adjustBruteLoss(-bruteheal * mult, forced = TRUE)// Heal BRUTE / BURN in random portions throughout the body.
 			C.adjustFireLoss(-fireheal * mult, forced = TRUE)
@@ -146,12 +147,12 @@
 		to_chat(C, "<span class='notice'>Your flesh knits as it regrows your [L]!</span>")
 		playsound(C, 'sound/magic/demon_consume.ogg', 50, TRUE)
 		return TRUE
-	/*for(var/obj/item/bodypart/BP in C.bodyparts)
+	for(var/obj/item/bodypart/BP in C.bodyparts) //If we dont do this, the bloodsucker can get stuck eternally trying to regenerate prosthetics.
 		if(!istype(BP) && !BP.status == 2)
 			return FALSE
 		to_chat(C, "<span class='notice'>Your body expels the [BP]!</span>")
 		BP.drop_limb()
-		return TRUE */
+		return TRUE 
 
 /datum/antagonist/bloodsucker/proc/CureDisabilities()
 	var/mob/living/carbon/C = owner.current
@@ -176,7 +177,7 @@
 	// EMPTY:	Frenzy!
 	// BLOOD_VOLUME_GOOD: [336]  Pale (handled in bloodsucker_integration.dm
 	// BLOOD_VOLUME_BAD: [224]  Jitter
-	if(owner.current.blood_volume < BLOOD_VOLUME_BAD && !prob(0.5))
+	if(owner.current.blood_volume < BLOOD_VOLUME_BAD && !prob(0.5 && HAS_TRAIT(owner, TRAIT_FAKEDEATH)) && !poweron_masquerade)
 		owner.current.Jitter(3)
 	// BLOOD_VOLUME_SURVIVE: [122]  Blur Vision
 	if(owner.current.blood_volume < BLOOD_VOLUME_BAD / 2)
@@ -230,16 +231,16 @@
 		Torpor_Begin()
 		to_chat(owner, "<span class='danger'>Your immortal body will not yet relinquish your soul to the abyss. You enter Torpor.</span>")
 		sleep(30) //To avoid spam
-		if(poweron_masquerade == TRUE)
+		if(poweron_masquerade)
 			to_chat(owner, "<span class='warning'>Your wounds will not heal until you disable the <span class='boldnotice'>Masquerade</span> power.</span>")
 	// End Torpor:
 	else	// No damage, OR toxin healed AND brute healed and NOT in coffin (since you cannot heal burn)
 		if(total_damage <= 0 || total_toxloss <= 0 && total_brute <= 0 && !istype(owner.current.loc, /obj/structure/closet/crate/coffin))
-			// Not Daytime, Not in Torpor
-			if(!SSticker.mode.is_daylight() && HAS_TRAIT_FROM(owner.current, TRAIT_FAKEDEATH, "bloodsucker"))
+			// Not Daytime, Not in Torpor, enough health to not die the moment you end torpor
+			if(!SSticker.mode.is_daylight() && HAS_TRAIT_FROM(owner.current, TRAIT_FAKEDEATH, "bloodsucker") && total_damage < owner.current.getMaxHealth())
 				Torpor_End()
 		// Fake Unconscious
-		if(poweron_masquerade == TRUE && total_damage >= owner.current.getMaxHealth() - HEALTH_THRESHOLD_FULLCRIT)
+		if(poweron_masquerade && total_damage >= owner.current.getMaxHealth() - HEALTH_THRESHOLD_FULLCRIT)
 			owner.current.Unconscious(20, 1)
 
 /datum/antagonist/bloodsucker/proc/Torpor_Begin(amInCoffin = FALSE)
@@ -249,6 +250,7 @@
 	ADD_TRAIT(owner.current, TRAIT_NODEATH, "bloodsucker")	// Without this, you'll just keep dying while you recover.
 	ADD_TRAIT(owner.current, TRAIT_RESISTHIGHPRESSURE, "bloodsucker")	// So you can heal in space. Otherwise you just...heal forever.
 	ADD_TRAIT(owner.current, TRAIT_RESISTLOWPRESSURE, "bloodsucker")
+	owner.current.Jitter(0)
 	// Visuals
 	owner.current.update_sight()
 	owner.current.reload_fullscreen()
@@ -256,6 +258,9 @@
 	for(var/datum/action/bloodsucker/power in powers)
 		if(power.active && !power.can_use_in_torpor)
 			power.DeactivatePower()
+	if(owner.current.suiciding)
+		owner.current.suiciding = FALSE //Youll die but not for long.
+		to_chat(owner.current, "<span class='warning'>Your body keeps you going, even as you try to end yourself.</span>")
 
 /datum/antagonist/bloodsucker/proc/Torpor_End()
 	owner.current.stat = SOFT_CRIT

--- a/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_life.dm
@@ -147,12 +147,6 @@
 		to_chat(C, "<span class='notice'>Your flesh knits as it regrows your [L]!</span>")
 		playsound(C, 'sound/magic/demon_consume.ogg', 50, TRUE)
 		return TRUE
-	for(var/obj/item/bodypart/BP in C.bodyparts) //If we dont do this, the bloodsucker can get stuck eternally trying to regenerate prosthetics.
-		if(!istype(BP) && !BP.status == 2)
-			return FALSE
-		to_chat(C, "<span class='notice'>Your body expels the [BP]!</span>")
-		BP.drop_limb()
-		return TRUE 
 
 /datum/antagonist/bloodsucker/proc/CureDisabilities()
 	var/mob/living/carbon/C = owner.current

--- a/code/modules/antagonists/bloodsucker/bloodsucker_sunlight.dm
+++ b/code/modules/antagonists/bloodsucker/bloodsucker_sunlight.dm
@@ -45,15 +45,15 @@
 		// (FINAL LIL WARNING)
 		while(time_til_cycle > 5)
 			sleep(10)
-			if (cancel_me)
+			if(cancel_me)
 				return
 		//sleep(TIME_BLOODSUCKER_DAY_FINAL_WARN - 50)
 		warn_daylight(3,"<span class = 'userdanger'>Seek cover, for Sol rises!</span>")
 
 		// Part 3: Night Ending
-		while (time_til_cycle > 0)
+		while(time_til_cycle > 0)
 			sleep(10)
-			if (cancel_me)
+			if(cancel_me)
 				return
 		//sleep(50)
 		warn_daylight(4,"<span class = 'userdanger'>Solar flares bombard the station with deadly UV light!</span><br><span class = ''>Stay in cover for the next [TIME_BLOODSUCKER_DAY / 60] minutes or risk Final Death!</span>",\
@@ -69,11 +69,11 @@
 		while(time_til_cycle > 0)
 			punish_vamps()
 			sleep(TIME_BLOODSUCKER_BURN_INTERVAL)
-			if (cancel_me)
+			if(cancel_me)
 				return
 			//daylight_time -= TIME_BLOODSUCKER_BURN_INTERVAL
 			// Issue Level Up!
-			if(!issued_XP && time_til_cycle <= 15)
+			if(!issued_XP && time_til_cycle <= 5)
 				issued_XP = TRUE
 				vamps_rank_up()
 

--- a/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
+++ b/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
@@ -227,7 +227,7 @@
 	// Traits
 	for(var/T in defaultTraits)
 		REMOVE_TRAIT(owner.current, T, BLOODSUCKER_TRAIT)
-	if(had_toxlover == TRUE)
+	if(had_toxlover)
 		ADD_TRAIT(owner.current, TRAIT_TOXINLOVER, SPECIES_TRAIT)
 
 	// Traits: Species

--- a/code/modules/antagonists/bloodsucker/powers/cloak.dm
+++ b/code/modules/antagonists/bloodsucker/powers/cloak.dm
@@ -19,7 +19,7 @@
 	if(!.)
 		return
 	// must have nobody around to see the cloak
-	for(var/mob/living/M in viewers(9, owner)))
+	for(var/mob/living/M in viewers(9, owner))
 		if(M != owner)
 			to_chat(owner, "<span class='warning'>You may only vanish into the shadows unseen.</span>")
 			return FALSE

--- a/code/modules/antagonists/bloodsucker/powers/cloak.dm
+++ b/code/modules/antagonists/bloodsucker/powers/cloak.dm
@@ -18,14 +18,11 @@
 	. = ..()
 	if(!.)
 		return
-	
 	// must have nobody around to see the cloak
-	var/watchers = viewers(9,get_turf(owner))
-	for(var/mob/living/M in watchers)
+	for(var/mob/living/M in viewers(9, owner)))
 		if(M != owner)
 			to_chat(owner, "<span class='warning'>You may only vanish into the shadows unseen.</span>")
 			return FALSE
-
 	return TRUE
 
 /datum/action/bloodsucker/cloak/ActivatePower()

--- a/code/modules/antagonists/bloodsucker/powers/masquerade.dm
+++ b/code/modules/antagonists/bloodsucker/powers/masquerade.dm
@@ -52,6 +52,7 @@
 	REMOVE_TRAIT(user, TRAIT_NOHARDCRIT, "bloodsucker")
 	REMOVE_TRAIT(user, TRAIT_NOSOFTCRIT, "bloodsucker")
 	REMOVE_TRAIT(user, TRAIT_VIRUSIMMUNE, "bloodsucker")
+	REMOVE_TRAIT(user, TRAIT_NOBREATH, "bloodsucker")
 	var/obj/item/organ/heart/vampheart/H = user.getorganslot(ORGAN_SLOT_HEART)
 	var/obj/item/organ/eyes/vassal/bloodsucker/E = user.getorganslot(ORGAN_SLOT_EYES)
 	E.flash_protect = 0
@@ -93,6 +94,7 @@
 	ADD_TRAIT(user, TRAIT_NOHARDCRIT, "bloodsucker")
 	ADD_TRAIT(user, TRAIT_NOSOFTCRIT, "bloodsucker")
 	ADD_TRAIT(user, TRAIT_VIRUSIMMUNE, "bloodsucker")
+	ADD_TRAIT(user, TRAIT_NOBREATH, "bloodsucker")
 
 	// HEART
 	var/obj/item/organ/heart/H = user.getorganslot(ORGAN_SLOT_HEART)

--- a/code/modules/antagonists/bloodsucker/powers/trespass.dm
+++ b/code/modules/antagonists/bloodsucker/powers/trespass.dm
@@ -28,7 +28,7 @@
 
 /datum/action/bloodsucker/targeted/trespass/CheckValidTarget(atom/A)
 	// Can't target my tile
-	if (A == get_turf(owner) || get_turf(A) == get_turf(owner))
+	if(A == get_turf(owner) || get_turf(A) == get_turf(owner))
 		return FALSE
 
 	return TRUE //  All we care about is destination. Anything you click is fine.
@@ -43,13 +43,13 @@
 	// Are either tiles WALLS?
 	var/turf/from_turf = get_turf(owner)
 	var/this_dir // = get_dir(from_turf, target_turf)
-	for (var/i=1 to 2)
+	for(var/i=1 to 2)
 		// Keep Prev Direction if we've reached final turf
-		if (from_turf != final_turf)
+		if(from_turf != final_turf)
 			this_dir = get_dir(from_turf, final_turf) // Recalculate dir so we don't overshoot on a diagonal.
 		from_turf = get_step(from_turf, this_dir)
 		// ERROR! Wall!
-		if (iswallturf(from_turf))
+		if(iswallturf(from_turf))
 			if (display_error)
 				var/wallwarning = (i == 1) ? "in the way" : "at your destination"
 				to_chat(owner, "<span class='warning'>There is a solid wall [wallwarning].</span>")
@@ -84,7 +84,7 @@
 	user.next_move = world.time + mist_delay
 	user.Stun(mist_delay, ignore_canstun = TRUE)
 	user.notransform = TRUE
-	user.density = 0
+	user.density = FALSE
 	var/invis_was = user.invisibility
 	user.invisibility = INVISIBILITY_MAXIMUM
 
@@ -94,7 +94,7 @@
 	sleep(mist_delay / 2)
 
 	// Move & Freeze
-	if (isturf(target_turf))
+	if(isturf(target_turf))
 		do_teleport(owner, target_turf, no_effects=TRUE, channel = TELEPORT_CHANNEL_QUANTUM) // in teleport.dm?
 	user.next_move = world.time + mist_delay / 2
 	user.Stun(mist_delay / 2, ignore_canstun = TRUE)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes some incorrect traits, causing broken functionality for things like being unconcious not taking blood, and gives bloodsuckers a slow passive burn regeneration while unconcious to prevent being stuck in torpor forever, as the logic for torpor was improved so it should only turn off when the bloodsucker wont die, hopefully. Plus makes jitter less annoying by making masquarade and being unconcious disable it.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Masquarade now stops jittering.
tweak: Bloodsuckers wont jitter from bloodloss while unconcious anymore.
fix: Torpor should work more consitently and only wake you up, not when you would instantly die.
tweak: Bloodsuckers now have slight burn regeneration while unconcious.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
