### PR TITLE
Rebalancing Ninja throwing star

### DIFF
--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -14,6 +14,6 @@
 
 /obj/item/throwing_star/ninja
 	name = "ninja throwing star"
-	desc = "A sharp carbin fiber throwing star freshly printed! Even has that new plastic smell"
+	desc = "A sharp carbon fiber throwing star freshly printed! Even has that new plastic smell"
 	throwforce = 25
 	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 70, "embedded_fall_chance" = 1)

--- a/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
+++ b/code/modules/ninja/suit/n_suit_verbs/ninja_stars.dm
@@ -14,5 +14,6 @@
 
 /obj/item/throwing_star/ninja
 	name = "ninja throwing star"
-	throwforce = 30
-	embedding = list("embedded_pain_multiplier" = 6, "embed_chance" = 100, "embedded_fall_chance" = 0)
+	desc = "A sharp carbin fiber throwing star freshly printed! Even has that new plastic smell"
+	throwforce = 25
+	embedding = list("embedded_pain_multiplier" = 4, "embed_chance" = 70, "embedded_fall_chance" = 1)


### PR DESCRIPTION

## About The Pull Request

100% enbed of 30 damage + enbed pain of **6** can be lethl to most people even in hardsuits do to this. Ive 1 shot a ninja before with this by misstake do to them being just that good.
Lowers it to 70% embed 1% fail, and pain to 4 as normal stars are. Lastly 25 damage rather then 30 making it a 2~ hit weapon to kill rather then 1

6 x 2 for 12 pain per action such as moving or being on a timer is a bit much...

## Why It's Good For The Game

Ninjas are meant to be powerfull correct! But this good only leads to spamming of stars to be throwing do to being flat out better then any other attack they normally have as well as most fire arms other and even now shotguns as they keep their 50% block tp stick of also death

## Changelog
:cl:
tweak: Ninja stars can now have a 1% fail rate well also being lowered to 70% enbed.
balance: Ninja star enbed pain timer has been lowered by 2 as well as damage lowered by 5.
/:cl: