### PR TITLE
Brings back the gas archive

### DIFF
--- a/code/__DEFINES/atmospherics.dm
+++ b/code/__DEFINES/atmospherics.dm
@@ -298,6 +298,8 @@ GLOBAL_LIST_INIT(atmos_adjacent_savings, list(0,0))
 
 #define ARCHIVE_TEMPERATURE(gas) gas.temperature_archived = gas.temperature
 
+#define ARCHIVE(gas) gas.temperature_archived = gas.temperature; gas.gas_archive = gas.gases.Copy();
+
 GLOBAL_LIST_INIT(pipe_paint_colors, list(
 		"amethyst" = rgb(130,43,255), //supplymain
 		"blue" = rgb(0,0,255),

--- a/code/game/objects/structures/transit_tubes/station.dm
+++ b/code/game/objects/structures/transit_tubes/station.dm
@@ -152,8 +152,8 @@
 		pod_moving = 0
 		if(!QDELETED(pod))
 			var/datum/gas_mixture/floor_mixture = loc.return_air()
-			ARCHIVE_TEMPERATURE(floor_mixture)
-			ARCHIVE_TEMPERATURE(pod.air_contents)
+			ARCHIVE(floor_mixture)
+			ARCHIVE(pod.air_contents)
 			pod.air_contents.share(floor_mixture, 1) //mix the pod's gas mixture with the tile it's on
 			air_update_turf()
 

--- a/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
+++ b/code/modules/atmospherics/environmental/LINDA_turf_tile.dm
@@ -89,7 +89,7 @@
 	temperature_archived = temperature
 
 /turf/open/archive()
-	ARCHIVE_TEMPERATURE(air)
+	ARCHIVE(air)
 	archived_cycle = SSair.times_fired
 	temperature_archived = temperature
 
@@ -215,7 +215,7 @@
 	if (planet_atmos) //share our air with the "atmosphere" "above" the turf
 		var/datum/gas_mixture/G = new
 		G.copy_from_turf(src)
-		ARCHIVE_TEMPERATURE(G)
+		ARCHIVE(G)
 		if(our_air.compare(G))
 			if(!our_excited_group)
 				var/datum/excited_group/EG = new


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

See title. Basically, on TGstation, gases are archived before sharing, so as to make the operation commutative--i.e. `a share b` will be identical to `b share a`. We removed this for performance reasons, but it causes a lot of weird jank, so I'm reverting this... sorta. I rolled my own archive system for it, instead of doing the weird list-of-list stuff TG does. The result should be the same.

## Why It's Good For The Game

People keep saying our atmos is scuffed and, well, this is the only real difference we have, so.

## Changelog
:cl:
refactor: Gas archive is back for share() and such
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
