### PR TITLE
makes the uranium mat two times less radioactive

### DIFF
--- a/code/datums/materials/basemats.dm
+++ b/code/datums/materials/basemats.dm
@@ -72,7 +72,7 @@ Unless you know what you're doing, only use the first three numbers. They're in 
 
 /datum/material/uranium/on_applied(atom/source, amount, material_flags)
 	. = ..()
-	source.AddComponent(/datum/component/radioactive, amount / 20, source, 0) //half-life of 0 because we keep on going.
+	source.AddComponent(/datum/component/radioactive, amount / 60, source, 0) //half-life of 0 because we keep on going.
 
 /datum/material/uranium/on_removed(atom/source, material_flags)
 	. = ..()


### PR DESCRIPTION
## About The Pull Request
Title. Web edit.

## Why It's Good For The Game
I must admit it's unnaturally strong and without decay. Also putnam's tweaks made radioactivity not inefficiently suck hay bales as much as it did before.

## Changelog
:cl:
balance: nerfed the radioactivity of custom uranium made items by two times.
/:cl:
