### PR TITLE
Halves wire pulse delay 

### DIFF
--- a/code/datums/wires/_wires.dm
+++ b/code/datums/wires/_wires.dm
@@ -142,7 +142,7 @@
 		if(level_diff > 0)
 			LAZYSET(current_users, user, TRUE)
 			to_chat(user, "<span class='notice'>You begin cutting [holder]'s [color] wire...</span>")
-			if(!do_after(user, 1.5 SECONDS * level_diff, target = holder) || !interactable(user))
+			if(!do_after(user, 0.75 SECONDS * level_diff, target = holder) || !interactable(user))
 				LAZYREMOVE(current_users, user)
 				return FALSE
 			LAZYREMOVE(current_users, user)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

1.5 seconds for untrained wire hacking is a little high.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Wire pulsing now takes 0.75 seconds per skill level difference, instead of 1.5.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
