### PR TITLE
Makes a single wall an r-wall in the box SM engine

### DIFF
--- a/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm.dmm
+++ b/_maps/RandomRuins/StationRuins/Box/Engine/engine_sm.dmm
@@ -2718,7 +2718,7 @@ wt
 av
 kA
 qo
-EL
+MP
 MP
 MP
 Cb


### PR DESCRIPTION
## About The Pull Request

One wall was a regular wall, and not an r-wall. No idea how, or why.

## Why It's Good For The Game

Fixing an oversight.

## Changelog
:cl:
fix: Made section around engine fully encased in r-walls
/:cl:
