### PR TITLE
Upgrade able Medical bot and Floor bot as well! + Clean bot fix!

### DIFF
--- a/code/__DEFINES/robots.dm
+++ b/code/__DEFINES/robots.dm
@@ -51,6 +51,19 @@
 #define ASSEMBLY_FOURTH_STEP    3
 #define ASSEMBLY_FIFTH_STEP     4
 
+//Bot Upgrade defines
+#define UPGRADE_CLEANER_ADVANCED_MOP 	      (1<<0)
+#define UPGRADE_CLEANER_BROOM            	  (1<<1)
+
+#define UPGRADE_MEDICAL_HYPOSPRAY       (1<<0)
+#define UPGRADE_MEDICAL_CHEM_BOARD      (1<<1)
+#define UPGRADE_MEDICAL_CRYO_BOARD      (1<<2)
+#define UPGRADE_MEDICAL_CHEM_MASTER     (1<<3)
+#define UPGRADE_MEDICAL_SLEEP_BOARD     (1<<4)
+#define UPGRADE_MEDICAL_PIERERCING      (1<<5)
+
+#define UPGRADE_FLOOR_ARTBOX 	     (1<<0)
+#define UPGRADE_FLOOR_SYNDIBOX     	 (1<<1)
 
 //Checks to determine borg availability depending on the server's config. These are defines in the interest of reducing copypasta
 #define BORG_SEC_AVAILABLE (!CONFIG_GET(flag/disable_secborg) && GLOB.security_level >= CONFIG_GET(number/minimum_secborg_alert))

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -22,7 +22,9 @@
 	var/clean_time = 50 //How long do we take to clean?
 	var/broom = FALSE //Do we have an speed buff from a broom?
 	var/adv_mop = FALSE //Do we have a cleaning buff from a better mop?
+	var/spray_bottle = FALSE//Do we have a spray bottle?
 
+	var/cleaning_distence = 0 //How far can we clean? 0 = Same tile as bot.
 
 	var/blood = 1
 	var/trash = 0
@@ -80,6 +82,19 @@
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
 				to_chat(user, "<span class='notice'>\The [src] doesn't seem to respect your authority.</span>")
+
+	else if(istype(W, /obj/item/reagent_containers/spray))
+		if(bot_core.allowed(user) && open && spray_bottle != TRUE)
+			to_chat(user, "<span class='notice'>You add to \the [src] a new spray bottle!</span>")
+			spray_bottle = TRUE
+			cleaning_distence = 2 //Can now clean 2 tiles away!
+			window_name = "Automatic Station Cleaner v3.7 ALPHA"
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a spray bottle!</span>")
 
 	if(istype(W, /obj/item/mop/advanced))
 		if(bot_core.allowed(user) && open && adv_mop == TRUE)
@@ -241,7 +256,7 @@
 	target_types = typecacheof(target_types)
 
 /mob/living/simple_animal/bot/cleanbot/UnarmedAttack(atom/A)
-	if(istype(A, /obj/effect/decal/cleanable))
+	if(istype(A, /obj/effect/decal/cleanable) && (get_dist(src,A) <= cleaning_distence))
 		anchored = TRUE
 		icon_state = "cleanbot-c"
 		visible_message("<span class='notice'>[src] begins to clean up [A].</span>")

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -84,34 +84,43 @@
 				to_chat(user, "<span class='notice'>\The [src] doesn't seem to respect your authority.</span>")
 
 	else if(istype(W, /obj/item/reagent_containers/spray))
-		if(bot_core.allowed(user) && open && spray_bottle != TRUE)
-			to_chat(user, "<span class='notice'>You add to \the [src] a new spray bottle!</span>")
-			spray_bottle = TRUE
-			cleaning_distence = 2 //Can now clean 2 tiles away!
-			window_name = "Automatic Station Cleaner v3.7 ALPHA"
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!spray_bottle)
+				to_chat(user, "<span class='notice'>You add to \the [src] a new spray bottle!</span>")
+				spray_bottle = TRUE
+				cleaning_distence = 2 //Can now clean 2 tiles away!
+				window_name = "Automatic Station Cleaner v3.7 ALPHA"
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
 		else
 			to_chat(user, "<span class='notice'>\the [src] already has a spray bottle!</span>")
 
