### PR TITLE
Fixes Electroplating for real this time! We promise!

### DIFF
--- a/code/datums/components/crafting/recipes/recipes_misc.dm
+++ b/code/datums/components/crafting/recipes/recipes_misc.dm
@@ -157,7 +157,7 @@
 /datum/crafting_recipe/goldenbox
 	name = "Gold Plated Toolbox"
 	result = /obj/item/storage/toolbox/gold_fake
-	tools = list(/obj/item/stock_parts/cell/upgraded/plus)
+	tools = list(/obj/item/stock_parts/cell/high)
 	reqs = list(/obj/item/stack/sheet/cardboard = 1, //so we dont null items in crafting
 				/obj/item/stack/cable_coil = 10,
 				/obj/item/stack/sheet/mineral/gold = 1,
@@ -184,7 +184,7 @@
 
 /datum/crafting_recipe/bronze_driver
 	name = "Bronze Plated Screwdriver"
-	tools = list(/obj/item/stock_parts/cell/upgraded/plus)
+	tools = list(/obj/item/stock_parts/cell/high)
 	result = /obj/item/screwdriver/bronze
 	reqs = list(/obj/item/screwdriver = 1,
 				/obj/item/stack/cable_coil = 10,
@@ -196,7 +196,7 @@
 
 /datum/crafting_recipe/bronze_welder
 	name = "Bronze Plated Welding Tool"
-	tools = list(/obj/item/stock_parts/cell/upgraded/plus)
+	tools = list(/obj/item/stock_parts/cell/high)
 	result = /obj/item/weldingtool/bronze
 	reqs = list(/obj/item/weldingtool = 1,
 				/obj/item/stack/cable_coil = 10,
@@ -208,7 +208,7 @@
 
 /datum/crafting_recipe/bronze_wirecutters
 	name = "Bronze Plated Wirecutters"
-	tools = list(/obj/item/stock_parts/cell/upgraded/plus)
+	tools = list(/obj/item/stock_parts/cell/high)
 	result = /obj/item/wirecutters/bronze
 	reqs = list(/obj/item/wirecutters = 1,
 				/obj/item/stack/cable_coil = 10,
@@ -220,7 +220,7 @@
 
 /datum/crafting_recipe/bronze_crowbar
 	name = "Bronze Plated Crowbar"
-	tools = list(/obj/item/stock_parts/cell/upgraded/plus)
+	tools = list(/obj/item/stock_parts/cell/high)
 	result = /obj/item/crowbar/bronze
 	reqs = list(/obj/item/crowbar = 1,
 				/obj/item/stack/cable_coil = 10,
@@ -232,7 +232,7 @@
 
 /datum/crafting_recipe/bronze_wrench
 	name = "Bronze Plated Wrench"
-	tools = list(/obj/item/stock_parts/cell/upgraded/plus)
+	tools = list(/obj/item/stock_parts/cell/high)
 	result = /obj/item/wrench/bronze
 	reqs = list(/obj/item/wrench = 1,
 				/obj/item/stack/cable_coil = 10,


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Fixes #10094's problem of using a cell that doesn't actually exist on station except occasionally in one singular APC in atmos, by using a cell that is more commonly available. 
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Having content that nobody can actually use is bad, having content that people can actually use is good!
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: changed all electroplating recipes to use high capacity power cells instead of Upgraded Power Cell+s, which are not craft-able, order-able, or lathe-able, and would require sabotage to acquire normally. 
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
