### PR TITLE
Nerfs lesser syndicate nanites (nukeops hypospray chemical)

### DIFF
--- a/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
+++ b/code/modules/reagents/chemistry/reagents/medicine_reagents.dm
@@ -1218,15 +1218,15 @@ datum/reagent/medicine/styptic_powder/overdose_start(mob/living/M)
 	value = REAGENT_VALUE_VERY_RARE
 
 /datum/reagent/medicine/lesser_syndicate_nanites/on_mob_life(mob/living/carbon/M)
-	M.adjustBruteLoss(-3*REM, FALSE) // hidden gold shh
-	M.adjustFireLoss(-3*REM, FALSE)
-	M.adjustOxyLoss(-15, FALSE)
-	M.adjustToxLoss(-3*REM, FALSE)
-	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -15*REM)
-	M.adjustCloneLoss(-3*REM, FALSE)
-	M.adjustStaminaLoss(-20*REM,FALSE)
+	M.adjustBruteLoss(-2*REM, FALSE)
+	M.adjustFireLoss(-2*REM, FALSE)
+	M.adjustOxyLoss(-5*REM, FALSE)
+	M.adjustToxLoss(-2*REM, FALSE)
+	M.adjustOrganLoss(ORGAN_SLOT_BRAIN, -5*REM)
+	M.adjustCloneLoss(-1.25*REM, FALSE)
+	M.adjustStaminaLoss(-4*REM,FALSE)
 	if(M.blood_volume < (BLOOD_VOLUME_NORMAL*M.blood_ratio))
-		M.blood_volume += 20 // blood fall out man bad
+		M.blood_volume += 3
 	..()
 	. = 1
 


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Brute, burn, tox healing at 66%
Oxygen healing at less than 33% when compouding in REM
Stamina healing at 25%
Brain/clone healing decreased by a ton
Blood volume healing down to 3 instead of 20.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Long overdue nerf, apparently no one wants to change 8 values because that somehow takes coding knowledge so here we are. For a 4 TC kit this is powerful as all fuck. Nukeops already get very good armor, they don't need a heal-all medikit that does this rapidly. The ship has medical supplies, the kit contains patches.
If there is need for patch/touch based rapid healing, add another uplink kit.
Furthermore why is this giving so much stamina? Buy a goddamn stimpack.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Lesser syndicate nanites, the stuff in nukeops hypospray chemicals, are now weaker.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
