### PR TITLE
Fixes a gibber runtime.

### DIFF
--- a/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
+++ b/code/modules/food_and_drinks/kitchen_machinery/gibber.dm
@@ -184,9 +184,9 @@
 
 	for (var/i=1 to meat_produced)
 		var/obj/item/reagent_containers/food/snacks/meat/slab/newmeat = new typeofmeat
-		newmeat.adjust_food_quality(meat_quality)
 		newmeat.name = "[sourcename] [newmeat.name]"
 		if(istype(newmeat))
+			newmeat.adjust_food_quality(meat_quality)
 			newmeat.subjectname = sourcename
 			newmeat.reagents.add_reagent (/datum/reagent/consumable/nutriment, sourcenutriment / meat_produced) // Thehehe. Fat guys go first
 			if(sourcejob)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Anything that didn't have meat would runtime and basically jam up the gibber.

## Why It's Good For The Game

Runtimes bad.

## Changelog
:cl:
fix: Gibber no longer runtimes when it attempts to make not-meat.
/:cl: