### PR TITLE
Replaces mosins in russian crates with 10mm surplus rifles

### DIFF
--- a/code/modules/cargo/packs/armory.dm
+++ b/code/modules/cargo/packs/armory.dm
@@ -170,8 +170,7 @@
 	cost = 7500
 	contraband = TRUE
 	contains = list(/obj/item/reagent_containers/food/snacks/rationpack,
-					/obj/item/ammo_box/a762,
-					/obj/item/storage/toolbox/ammo,
+					/obj/item/ammo_box/magazine/m10mm/rifle,
 					/obj/item/clothing/suit/armor/vest/russian,
 					/obj/item/clothing/head/helmet/rus_helmet,
 					/obj/item/clothing/shoes/russian,
@@ -181,7 +180,7 @@
 					/obj/item/clothing/mask/russian_balaclava,
 					/obj/item/clothing/head/helmet/rus_ushanka,
 					/obj/item/clothing/suit/armor/vest/russian_coat,
-					/obj/item/gun/ballistic/shotgun/boltaction)
+					/obj/item/gun/ballistic/automatic/surplus)
 	crate_name = "surplus military crate"
 
 /datum/supply_pack/security/armory/russian/fill(obj/structure/closet/crate/C)

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -111,8 +111,8 @@
 					/obj/item/clothing/head/helmet/alt,
 					/obj/item/clothing/gloves/tackler/combat/insulated,
 					/obj/item/clothing/mask/gas,
-					/obj/item/gun/ballistic/shotgun/boltaction,
-					/obj/item/ammo_box/a762)
+					/obj/item/ammo_box/magazine/m10mm/rifle,
+					/obj/item/gun/ballistic/automatic/surplus)
 	crate_name = "surplus russian gear"
 	crate_type = /obj/structure/closet/crate/internals
 

--- a/code/modules/cargo/packs/security.dm
+++ b/code/modules/cargo/packs/security.dm
@@ -99,11 +99,11 @@
 	crate_type = /obj/structure/closet/crate/internals
 
 /datum/supply_pack/security/russianmosin
-	name = "Russian Minutemen Gear"
-	desc = "An old russian Minutemen crate, comes with a full russian outfit, a mosin and a stripper clip."
+	name = "Russian Partisan Gear"
+	desc = "An old russian partisan equipment crate, comes with a full russian outfit, a loaded surplus rifle and a second magazine."
 	contraband = TRUE
 	access = FALSE
-	cost = 6500 //
+	cost = 6500
 	contains = list(/obj/item/clothing/suit/armor/navyblue/russian,
 					/obj/item/clothing/shoes/combat,
 					/obj/item/clothing/head/ushanka,


### PR DESCRIPTION
## About The Pull Request
Replaces the ammo, gun and toolbox's ammo with 10mm ammo and surplus rifles


## Why It's Good For The Game
Less powerfull, less antag gear in cargo is always nice. After all russian crate is aften abused do to being on of the most powerfull crates you can get other then combat shotguns weapon wise.

This keeps in line with the removal of null crates, as these are infact antag gear that nukies can get
```
/datum/uplink_item/dangerous/bolt_action
	name = "Surplus Rifle"
	desc = "A horribly outdated bolt action weapon. You've got to be desperate to use this."
	item = /obj/item/gun/ballistic/shotgun/boltaction
	cost = 2
	include_modes = list(/datum/game_mode/nuclear)
```

## Changelog
:cl:
balance: Mosins have been replaced with surplus rifles in cargo
/:cl: