### PR TITLE
Crew objectives framework

### DIFF
--- a/code/__HELPERS/roundend.dm
+++ b/code/__HELPERS/roundend.dm
@@ -274,6 +274,12 @@
 	parts += antag_report()
 
 	CHECK_TICK
+
+	//Crew objectives
+	parts += crew_report()
+
+	CHECK_TICK
+	
 	//Medals
 	parts += medal_report()
 	//Station Goals
@@ -494,6 +500,24 @@
 		result += "</div>"
 
 	return result.Join()
+
+/datum/controller/subsystem/ticker/proc/crew_report()
+	var/list/result = list()
+	for(var/P in GLOB.player_list)
+		if(ismob(P))
+			var/mob/M = P
+			if(M.mind?.objectives?.len)
+				var/objectives_complete = TRUE
+				report += printobjectives(M.mind.objectives)
+				for(var/datum/objective/objective in objectives)
+					if(objective.completable && !objective.check_completion())
+						objectives_complete = FALSE
+						break
+				if(objectives_complete)
+					report += "<span class='greentext big'>[M.name] was successful!</span>"
+				else
+					report += "<span class='redtext big'>[M.name] has failed!</span>"
+	return result.Join("<br>")
 
 /proc/cmp_antag_category(datum/antagonist/A,datum/antagonist/B)
 	return sorttext(B.roundend_category,A.roundend_category)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Allowing non-antag crew to have objectives attached, which show in the round end.

## Why It's Good For The Game

Uhhhh let the people who mentioned it needs to be done explain this, I'm not sure (heck, I'll edit it in here after).

## Changelog
:cl:
add: Crew objectives framework
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
