### PR TITLE
Adds manual play internet sound for when youtubedl doesn't work and MORE IMPORTANTLY I guess this also fixes movespeed configs somewhat

### DIFF
--- a/code/modules/admin/admin_verbs.dm
+++ b/code/modules/admin/admin_verbs.dm
@@ -81,7 +81,7 @@ GLOBAL_PROTECT(admin_verbs_admin)
 	)
 GLOBAL_LIST_INIT(admin_verbs_ban, list(/client/proc/unban_panel, /client/proc/DB_ban_panel, /client/proc/stickybanpanel))
 GLOBAL_PROTECT(admin_verbs_ban)
-GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_sound, /client/proc/set_round_end_sound))
+GLOBAL_LIST_INIT(admin_verbs_sounds, list(/client/proc/play_local_sound, /client/proc/play_sound, /client/proc/manual_play_web_sound, /client/proc/set_round_end_sound))
 GLOBAL_PROTECT(admin_verbs_sounds)
 GLOBAL_LIST_INIT(admin_verbs_fun, list(
 	/client/proc/cmd_admin_dress,

--- a/code/modules/admin/verbs/playsound.dm
+++ b/code/modules/admin/verbs/playsound.dm
@@ -138,6 +138,49 @@
 
 	SSblackbox.record_feedback("tally", "admin_verb", 1, "Play Internet Sound")
 
+/client/proc/manual_play_web_sound()
+	set category = "Fun"
+	set name = "Manual Play Internet Sound"
+	if(!check_rights(R_SOUNDS))
+		return
+
+	var/web_sound_input = input("Enter content stream URL (fetch this from local youtube-dl!)", "Play Internet Sound via direct URL") as text|null
+	if(istext(web_sound_input))
+		if(!length(web_sound_input))
+			log_admin("[key_name(src)] stopped web sound")
+			message_admins("[key_name(src)] stopped web sound")
+			var/mob/M
+			for(var/i in GLOB.player_list)
+				M = i
+				M?.client?.chatOutput?.stopMusic()
+			return
+		else
+			if(web_sound_input && !findtext(web_sound_input, GLOB.is_http_protocol))
+				to_chat(src, "<span class='boldwarning'>BLOCKED: Content URL not using http(s) protocol</span>")
+				return
+			var/freq = input(usr, "What frequency would you like the sound to play at?",, 1) as null|num
+			if(isnull(freq))
+				return
+			if(!freq)
+				freq = 1
+			SSblackbox.record_feedback("nested tally", "played_url", 1, list("[ckey]", "[web_sound_input]"))
+			var/logstr = "[key_name(src)] played web sound at freq [freq]: [web_sound_input]"
+			log_admin(logstr)
+			message_admins(logstr)
+			var/mob/M
+			var/client/C
+			var/datum/chatOutput/O
+			for(var/i in GLOB.player_list)
+				M = i
+				C = M.client
+				if(!(C?.prefs?.toggles & SOUND_MIDI))
+					continue
+				O = C.chatOutput
+				if(!O || O.broken || !O.loaded)
+					continue
+				O.sendMusic(web_sound_input, freq)
+		SSblackbox.record_feedback("tally", "admin_verb", 1, "Manual Play Internet Sound")
+
 /client/proc/set_round_end_sound(S as sound)
 	set category = "Fun"
 	set name = "Set Round End Sound"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Movespeed configs now override by priority of deepest path (so for example, defining simple_animal/clockwork overrides a simple_animal define) rather than order in config

See order in config could work but 

- If you're overwriting deeper entries you're doing it wrong because you don't need to define them at all if you wanted to overwrite them 
- If there's a default thing, when BYOND writes to a keyed list it's going to preserve order which means suddenly the order of defaults defined in the code matters which is a big yikes because you're supposed to be able to override them
- In a perfect world I'd add a variable for keyed list that allows you to forcefully null out defaults rather than having to override them but I'm lazy so have your totally-not-halfassed-fix that works for our purposes and if someone wants that in the future they can bug me when I have more time to be doing this or code themselves
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Alien configs don't work because they're put in in the wrong order and there's no way to fix it other than this or removing the defaults.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Manual play internet sound added 
tweak: Movespeed config backend changed, now deeper paths will always override parent paths. If your config requires parent paths to override deeper paths you are doing it wrong anyways. You will have to manually override defaults, but this is probably the better of two poisons.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