-	if(istype(W, /obj/item/mop/advanced))
-		if(bot_core.allowed(user) && open && adv_mop == TRUE)
-			to_chat(user, "<span class='notice'>You replace \the [src] old mop with a new better one!</span>")
-			adv_mop = TRUE
-			clean_time = 20 //2.5 the speed!
-			window_name = "Automatic Station Cleaner v2.1 BETA" //New!
-			qdel(W)
+	else if(istype(W, /obj/item/mop/advanced))
+		if(bot_core.allowed(user) && open)
+			if(!adv_mop)
+				to_chat(user, "<span class='notice'>You replace \the [src] old mop with a new better one!</span>")
+				adv_mop = TRUE
+				clean_time = 20 //2.5 the speed!
+				window_name = "Automatic Station Cleaner v2.1 BETA" //New!
+				qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
 		else
 			to_chat(user, "<span class='notice'>\the [src] already has this mop!</span>")
 
-	if(istype(W, /obj/item/twohanded/broom))
-		if(bot_core.allowed(user) && open && broom == TRUE)
-			to_chat(user, "<span class='notice'>You add to \the [src] a broom speeding it up!</span>")
-			broom = TRUE
-			base_speed = 1 //2x faster!
-			qdel(W)
+	else if(istype(W, /obj/item/twohanded/broom))
+		if(bot_core.allowed(user) && open)
+			if(!broom)
+				to_chat(user, "<span class='notice'>You add to \the [src] a broom speeding it up!</span>")
+				broom = TRUE
+				base_speed = 1 //2x faster!
+				qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
 		else
 			to_chat(user, "<span class='notice'>\the [src] already has a broom!</span>")
 
@@ -197,14 +206,19 @@
 				shuffle = TRUE	//Shuffle the list the next time we scan so we dont both go the same way.
 			path = list()
 
-		if(!path || path.len == 0) //No path, need a new one
+		if(!path || path.len) //No path, need a new one
 			//Try to produce a path to the target, and ignore airlocks to which it has access.
 			path = get_path_to(src, target.loc, /turf/proc/Distance_cardinal, 0, 30, id=access_card)
-			if(!bot_move(target))
-				add_to_ignore(target)
-				target = null
-				path = list()
-				return
+		if(target && path.len == 0 && (get_dist(src,target) > 1))
+			path = get_path_to(src, get_turf(target), /turf/proc/Distance_cardinal, 0, 30,id=access_card)
+			mode = BOT_MOVING
+			if(!path.len) //try to get closer if you can't reach the cleanable directly
+				path = get_path_to(src, get_turf(target), /turf/proc/Distance_cardinal, 0, 30,1,id=access_card)
+				if(!path.len) //Do not glue to a stuff we can not get to
+					add_to_ignore(target)
+					target = null
+					path = list()
+					return
 			mode = BOT_MOVING
 		else if(!bot_move(target))
 			target = null

--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -20,8 +20,7 @@
 	weather_immunities = list("lava","ash")
 
 	var/clean_time = 50 //How long do we take to clean?
-	var/broom = FALSE //Do we have an speed buff from a broom?
-	var/adv_mop = FALSE //Do we have a cleaning buff from a better mop?
+	var/upgrades = 0
 
 	var/blood = 1
 	var/trash = 0
@@ -78,34 +77,38 @@
 			if(open)
 				to_chat(user, "<span class='warning'>Please close the access panel before locking it.</span>")
 			else
-				to_chat(user, "<span class='notice'>\The [src] doesn't seem to respect your authority.</span>")
+				to_chat(user, "<span class='notice'>The [src] doesn't seem to respect your authority.</span>")
 
 	else if(istype(W, /obj/item/mop/advanced))
-		if(bot_core.allowed(user) && open)
-			if(!adv_mop)
-				to_chat(user, "<span class='notice'>You replace \the [src] old mop with a new better one!</span>")
-				adv_mop = TRUE
-				clean_time = 20 //2.5 the speed!
-				window_name = "Automatic Station Cleaner v2.1 BETA" //New!
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_CLEANER_ADVANCED_MOP))
+			to_chat(user, "<span class='notice'>You replace \the [src] old mop with a new better one!</span>")
+			upgrades |= UPGRADE_CLEANER_ADVANCED_MOP
+			clean_time = 20 //2.5 the speed!
+			window_name = "Automatic Station Cleaner v2.1 BETA" //New!
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannle is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has this mop!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has this mop!</span>")
 
 	else if(istype(W, /obj/item/twohanded/broom))
