### PR TITLE
Nerfs cargo gas selling - MK different pr then the one that addresses this

### DIFF
--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -177,7 +177,7 @@
 	worth += gases[/datum/gas/miasma]*1
 	worth += gases[/datum/gas/tritium]*4
 	worth += gases[/datum/gas/pluoxium]*3
-	worth += gases[/datum/gas/nitryl]*25
+	worth += gases[/datum/gas/nitryl]*30
 	return worth
 
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -171,13 +171,13 @@
 	var/worth = 10
 	var/gases = C.air_contents.gases
 
-	worth += gases[/datum/gas/bz]*4
-	worth += gases[/datum/gas/stimulum]*25
-	worth += gases[/datum/gas/hypernoblium]*1000
-	worth += gases[/datum/gas/miasma]*4
-	worth += gases[/datum/gas/tritium]*7
-	worth += gases[/datum/gas/pluoxium]*6
-	worth += gases[/datum/gas/nitryl]*30
+	worth += gases[/datum/gas/bz]*2
+	worth += gases[/datum/gas/stimulum]*20
+	worth += gases[/datum/gas/hypernoblium]*100
+	worth += gases[/datum/gas/miasma]*1
+	worth += gases[/datum/gas/tritium]*4
+	worth += gases[/datum/gas/pluoxium]*3
+	worth += gases[/datum/gas/nitryl]*25
 	return worth
 
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -171,13 +171,12 @@
 	var/worth = 10
 	var/gases = C.air_contents.gases
 
-	worth += gases[/datum/gas/bz]*2
-	worth += gases[/datum/gas/stimulum]*20
-	worth += gases[/datum/gas/hypernoblium]*100
-	worth += gases[/datum/gas/miasma]*1
-	worth += gases[/datum/gas/tritium]*4
-	worth += gases[/datum/gas/pluoxium]*3
-	worth += gases[/datum/gas/nitryl]*30
+	worth += gases[/datum/gas/bz]*3
+	worth += gases[/datum/gas/stimulum]*25
+	worth += gases[/datum/gas/hypernoblium]*1000
+	worth += gases[/datum/gas/miasma]*2
+	worth += gases[/datum/gas/tritium]*7
+	worth += gases[/datum/gas/pluoxium]*6
 	return worth
 
 

--- a/code/modules/cargo/exports/large_objects.dm
+++ b/code/modules/cargo/exports/large_objects.dm
@@ -177,6 +177,7 @@
 	worth += gases[/datum/gas/miasma]*2
 	worth += gases[/datum/gas/tritium]*7
 	worth += gases[/datum/gas/pluoxium]*6
+	worth += gases[/datum/gas/nitryl]*30
 	return worth
 
 


### PR DESCRIPTION
## About The Pull Request
Coolaid BZ  4 to 3
Simple nerfs most gas selling, from stinky sci gas from  4 to 2

## Why It's Good For The Game
Gas selling is one of the easist ways to brake cargo from around the 30 min mark do to some rather effectice set ups of the SM to atmos setting up a turbin and forgetting before selling off 9000 kpa of 20ishc 
Its also for plux or masiam passive income once cargo sets it up in base, thats not ideal for what we want form are cargo techies 
Numbers are infact arbitrary just as money is
BZ  worst offender here for a set forget  you dont neven need to cool it to start the reaction and heat seems to not really even slow it down to a noticeable affect its basicly free money faster around 10~min mark from buying the plasma and n20 can... 

## Changelog
:cl:
tweak: Gasses like BZ and Masiam seem to just sell for less in cargo, markets seem to change it seems
/:cl:
