### PR TITLE
Removes alien crate adds ape crate

### DIFF
--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -10,24 +10,13 @@
 	group = "Science"
 	crate_type = /obj/structure/closet/crate/science
 
-/* For later
-/datum/supply_pack/science/monkey
+/datum/supply_pack/science/monkey  //Ape out!
 	name = "Ape Cube Crate"
 	desc = "Pss what a new test subject with supper strangth, speed, and love for bananas all at the same time? Say no more... Contains a single ape cube. Dont add water!"
 	contraband = TRUE
 	cost = 2500
 	contains = list (/obj/item/reagent_containers/food/snacks/monkeycube/ape)
 	crate_name = "ape cube crate"
-*/
-
-/datum/supply_pack/science/aliens
-	name = "Advanced Alien Alloy Crate Crate"
-	desc = "Hello brothers from the stars!!! Our fellow brethren have made contact at long last and gave us gifts man! They really did build the prymi- Connection Error- Bro we’ll send you a sheet of advanced alien alloy."
-	cost = 15000
-	DropPodOnly = TRUE
-	contraband = TRUE
-	contains = list(/obj/item/stack/sheet/mineral/abductor)
-	crate_name = "alien bro alloy crate"
 
 /datum/supply_pack/science/beakers
 	name = "Chemistry Beakers Crate"

--- a/code/modules/cargo/packs/science.dm
+++ b/code/modules/cargo/packs/science.dm
@@ -10,12 +10,12 @@
 	group = "Science"
 	crate_type = /obj/structure/closet/crate/science
 
-/datum/supply_pack/science/monkey  //Ape out!
+/datum/supply_pack/science/ape  //Ape out!
 	name = "Ape Cube Crate"
 	desc = "Pss what a new test subject with supper strangth, speed, and love for bananas all at the same time? Say no more... Contains a single ape cube. Dont add water!"
 	contraband = TRUE
 	cost = 2500
-	contains = list (/obj/item/reagent_containers/food/snacks/monkeycube/ape)
+	contains = list (/obj/item/reagent_containers/food/snacks/cube/ape)
 	crate_name = "ape cube crate"
 
 /datum/supply_pack/science/beakers

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -397,8 +397,8 @@
 
 /obj/item/reagent_containers/food/snacks/cube/ape
 	name = "ape cube"
-	desc = "Dont add water"
-	tastes = list("banana" = 1, "beef" = 1)
+	desc = "Don't add water."
+	tastes = list("the jungle" = 1, "bananas" = 1, "jimmies" = 1)
 	dried_being = /mob/living/simple_animal/hostile/gorilla
 
 /obj/item/reagent_containers/food/snacks/cube/egg

--- a/code/modules/food_and_drinks/food/snacks_meat.dm
+++ b/code/modules/food_and_drinks/food/snacks_meat.dm
@@ -395,6 +395,12 @@
 	tastes = list("milk" = 1, "beef" = 1)
 	dried_being = /mob/living/simple_animal/cow
 
+/obj/item/reagent_containers/food/snacks/cube/ape
+	name = "ape cube"
+	desc = "Dont add water"
+	tastes = list("banana" = 1, "beef" = 1)
+	dried_being = /mob/living/simple_animal/hostile/gorilla
+
 /obj/item/reagent_containers/food/snacks/cube/egg
 //Well eggs normally are able to hatch into small birds, this one does not.
 //Also in order to have a normal egg hatch you need a hen to lay the egg that is able to hatch, meaning this one is for on-demand hen needs.


### PR DESCRIPTION

## About The Pull Request
Alien crate is gone, its never going to be gotton
Ape crate is now a crate you can get for a strong monkey!

## Why It's Good For The Game

Alien crate is never going to be gotton anymore as it needs 10x crate in an rng location - kinda dumb

ape crate is a cool way to get better meat without needing sci/gene to do anything like make a ape armoy...

## Changelog
:cl:
add: Ape crate is now gettable via hackes and sci
del: Aliens are running away from us!
/:cl:
