### PR TITLE
Makes G gluid calcs only happen when it's required

### DIFF
--- a/modular_citadel/code/modules/arousal/arousal.dm
+++ b/modular_citadel/code/modules/arousal/arousal.dm
@@ -63,10 +63,12 @@
 	if(!target || !R)
 		return
 	var/turfing = isturf(target)
+	G.generate_fluid()
 	if(spill && R.total_volume >= 5)
 		R.reaction(turfing ? target : target.loc, TOUCH, 1, 0)
 	if(!turfing)
 		R.trans_to(target, R.total_volume * (spill ? G.fluid_transfer_factor : 1))
+	G.time_since_last_orgasm = 0
 	R.clear_reagents()
 
 /mob/living/carbon/human/proc/mob_climax_outside(obj/item/organ/genital/G, mb_time = 30) //This is used for forced orgasms and other hands-free climaxes

--- a/modular_citadel/code/modules/arousal/genitals.dm
+++ b/modular_citadel/code/modules/arousal/genitals.dm
@@ -15,6 +15,7 @@
 	var/fluid_efficiency = 1
 	var/fluid_rate = CUM_RATE
 	var/fluid_mult = 1
+	var/time_since_last_orgasm = 500
 	var/aroused_state = FALSE //Boolean used in icon_state strings
 	var/obj/item/organ/genital/linked_organ
 	var/linked_organ_slot //used for linking an apparatus' organ to its other half on update_link().
@@ -155,20 +156,13 @@
 		return
 	reagents.maximum_volume = fluid_max_volume
 	if(fluid_id && CHECK_BITFIELD(genital_flags, GENITAL_FUID_PRODUCTION))
-		generate_fluid()
+		time_since_last_orgasm++
 
 /obj/item/organ/genital/proc/generate_fluid()
-	var/amount = fluid_rate
-	if(!reagents.total_volume && amount < 0.1) // Apparently, 0.015 gets rounded down to zero and no reagents are created if we don't start it with 0.1 in the tank.
-		amount += 0.1
-	var/multiplier = fluid_mult
-	if(reagents.total_volume >= 5)
-		multiplier *= 0.8
-	if(reagents.total_volume < reagents.maximum_volume)
-		reagents.isolate_reagent(fluid_id)//remove old reagents if it changed and just clean up generally
-		reagents.add_reagent(fluid_id, (amount * multiplier))//generate the cum
-		return TRUE
-	return FALSE
+	var/amount = clamp(fluid_rate * time_since_last_orgasm * multiplier,0,fluid_max_volume)
+	reagents.clear_reagents()
+	reagents.add_reagent(fluid_id,amount)
+	return TRUE
 
 /obj/item/organ/genital/proc/update_link()
 	if(owner)

--- a/modular_citadel/code/modules/arousal/genitals.dm
+++ b/modular_citadel/code/modules/arousal/genitals.dm
@@ -159,7 +159,7 @@
 		time_since_last_orgasm++
 
 /obj/item/organ/genital/proc/generate_fluid()
-	var/amount = clamp(fluid_rate * time_since_last_orgasm * multiplier,0,fluid_max_volume)
+	var/amount = clamp(fluid_rate * time_since_last_orgasm * fluid_mult,0,fluid_max_volume)
 	reagents.clear_reagents()
 	reagents.add_reagent(fluid_id,amount)
 	return TRUE

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -19,7 +19,7 @@
 /obj/item/organ/genital/testicles/generate_fluid()
 	if(!linked_organ && !update_link())
 		return FALSE
-	. = ..()
+	return ..()
 	// in memoriam "Your balls finally feel full, again." ??-2020
 
 /obj/item/organ/genital/testicles/upon_link()

--- a/modular_citadel/code/modules/arousal/organs/testicles.dm
+++ b/modular_citadel/code/modules/arousal/organs/testicles.dm
@@ -20,8 +20,7 @@
 	if(!linked_organ && !update_link())
 		return FALSE
 	. = ..()
-	if(. && reagents.holder_full())
-		to_chat(owner, "Your balls finally feel full, again.")
+	// in memoriam "Your balls finally feel full, again." ??-2020
 
 /obj/item/organ/genital/testicles/upon_link()
 	size = linked_organ.size

--- a/strings/traumas.json
+++ b/strings/traumas.json
@@ -129,7 +129,8 @@
 		"@pick(semicolon)*nya",
 		"@pick(semicolon)*awoo",
 		"@pick(semicolon)*merp",
-		"@pick(semicolon)*weh"
+		"@pick(semicolon)*weh",
+		"@pick(semicolon)My balls finally feel full, again."
     ],
 
     "mutations": [


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Genitals will no longer do a big calculation every dang tick, instead just doing it when it's needed.

## Why It's Good For The Game

Minor performance improvement.

## Changelog
:cl:
tweak: Genital fluids now calculate less often.
add: A new brain damage message, to commemorate the loss of a classic message.
/:cl: