### PR TITLE
Implementing the NO_PUBLIC_LATHE build_type flag.

### DIFF
--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -17,7 +17,6 @@
 	var/list/L = list()
 	var/list/LL = list()
 	var/hacked = FALSE
-	var/hackable = TRUE
 	var/disabled = 0
 	var/shocked = FALSE
 	var/hack_wire
@@ -420,8 +419,6 @@
 
 /obj/machinery/autolathe/proc/adjust_hacked(state)
 	hacked = state
-	if(!hackable && hacked)
-		return
 	for(var/id in SSresearch.techweb_designs)
 		var/datum/design/D = SSresearch.techweb_design_by_id(id)
 		if((D.build_type & AUTOLATHE) && ("hacked" in D.category))
@@ -436,8 +433,7 @@
 
 /obj/machinery/autolathe/secure
 	name = "secured autolathe"
-	desc = "An autolathe reprogrammed with security protocols to prevent hacking."
-	hackable = FALSE
+	desc = "It produces items using metal and glass. This model was reprogrammed without some of the more hazardous designs."
 	circuit = /obj/item/circuitboard/machine/autolathe/secure
 	stored_research = /datum/techweb/specialized/autounlocking/autolathe/public
 

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -31,7 +31,7 @@
 	var/selected_category
 	var/screen = 1
 
-	var/datum/techweb/stored_research = /datum/techweb/specialized/autounlocking/autolathe
+	var/datum/techweb/specialized/autounlocking/stored_research = /datum/techweb/specialized/autounlocking/autolathe
 	var/list/categories = list(
 							"Tools",
 							"Electronics",

--- a/code/game/machinery/autolathe.dm
+++ b/code/game/machinery/autolathe.dm
@@ -421,7 +421,9 @@
 	hacked = state
 	for(var/id in SSresearch.techweb_designs)
 		var/datum/design/D = SSresearch.techweb_design_by_id(id)
-		if((D.build_type & AUTOLATHE) && ("hacked" in D.category))
+		if(D.build_type & stored_research.design_autounlock_skip_types)
+			continue
+		if((D.build_type & stored_research.design_autounlock_buildtypes) && ("hacked" in D.category))
 			if(hacked)
 				stored_research.add_design(D)
 			else

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_construction.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_construction.dm
@@ -112,8 +112,8 @@
 /datum/design/rcd_ammo_large
 	name = "Large Compressed Matter Cartridge"
 	id = "rcd_ammo_large"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 48000, /datum/material/glass = 32000)
 	build_path = /obj/item/rcd_ammo/large
-	category = list("Tool Designs")
+	category = list("hacked", "Construction", "Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_medical_and_dinnerware.dm
@@ -8,7 +8,7 @@
 /datum/design/kitchen_knife
 	name = "Kitchen Knife"
 	id = "kitchen_knife"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 12000)
 	build_path = /obj/item/kitchen/knife
 	category = list("initial","Dinnerware")
@@ -140,7 +140,7 @@
 /datum/design/healthanalyzer
 	name = "Health Analyzer"
 	id = "healthanalyzer"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 500, /datum/material/glass = 50)
 	build_path = /obj/item/healthanalyzer
 	category = list("initial", "Medical")

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_sec_and_hacked.dm
@@ -36,7 +36,7 @@
 /datum/design/large_welding_tool
 	name = "Industrial Welding Tool"
 	id = "large_welding_tool"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 70, /datum/material/glass = 60)
 	build_path = /obj/item/weldingtool/largetank
 	category = list("hacked", "Tools")
@@ -44,7 +44,7 @@
 /datum/design/flamethrower
 	name = "Flamethrower"
 	id = "flamethrower"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/flamethrower/full
 	category = list("hacked", "Security")
@@ -52,7 +52,7 @@
 /datum/design/rcd
 	name = "Rapid Construction Device (RCD)"
 	id = "rcd"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/construction/rcd
 	category = list("hacked", "Construction")
@@ -60,7 +60,7 @@
 /datum/design/rpd
 	name = "Rapid Pipe Dispenser (RPD)"
 	id = "rpd"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 75000, /datum/material/glass = 37500)
 	build_path = /obj/item/pipe_dispenser
 	category = list("hacked", "Construction")
@@ -68,7 +68,7 @@
 /datum/design/handcuffs
 	name = "Handcuffs"
 	id = "handcuffs"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 500)
 	build_path = /obj/item/restraints/handcuffs
 	category = list("hacked", "Security")
@@ -76,7 +76,7 @@
 /datum/design/receiver
 	name = "Modular Receiver"
 	id = "receiver"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 15000)
 	build_path = /obj/item/weaponcrafting/receiver
 	category = list("hacked", "Security")
@@ -84,7 +84,7 @@
 /datum/design/shotgun_slug
 	name = "Shotgun Slug"
 	id = "shotgun_slug"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun
 	category = list("hacked", "Security")
@@ -92,7 +92,7 @@
 /datum/design/buckshot_shell
 	name = "Buckshot Shell"
 	id = "buckshot_shell"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/buckshot
 	category = list("hacked", "Security")
@@ -100,7 +100,7 @@
 /datum/design/shotgun_dart
 	name = "Shotgun Dart"
 	id = "shotgun_dart"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/dart
 	category = list("hacked", "Security")
@@ -108,7 +108,7 @@
 /datum/design/incendiary_slug
 	name = "Incendiary Slug"
 	id = "incendiary_slug"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/shotgun/incendiary
 	category = list("hacked", "Security")
@@ -116,7 +116,7 @@
 /datum/design/riot_dart
 	name = "Foam Riot Dart"
 	id = "riot_dart"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 1125) //Discount for making individually - no box = less metal!
 	build_path = /obj/item/ammo_casing/caseless/foam_dart/riot
 	category = list("hacked", "Security")
@@ -124,7 +124,7 @@
 /datum/design/riot_darts
 	name = "Foam Riot Dart Box"
 	id = "riot_darts"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 50000) //Comes with 40 darts
 	build_path = /obj/item/ammo_box/foambox/riot
 	category = list("hacked", "Security")
@@ -132,7 +132,7 @@
 /datum/design/a357
 	name = "Revolver Bullet (.357)"
 	id = "a357"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 4000)
 	build_path = /obj/item/ammo_casing/a357
 	category = list("hacked", "Security")
@@ -140,7 +140,7 @@
 /datum/design/a762
 	name = "Rifle Bullet (7.62mm)"
 	id = "a762"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 5000) //need seclathe for clips
 	build_path = /obj/item/ammo_casing/a762
 	category = list("hacked", "Security")
@@ -148,7 +148,7 @@
 /datum/design/c10mm
 	name = "Ammo Box (10mm)"
 	id = "c10mm"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c10mm
 	category = list("hacked", "Security")
@@ -156,7 +156,7 @@
 /datum/design/c45
 	name = "Ammo Box (.45)"
 	id = "c45"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c45
 	category = list("hacked", "Security")
@@ -164,7 +164,7 @@
 /datum/design/c9mm
 	name = "Ammo Box (9mm)"
 	id = "c9mm"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 30000)
 	build_path = /obj/item/ammo_box/c9mm
 	category = list("hacked", "Security")
@@ -172,7 +172,7 @@
 /datum/design/electropack
 	name = "Electropack"
 	id = "electropack"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 10000, /datum/material/glass = 2500)
 	build_path = /obj/item/electropack
 	category = list("hacked", "Security")
@@ -180,7 +180,7 @@
 /datum/design/cleaver
 	name = "Butcher's Cleaver"
 	id = "cleaver"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 18000)
 	build_path = /obj/item/kitchen/knife/butcher
 	category = list("hacked", "Dinnerware")

--- a/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
+++ b/code/modules/research/designs/autolathe_desings/autolathe_designs_tools.dm
@@ -49,7 +49,7 @@
 /datum/design/multitool
 	name = "Multitool"
 	id = "multitool"