-		if(bot_core.allowed(user) && open)
-			if(!broom)
-				to_chat(user, "<span class='notice'>You add to \the [src] a broom speeding it up!</span>")
-				broom = TRUE
-				base_speed = 1 //2x faster!
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_CLEANER_BROOM))
+			to_chat(user, "<span class='notice'>You add to \the [src] a broom speeding it up!</span>")
+			upgrades |= UPGRADE_CLEANER_BROOM
+			base_speed = 1 //2x faster!
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannel is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a broom!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has a broom!</span>")
 
 	else
 		return ..()

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -33,6 +33,9 @@
 	var/oldloc = null
 	var/toolbox = /obj/item/storage/toolbox/mechanical
 
+	var/storage_upgrade = FALSE
+	var/syndicate_toolbox = FALSE
+
 	#define HULL_BREACH		1
 	#define LINE_SPACE_MODE		2
 	#define FIX_TILE		3
@@ -120,6 +123,30 @@
 			to_chat(user, "<span class='notice'>You load [loaded] tiles into the floorbot. It now contains [specialtiles] tiles.</span>")
 		else
 			to_chat(user, "<span class='warning'>You need at least one floor tile to put into [src]!</span>")
+
+	else if(istype(W, /obj/item/storage/toolbox/artistic))
+		if(bot_core.allowed(user) && open && storage_upgrade != TRUE)
+			to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
+			storage_upgrade = TRUE
+			maxtiles += 100 //Double the storage!
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a upgraded case!</span>")
+
+	else if(istype(W, /obj/item/storage/toolbox/syndicate))
+		if(bot_core.allowed(user) && open && syndicate_toolbox != TRUE)
+			to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
+			syndicate_toolbox = TRUE
+			maxtiles += 200 //Double bse storage
+			base_speed = 1 //2x faster!
+			qdel(W)
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a upgraded case!</span>")
+
+
 	else
 		..()
 

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -125,11 +125,12 @@
 			to_chat(user, "<span class='warning'>You need at least one floor tile to put into [src]!</span>")
 
 	else if(istype(W, /obj/item/storage/toolbox/artistic))
-		if(bot_core.allowed(user) && open && storage_upgrade != TRUE)
-			to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
-			storage_upgrade = TRUE
-			maxtiles += 100 //Double the storage!
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!storage_upgrade)
+				to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
+				storage_upgrade = TRUE
+				maxtiles += 100 //Double the storage!
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
@@ -137,12 +138,13 @@
 			to_chat(user, "<span class='notice'>\the [src] already has a upgraded case!</span>")
 
 	else if(istype(W, /obj/item/storage/toolbox/syndicate))
-		if(bot_core.allowed(user) && open && syndicate_toolbox != TRUE)
-			to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
-			syndicate_toolbox = TRUE
-			maxtiles += 200 //Double bse storage
-			base_speed = 1 //2x faster!
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!syndicate_toolbox)
+				to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
+				syndicate_toolbox = TRUE
+				maxtiles += 200 //Double bse storage
+				base_speed = 1 //2x faster!
+				qdel(W)
 		else
 			to_chat(user, "<span class='notice'>\the [src] already has a upgraded case!</span>")
 

--- a/code/modules/mob/living/simple_animal/bot/floorbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/floorbot.dm
@@ -33,8 +33,7 @@
 	var/oldloc = null
 	var/toolbox = /obj/item/storage/toolbox/mechanical
 
-	var/storage_upgrade = FALSE
-	var/syndicate_toolbox = FALSE
+	var/upgrades = 0
 
 	#define HULL_BREACH		1
 	#define LINE_SPACE_MODE		2
@@ -125,28 +124,32 @@
 			to_chat(user, "<span class='warning'>You need at least one floor tile to put into [src]!</span>")
 
 	else if(istype(W, /obj/item/storage/toolbox/artistic))
-		if(bot_core.allowed(user) && open)
-			if(!storage_upgrade)
-				to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
-				storage_upgrade = TRUE
-				maxtiles += 100 //Double the storage!
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_FLOOR_ARTBOX))
+			to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
+			upgrades |= UPGRADE_FLOOR_ARTBOX
+			maxtiles += 100 //Double the storage!
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannle is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a upgraded case!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has a upgraded case!</span>")
 
 	else if(istype(W, /obj/item/storage/toolbox/syndicate))
