### PR TITLE
hey can we don't have sentient megafauna as part of a random event that would be appreciated thank you

### DIFF
--- a/code/modules/events/sentience.dm
+++ b/code/modules/events/sentience.dm
@@ -9,6 +9,8 @@
 	role_name = "random animal"
 	var/animals = 1
 	var/one = "one"
+	/// Blacklisted mob_biotypes - Hey can we like, not have player controlled megafauna? 
+	var/blacklisted_biotypes = MOB_EPIC
 	fakeable = TRUE
 
 /datum/round_event/ghost_role/sentience/announce(fake)
@@ -32,6 +34,8 @@
 	for(var/mob/living/simple_animal/L in GLOB.alive_mob_list)
 		var/turf/T = get_turf(L)
 		if(!T || !is_station_level(T.z))
+			continue
+		if(L.mob_biotypes & blacklisted_biotypes)		//hey can you don't
 			continue
 		if(!(L in GLOB.player_list) && !L.mind)
 			potential += L


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

adds blacklisted_biotypes to sentient event spawn, defaulting to MOB_EPIC for megafauna
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

as hilarious as this would be a player controlled megafauna would be fun for just about no one but the person controlling it if they decide to go on a rampage so can we don't please?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Megafauna can no longer be made sentient by random events.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