-	build_type = AUTOLATHE | PROTOLATHE
+	build_type = AUTOLATHE | PROTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 50, /datum/material/glass = 20)
 	build_path = /obj/item/multitool
 	category = list("initial","Tools","Tool Designs")
@@ -75,7 +75,7 @@
 /datum/design/weldingtool
 	name = "Welding Tool"
 	id = "welding_tool"
-	build_type = AUTOLATHE
+	build_type = AUTOLATHE | NO_PUBLIC_LATHE
 	materials = list(/datum/material/iron = 70, /datum/material/glass = 20)
 	build_path = /obj/item/weldingtool
 	category = list("initial","Tools","Tool Designs")
@@ -97,6 +97,7 @@
 	build_path = /obj/item/screwdriver
 	category = list("initial","Tools","Tool Designs")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING | DEPARTMENTAL_FLAG_SCIENCE
+
 /datum/design/wirecutters
 	name = "Wirecutters"
 	id = "wirecutters"

--- a/code/modules/research/designs/autoylathe_designs.dm
+++ b/code/modules/research/designs/autoylathe_designs.dm
@@ -562,6 +562,7 @@
 	materials = list(/datum/material/plastic = 4000, /datum/material/iron = 500)
 	build_path = /obj/item/gun/ballistic/automatic/x9/toy
 	category = list("initial", "Rifles")
+	build_type = TOYLATHE | NO_PUBLIC_LATHE
 
 /datum/design/foam_dart
 	name = "Box of Foam Darts"
@@ -586,6 +587,7 @@
 	materials = list(/datum/material/plastic = 4000, /datum/material/iron = 500)
 	build_path = /obj/item/gun/ballistic/automatic/toy/magrifle
 	category = list("initial", "Rifles")
+	build_type = TOYLATHE | NO_PUBLIC_LATHE
 
 /datum/design/foam_hyperburst
 	name = "MagTag Hyper Rifle"
@@ -618,6 +620,7 @@
 	materials = list(/datum/material/plastic = 4000, /datum/material/iron = 500)
 	build_path = /obj/item/gun/ballistic/automatic/AM4C
 	category = list("initial", "Rifles")
+	build_type = TOYLATHE | NO_PUBLIC_LATHE
 
 /datum/design/foam_f3
 	name = "Replica F3 Justicar"
@@ -650,6 +653,7 @@
 	materials = list(/datum/material/plastic = 2000, /datum/material/iron = 250)
 	build_path = /obj/item/gun/ballistic/automatic/toy/unrestricted
 	category = list("initial", "Pistols")
+	build_type = TOYLATHE | NO_PUBLIC_LATHE
 
 /datum/design/foam_pistol
 	name = "Foam Force Pistol"
@@ -698,6 +702,7 @@
 	materials = list(/datum/material/plastic = 4000, /datum/material/iron = 500)
 	build_path = /obj/item/gun/ballistic/automatic/c20r/toy/unrestricted
 	category = list("hacked", "Rifles")
+	build_type = TOYLATHE | NO_PUBLIC_LATHE
 
 /datum/design/foam_l6
 	name = "Donksoft LMG"
@@ -706,3 +711,4 @@
 	materials = list(/datum/material/plastic = 4000, /datum/material/iron = 500)
 	build_path = /obj/item/gun/ballistic/automatic/l6_saw/toy/unrestricted
 	category = list("hacked", "Rifles")
+	build_type = TOYLATHE | NO_PUBLIC_LATHE


### PR DESCRIPTION
## About The Pull Request
Further preparations to economy. Only a few designs not in the hacked category were blacklisted:
multitool, welding tool (there is a mini version anyway), large rcd ammo, kitchen knife and health scanner.
On the other side, tinfoil hats can now printed from secure autolathes, provided they are hacked.

## Why It's Good For The Game
Further preparations to economy.

## Changelog
:cl:
balance: blacklisted the multitool, welding tool (there is a mini version anyway), large rcd ammo, kitchen knife and health scanner designs from secured autolathes, in preparation to goofconomy. Unblacklisted (hacked category) tinfoil hats. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