-		if(bot_core.allowed(user) && open)
-			if(!syndicate_toolbox)
-				to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
-				syndicate_toolbox = TRUE
-				maxtiles += 200 //Double bse storage
-				base_speed = 1 //2x faster!
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_FLOOR_SYNDIBOX))
+			to_chat(user, "<span class='notice'>You upgrade \the [src] case to hold more!</span>")
+			upgrades |= UPGRADE_FLOOR_SYNDIBOX
+			maxtiles += 200 //Double bse storage
+			base_speed = 1 //2x faster!
+			qdel(W)
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
+			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a upgraded case!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has a upgraded case!</span>")
 
 
 	else

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -228,7 +228,6 @@
 
 /mob/living/simple_animal/bot/medbot/attackby(obj/item/W as obj, mob/user as mob, params)
 	if(istype(W, /obj/item/reagent_containers/glass))
-		. = 1 //no afterattack
 		if(locked)
 			to_chat(user, "<span class='warning'>You cannot insert a beaker because the panel is locked!</span>")
 			return
@@ -243,10 +242,11 @@
 		show_controls(user)
 
 	else if(istype(W, /obj/item/reagent_containers/syringe/piercing))
-		if(bot_core.allowed(user) && open && piercing != TRUE)
-			to_chat(user, "<span class='notice'>You replace \the [src] syringe with a diamond-tipped one!</span>")
-			piercing = TRUE
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!piercing)
+				to_chat(user, "<span class='notice'>You replace \the [src] syringe with a diamond-tipped one!</span>")
+				piercing = TRUE
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
@@ -254,12 +254,13 @@
 			to_chat(user, "<span class='notice'>\the [src] already has a diamond-tipped syringe!</span>")
 
 	else if(istype(W, /obj/item/hypospray/mkii))
-		if(bot_core.allowed(user) && open && hypospray != TRUE)
-			to_chat(user, "<span class='notice'>You replace \the [src] syringe base with a DeForest Medical MK.II Hypospray!</span>")
-			hypospray = TRUE
-			injection_time = 15 //Half the time half the death!
-			window_name = "Automatic Medical Unit v2.4 ALPHA"
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!hypospray)
+				to_chat(user, "<span class='notice'>You replace \the [src] syringe base with a DeForest Medical MK.II Hypospray!</span>")
+				hypospray = TRUE
+				injection_time = 15 //Half the time half the death!
+				window_name = "Automatic Medical Unit v2.4 ALPHA"
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
@@ -268,11 +269,12 @@
 
 
 	else if(istype(W, /obj/item/circuitboard/machine/chem_dispenser))
-		if(bot_core.allowed(user) && open && upgraded_dispenser_1 != TRUE)
-			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-			upgraded_dispenser_1 = TRUE
-			treatment_oxy = /datum/reagent/medicine/salbutamol //Replaces Dex with salbutamol "better" healing of o2
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!upgraded_dispenser_1)
+				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+				upgraded_dispenser_1 = TRUE
+				treatment_oxy = /datum/reagent/medicine/salbutamol //Replaces Dex with salbutamol "better" healing of o2
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
@@ -280,11 +282,12 @@
 			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/cryo_tube))
-		if(bot_core.allowed(user) && open && upgraded_dispenser_2 != TRUE)
-			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-			upgraded_dispenser_2 = TRUE
-			treatment_fire = /datum/reagent/medicine/oxandrolone //Replaces Kep with oxandrolone "better" healing of burns
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!upgraded_dispenser_2)
+				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+				upgraded_dispenser_2 = TRUE
+				treatment_fire = /datum/reagent/medicine/oxandrolone //Replaces Kep with oxandrolone "better" healing of burns
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
@@ -292,11 +295,12 @@
 			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/chem_master))
-		if(bot_core.allowed(user) && open && upgraded_dispenser_3 != TRUE)
-			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-			upgraded_dispenser_3 = TRUE
-			treatment_brute = /datum/reagent/medicine/sal_acid //Replaces Bic with Sal Acid "better" healing of brute
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!upgraded_dispenser_3)
+				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+				upgraded_dispenser_3 = TRUE
+				treatment_brute = /datum/reagent/medicine/sal_acid //Replaces Bic with Sal Acid "better" healing of brute
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return
@@ -304,12 +308,13 @@
 			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/sleeper))
