### PR TITLE
Fixes explosions hanging mid-air

### DIFF
--- a/code/datums/explosion.dm
+++ b/code/datums/explosion.dm
@@ -76,7 +76,9 @@ GLOBAL_LIST_EMPTY(explosions)
 	//I would make this not ex_act the thing that triggered the explosion,
 	//but everything that explodes gives us their loc or a get_turf()
 	//and somethings expect us to ex_act them so they can qdel()
-	stoplag() //tldr, let the calling proc call qdel(src) before we explode
+	//stoplag() //tldr, let the calling proc call qdel(src) before we explode
+	// no - use sleep. stoplag() results in quirky things like explosions taking too long to process and hanging mid-air for no reason.
+	sleep(0)
 
 	EX_PREPROCESS_EXIT_CHECK
 

--- a/code/modules/power/singularity/singularity.dm
+++ b/code/modules/power/singularity/singularity.dm
@@ -119,13 +119,12 @@
 
 
 /obj/singularity/Bump(atom/A)
+	set waitfor = FALSE
 	consume(A)
-	return
-
 
 /obj/singularity/Bumped(atom/movable/AM)
+	set waitfor = FALSE
 	consume(AM)
-
 
 /obj/singularity/process()
 	if(current_size >= STAGE_TWO)
@@ -268,6 +267,7 @@
 
 
 /obj/singularity/proc/eat()
+	set waitfor = FALSE
 	for(var/tile in spiral_range_turfs(grav_pull, src))
 		var/turf/T = tile
 		if(!T || !isturf(loc))
@@ -284,8 +284,6 @@
 				else
 					consume(X)
 			CHECK_TICK
-	return
-
 
 /obj/singularity/proc/consume(atom/A)
 	var/gain = A.singularity_act(current_size, src)
@@ -295,8 +293,6 @@
 		name = "supermatter-charged [initial(name)]"
 		consumedSupermatter = 1
 		set_light(10)
-	return
-
 
 /obj/singularity/proc/move(force_move = 0)
 	if(!move_self)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

changes stoplag() to sleep(0)

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

no need for stoplag(), it halts for too long when there's other explosions running.
explosions use their own tick checking underneath so there's not too much of a loss.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: explosions are now quicker when stacking.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
