### PR TITLE
What if you wanted to pilot Neovgre, but god said 'Zrpu znpuvar oebxr.'.

### DIFF
--- a/code/game/mecha/combat/neovgre.dm
+++ b/code/game/mecha/combat/neovgre.dm
@@ -75,7 +75,7 @@
 					cell.charge += delta
 					adjust_clockwork_power(-delta)
 		if(obj_integrity < max_integrity && istype(loc, /turf/open/floor/clockwork))
-			obj_integrity += min(max_integrity - obj_integrity, max_integrity / 100)
+			obj_integrity += min(max_integrity - obj_integrity, max_integrity / 200)
 		CHECK_TICK
 
 /obj/mecha/combat/neovgre/Initialize()

--- a/code/game/mecha/combat/neovgre.dm
+++ b/code/game/mecha/combat/neovgre.dm
@@ -62,18 +62,21 @@
 
 /obj/mecha/combat/neovgre/process()
 	..()
-	if(GLOB.ratvar_awakens) // At this point only timley intervention by lord singulo could hople to stop the superweapon
+	if(GLOB.ratvar_awakens) // At this point only timley intervention by lord singulo could hope to stop the superweapon
 		cell.charge = INFINITY
 		max_integrity = INFINITY
 		obj_integrity = max_integrity
 		CHECK_TICK //Just to be on the safe side lag wise
-	else if(cell.charge < cell.maxcharge)
-		for(var/obj/effect/clockwork/sigil/transmission/T in range(SIGIL_ACCESS_RANGE, src))
-			var/delta = min(recharge_rate, cell.maxcharge - cell.charge)
-			if (get_clockwork_power() <= delta)
-				cell.charge += delta
-				adjust_clockwork_power(-delta)
-			CHECK_TICK
+	else
+		if(cell.charge < cell.maxcharge)
+			for(var/obj/effect/clockwork/sigil/transmission/T in range(SIGIL_ACCESS_RANGE, src))
+				var/delta = min(recharge_rate, cell.maxcharge - cell.charge)
+				if (get_clockwork_power() >= delta)
+					cell.charge += delta
+					adjust_clockwork_power(-delta)
+		if(obj_integrity < max_integrity && istype(loc, /turf/open/floor/clockwork))
+			obj_integrity += min(max_integrity - obj_integrity, max_integrity / 100)
+		CHECK_TICK
 
 /obj/mecha/combat/neovgre/Initialize()
 	.=..()
@@ -90,7 +93,7 @@
 	energy_drain = 30
 	name = "Aribter Laser Cannon"
 	desc = "Please re-attach this to neovgre and stop asking questions about why it looks like a normal Nanotrasen issue Solaris laser cannon - Nezbere"
-	fire_sound = "sound/weapons/neovgre_laser.ogg"
+	fire_sound = 'sound/weapons/neovgre_laser.ogg'
 
 /obj/item/mecha_parts/mecha_equipment/weapon/energy/laser/heavy/neovgre/can_attach(obj/mecha/combat/neovgre/M)
 	if(istype(M))


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
...... Neovgre, while being able to be summoned, was very very broken before, with all its three special things not working.

- The selfheal on clock tiles was nonexistant, as there was nothing for it implemented at all..
   Its now set to 0.5% of integrity per mech process tick (aka here: second)
- The transmission sigil recharge had a > the wrong way around
- The sound had "s instead of 's

This PR fixes all of that. Why do people not proofread their PRs...
Locally tested.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Neovgre working as it was described in its initial PR might be a good idea? Maybe?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Neovgre now works as it was intended.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