-		if(bot_core.allowed(user) && open && upgraded_dispenser_4 != TRUE)
-			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-			upgraded_dispenser_4 = TRUE
-			treatment_tox = /datum/reagent/medicine/pen_acid //replaces charcoal with pen acid a "better" healing of toxins
-			treatment_tox_toxlover = /datum/reagent/medicine/pen_acid/pen_jelly //Injects pen jelly into people that heal via toxins
-			qdel(W)
+		if(bot_core.allowed(user) && open)
+			if(!upgraded_dispenser_4)
+				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+				upgraded_dispenser_4 = TRUE
+				treatment_tox = /datum/reagent/medicine/pen_acid //replaces charcoal with pen acid a "better" healing of toxins
+				treatment_tox_toxlover = /datum/reagent/medicine/pen_acid/pen_jelly //Injects pen jelly into people that heal via toxins
+				qdel(W)
 		if(!open)
 			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
 			return

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -42,6 +42,7 @@
 	var/declare_crit = 1 //If active, the bot will transmit a critical patient alert to MedHUD users.
 	var/declare_cooldown = 0 //Prevents spam of critical patient alerts.
 	var/stationary_mode = 0 //If enabled, the Medibot will not move automatically.
+	var/injection_time = 30 //How long we take to inject someone
 	//Setting which reagents to use to treat what by default. By id.
 	var/treatment_brute_avoid = /datum/reagent/medicine/tricordrazine
 	var/treatment_brute = /datum/reagent/medicine/bicaridine
@@ -51,19 +52,26 @@
 	var/treatment_fire = /datum/reagent/medicine/kelotane
 	var/treatment_tox_avoid = /datum/reagent/medicine/tricordrazine
 	var/treatment_tox = /datum/reagent/medicine/charcoal
-	var/treatment_tox_toxlover = /datum/reagent/toxin
+	var/treatment_tox_toxlover = /datum/reagent/toxin //Injects toxins into people that heal via toxins
 	var/treatment_virus_avoid = null
 	var/treatment_virus = /datum/reagent/medicine/spaceacillin
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
 
+	var/piercing = FALSE //Do we pierc through clothing?
+	var/hypospray = FALSE //Do we have the nicer needle? - Injects faster
+	var/upgraded_dispenser_1 //Do we have the nicer chemicals? - replaces dex with salbutamol
+	var/upgraded_dispenser_2 //Do we have the nicer chemicals? - replaces kep with oxandrolone
+	var/upgraded_dispenser_3 //Do we have the nicer chemicals? - replaces bic with sal acid
+	var/upgraded_dispenser_4 //Do we have the nicer chemicals? - replaces charcoal/toxin with pentetic acid / pentetic jelly
+
 /mob/living/simple_animal/bot/medbot/mysterious
 	name = "\improper Mysterious Medibot"
 	desc = "International Medibot of mystery."
 	skin = "bezerk"
-	treatment_brute = /datum/reagent/medicine/tricordrazine
-	treatment_fire = /datum/reagent/medicine/tricordrazine
-	treatment_tox = /datum/reagent/medicine/tricordrazine
+	treatment_brute = /datum/reagent/medicine/regen_jelly
+	treatment_fire = /datum/reagent/medicine/regen_jelly
+	treatment_tox = /datum/reagent/medicine/regen_jelly
 
 /mob/living/simple_animal/bot/medbot/derelict
 	name = "\improper Old Medibot"
@@ -234,6 +242,81 @@
 		to_chat(user, "<span class='notice'>You insert [W].</span>")
 		show_controls(user)
 
