### PR TITLE
Fixes space mirage not having parallax

### DIFF
--- a/code/datums/components/mirage_border.dm
+++ b/code/datums/components/mirage_border.dm
@@ -39,4 +39,5 @@
 /obj/effect/abstract/mirage_holder
 	name = "Mirage holder"
 	anchored = TRUE
+	plane = PLANE_SPACE
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Moves mirage holder to PLANE_SPACE
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Now that vis_flags inherit plane is a thing for turfs for multiz, this is necessary for the space in the vis contents to actually render in the space plane instead of well, above the space parallax plane.

other option is to remove vis_inherit_plane from space vis flags but that'd break multiz (although it isn't much of an issue i guess as openspace was never meant to be used for above-space.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Space mirage holders are now PLANE_SPACE plane.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
