### PR TITLE
Nerfs multiple ice ruins 

### DIFF
--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -175,6 +175,11 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
+"aI" = (
+/obj/effect/turf_decal/stripes/line,
+/obj/item/clothing/suit/space/hardsuit/engine,
+/turf/open/floor/plating/snowed/smoothed/icemoon,
+/area/icemoon/surface/outdoors)
 "aJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
@@ -343,6 +348,7 @@
 "bf" = (
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/core,
+/obj/item/clothing/suit/space/hardsuit/engine,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bg" = (
@@ -1474,7 +1480,7 @@ bA
 aa
 aa
 af
-cA
+aI
 DM
 dc
 al

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -175,12 +175,6 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"aI" = (
-/obj/item/pda/engineering{
-	note = "To-do: Check on singularity status. Get a pint at eat. Nag the research manager for RCDs."
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "aJ" = (
 /obj/effect/decal/cleanable/dirt,
 /turf/open/floor/plating/icemoon,
@@ -346,18 +340,7 @@
 /obj/effect/decal/cleanable/blood/splatter,
 /turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
-"be" = (
-/obj/item/card/id{
-	access = list(200,204,11,12,10);
-	assignment = "Senior Station Engineer";
-	desc = "A card used to provide ID and determine access across the station. There's blood dripping from the corner. Ew.";
-	name = "George 'Plastic' Miller's ID Card (Senior Station Engineer)";
-	registered_name = "George 'Plastic' Miller"
-	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
-/area/icemoon/surface/outdoors)
 "bf" = (
-/obj/effect/gibspawner/generic,
 /obj/effect/decal/cleanable/blood,
 /obj/effect/decal/cleanable/blood/gibs/core,
 /turf/open/floor/plating/asteroid/snow/icemoon,
@@ -543,10 +526,6 @@
 	},
 /obj/item/shard/plasma,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
-"bz" = (
-/obj/item/clothing/suit/space/hardsuit/engine,
-/turf/open/floor/plating/asteroid/snow/icemoon,
 /area/icemoon/surface/outdoors)
 "bA" = (
 /obj/item/flashlight/flare,
@@ -1013,13 +992,6 @@
 	},
 /turf/open/floor/plating/icemoon,
 /area/icemoon/surface/outdoors)
-"cU" = (
-/obj/effect/mob_spawn/human/engineer/rig,
-/obj/structure/cable{
-	icon_state = "4-8"
-	},
-/turf/open/floor/plating/icemoon,
-/area/icemoon/surface/outdoors)
 "cV" = (
 /obj/effect/turf_decal/trimline/neutral/filled/line,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
@@ -1032,12 +1004,7 @@
 	},
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"cX" = (
-/obj/machinery/rnd/production/circuit_imprinter,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "cY" = (
-/obj/machinery/rnd/production/protolathe/department/engineering,
 /obj/machinery/light/small/broken,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
@@ -1437,9 +1404,9 @@ aa
 aa
 aa
 aa
-aI
 aa
-be
+aa
+aa
 aa
 aa
 aa
@@ -1461,7 +1428,7 @@ aa
 aa
 aa
 bf
-bz
+aa
 aa
 aa
 af
@@ -1529,7 +1496,7 @@ aa
 ab
 ab
 cF
-cU
+gA
 al
 al
 aO
@@ -1698,7 +1665,7 @@ cf
 cr
 cB
 cI
-cX
+ab
 aB
 aa
 aa

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_engioutpost.dmm
@@ -5,10 +5,6 @@
 "ab" = (
 /turf/open/floor/plating/snowed/smoothed/icemoon,
 /area/icemoon/surface/outdoors)
-"ac" = (
-/obj/effect/mob_spawn/human/engineer/rig,
-/turf/open/floor/plating/snowed/smoothed/icemoon,
-/area/icemoon/surface/outdoors)
 "ad" = (
 /obj/machinery/power/floodlight,
 /obj/structure/cable{
@@ -1425,7 +1421,7 @@ ak
 aa
 "}
 (9,1,1) = {"
-ac
+ab
 ab
 al
 ap

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_hotsprings.dmm
@@ -1,6 +1,6 @@
 //MAP CONVERTED BY dmm2tgm.py THIS HEADER COMMENT PREVENTS RECONVERSION, DO NOT REMOVE
 "a" = (
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/closed/indestructible/riveted/uranium,
 /area/icemoon/surface/outdoors)
 "b" = (
 /turf/closed/mineral/random/snow/no_caves,
@@ -12,7 +12,17 @@
 /obj/item/paper/crumpled{
 	info = "When one falls into this hot spring, they shall forever be turned into..."
 	},
-/turf/open/floor/plating/asteroid/snow/icemoon,
+/turf/open/floor/plating/beach/sand,
+/area/icemoon/surface/outdoors)
+"I" = (
+/turf/closed/indestructible/fakeglass,
+/area/icemoon/surface/outdoors)
+"L" = (
+/obj/structure/fluff/beach_umbrella,
+/turf/open/floor/plating/beach/sand,
+/area/icemoon/surface/outdoors)
+"U" = (
+/turf/open/floor/plating/beach/sand,
 /area/icemoon/surface/outdoors)
 
 (1,1,1) = {"
@@ -34,7 +44,7 @@ b
 b
 a
 a
-a
+I
 a
 a
 b
@@ -45,11 +55,11 @@ b
 b
 b
 a
-a
-a
-a
-a
-a
+U
+U
+U
+U
+U
 a
 b
 b
@@ -57,65 +67,65 @@ b
 (4,1,1) = {"
 b
 a
-a
-a
+U
+L
 c
 c
 c
-a
-a
+U
+U
 a
 b
 "}
 (5,1,1) = {"
 b
 a
-a
+U
 c
 c
 c
 c
 c
-a
+U
 a
 b
 "}
 (6,1,1) = {"
 b
-a
-a
+I
+U
 c
 c
 c
 c
 c
-a
-a
+U
+I
 b
 "}
 (7,1,1) = {"
 b
 a
-a
+U
 c
 c
 c
 c
 c
-a
+U
 a
 b
 "}
 (8,1,1) = {"
 b
 a
-a
-a
+U
+L
 c
 c
 c
-a
-a
+U
+U
 a
 b
 "}
@@ -123,11 +133,11 @@ b
 b
 b
 a
-a
-a
+U
+U
 d
-a
-a
+U
+U
 a
 b
 b
@@ -138,7 +148,7 @@ b
 b
 a
 a
-a
+I
 a
 a
 b

--- a/_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
+++ b/_maps/RandomRuins/IceRuins/icemoon_surface_lust.dmm
@@ -20,12 +20,6 @@
 	},
 /turf/open/floor/mineral/diamond,
 /area/icemoon/surface/outdoors)
-"f" = (
-/obj/structure/sign/poster/contraband/lusty_xenomorph,
-/obj/structure/falsewall/abductor,
-/obj/structure/fans/tiny,
-/turf/open/floor/mineral/diamond,
-/area/icemoon/surface/outdoors)
 
 (1,1,1) = {"
 a
@@ -101,7 +95,7 @@ d
 e
 d
 c
-f
+b
 a
 a
 "}

--- a/code/game/turfs/simulated/floor/plating/asteroid.dm
+++ b/code/game/turfs/simulated/floor/plating/asteroid.dm
@@ -203,8 +203,7 @@
 	mob_spawn_list = list(/mob/living/simple_animal/hostile/asteroid/wolf = 50, /obj/structure/spawner/ice_moon = 3, \
 						  /mob/living/simple_animal/hostile/asteroid/polarbear = 30, /obj/structure/spawner/ice_moon/polarbear = 3, \
 						  /mob/living/simple_animal/hostile/asteroid/hivelord/legion/snow = 50, /mob/living/simple_animal/hostile/asteroid/goldgrub = 10)
-
-	flora_spawn_list = list(/obj/structure/flora/tree/pine = 2, /obj/structure/flora/grass/both = 12)
+	flora_spawn_list = list(/obj/structure/flora/tree/pine = 2, /obj/structure/flora/grass/both = 12, /obj/structure/flora/rock/icy = 6, /obj/structure/flora/rock/pile/icy = 6)
 	data_having_type = /turf/open/floor/plating/asteroid/airless/cave/snow/has_data
 	turf_type = /turf/open/floor/plating/asteroid/snow/icemoon
 	choose_turf_type = list(/turf/open/floor/plating/asteroid/snow/icemoon = 19, /turf/open/floor/plating/ice/icemoon = 1)


### PR DESCRIPTION
## About The Pull Request

- Engineering Ruin no longer has ID cards; nor engilathes, it retains an autolathe and some other items.
- Lust ruin is now surrounded in unbreakable walls, you will have to teleport, or otherwise glitch yourself in akin to the wish granter, no more free alien tech every round.
- The hotspring is similarly surrounded in unbreakable walls, has been revamped to look more like a beach/oasis in the snow. This is both to prevent low effort metarushes for the pool (which can still be done with some effort) and to stop people accidentally falling into it and being changed.

## Why It's Good For The Game

I've noticed people metarushing these ruins (since station-level ruins appear on the minimap people can just metagame their locations) and using them for rather OP gains. I've heard the 'oh but icemoon is useless then!!" argument too many times in regards to broken shit. if you want icemoon to have more powergamer loot, add it yourself, I'm not facilitating this shit getting abused every round.

## Changelog
:cl:
balance: makes two ice ruins harder to get into, nukes most of the loot on a third.
/:cl:
