### PR TITLE
Makes Caeser salad apart of the conspiracies phobia

### DIFF
--- a/code/controllers/subsystem/traumas.dm
+++ b/code/controllers/subsystem/traumas.dm
@@ -99,7 +99,7 @@ SUBSYSTEM_DEF(traumas)
 												 /obj/item/clothing/suit/space/hardsuit/ert, /obj/item/clothing/suit/space/hardsuit/ert/sec,
 												 /obj/item/clothing/suit/space/hardsuit/ert/engi, /obj/item/clothing/suit/space/hardsuit/ert/med,
 												 /obj/item/clothing/suit/space/hardsuit/deathsquad, /obj/item/clothing/head/helmet/space/hardsuit/deathsquad,
-												 /obj/machinery/door/airlock/centcom)),
+												 /obj/machinery/door/airlock/centcom, /obj/item/reagent_containers/food/snacks/salad/caesar)),
 					"robots"   = typecacheof(list(/obj/machinery/computer/upload, /obj/item/aiModule/, /obj/machinery/recharge_station,
 						/obj/item/aicard, /obj/item/deactivated_swarmer, /obj/effect/mob_spawn/swarmer)),
 


### PR DESCRIPTION

## About The Pull Request

Makes Caeser salad apart of the conspiracies phobia

## Why It's Good For The Game
It fits...

## Changelog
:cl:
fix: The conspiracies to kill Caeser are now apart of conspiracies listing
/:cl: