### PR TITLE
sliced foods have the same quality as the item that was cut

### DIFF
--- a/code/modules/food_and_drinks/food/snacks.dm
+++ b/code/modules/food_and_drinks/food/snacks.dm
@@ -260,6 +260,7 @@ All foods are distributed among various categories. Use common sense.
 		slice.desc = "[desc]"
 	if(foodtype != initial(foodtype))
 		slice.foodtype = foodtype //if something happens that overrode our food type, make sure the slice carries that over
+	slice.adjust_food_quality(food_quality)
 
 /obj/item/reagent_containers/food/snacks/proc/generate_trash(atom/location)
 	if(trash)

--- a/code/modules/food_and_drinks/food/snacks/meat.dm
+++ b/code/modules/food_and_drinks/food/snacks/meat.dm
@@ -47,6 +47,7 @@
 		slice.name = "raw [subjectname] cutlet"
 	else if(subjectjob)
 		slice.name = "raw [subjectjob] cutlet"
+	slice.adjust_food_quality(food_quality)
 
 /obj/item/reagent_containers/food/snacks/meat/slab/human/initialize_cooked_food(obj/item/reagent_containers/food/snacks/meat/S, cooking_efficiency)
 	..()


### PR DESCRIPTION
## About The Pull Request
sliced foods have the same quality as the item that was cut
quick one line change to meat and snacks so that when sliced, they keep the food quality of the thing that was cut, instead of defaulting back to 50

this means food quality actually works on: onions/watermelons/pineapples/cakes/pizzas/cutlets/etc

## Why It's Good For The Game
because food quality is a nice feature that I want to expand on, and so having it work fully would be nice

## Changelog
:cl:
fix: sliced foods now have the correct food quality (equal to the sliced item's)
/:cl:
