### PR TITLE
Fixes cloner sabotage to only check on station Z

### DIFF
--- a/code/game/gamemodes/objective_sabotage.dm
+++ b/code/game/gamemodes/objective_sabotage.dm
@@ -90,7 +90,10 @@
 	sabotage_type = "cloner"
 
 /datum/sabotage_objective/cloner/check_conditions()
-	return !(locate(/obj/machinery/clonepod) in GLOB.machines)
+	for(var/obj/machinery/clonepod/cloner in GLOB.machines)
+		if(is_station_level(cloner.z))
+			return FALSE
+	return TRUE
 
 /datum/sabotage_objective/ai_law
 	name = "Upload a hacked law to the AI."


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title.

## Why It's Good For The Game

Complaints about getting cucked by golems. Yeah, that's bad.

## Changelog
:cl:
fix: NT cloner sabotage now checks for *NT* cloners.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