+	else if(istype(W, /obj/item/reagent_containers/syringe/piercing))
+		if(bot_core.allowed(user) && open && piercing != TRUE)
+			to_chat(user, "<span class='notice'>You replace \the [src] syringe with a diamond-tipped one!</span>")
+			piercing = TRUE
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a diamond-tipped syringe!</span>")
+
+	else if(istype(W, /obj/item/hypospray/mkii))
+		if(bot_core.allowed(user) && open && hypospray != TRUE)
+			to_chat(user, "<span class='notice'>You replace \the [src] syringe base with a DeForest Medical MK.II Hypospray!</span>")
+			hypospray = TRUE
+			injection_time = 15 //Half the time half the death!
+			window_name = "Automatic Medical Unit v2.4 ALPHA"
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a DeForest Medical Hypospray base!</span>")
+
+
+	else if(istype(W, /obj/item/circuitboard/machine/chem_dispenser))
+		if(bot_core.allowed(user) && open && upgraded_dispenser_1 != TRUE)
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgraded_dispenser_1 = TRUE
+			treatment_oxy = /datum/reagent/medicine/salbutamol //Replaces Dex with salbutamol "better" healing of o2
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+
+	else if(istype(W, /obj/item/circuitboard/machine/cryo_tube))
+		if(bot_core.allowed(user) && open && upgraded_dispenser_2 != TRUE)
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgraded_dispenser_2 = TRUE
+			treatment_fire = /datum/reagent/medicine/oxandrolone //Replaces Kep with oxandrolone "better" healing of burns
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+
+	else if(istype(W, /obj/item/circuitboard/machine/chem_master))
+		if(bot_core.allowed(user) && open && upgraded_dispenser_3 != TRUE)
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgraded_dispenser_3 = TRUE
+			treatment_brute = /datum/reagent/medicine/sal_acid //Replaces Bic with Sal Acid "better" healing of brute
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+
+	else if(istype(W, /obj/item/circuitboard/machine/sleeper))
+		if(bot_core.allowed(user) && open && upgraded_dispenser_4 != TRUE)
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgraded_dispenser_4 = TRUE
+			treatment_tox = /datum/reagent/medicine/pen_acid //replaces charcoal with pen acid a "better" healing of toxins
+			treatment_tox_toxlover = /datum/reagent/medicine/pen_acid/pen_jelly //Injects pen jelly into people that heal via toxins
+			qdel(W)
+		if(!open)
+			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			return
+		else
+			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+
+
 	else
 		var/current_health = health
 		..()
@@ -249,6 +332,7 @@
 		audible_message("<span class='danger'>[src] buzzes oddly!</span>")
 		flick("medibot_spark", src)
 		playsound(src, "sparks", 75, 1)
+		piercing = TRUE //Jabs even harder through the clothing!
 		if(user)
 			oldpatient = user
 
@@ -361,7 +445,7 @@
 
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing))
+		if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing) && piercing != TRUE)
 			var/obj/item/clothing/CS = H.wear_suit
 			var/obj/item/clothing/CH = H.head
 			if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)
@@ -504,7 +588,7 @@
 			"<span class='userdanger'>[src] is trying to inject you!</span>")
 
 		var/failed = FALSE
-		if(do_mob(src, patient, 30))	//Is C == patient? This is so confusing
+		if(do_mob(src, patient, injection_time))	//Is C == patient? This is so confusing
 			if((get_dist(src, patient) <= 1) && (on) && assess_patient(patient))
 				if(reagent_id == "internal_beaker")
 					if(use_beaker && reagent_glass && reagent_glass.reagents.total_volume)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -58,8 +58,7 @@
 	var/treat_virus = 1 //If on, the bot will attempt to treat viral infections, curing them if possible.
 	var/shut_up = 0 //self explanatory :)
 
-	var/piercing = FALSE //Do we pierc through clothing?
-	var/hypospray = FALSE //Do we have the nicer needle? - Injects faster
+	var/upgrades = 0
 	var/upgraded_dispenser_1 //Do we have the nicer chemicals? - replaces dex with salbutamol
 	var/upgraded_dispenser_2 //Do we have the nicer chemicals? - replaces kep with oxandrolone
 	var/upgraded_dispenser_3 //Do we have the nicer chemicals? - replaces bic with sal acid
@@ -242,85 +241,95 @@
 		show_controls(user)
 
 	else if(istype(W, /obj/item/reagent_containers/syringe/piercing))
-		if(bot_core.allowed(user) && open)
-			if(!piercing)
-				to_chat(user, "<span class='notice'>You replace \the [src] syringe with a diamond-tipped one!</span>")
-				piercing = TRUE
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_PIERERCING))
+			to_chat(user, "<span class='notice'>You replace \the [src] syringe with a diamond-tipped one!</span>")
+			upgrades |= UPGRADE_MEDICAL_PIERERCING
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannel is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a diamond-tipped syringe!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has a diamond-tipped syringe!</span>")
 
 	else if(istype(W, /obj/item/hypospray/mkii))
-		if(bot_core.allowed(user) && open)
-			if(!hypospray)
-				to_chat(user, "<span class='notice'>You replace \the [src] syringe base with a DeForest Medical MK.II Hypospray!</span>")
-				hypospray = TRUE
-				injection_time = 15 //Half the time half the death!
-				window_name = "Automatic Medical Unit v2.4 ALPHA"
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_HYPOSPRAY))
+			to_chat(user, "<span class='notice'>You replace \the [src] syringe base with a DeForest Medical MK.II Hypospray!</span>")
+			upgrades |= UPGRADE_MEDICAL_HYPOSPRAY
+			injection_time = 15 //Half the time half the death!
+			window_name = "Automatic Medical Unit v2.4 ALPHA"
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannel is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a DeForest Medical Hypospray base!</span>")
-
+			to_chat(user, "<span class='notice'>The [src] already has a DeForest Medical Hypospray base!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/chem_dispenser))
-		if(bot_core.allowed(user) && open)
-			if(!upgraded_dispenser_1)
-				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-				upgraded_dispenser_1 = TRUE
-				treatment_oxy = /datum/reagent/medicine/salbutamol //Replaces Dex with salbutamol "better" healing of o2
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_CHEM_BOARD))
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgrades |= UPGRADE_MEDICAL_CHEM_BOARD
+			treatment_oxy = /datum/reagent/medicine/salbutamol //Replaces Dex with salbutamol "better" healing of o2
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannel is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has a this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/cryo_tube))
-		if(bot_core.allowed(user) && open)
-			if(!upgraded_dispenser_2)
-				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-				upgraded_dispenser_2 = TRUE
-				treatment_fire = /datum/reagent/medicine/oxandrolone //Replaces Kep with oxandrolone "better" healing of burns
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_CRYO_BOARD))
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgrades |= UPGRADE_MEDICAL_CRYO_BOARD
+			treatment_fire = /datum/reagent/medicine/oxandrolone //Replaces Kep with oxandrolone "better" healing of burns
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannel is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has a this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/chem_master))
-		if(bot_core.allowed(user) && open)
-			if(!upgraded_dispenser_3)
-				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-				upgraded_dispenser_3 = TRUE
-				treatment_brute = /datum/reagent/medicine/sal_acid //Replaces Bic with Sal Acid "better" healing of brute
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_CHEM_MASTER))
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgrades |= UPGRADE_MEDICAL_CHEM_MASTER
+			treatment_brute = /datum/reagent/medicine/sal_acid //Replaces Bic with Sal Acid "better" healing of brute
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>the [src] access pannel is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>the [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>the [src] already has a this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/sleeper))
-		if(bot_core.allowed(user) && open)
-			if(!upgraded_dispenser_4)
-				to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
-				upgraded_dispenser_4 = TRUE
-				treatment_tox = /datum/reagent/medicine/pen_acid //replaces charcoal with pen acid a "better" healing of toxins
-				treatment_tox_toxlover = /datum/reagent/medicine/pen_acid/pen_jelly //Injects pen jelly into people that heal via toxins
-				qdel(W)
+		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_SLEEP_BOARD))
+			to_chat(user, "<span class='notice'>You add in the board upgrading \the [src] reagent banks!</span>")
+			upgrades |= UPGRADE_MEDICAL_SLEEP_BOARD
+			treatment_tox = /datum/reagent/medicine/pen_acid //replaces charcoal with pen acid a "better" healing of toxins
+			treatment_tox_toxlover = /datum/reagent/medicine/pen_acid/pen_jelly //Injects pen jelly into people that heal via toxins
+			qdel(W)
 		if(!open)
-			to_chat(user, "<span class='notice'>\the [src] access pannle is not open!</span>")
+			to_chat(user, "<span class='notice'>The [src] access pannle is not open!</span>")
+			return
+		if(!bot_core.allowed(user))
+			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>\the [src] already has a this upgrade!</span>")
-
+			to_chat(user, "<span class='notice'>The [src] already has a this upgrade!</span>")
 
 	else
 		var/current_health = health
@@ -337,7 +346,8 @@
 		audible_message("<span class='danger'>[src] buzzes oddly!</span>")
 		flick("medibot_spark", src)
 		playsound(src, "sparks", 75, 1)
-		piercing = TRUE //Jabs even harder through the clothing!
+		if(!CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_PIERERCING))
+			upgrades |= UPGRADE_MEDICAL_PIERERCING //Jabs even harder through the clothing!
 		if(user)
 			oldpatient = user
 
@@ -450,7 +460,7 @@
 
 	if(ishuman(C))
 		var/mob/living/carbon/human/H = C
-		if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing) && piercing != TRUE)
+		if (H.wear_suit && H.head && istype(H.wear_suit, /obj/item/clothing) && istype(H.head, /obj/item/clothing) && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_PIERERCING))
 			var/obj/item/clothing/CS = H.wear_suit
 			var/obj/item/clothing/CH = H.head
 			if (CS.clothing_flags & CH.clothing_flags & THICKMATERIAL)

--- a/code/modules/mob/living/simple_animal/bot/medbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/medbot.dm
@@ -283,7 +283,7 @@
 			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>The [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/cryo_tube))
 		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_CRYO_BOARD))
@@ -298,7 +298,7 @@
 			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>The [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/chem_master))
 		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_CHEM_MASTER))
@@ -313,7 +313,7 @@
 			to_chat(user, "<span class='notice'>the [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>the [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>the [src] already has this upgrade!</span>")
 
 	else if(istype(W, /obj/item/circuitboard/machine/sleeper))
 		if(bot_core.allowed(user) && open && !CHECK_BITFIELD(upgrades,UPGRADE_MEDICAL_SLEEP_BOARD))
@@ -329,7 +329,7 @@
 			to_chat(user, "<span class='notice'>The [src] access pannel locked off to you!</span>")
 			return
 		else
-			to_chat(user, "<span class='notice'>The [src] already has a this upgrade!</span>")
+			to_chat(user, "<span class='notice'>The [src] already has this upgrade!</span>")
 
 	else
 		var/current_health = health

--- a/strings/tips.txt
+++ b/strings/tips.txt
@@ -64,6 +64,7 @@ As a Roboticist, you can greatly help out Shaft Miners by building a Firefighter
 As a Roboticist, you can augment people with cyborg limbs. Augmented limbs can easily be repaired with cables and welders.
 As a Roboticist, you can use your printer that is linked to the ore silo to teleport mats into your work place!
 As a Roboticist, you can upgrade cleanbots with adv mops and brooms to make them faster and better!
+As a Roboticist, you can upgrade medical bots with diamond-tipped syringes, MK.II Hypospray, dispenser-sleeper-chemheater boards to make them inject faster, harder and better chems!
 As the AI, you can click on people's names to look at them. This only works if there are cameras that can see them.
 As the AI, you can quickly open and close doors by holding shift while clicking them, bolt them when holding ctrl, and even shock them while holding alt.
 As the AI, you can take pictures with your camera and upload them to newscasters.


### PR DESCRIPTION
## About The Pull Request

Medical bots have a lot of upgrades now! 
MK II hypo makes them inject 2x faster!
Different medical boards make them inject even better chemicals*!
Diamond syringes allow them to inject harder through suits!
Emaging also now injects harder through suits 

Floor bots can be upgraded with green toolboxes for 100+ storage and Syndi boxes for SPEED and even more storage!
closes #12105

## Why It's Good For The Game

It just is! Change my mind - note you cant
This allows people to interact more so with bots then before giving them even more of  reason to go around and collect the trash they need to upgrade their sex bots into being just a little bit more usefull before placing  pAI in them for robo-sex, but *better*

Joking aside this allows medibot bots to be upgraded to deal with more exstream cases of burns/brutes well having EMT bots in the halls for minor healing. Most of the chemical stuff only is a "upgrade" for tox and o2 loss - both needing a buff anyways with how outdated they are, and upgrading brute/burns may lead to cases were its a downgrate! 

## Changelog
:cl: With help of Putnam
add: Medibots can now be upgraded with MK II hypos diamond needles and medical based boards
add: Floor bot can now be upgraded with art tool boxes and syndi boxes
fix: Medibot now can be opened via access like before but works
/:cl: