### PR TITLE
Makes arrows more deadly to lava land

### DIFF
--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -15,14 +15,10 @@
 
 /obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
 	. = ..()
-
-	if(is_type_in_typecache(target, hunted))
-		to_chat(user, "<span class='warning'>You easily land a critical shot on the [target].</span>") //To give feedback
-			if(istype(target, /mob/living/))
-				var/mob/living/simple_animal/hostile/asteroid/ashlands = target
-				ashlands.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
-
 	handle_drop()
+	if(is_type_in_typecache(target, hunted, /mob/living/))
+		var/mob/living/simple_animal/hostile/asteroid/ashlands = target
+		ashlands.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
 
 /obj/item/projectile/bullet/reusable/arrow/ash
 	name = "ashen arrow"

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -2,13 +2,33 @@
 	name = "wooden arrow"
 	desc = "Woosh!"
 	damage = 15
+	var/list/hunted
+	var/hunted = 20
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
+
+/obj/item/projectile/bullet/reusable/arrow/Initialize()
+	. = ..()
+	hunted = typecacheof(list(
+					/mob/living/simple_animal/hostile/asteroid
+	))
+
+/obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
+	. = ..()
+
+	if(is_type_in_typecache(target, hunted))
+			to_chat(user, "<span class='warning'>You easily land a critical shot on the [target].</span>")
+			if(istype(target, /mob/living/))
+				var/mob/living/simple_animal/hostile/asteroid = target
+				asteroid.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
+
+	handle_drop()
 
 /obj/item/projectile/bullet/reusable/arrow/ash
 	name = "ashen arrow"
 	desc = "Fire harderned arrow."
 	damage = 25
+	hunted = 50 //Yes we now one shot legion!
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/ash
 
 /obj/item/projectile/bullet/reusable/arrow/bone //AP for ashwalkers
@@ -16,10 +36,12 @@
 	desc = "Arrow made of bone and sinew."
 	damage = 35
 	armour_penetration = 40
+	hunted = 100
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bone
 
 /obj/item/projectile/bullet/reusable/arrow/bronze //Just some AP shots
 	name = "bronze arrow"
 	desc = "Bronze tipped arrow."
 	armour_penetration = 10
+	hunted = 40 //Metal tip 
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/bronze

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -10,14 +10,14 @@
 /obj/item/projectile/bullet/reusable/arrow/Initialize()
 	. = ..()
 	hunted = typecacheof(list(
-					/mob/living/simple_animal/hostile/asteroid
+					/mob/living/simple_animal/hostile/asteroid/
 	))
 
 /obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 
 	if(is_type_in_typecache(target, hunted))
-			to_chat(user, "<span class='warning'>You easily land a critical shot on the [target].</span>")
+		to_chat(user, "<span class='warning'>You easily land a critical shot on the [target].</span>") //To give feedback
 			if(istype(target, /mob/living/))
 				var/mob/living/simple_animal/hostile/asteroid/ashlands = target
 				ashlands.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -19,8 +19,8 @@
 	if(is_type_in_typecache(target, hunted))
 			to_chat(user, "<span class='warning'>You easily land a critical shot on the [target].</span>")
 			if(istype(target, /mob/living/))
-				var/mob/living/simple_animal/hostile/asteroid = target
-				asteroid.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
+				var/mob/living/simple_animal/hostile/asteroid/ashlands = target
+				ashlands.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
 
 	handle_drop()
 

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -2,21 +2,21 @@
 	name = "wooden arrow"
 	desc = "Woosh!"
 	damage = 15
-	var/list/hunted
+	var/list/hunt
 	var/hunted = 20
 	icon_state = "arrow"
 	ammo_type = /obj/item/ammo_casing/caseless/arrow/wood
 
 /obj/item/projectile/bullet/reusable/arrow/Initialize()
 	. = ..()
-	hunted = typecacheof(list(
+	hunt = typecacheof(list(
 					/mob/living/simple_animal/hostile/asteroid/
 	))
 
 /obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	handle_drop()
-	if(is_type_in_typecache(target, hunted))
+	if(is_type_in_typecache(target, hunt))
 		var/mob/living/simple_animal/hostile/asteroid/ashlands = target
 		ashlands.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
 

--- a/code/modules/projectiles/projectile/reusable/arrow.dm
+++ b/code/modules/projectiles/projectile/reusable/arrow.dm
@@ -16,7 +16,7 @@
 /obj/item/projectile/bullet/reusable/arrow/on_hit(atom/target, blocked = FALSE)
 	. = ..()
 	handle_drop()
-	if(is_type_in_typecache(target, hunted, /mob/living/))
+	if(is_type_in_typecache(target, hunted))
 		var/mob/living/simple_animal/hostile/asteroid/ashlands = target
 		ashlands.adjustBruteLoss(-hunted) //Were doing it via ajust so we work around armor
 


### PR DESCRIPTION

## About The Pull Request

Makes all arrows deal more damage t lava land mobs
Depending on the arrorw type means you deal more damage
## Why It's Good For The Game
Lava land bows are really trash at fighting the things they are meant to, lava land mobs.
This should make them comparable to a KPA but slower...
## Changelog
:cl:
add: Arrows now deal more damage to mobs on lava land.
/:cl: