### PR TITLE
Removes turning towards the thing you're pulling unless you're in an aggressive or above grab

### DIFF
--- a/code/modules/mob/mob_movement.dm
+++ b/code/modules/mob/mob_movement.dm
@@ -100,7 +100,7 @@
 		if(mob.throwing)
 			mob.throwing.finalize(FALSE)
 
-	if(L.pulling && !(L.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE))
+	if(L.pulling && (L.grab_state > GRAB_PASSIVE) && !(L.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE))
 		L.setDir(turn(L.dir, 180))
 
 	SEND_SIGNAL(mob, COMSIG_MOB_CLIENT_MOVE, src, direction, n, oldloc)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Makes no sense to be doing this below aggrograbs, just makes the game more obnoxious to play. You shouldn't have to be in combat mode to pull things without turning for crying out loud.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: You no longer turn towards things you pull unless you are aggressively or up grabbing someone.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
