### PR TITLE
Removes crocin, hexacrocin from emagged booze dispenser; makes crocin no longer "roofies" (??)

### DIFF
--- a/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_dispenser.dm
@@ -575,9 +575,7 @@
 		/datum/reagent/consumable/ethanol/alexander,
 		/datum/reagent/consumable/clownstears,
 		/datum/reagent/toxin/minttoxin,
-		/datum/reagent/consumable/ethanol/atomicbomb,
-		/datum/reagent/drug/aphrodisiac,
-		/datum/reagent/drug/aphrodisiacplus
+		/datum/reagent/consumable/ethanol/atomicbomb
 	)
 
 /obj/machinery/chem_dispenser/drinks/beer/fullupgrade //fully ugpraded stock parts, emagged

--- a/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
+++ b/modular_citadel/code/modules/reagents/reagents/cit_reagents.dm
@@ -92,8 +92,7 @@
 /datum/reagent/drug/aphrodisiac
 	name = "Crocin"
 	description = "Naturally found in the crocus and gardenia flowers, this drug acts as a natural and safe aphrodisiac."
-	taste_description = "strawberry roofies"
-	taste_mult = 2 //Hide the roofies in stronger flavors
+	taste_description = "strawberries"
 	color = "#FFADFF"//PINK, rgb(255, 173, 255)
 	can_synth = FALSE
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

As title. Traitor-only ERP chem dispensing is ???, making one of our ERP chems explicitly named after and apparently *mechanically intended to be* date rape drugs is !!!

## Why It's Good For The Game

Sorry y'all there's lots of stuff that can be mechanically allowed but this ain't it.

## Changelog
:cl:
del: The crocins are now gone from emagged booze dispensers.
tweak: Crocin now just tastes like strawberries.
/:cl: