### PR TITLE
Moves fire alarm in box station in the chem department

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -24736,9 +24736,6 @@
 /obj/machinery/camera{
 	c_tag = "Chemistry"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27777,6 +27774,10 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -39446,14 +39447,6 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
-"bPh" = (
-/obj/machinery/atmospherics/pipe/simple/cyan/visible,
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/atmospherics/pipe/layer_manifold{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/engine/atmos)
 "bPi" = (
 /obj/machinery/light{
 	dir = 4
@@ -41472,13 +41465,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bUN" = (
-/obj/machinery/portable_atmospherics/canister,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
-"bUO" = (
 /obj/machinery/portable_atmospherics/canister,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1
@@ -93957,7 +93943,7 @@ bMQ
 bRC
 rdl
 daq
-bUO
+bUN
 bOd
 bOd
 bOd
@@ -94214,7 +94200,7 @@ cBF
 bRD
 rdl
 daq
-bUO
+bUN
 bOd
 bOd
 bOd
@@ -94471,7 +94457,7 @@ bQs
 cez
 ceA
 daq
-bUO
+bUN
 bOd
 bOd
 bOd

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -24888,9 +24888,6 @@
 /obj/machinery/camera{
 	c_tag = "Chemistry"
 	},
-/obj/machinery/firealarm{
-	pixel_y = 24
-	},
 /obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -27914,6 +27911,10 @@
 	},
 /obj/machinery/light{
 	dir = 8
+	},
+/obj/machinery/firealarm{
+	dir = 4;
+	pixel_x = -24
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)


### PR DESCRIPTION
## About The Pull Request

Moves the fire alarm in the chem department just a tiny bit over.

## Why It's Good For The Game

Makes it so that when the fire alarm inevitably gets acid-d it can get replaced in the same location without breaking the heater.

## Changelog
:cl:
tweak: Adjusted fire alarm location in chem department
/:cl:
