### PR TITLE
Moving wall stuff such as buttons around away from windows.

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -16717,10 +16717,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/robust_softdrinks{
-	pixel_x = -32;
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMh" = (
@@ -17943,7 +17939,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -17961,21 +17956,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
-"aPW" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -55990,6 +55970,10 @@
 /area/maintenance/fore/secondary)
 "khV" = (
 /obj/machinery/vending/cola/red,
+/obj/structure/sign/poster/contraband/robust_softdrinks{
+	pixel_x = -32;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "kls" = (
@@ -58150,7 +58134,7 @@
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 1
 	},
-/turf/open/floor/plasteel,
+/turf/closed/wall,
 /area/security/brig)
 "rdl" = (
 /obj/effect/spawner/structure/window/reinforced,
@@ -58450,6 +58434,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
+"rNG" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/ai_monitored/storage/eva)
 "rPU" = (
 /turf/open/floor/plasteel/white/side{
 	dir = 4
@@ -60877,6 +60865,10 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plating,
 /area/maintenance/fore/secondary)
+"yeA" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/hallway/primary/central)
 "yhx" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 5
@@ -79018,7 +79010,7 @@ blW
 blW
 bqi
 cyD
-blW
+aZE
 cyD
 bvS
 blW
@@ -87987,7 +87979,7 @@ ayL
 ayW
 ayW
 ayW
-ayW
+rNG
 aJq
 aJq
 aOE
@@ -90561,7 +90553,7 @@ aKF
 aMf
 aNB
 aOE
-aPW
+aPS
 aRr
 aSD
 ceh
@@ -91585,7 +91577,7 @@ gfD
 woR
 dgz
 aJw
-aJw
+yeA
 aMh
 aJq
 aOE

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -17073,7 +17073,7 @@
 /area/security/brig)
 "aLl" = (
 /obj/effect/turf_decal/delivery,
-/obj/machinery/vending/autodrobe/all_access,
+/obj/machinery/vending/autodrobe,
 /turf/open/floor/plasteel,
 /area/hallway/primary/port/fore)
 "aLm" = (
@@ -28450,7 +28450,7 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/warehouse)
 "bjN" = (
-/obj/machinery/vending/autodrobe/all_access,
+/obj/machinery/vending/autodrobe,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
@@ -72362,6 +72362,9 @@
 /obj/item/pen,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
+"xxP" = (
+/turf/closed/wall,
+/area/quartermaster/storage)
 "xCy" = (
 /obj/machinery/atmospherics/components/binary/pump,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
@@ -121108,7 +121111,7 @@ bgT
 bjr
 bkr
 ble
-bgT
+xxP
 bnC
 boD
 bgT

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -14150,10 +14150,6 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
-"aEh" = (
-/obj/effect/spawner/structure/window/reinforced,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "aEi" = (
 /obj/structure/cable/white{
 	icon_state = "0-2"
@@ -42579,7 +42575,9 @@
 /obj/structure/cable/white{
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "!interrogation_room"
+	},
 /turf/open/floor/plating,
 /area/security/main)
 "byP" = (
@@ -43653,7 +43651,9 @@
 /obj/structure/cable/white{
 	icon_state = "0-4"
 	},
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "!interrogation_room"
+	},
 /turf/open/floor/plating,
 /area/security/main)
 "bAt" = (
@@ -44960,9 +44960,11 @@
 /area/security/main)
 "bCm" = (
 /obj/structure/cable/white,
-/obj/effect/spawner/structure/window/reinforced/tinted,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
+	},
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "!interrogation_room"
 	},
 /turf/open/floor/plating,
 /area/security/main)
@@ -44982,6 +44984,10 @@
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
+	},
+/obj/machinery/button/electrochromatic{
+	id = "!interrogation_room";
+	pixel_y = -26
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/main)
@@ -127098,6 +127104,12 @@
 /obj/effect/turf_decal/tile/purple,
 /turf/open/floor/plasteel/white,
 /area/science/misc_lab)
+"wFu" = (
+/obj/machinery/button/electrochromatic{
+	pixel_y = -26
+	},
+/turf/closed/wall/r_wall,
+/area/space/nearstation)
 "wHv" = (
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
@@ -173137,7 +173149,7 @@ azG
 aAI
 aCb
 aDf
-aEh
+avW
 aFk
 aGD
 aHW
@@ -182163,7 +182175,7 @@ buU
 biQ
 aad
 ajr
-ajr
+wFu
 aad
 ajr
 ajr

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -16869,10 +16869,6 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/structure/sign/poster/contraband/robust_softdrinks{
-	pixel_x = -32;
-	pixel_y = 32
-	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "aMh" = (
@@ -18095,7 +18091,6 @@
 /obj/structure/cable{
 	icon_state = "0-8"
 	},
-/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -18113,21 +18108,6 @@
 /obj/structure/cable{
 	icon_state = "0-2"
 	},
-/obj/effect/spawner/structure/window/reinforced,
-/obj/machinery/door/poddoor/preopen{
-	id = "bridge blast";
-	name = "bridge blast door"
-	},
-/turf/open/floor/plating,
-/area/bridge)
-"aPW" = (
-/obj/structure/cable{
-	icon_state = "0-8"
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/obj/machinery/status_display/evac,
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/door/poddoor/preopen{
 	id = "bridge blast";
@@ -56356,6 +56336,10 @@
 /area/maintenance/fore/secondary)
 "khV" = (
 /obj/machinery/vending/cola/red,
+/obj/structure/sign/poster/contraband/robust_softdrinks{
+	pixel_x = -32;
+	pixel_y = 32
+	},
 /turf/open/floor/plasteel/dark,
 /area/hallway/primary/central)
 "kjm" = (
@@ -59567,6 +59551,10 @@
 	},
 /turf/open/floor/plasteel,
 /area/crew_quarters/fitness)
+"sKd" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/hallway/primary/central)
 "sLa" = (
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -61093,6 +61081,10 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
+"vUI" = (
+/obj/machinery/status_display/evac,
+/turf/closed/wall,
+/area/ai_monitored/storage/eva)
 "vZA" = (
 /obj/structure/cable,
 /turf/open/floor/plating/snowed/smoothed/icemoon,
@@ -80140,7 +80132,7 @@ blW
 blW
 bqi
 cyD
-blW
+aZE
 cyD
 bvS
 blW
@@ -89109,7 +89101,7 @@ ayL
 ayW
 ayW
 ayW
-ayW
+vUI
 aJq
 aJq
 aOE
@@ -91683,7 +91675,7 @@ aKF
 aMf
 aNB
 aOE
-aPW
+aPS
 aRr
 aSD
 ceh
@@ -92707,7 +92699,7 @@ gfD
 woR
 dgz
 aJw
-aJw
+sKd
 aMh
 aJq
 aOE

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -29538,6 +29538,14 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 4;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_x = -32
+	},
 /turf/open/floor/plasteel/dark,
 /area/science/mixing)
 "aVT" = (
@@ -33284,14 +33292,6 @@
 /obj/structure/chair{
 	dir = 4
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
@@ -33792,14 +33792,6 @@
 	id = "toxinsdriver";
 	pixel_x = 24;
 	pixel_y = -24
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
 	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
@@ -62906,6 +62898,11 @@
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 24
 	},
+/obj/machinery/button/electrochromatic{
+	pixel_x = 38;
+	pixel_y = -5;
+	id = "!interrogation_room"
+	},
 /turf/open/floor/plasteel,
 /area/security/warden)
 "bWO" = (
@@ -73512,7 +73509,7 @@
 	},
 /mob/living/simple_animal/bot/cleanbot{
 	auto_patrol = 1;
-	name = "\imprper Cleaner Bot"
+	name = "\improper Cleaner Bot"
 	},
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/prison)
@@ -85513,6 +85510,12 @@
 "uRM" = (
 /turf/open/floor/wood,
 /area/security/vacantoffice)
+"vjT" = (
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "!interrogation_room"
+	},
+/turf/open/floor/plating,
+/area/security/warden)
 "vle" = (
 /obj/structure/festivus,
 /turf/open/floor/wood,
@@ -107879,7 +107882,7 @@ agX
 agX
 agX
 aef
-acH
+vjT
 aBH
 aef
 aef
@@ -126371,7 +126374,7 @@ bki
 bhQ
 bkN
 bIG
-bki
+bhQ
 bMB
 blH
 bhQ

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -707,24 +707,8 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "acc" = (
-/obj/machinery/computer/security/telescreen/toxins{
-	layer = 4;
-	network = list("toxins");
-	pixel_y = 30
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
-	},
-/turf/open/floor/plasteel,
-/area/science/mixing)
-"acd" = (
-/obj/machinery/computer/security/telescreen/toxins{
-	layer = 4;
-	network = list("toxins");
-	pixel_y = 30
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -1182,6 +1166,10 @@
 	dir = 4;
 	name = "Mass Driver Door";
 	req_access_txt = "7"
+	},
+/obj/machinery/computer/security/telescreen/toxins{
+	dir = 1;
+	pixel_y = -32
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
@@ -112984,7 +112972,7 @@ aAY
 aAY
 aAY
 abK
-acd
+ace
 acH
 ajC
 abJ
@@ -134611,7 +134599,7 @@ aab
 aab
 aJw
 aKk
-aKk
+aPB
 aLY
 aMU
 aNT

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -10143,14 +10143,6 @@
 /obj/structure/chair,
 /turf/open/floor/plasteel/grimy,
 /area/security/main)
-"asN" = (
-/obj/structure/chair,
-/obj/machinery/computer/security/telescreen/interrogation{
-	dir = 1;
-	pixel_y = -30
-	},
-/turf/open/floor/plasteel/grimy,
-/area/security/main)
 "asO" = (
 /obj/item/paper_bin{
 	pixel_x = -3;
@@ -10707,7 +10699,9 @@
 /turf/open/floor/plating,
 /area/security/main)
 "atZ" = (
-/obj/effect/spawner/structure/window/reinforced/tinted,
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic{
+	electrochromatic_id = "!interrogation_room"
+	},
 /turf/open/floor/plating,
 /area/security/main)
 "aua" = (
@@ -46094,7 +46088,7 @@
 /area/bridge/showroom/corporate)
 "bNg" = (
 /obj/machinery/light_switch{
-	pixel_y = 24
+	pixel_y = 25
 	},
 /obj/machinery/light/small{
 	dir = 1
@@ -52693,7 +52687,9 @@
 /area/maintenance/starboard)
 "caX" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/machinery/light_switch,
+/obj/machinery/light_switch{
+	pixel_y = 25
+	},
 /turf/closed/wall,
 /area/maintenance/disposal/incinerator)
 "caY" = (
@@ -62407,7 +62403,7 @@
 	dir = 10
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24
+	pixel_y = 25
 	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
@@ -63922,7 +63918,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_y = 24
+	pixel_y = 25
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
@@ -66314,6 +66310,7 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
+/obj/structure/sign/warning/biohazard,
 /turf/closed/wall,
 /area/science/mixing)
 "cAM" = (
@@ -66338,14 +66335,6 @@
 "cAO" = (
 /obj/structure/chair{
 	dir = 4
-	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
@@ -66770,14 +66759,6 @@
 	pixel_x = 24;
 	pixel_y = -24
 	},
-/obj/machinery/computer/security/telescreen{
-	desc = "Used for watching the test chamber.";
-	dir = 8;
-	layer = 4;
-	name = "Test Chamber Telescreen";
-	network = list("toxins");
-	pixel_x = 30
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -67190,6 +67171,15 @@
 	req_access_txt = "7"
 	},
 /obj/effect/turf_decal/loading_area,
+/obj/machinery/computer/security/telescreen{
+	desc = "Used for watching the test chamber.";
+	dir = 4;
+	layer = 4;
+	name = "Test Chamber Telescreen";
+	network = list("toxins");
+	pixel_x = -32;
+	pixel_y = 0
+	},
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "cCH" = (
@@ -74545,7 +74535,7 @@
 	dir = 8
 	},
 /obj/machinery/light_switch{
-	pixel_x = -23
+	pixel_y = 25
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -81876,6 +81866,14 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/primary/port)
+"kRi" = (
+/obj/structure/chair,
+/obj/machinery/button/electrochromatic{
+	id = "!interrogation_room";
+	pixel_x = -25
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/main)
 "kVo" = (
 /obj/structure/cable/yellow{
 	icon_state = "1-2"
@@ -82166,6 +82164,12 @@
 /obj/item/storage/fancy/candle_box,
 /turf/open/floor/engine/cult,
 /area/library)
+"oaM" = (
+/obj/machinery/computer/security/telescreen/interrogation{
+	pixel_y = 32
+	},
+/turf/open/floor/plasteel/grimy,
+/area/security/main)
 "obb" = (
 /obj/structure/target_stake,
 /obj/effect/turf_decal/stripes/line{
@@ -99950,7 +99954,7 @@ aIg
 aIg
 aKN
 dIs
-aIg
+aUe
 dIs
 aQg
 aIg
@@ -115353,7 +115357,7 @@ aiJ
 aoK
 aqa
 arv
-asM
+kRi
 atZ
 avk
 aww
@@ -115609,8 +115613,8 @@ amr
 anD
 aoL
 ajD
-arv
-asN
+oaM
+asM
 atZ
 avk
 awx
@@ -118521,7 +118525,7 @@ krD
 czD
 cAL
 cBG
-cyy
+czD
 czD
 czD
 cFu

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -2150,11 +2150,6 @@
 /obj/machinery/status_display/supply,
 /turf/closed/wall,
 /area/quartermaster/storage)
-"adq" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "adr" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -37688,6 +37683,10 @@
 /obj/machinery/atmospherics/miner/carbon_dioxide,
 /turf/open/floor/engine/co2,
 /area/engine/atmos)
+"hQH" = (
+/obj/structure/sign/warning/vacuum,
+/turf/closed/wall,
+/area/quartermaster/storage)
 "hTn" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/door/airlock/research/glass{
@@ -38292,14 +38291,6 @@
 /obj/structure/flora/ausbushes/ywflowers,
 /turf/open/floor/grass,
 /area/hallway/secondary/entry)
-"lvt" = (
-/obj/effect/spawner/structure/window/reinforced,
-/obj/structure/sign/warning/vacuum,
-/obj/machinery/light{
-	dir = 4
-	},
-/turf/open/floor/plating,
-/area/quartermaster/storage)
 "lvw" = (
 /obj/machinery/atmospherics/pipe/simple/orange/visible,
 /obj/effect/decal/cleanable/dirt,
@@ -91224,7 +91215,7 @@ aac
 swM
 aeh
 agB
-ado
+adn
 agB
 ahq
 adp
@@ -91478,13 +91469,13 @@ aaa
 aaa
 aaa
 aaa
-adq
+ado
 aeg
 aeX
-adp
+hQH
 agC
 ahr
-lvt
+ado
 aae
 aae
 aae

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -20116,20 +20116,6 @@
 /obj/machinery/conveyor_switch/oneway{
 	id = "QMLoad"
 	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor2";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = -8
-	},
-/obj/machinery/button/door{
-	id = "QMLoaddoor";
-	layer = 4;
-	name = "Loading Doors";
-	pixel_x = 24;
-	pixel_y = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Cargo Supply Dock";
 	dir = 8
@@ -21567,6 +21553,20 @@
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
+	},
+/obj/machinery/button/door{
+	id = "QMLoaddoor2";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = 24;
+	pixel_y = -8
+	},
+/obj/machinery/button/door{
+	id = "QMLoaddoor";
+	layer = 4;
+	name = "Loading Doors";
+	pixel_x = 24;
+	pixel_y = 8
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -52603,12 +52603,6 @@
 /obj/machinery/status_display/ai,
 /turf/closed/wall/r_wall,
 /area/engine/supermatter)
-"cCO" = (
-/obj/structure/disposalpipe/segment{
-	dir = 4
-	},
-/turf/closed/wall,
-/area/security/brig)
 "cCP" = (
 /obj/effect/turf_decal/bot/right,
 /turf/open/floor/plasteel/white,
@@ -55293,6 +55287,9 @@
 /turf/open/floor/plasteel/dark,
 /area/science/xenobiology)
 "ivO" = (
+/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
+	dir = 4
+	},
 /mob/living/simple_animal/bot/secbot{
 	arrest_type = 1;
 	health = 45;
@@ -55300,9 +55297,6 @@
 	idcheck = 1;
 	name = "Sergeant-at-Armsky";
 	weaponscheck = 1
-	},
-/obj/machinery/atmospherics/pipe/simple/cyan/hidden{
-	dir = 4
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/armory)
@@ -89169,7 +89163,7 @@ apj
 ajM
 ajM
 ajM
-cCO
+ajM
 ajM
 ajM
 avL

--- a/_maps/map_files/debug/multiz.dmm
+++ b/_maps/map_files/debug/multiz.dmm
@@ -473,12 +473,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/gravity_generator)
-"bs" = (
-/obj/structure/cable{
-	icon_state = "1-2"
-	},
-/turf/closed/wall/r_wall,
-/area/engine/gravity_generator)
 "bt" = (
 /obj/machinery/atmospherics/pipe/manifold/supply/hidden{
 	dir = 8
@@ -654,7 +648,9 @@
 	pixel_x = -25
 	},
 /obj/structure/closet/firecloset/full,
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
 /turf/open/floor/plasteel{
 	dir = 9
 	},
@@ -793,7 +789,9 @@
 	},
 /area/hallway/primary/central)
 "cl" = (
-/obj/structure/cable,
+/obj/structure/cable{
+	icon_state = "1-2"
+	},
 /turf/open/floor/plasteel{
 	dir = 8
 	},
@@ -3614,8 +3612,8 @@ ak
 aT
 ak
 ak
-bs
-bL
+ak
+bE
 bE
 bE
 cc
@@ -3669,7 +3667,7 @@ aU
 bg
 bq
 ak
-bL
+bE
 bE
 bE
 cd
@@ -3723,7 +3721,7 @@ bh
 bh
 br
 ak
-bL
+bE
 bE
 bE
 cc

--- a/_maps/map_files/debug/runtimestation.dmm
+++ b/_maps/map_files/debug/runtimestation.dmm
@@ -9437,7 +9437,7 @@ fh
 fh
 eY
 eR
-fh
+et
 eR
 fc
 fh

--- a/_maps/map_files/generic/CentCom.dmm
+++ b/_maps/map_files/generic/CentCom.dmm
@@ -58771,7 +58771,7 @@ iX
 iX
 jm
 jr
-iX
+iF
 jr
 jK
 iX

--- a/code/__DEFINES/construction.dm
+++ b/code/__DEFINES/construction.dm
@@ -104,3 +104,8 @@
 
 #define RCD_UPGRADE_FRAMES 1
 #define RCD_UPGRADE_SIMPLE_CIRCUITS 2
+
+//Electrochromatic window defines.
+#define NOT_ELECTROCHROMATIC		0
+#define ELECTROCHROMATIC_OFF		1
+#define ELECTROCHROMATIC_DIMMED		2

--- a/code/game/machinery/buttons.dm
+++ b/code/game/machinery/buttons.dm
@@ -17,7 +17,7 @@
 
 /obj/machinery/button/Initialize(mapload, ndir = 0, built = 0)
 	if(istext(id) && mapload)
-		if(copytext(id, 1, 2) == "!")
+		if(id[1] == "!")
 			id = SSmapping.get_obfuscated_id(id)
 	. = ..()
 	if(built)

--- a/code/game/objects/effects/spawners/structure.dm
+++ b/code/game/objects/effects/spawners/structure.dm
@@ -24,6 +24,23 @@ again.
 	name = "window spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/fulltile)
 	dir = SOUTH
+	var/electrochromatic
+	var/electrochromatic_id
+
+/obj/effect/spawner/structure/window/Initialize()
+	. = ..()
+	if(!electrochromatic)
+		return
+	if(!electrochromatic_id)
+		stack_trace("Electrochromatic window spawner set without electromatic id.")
+		return
+	if(electrochromatic_id[1] == "!")
+		electrochromatic_id = SSmapping.get_obfuscated_id(electrochromatic_id)
+	for(var/obj/structure/window/W in get_turf(src))
+		W.electrochromatic_id = electrochromatic_id
+		W.make_electrochromatic()
+		if(electrochromatic == ELECTROCHROMATIC_DIMMED)
+			W.electrochromatic_dim()
 
 /obj/effect/spawner/structure/window/hollow
 	name = "hollow window spawner"
@@ -140,13 +157,16 @@ again.
 			spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/spawner/north, /obj/structure/window/reinforced/spawner/west)
 	. = ..()
 
-//tinted
+//tinted and electrochromatic
 
 /obj/effect/spawner/structure/window/reinforced/tinted
 	name = "tinted reinforced window spawner"
 	icon_state = "twindow_spawner"
 	spawn_list = list(/obj/structure/grille, /obj/structure/window/reinforced/tinted/fulltile)
 
+/obj/effect/spawner/structure/window/reinforced/tinted/electrochromatic
+	name = "electrochromatic reinforced window spawner"
+	electrochromatic = ELECTROCHROMATIC_DIMMED
 
 //shuttle window
 

--- a/code/game/objects/structures/window.dm
+++ b/code/game/objects/structures/window.dm
@@ -1,7 +1,3 @@
-#define NOT_ELECTROCHROMATIC		0
-#define ELECTROCHROMATIC_OFF		1
-#define ELECTROCHROMATIC_DIMMED		2
-
 GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 
 /proc/do_electrochromatic_toggle(new_status, id)
@@ -74,9 +70,8 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 	if(reinf && anchored)
 		state = WINDOW_SCREWED_TO_FRAME
 
-	if(mapload && electrochromatic_id)
-		if(copytext(electrochromatic_id, 1, 2) == "!")
-			electrochromatic_id = SSmapping.get_obfuscated_id(electrochromatic_id)
+	if(mapload && electrochromatic_id && electrochromatic_id[1] == "!")
+		electrochromatic_id = SSmapping.get_obfuscated_id(electrochromatic_id)
 
 	ini_dir = dir
 	air_update_turf(1)
@@ -885,7 +880,3 @@ GLOBAL_LIST_EMPTY(electrochromatic_window_lookup)
 			return
 	..()
 	update_icon()
-
-#undef NOT_ELECTROCHROMATIC
-#undef ELECTROCHROMATIC_OFF
-#undef ELECTROCHROMATIC_DIMMED


### PR DESCRIPTION
## About The Pull Request
Title, this is required for FoV, since I don't want to bloat that PR by furthermore reorganizing planes and objects.
Also made the tinted windows by kilo, delta and meta interrogation rooms electrochromatic to justify their whole existence and move the telescreen away.

## Why It's Good For The Game
Buttons and screens shouldn't be located into windows.

## Changelog
:cl:
tweak: Moved some buttons and screens away from windows.
add: Meta, Delta and Kilo interrogation rooms now have electrochromatic windows, not just tinted ones. There should be a button around the corner on the listening room you can use to toggle (un)dim them.
/:cl:

