### PR TITLE
Lets actually use all the positions

### DIFF
--- a/code/modules/jobs/job_types/atmospheric_technician.dm
+++ b/code/modules/jobs/job_types/atmospheric_technician.dm
@@ -5,7 +5,7 @@
 	department_flag = ENGSEC
 	faction = "Station"
 	total_positions = 3
-	spawn_positions = 2
+	spawn_positions = 3
 	supervisors = "the chief engineer"
 	selection_color = "#ff9b3d"
 	exp_requirements = 60


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Okay so we ALREADY have three atmospheric jobslots on every station because of the job datum being set to two, but for some reason the third position is unavailable during round-start, this seems unintended to me so I made this 1 line PR to let there be three atmospheric techs roundstart.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Ahem,
ATMOS GANG!
ATMOS GANG!
ATMOS GANG!

Alright, now that I have gotten that out of the way, personally I think its dumb that there are three slots in total and one of them is unavailable for someone who readies up, so they do not qualify for the job only to be able to choose it after the round starts.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Atmospheric Technician Spawn Positions Increased To 3 (Up From 2)
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
