### PR TITLE
Buget Cuts - Aka Map cutting

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -8,9 +8,6 @@
 	pixel_x = 24
 	},
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
@@ -1401,7 +1398,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "adk" = (
-/obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -2251,7 +2247,6 @@
 /obj/machinery/light/small{
 	dir = 8
 	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -4973,7 +4968,6 @@
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "ajg" = (
-/obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5290,8 +5284,8 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "ajL" = (
-/obj/machinery/computer/security,
 /obj/effect/turf_decal/bot,
+/obj/machinery/computer/secure_data,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "ajM" = (
@@ -5910,6 +5904,7 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -7947,14 +7942,7 @@
 /area/maintenance/fore/secondary)
 "apv" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 3
-	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apw" = (
@@ -15868,7 +15856,8 @@
 /area/chapel/office)
 "aJO" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aJP" = (
@@ -17650,8 +17639,8 @@
 /turf/open/floor/carpet,
 /area/library)
 "aOT" = (
-/obj/machinery/gibber,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aOU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -17668,10 +17657,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aOW" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/camera{
 	c_tag = "Hydroponics North"
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aOX" = (
@@ -18592,7 +18581,6 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRD" = (
@@ -18620,10 +18608,6 @@
 /area/crew_quarters/kitchen)
 "aRG" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
@@ -19697,7 +19681,6 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aUz" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -20235,10 +20218,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aVM" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aVN" = (
@@ -20980,12 +20963,13 @@
 /area/crew_quarters/kitchen)
 "aXn" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
 	pixel_x = 30
 	},
+/obj/item/pestle,
+/obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXo" = (
@@ -24606,6 +24590,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bgQ" = (
@@ -24700,24 +24685,23 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhb" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhc" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry"
 	},
-/obj/machinery/chem_heater,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhd" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -24725,6 +24709,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhe" = (
@@ -25274,7 +25259,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/chemical,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bip" = (
@@ -25407,21 +25404,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"biG" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "biH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25429,12 +25414,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "biI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "biJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -25906,10 +25891,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjO" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bjP" = (
@@ -25926,23 +25911,14 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "bjR" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bjS" = (
@@ -26264,10 +26240,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bkL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/machinery/sleeper,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "bkM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26615,9 +26590,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bls" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/large,
 /obj/machinery/camera{
 	c_tag = "Mech Bay";
 	dir = 1
@@ -26626,29 +26598,21 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blt" = (
-/obj/machinery/recharge_station,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/sign/poster/official/state_laws{
 	pixel_y = -32
 	},
-/obj/effect/landmark/start/cyborg,
+/obj/structure/table,
+/obj/item/crowbar/large,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blu" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blv" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -27113,11 +27077,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmG" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmH" = (
@@ -27131,7 +27095,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bmI" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27139,6 +27102,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmJ" = (
@@ -27878,11 +27842,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "boq" = (
-/obj/structure/bed/roller,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bor" = (
@@ -28076,7 +28040,6 @@
 /area/science/lab)
 "boQ" = (
 /obj/structure/table,
-/obj/machinery/cell_charger,
 /obj/item/stock_parts/cell/high/plus,
 /obj/item/stock_parts/cell/high/plus,
 /turf/open/floor/plasteel/white,
@@ -28310,7 +28273,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bpu" = (
-/obj/structure/bed/roller,
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
@@ -28428,7 +28390,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bpI" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -28436,6 +28397,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bpJ" = (
@@ -28589,13 +28556,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bqd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "robo2"
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/storage)
 "bqe" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -28869,9 +28832,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqP" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bqQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -28988,9 +28951,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "brb" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -28998,6 +28958,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/folder/white,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "brc" = (
@@ -30106,7 +30069,6 @@
 /obj/item/pen/fountain,
 /obj/structure/table,
 /obj/item/pen/fourcolor,
-/obj/item/stamp/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "btE" = (
@@ -30553,6 +30515,10 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buF" = (
@@ -30637,15 +30603,14 @@
 /obj/machinery/keycard_auth{
 	pixel_x = -24
 	},
-/obj/machinery/computer/cargo{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "buN" = (
@@ -30656,7 +30621,6 @@
 /area/crew_quarters/heads/hop)
 "buO" = (
 /obj/structure/table,
-/obj/item/folder/blue,
 /obj/item/stack/packageWrap{
 	pixel_x = -1;
 	pixel_y = -1
@@ -31280,7 +31244,8 @@
 /area/crew_quarters/heads/hop)
 "bwk" = (
 /obj/structure/table,
-/obj/machinery/recharger,
+/obj/item/folder/blue,
+/obj/item/stamp/hop,
 /turf/open/floor/plasteel,
 /area/crew_quarters/heads/hop)
 "bwl" = (
@@ -31375,9 +31340,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "bwD" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwE" = (
@@ -31387,14 +31350,7 @@
 /area/medical/sleeper)
 "bwF" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwG" = (
@@ -31671,9 +31627,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bxi" = (
-/obj/machinery/computer/aifixer{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -31686,11 +31639,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxj" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxk" = (
@@ -31980,17 +31934,13 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/medical/sleeper)
+/area/science/storage)
 "bxT" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
+/obj/structure/closet/l3closet,
+/turf/open/floor/plasteel/white,
+/area/medical/virology)
 "bxU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -31998,7 +31948,9 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxV" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxW" = (
@@ -33118,20 +33070,18 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bAq" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bAr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
+/obj/machinery/portable_atmospherics/canister/toxins,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "bAs" = (
 /obj/machinery/atmospherics/components/unary/portables_connector/visible{
 	dir = 1;
@@ -34209,7 +34159,6 @@
 /obj/item/folder/white,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCH" = (
@@ -34291,13 +34240,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"bCT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCU" = (
@@ -36557,10 +36499,6 @@
 /area/science/xenobiology)
 "bIi" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36579,8 +36517,6 @@
 /obj/machinery/light,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
@@ -36588,10 +36524,6 @@
 /area/medical/sleeper)
 "bIk" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36606,10 +36538,6 @@
 /area/medical/sleeper)
 "bIl" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36629,10 +36557,6 @@
 /area/medical/sleeper)
 "bIn" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36870,13 +36794,6 @@
 /area/science/xenobiology)
 "bIO" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
-/turf/open/floor/plasteel/white,
-/area/science/xenobiology)
-"bIP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bIQ" = (
@@ -37362,10 +37279,6 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"bJY" = (
-/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bJZ" = (
@@ -38109,22 +38022,20 @@
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
-"bLJ" = (
-/obj/machinery/computer/atmos_control,
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "bLK" = (
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "bLL" = (
-/obj/machinery/computer/station_alert,
 /obj/machinery/airalarm{
 	pixel_y = 23
 	},
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bLM" = (
-/obj/machinery/computer/atmos_alert,
+/obj/machinery/portable_atmospherics/canister,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bLN" = (
@@ -39504,7 +39415,6 @@
 	dir = 8;
 	pixel_x = 24
 	},
-/obj/structure/closet/l3closet,
 /obj/machinery/light{
 	dir = 4
 	},
@@ -39585,9 +39495,6 @@
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bPA" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40111,7 +40018,6 @@
 /area/science/misc_lab)
 "bQY" = (
 /obj/structure/table/reinforced,
-/obj/item/integrated_circuit_printer,
 /obj/machinery/computer/security/telescreen/circuitry{
 	pixel_y = 30
 	},
@@ -47148,7 +47054,6 @@
 /turf/open/floor/plating,
 /area/construction)
 "cjM" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/machinery/light/small{
 	dir = 8
 	},
@@ -52681,17 +52586,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"cHV" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "robo2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "cHW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHX" = (
@@ -52731,10 +52629,6 @@
 "cIb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "robo2"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -53364,6 +53258,9 @@
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
+	},
+/obj/machinery/computer/bounty{
+	dir = 8
 	},
 /turf/open/floor/plasteel,
 /area/construction/mining/aux_base)
@@ -54464,9 +54361,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGf" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
 /obj/structure/table,
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -54504,12 +54398,6 @@
 /obj/effect/landmark/event_spawn,
 /turf/open/floor/plasteel,
 /area/science/circuit)
-"fKC" = (
-/obj/structure/chair/office/dark{
-	dir = 1
-	},
-/turf/open/floor/plasteel,
-/area/engine/atmos)
 "fMp" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/plasteel/dark,
@@ -57066,10 +56954,10 @@
 /turf/open/space/basic,
 /area/space/nearstation)
 "nGf" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "nGt" = (
@@ -58144,11 +58032,11 @@
 /turf/open/floor/plating,
 /area/engine/atmos)
 "rdG" = (
-/obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "reA" = (
@@ -58831,15 +58719,6 @@
 /obj/structure/chair/office/light,
 /turf/open/floor/plasteel/white,
 /area/science/circuit)
-"sWR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "sXy" = (
 /obj/machinery/door/airlock/external{
 	name = "Security External Airlock";
@@ -59112,11 +58991,6 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
-"tPT" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "tRe" = (
 /obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
@@ -82635,7 +82509,7 @@ bVG
 bHE
 bHE
 bCq
-tPT
+bcU
 tRF
 mrR
 dKP
@@ -83636,7 +83510,7 @@ bnG
 bnz
 bpA
 bbR
-sWR
+bkM
 jlm
 bud
 eyM
@@ -86502,7 +86376,7 @@ ccw
 chY
 ciX
 cjM
-ckB
+ciZ
 ckB
 ckB
 ccw
@@ -86759,9 +86633,9 @@ ccw
 chY
 ciZ
 ciW
+ciZ
 ckB
 ckB
-ckC
 ccw
 cnX
 coH
@@ -87013,10 +86887,10 @@ ced
 bVI
 cay
 ccw
+bAr
 ciZ
 ciZ
 ciZ
-ckC
 ckC
 ckC
 ccw
@@ -90846,7 +90720,7 @@ bGB
 bCv
 bJs
 bKy
-bLJ
+bLM
 bWR
 bNP
 bOS
@@ -91104,7 +90978,7 @@ bCv
 bJs
 bKy
 bLM
-fKC
+bOd
 bNQ
 bOV
 bQk
@@ -95196,7 +95070,7 @@ bhc
 bip
 bgP
 bjL
-bkL
+bjL
 bmT
 bnD
 bpM
@@ -96227,7 +96101,7 @@ wbE
 bmJ
 bof
 bpu
-bqP
+bhh
 bsy
 bEe
 bvh
@@ -97266,7 +97140,7 @@ bvj
 bvj
 bzW
 bDZ
-bCT
+bCJ
 bGR
 bIj
 bJC
@@ -97519,7 +97393,7 @@ bvh
 bwF
 bxQ
 bxQ
-bAr
+bxQ
 bvj
 bzV
 bDZ
@@ -97773,8 +97647,8 @@ bhh
 bsx
 btV
 bvj
-bwI
-bxT
+bkL
+bxQ
 bxQ
 bAt
 bvj
@@ -98031,7 +97905,7 @@ bsx
 btV
 bvh
 bwH
-bxS
+bxQ
 bzh
 bAs
 bvj
@@ -98819,7 +98693,7 @@ bIJ
 bPo
 bQE
 bRM
-bOr
+bxT
 bTZ
 bKH
 bzs
@@ -99809,7 +99683,7 @@ aJI
 aRG
 aSO
 aTO
-cCq
+aOT
 aVz
 aVz
 qus
@@ -100061,7 +99935,7 @@ aJI
 aJI
 aJI
 aNO
-aOT
+aMF
 aJI
 aRF
 aSN
@@ -100339,7 +100213,7 @@ biz
 bla
 bmY
 boq
-boq
+biI
 brj
 bpE
 btk
@@ -100833,12 +100707,12 @@ aKH
 aMI
 aIp
 aOV
-aOX
+aSR
 aOX
 aSR
 aUi
 aVJ
-aOX
+aSR
 aiJ
 bal
 bam
@@ -102117,7 +101991,7 @@ aIp
 aKL
 aMz
 aNQ
-aOX
+aSR
 aQm
 lva
 nUV
@@ -102633,11 +102507,11 @@ aMN
 aNQ
 aOZ
 aOX
-aOX
+aSR
 rdG
 aUz
 aVM
-aOX
+aSR
 aYT
 bam
 iuR
@@ -103160,8 +103034,8 @@ bcj
 beC
 bfT
 cHF
-biG
-blw
+blu
+bnb
 blu
 bnb
 bfT
@@ -103417,9 +103291,9 @@ aXq
 bfU
 bhu
 cHG
-biI
 bkh
-biI
+bkh
+bkh
 cHQ
 bfT
 boE
@@ -103441,7 +103315,7 @@ bJJ
 bKY
 bMi
 bNo
-bIP
+bOx
 bPA
 bJN
 bRU
@@ -104964,7 +104838,7 @@ bkm
 cHO
 blG
 biL
-cHV
+biL
 cIa
 biL
 box
@@ -105479,7 +105353,7 @@ cHP
 cHR
 bou
 bpT
-bqd
+cId
 biL
 box
 btS
@@ -106003,7 +105877,7 @@ bzD
 bxv
 bCc
 bDc
-bEo
+bqd
 bDj
 bDY
 bIA
@@ -106260,10 +106134,10 @@ bzC
 bAH
 bCb
 bDc
-bEo
+bqP
 bDf
 bEb
-bGY
+bxS
 bGY
 bJN
 bMp
@@ -109348,7 +109222,7 @@ bEy
 bFU
 bFT
 bFU
-bJY
+bFU
 bEC
 bMv
 bNv

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -1228,11 +1228,9 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
-/obj/structure/closet/crate/freezer,
 /obj/machinery/firealarm{
 	pixel_y = 26
 	},
-/obj/item/reagent_containers/food/snacks/meat/slab,
 /turf/open/floor/plasteel,
 /area/crew_quarters/lounge)
 "acW" = (
@@ -2199,7 +2197,6 @@
 /area/construction)
 "afq" = (
 /obj/structure/table,
-/obj/item/modular_computer/laptop/preset/civilian,
 /turf/open/floor/plasteel,
 /area/crew_quarters/lounge)
 "afr" = (
@@ -2894,9 +2891,6 @@
 /area/maintenance/starboard/fore)
 "aha" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_y = 8
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ahb" = (
@@ -3441,7 +3435,6 @@
 /area/crew_quarters/theatre/mime)
 "aiv" = (
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -3616,7 +3609,6 @@
 /area/maintenance/port/fore)
 "aiU" = (
 /obj/structure/disposalpipe/segment,
-/obj/machinery/deepfryer,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aiV" = (
@@ -3975,9 +3967,6 @@
 /area/crew_quarters/observatory)
 "ajM" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
 /obj/item/reagent_containers/food/condiment/saltshaker{
 	pixel_x = -8;
 	pixel_y = 12
@@ -3987,6 +3976,8 @@
 	pixel_y = 6
 	},
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden,
+/obj/item/pestle,
+/obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ajN" = (
@@ -4636,7 +4627,6 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "alm" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 1;
 	light_color = "#e8eaff"
@@ -7388,9 +7378,13 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "ary" = (
-/obj/machinery/food_cart,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/obj/effect/turf_decal/tile/brown{
+	dir = 8
+	},
+/obj/effect/turf_decal/tile/purple,
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/turf/open/floor/plasteel,
+/area/quartermaster/miningoffice)
 "arz" = (
 /obj/machinery/atmospherics/pipe/simple/cyan/hidden{
 	dir = 4
@@ -8661,9 +8655,8 @@
 	dir = 1
 	},
 /obj/structure/table/glass,
-/obj/machinery/reagentgrinder{
-	pixel_y = 6
-	},
+/obj/item/pestle,
+/obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aup" = (
@@ -10168,14 +10161,12 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/accessory/armband/science,
-/obj/item/encryptionkey/headset_sci,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axB" = (
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/accessory/armband/medblue,
-/obj/item/encryptionkey/headset_med,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "axC" = (
@@ -11266,9 +11257,6 @@
 /area/crew_quarters/toilet)
 "azM" = (
 /obj/structure/table,
-/obj/machinery/recharger{
-	pixel_y = 2
-	},
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
@@ -11431,7 +11419,6 @@
 /area/crew_quarters/barbershop)
 "aAg" = (
 /obj/machinery/atmospherics/pipe/heat_exchanging/junction,
-/obj/machinery/gibber,
 /obj/machinery/camera{
 	c_tag = "Kitchen Coldroom";
 	dir = 8
@@ -11823,7 +11810,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/accessory/armband/engine,
-/obj/item/encryptionkey/headset_eng,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aAT" = (
@@ -12402,7 +12388,6 @@
 	light_color = "#e8eaff"
 	},
 /obj/item/clothing/accessory/armband/cargo,
-/obj/item/encryptionkey/headset_cargo,
 /turf/open/floor/plasteel,
 /area/security/brig)
 "aCd" = (
@@ -15791,8 +15776,6 @@
 /turf/open/floor/plasteel,
 /area/tcommsat/computer)
 "aIN" = (
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
@@ -17812,7 +17795,6 @@
 	},
 /area/chapel/main)
 "aMK" = (
-/obj/vehicle/ridden/wheelchair,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -18867,7 +18849,6 @@
 /obj/structure/closet/secure_closet/security/sec,
 /obj/effect/turf_decal/bot,
 /obj/item/clothing/accessory/armband/hydro,
-/obj/item/encryptionkey/headset_service,
 /obj/item/clothing/under/misc/vice_officer,
 /obj/machinery/atmospherics/pipe/simple/supplymain/hidden{
 	dir = 4
@@ -19942,9 +19923,8 @@
 	name = "Station Intercom (Common)";
 	pixel_y = 26
 	},
-/obj/machinery/sleep_console{
-	dir = 8
-	},
+/obj/machinery/iv_drip,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical{
 	name = "Medical Booth"
@@ -21494,9 +21474,7 @@
 /turf/open/floor/plasteel/dark/side,
 /area/security/courtroom)
 "aUF" = (
-/obj/machinery/computer/bounty{
-	dir = 1
-	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/heads/hop)
 "aUG" = (
@@ -29485,9 +29463,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "blR" = (
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -30302,7 +30277,10 @@
 	name = "Cargo Desk";
 	req_access_txt = "31"
 	},
-/obj/item/folder,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
 /turf/open/floor/plasteel,
 /area/quartermaster/sorting)
 "bno" = (
@@ -32026,13 +32004,11 @@
 /turf/open/floor/plating,
 /area/maintenance/department/eva)
 "brd" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/tile/brown{
-	dir = 4
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
 	},
-/obj/effect/turf_decal/tile/purple,
-/turf/open/floor/plasteel,
-/area/quartermaster/miningoffice)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/lobby)
 "bre" = (
 /obj/effect/spawner/lootdrop/maintenance,
 /obj/structure/cable{
@@ -32144,7 +32120,6 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/machinery/smartfridge/disks,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "brq" = (
@@ -32180,9 +32155,6 @@
 /turf/open/floor/plating,
 /area/chapel/office)
 "bru" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -32397,10 +32369,12 @@
 	},
 /area/hallway/secondary/exit)
 "brO" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/landmark/start/medical_doctor,
 /obj/structure/disposalpipe/segment{
 	dir = 4
+	},
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2{
@@ -32677,9 +32651,6 @@
 	dir = 4
 	},
 /obj/structure/table/glass,
-/obj/machinery/plantgenes{
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bso" = (
@@ -32882,7 +32853,6 @@
 /turf/open/floor/grass,
 /area/hydroponics)
 "bsK" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light,
 /turf/open/floor/grass,
 /area/hydroponics)
@@ -37714,11 +37684,11 @@
 /turf/open/floor/plasteel/stairs,
 /area/crew_quarters/bar)
 "bDT" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line,
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "bDU" = (
@@ -39775,9 +39745,7 @@
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
 "bHT" = (
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 4
-	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bHU" = (
@@ -40309,7 +40277,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bJb" = (
-/obj/machinery/bloodbankgen,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
@@ -40578,10 +40545,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bJD" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "bJE" = (
@@ -40771,11 +40738,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "bKb" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
 /obj/machinery/light,
+/obj/structure/table/glass,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "bKc" = (
@@ -41086,9 +41053,6 @@
 /turf/open/floor/engine,
 /area/science/xenobiology)
 "bKG" = (
-/obj/machinery/computer/cargo/request{
-	dir = 1
-	},
 /obj/machinery/keycard_auth{
 	pixel_x = 24;
 	pixel_y = -8
@@ -41096,6 +41060,7 @@
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/structure/table/wood,
 /turf/open/floor/carpet/green,
 /area/crew_quarters/heads/hop)
 "bKH" = (
@@ -41863,21 +41828,19 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bMf" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple,
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bMg" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bMh" = (
@@ -42131,7 +42094,6 @@
 /area/hallway/primary/central)
 "bMH" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
@@ -43997,14 +43959,12 @@
 	},
 /obj/item/weldingtool,
 /obj/item/wrench/medical,
+/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2{
 	name = "Medbay Treatment Center"
 	})
 "bQC" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 6
-	},
 /obj/effect/turf_decal/tile/red{
 	dir = 8
 	},
@@ -47980,7 +47940,6 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
-/obj/machinery/recharger,
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -48195,7 +48154,6 @@
 	name = "Research Sector"
 	})
 "bYB" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -48206,11 +48164,8 @@
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow,
-/obj/item/clothing/gloves/color/latex,
-/obj/item/book/manual/wiki/chemistry,
-/obj/item/reagent_containers/dropper,
-/obj/item/radio/headset/headset_medsci,
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bYC" = (
@@ -50736,20 +50691,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "cdX" = (
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/obj/machinery/sleeper{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/clothing/gloves/color/latex,
+/obj/item/book/manual/wiki/chemistry,
+/obj/item/reagent_containers/dropper,
+/obj/item/radio/headset/headset_medsci,
 /turf/open/floor/plasteel/white,
-/area/medical/medbay/lobby)
+/area/medical/chemistry)
 "cdY" = (
 /obj/effect/turf_decal/tile/blue,
-/obj/machinery/sleep_console{
-	dir = 4
-	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/lobby)
 "cdZ" = (
@@ -50803,7 +50753,6 @@
 	pixel_y = 4
 	},
 /obj/structure/disposalpipe/segment,
-/obj/machinery/mecha_part_fabricator,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
 /obj/item/stack/sheet/metal/fifty,
@@ -51024,11 +50973,6 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/brute,
 /obj/item/clothing/glasses/hud/health,
@@ -51053,11 +50997,6 @@
 	pixel_x = 2;
 	pixel_y = 4
 	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 2;
-	pixel_y = 4
-	},
-/obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/o2,
 /turf/open/floor/plasteel/white,
@@ -51870,9 +51809,6 @@
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "cgf" = (
-/obj/structure/table,
-/obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
@@ -51890,6 +51826,7 @@
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
 	dir = 9
 	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cgg" = (
@@ -53779,11 +53716,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "ckb" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "ckc" = (
@@ -55139,11 +55076,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cmS" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
 /obj/machinery/light,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "cmT" = (
@@ -55247,8 +55184,8 @@
 	dir = 1
 	},
 /obj/structure/window/reinforced/spawner/west,
-/obj/machinery/atmospherics/components/unary/cryo_cell{
-	dir = 1
+/obj/machinery/sleeper{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2{
@@ -55705,19 +55642,17 @@
 	},
 /area/library)
 "cnX" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cnY" = (
-/obj/vehicle/ridden/secway,
-/obj/item/key/security,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "cnZ" = (
@@ -56270,7 +56205,6 @@
 	name = "Medbay Treatment Center"
 	})
 "coY" = (
-/obj/structure/table,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 8
@@ -56279,11 +56213,12 @@
 	dir = 1;
 	pixel_y = -26
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/machinery/camera{
 	c_tag = "Medbay - Cryogenics";
 	dir = 1
+	},
+/obj/machinery/sleep_console{
+	dir = 8
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone2{
@@ -56532,6 +56467,7 @@
 	pixel_x = -30;
 	receive_ore_updates = 1
 	},
+/obj/machinery/reagentgrinder,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "cpx" = (
@@ -58335,7 +58271,6 @@
 /turf/open/floor/plating,
 /area/storage/tech)
 "csV" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
@@ -58346,6 +58281,7 @@
 	name = "Station Intercom (Common)";
 	pixel_y = 26
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "csW" = (
@@ -59709,10 +59645,6 @@
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = 2;
-	pixel_y = 4
 	},
 /obj/item/storage/firstaid/regular{
 	pixel_x = 2;
@@ -63432,12 +63364,10 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
+/obj/vehicle/ridden/wheelchair,
 /turf/open/floor/plasteel/white,
 /area/medical{
 	name = "Medical Booth"
@@ -91825,7 +91755,7 @@ cnz
 cGF
 cGL
 cGP
-cGV
+cnO
 cHa
 cbb
 bxV
@@ -92339,7 +92269,7 @@ cnV
 cGG
 cGM
 cGP
-cGV
+cnO
 cGV
 cbb
 bxT
@@ -95950,7 +95880,7 @@ bIM
 bIM
 bIM
 cvt
-bJD
+cdX
 bJH
 aaU
 aaa
@@ -101849,7 +101779,7 @@ bXz
 bqm
 cmU
 cyG
-cdX
+bAq
 buS
 cDZ
 czg
@@ -102106,7 +102036,7 @@ bPw
 bqm
 bsG
 cyG
-bsG
+brd
 buS
 bAJ
 czh
@@ -112297,7 +112227,7 @@ ajs
 atO
 ayl
 bml
-ary
+ahx
 afK
 atR
 cmC
@@ -119836,7 +119766,7 @@ cxM
 cxO
 cND
 bpf
-brS
+ary
 bte
 cdT
 ceZ
@@ -120349,7 +120279,7 @@ boY
 bpk
 bpf
 bpY
-brd
+btd
 brT
 boI
 btS
@@ -120788,7 +120718,7 @@ bbR
 aqB
 apE
 aov
-amU
+amV
 ahu
 aaU
 aaa

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -1026,7 +1026,6 @@
 "add" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/mining_voucher,
 /obj/machinery/camera{
 	c_tag = "Auxillary Construction - Storage";
 	dir = 4;
@@ -14583,7 +14582,6 @@
 /area/crew_quarters/bar)
 "aEV" = (
 /obj/structure/table/wood,
-/obj/machinery/chem_dispenser/drinks/beer,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -23931,9 +23929,6 @@
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -23944,6 +23939,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "aUb" = (
@@ -28191,7 +28187,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "baA" = (
-/obj/machinery/gibber,
 /obj/machinery/light{
 	dir = 1
 	},
@@ -28383,9 +28378,6 @@
 	name = "Station Intercom (General)";
 	pixel_x = 28
 	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/brown,
 /obj/effect/turf_decal/tile/brown{
 	dir = 4
@@ -28393,6 +28385,7 @@
 /obj/effect/turf_decal/tile/brown{
 	dir = 8
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "baQ" = (
@@ -30637,40 +30630,30 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bfe" = (
-/obj/machinery/deepfryer,
+/obj/structure/cable{
+	icon_state = "0-2"
+	},
+/turf/open/floor/circuit/green,
+/area/engine/atmospherics_engine)
+"bff" = (
+/obj/machinery/holopad,
+/obj/effect/landmark/start/cook,
+/turf/open/floor/plasteel/white,
+/area/crew_quarters/kitchen)
+"bfg" = (
 /obj/effect/turf_decal/tile/red{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
-/obj/effect/turf_decal/tile/red{
+/obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
 /mob/living/carbon/monkey/punpun,
 /turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
-"bff" = (
-/obj/machinery/holopad,
-/obj/effect/landmark/start/cook,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
-"bfg" = (
-/obj/machinery/deepfryer,
-/obj/effect/turf_decal/tile/red{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/red,
-/obj/effect/turf_decal/tile/red{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/red{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/crew_quarters/kitchen)
+/area/crew_quarters/bar/atrium)
 "bfh" = (
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel/white,
@@ -31331,9 +31314,8 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bgs" = (
-/obj/structure/table/reinforced,
-/obj/item/storage/bag/tray,
 /obj/effect/turf_decal/bot,
+/obj/machinery/deepfryer,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bgt" = (
@@ -31956,12 +31938,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bhD" = (
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
 /obj/structure/table/glass,
 /obj/effect/turf_decal/bot,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bhE" = (
@@ -32108,6 +32088,7 @@
 "bhR" = (
 /obj/structure/table/reinforced,
 /obj/effect/turf_decal/bot,
+/obj/item/storage/bag/tray,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "bhS" = (
@@ -33642,10 +33623,6 @@
 /obj/item/clothing/gloves/color/latex,
 /obj/item/healthanalyzer,
 /obj/item/reagent_containers/spray/cleaner{
-	pixel_x = -3;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/spray/cleaner{
 	pixel_x = 5;
 	pixel_y = -1
 	},
@@ -34147,11 +34124,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "bld" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "ble" = (
@@ -34306,7 +34283,6 @@
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "blr" = (
-/obj/machinery/food_cart,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -34365,14 +34341,12 @@
 /area/crew_quarters/kitchen)
 "blw" = (
 /obj/structure/table/reinforced,
-/obj/machinery/reagentgrinder{
-	desc = "Used to grind things up into raw materials and liquids.";
-	pixel_y = 5
-	},
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
 "blx" = (
@@ -34421,11 +34395,6 @@
 /area/crew_quarters/kitchen)
 "blB" = (
 /obj/structure/table/reinforced,
-/obj/machinery/microwave{
-	desc = "Cooks and boils stuff, somehow.";
-	pixel_x = -3;
-	pixel_y = 5
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/crew_quarters/kitchen)
@@ -35352,11 +35321,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bng" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bnh" = (
@@ -36155,11 +36122,11 @@
 /turf/closed/wall/r_wall,
 /area/engine/atmos)
 "boy" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/sign/departments/botany{
 	pixel_x = -32
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boz" = (
@@ -36179,9 +36146,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "boC" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -37422,11 +37386,9 @@
 /turf/open/floor/plating,
 /area/maintenance/port/fore)
 "bqy" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/newscaster{
 	pixel_x = -32
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqz" = (
@@ -37444,14 +37406,14 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqA" = (
-/obj/machinery/seed_extractor,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/effect/turf_decal/bot,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqB" = (
-/obj/machinery/biogenerator,
 /obj/effect/turf_decal/bot,
+/obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqC" = (
@@ -38639,11 +38601,11 @@
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
 "bsw" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = -26
 	},
 /obj/effect/turf_decal/delivery,
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bsx" = (
@@ -41343,12 +41305,10 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bwO" = (
-/obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
 	name = "Station Intercom";
 	pixel_y = -26
 	},
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bwP" = (
@@ -44509,7 +44469,6 @@
 "bBF" = (
 /obj/structure/table/reinforced,
 /obj/item/clipboard,
-/obj/item/mining_voucher,
 /turf/open/floor/plasteel/dark,
 /area/bridge)
 "bBG" = (
@@ -62307,7 +62266,6 @@
 	dir = 4
 	},
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
@@ -66995,7 +66953,6 @@
 /area/security/brig)
 "ciO" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger,
 /obj/structure/cable/white{
 	icon_state = "2-8"
 	},
@@ -70584,18 +70541,8 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"cpj" = (
-/obj/machinery/shieldgen,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "cpk" = (
 /obj/machinery/shieldgen,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
-/obj/structure/sign/warning/nosmoking{
-	pixel_y = 32
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -71247,20 +71194,14 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqF" = (
-/obj/machinery/field/generator,
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
-	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
-/area/engine/engineering)
+/area/hydroponics)
 "cqG" = (
 /obj/machinery/field/generator,
-/obj/effect/decal/cleanable/dirt,
+/obj/effect/turf_decal/bot,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 10
 	},
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cqH" = (
@@ -72908,25 +72849,20 @@
 	},
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ctA" = (
+"ctB" = (
 /obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
-"ctB" = (
-/obj/machinery/power/tesla_coil,
-/obj/effect/turf_decal/bot,
-/turf/open/floor/plasteel,
-/area/engine/engineering)
 "ctC" = (
-/obj/machinery/power/emitter,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/decal/cleanable/dirt,
+/obj/machinery/power/tesla_coil,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "ctD" = (
 /obj/machinery/power/emitter,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -73805,19 +73741,11 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cva" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/decal/cleanable/dirt,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "cvb" = (
-/obj/machinery/power/tesla_coil,
+/obj/machinery/portable_atmospherics/canister/toxins,
 /obj/effect/decal/cleanable/dirt,
-/obj/machinery/camera{
-	c_tag = "Engineering - Secure Storage";
-	dir = 1;
-	name = "engineering camera"
-	},
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/engine/engineering)
@@ -75423,7 +75351,6 @@
 	name = "Station Intercom";
 	pixel_y = 26
 	},
-/obj/machinery/suit_storage_unit/engine,
 /obj/effect/turf_decal/stripes/line,
 /turf/open/floor/plasteel,
 /area/engine/storage)
@@ -87918,10 +87845,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/fire{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/structure/window/reinforced{
 	dir = 1
 	},
@@ -87965,10 +87888,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/machinery/light{
 	dir = 4
 	},
@@ -89040,10 +88959,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/brute{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/machinery/door/window/eastleft{
 	name = "First-Aid Supplies";
 	red_alert_access = 1;
@@ -89078,10 +88993,6 @@
 	pixel_y = 3
 	},
 /obj/item/storage/firstaid/regular,
-/obj/item/storage/firstaid/o2{
-	pixel_x = -3;
-	pixel_y = -3
-	},
 /obj/machinery/door/window/westleft{
 	name = "First-Aid Supplies";
 	red_alert_access = 1;
@@ -92875,16 +92786,15 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dbc" = (
-/obj/structure/table/glass,
-/obj/item/clipboard,
-/obj/item/toy/figure/chemist,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
+/obj/structure/table/glass,
+/obj/item/hand_labeler,
+/obj/item/stack/packageWrap,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dbd" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
@@ -93950,22 +93860,6 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "dcN" = (
-/obj/structure/table/glass,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/igniter,
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
-/obj/item/assembly/timer{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/machinery/status_display/evac{
 	pixel_x = -32
 	},
@@ -93975,13 +93869,13 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dcO" = (
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dcP" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
@@ -94968,12 +94862,10 @@
 /turf/open/floor/plating,
 /area/security/checkpoint/medical)
 "deC" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 4
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "deD" = (
@@ -94993,12 +94885,10 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "deF" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/effect/turf_decal/stripes/end{
 	dir = 8
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "deG" = (
@@ -97959,7 +97849,6 @@
 /area/science/explab)
 "djB" = (
 /obj/structure/table/reinforced,
-/obj/item/storage/toolbox/mechanical,
 /obj/item/flashlight,
 /obj/effect/turf_decal/bot,
 /obj/structure/sign/poster/official/science{
@@ -98319,7 +98208,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/aft)
 "dkg" = (
-/obj/machinery/chem_master,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
@@ -98328,13 +98216,14 @@
 	pixel_y = -32
 	},
 /obj/effect/turf_decal/stripes/line,
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dkh" = (
-/obj/machinery/chem_heater,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/chemistry)
 "dki" = (
@@ -98347,9 +98236,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dkj" = (
-/obj/structure/table/glass,
-/obj/item/stack/packageWrap,
-/obj/item/hand_labeler,
 /obj/machinery/airalarm{
 	dir = 1;
 	pixel_y = -22
@@ -98358,6 +98244,7 @@
 	dir = 4
 	},
 /obj/effect/turf_decal/tile/yellow,
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "dkk" = (
@@ -99951,10 +99838,6 @@
 	pixel_x = -6;
 	pixel_y = 6
 	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 6;
-	pixel_y = 6
-	},
 /obj/item/storage/pill_bottle/mannitol,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -99962,10 +99845,10 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dny" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 5
 	},
+/obj/machinery/sleeper,
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dnz" = (
@@ -100707,11 +100590,11 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "doW" = (
-/obj/machinery/recharge_station,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "doX" = (
@@ -100719,7 +100602,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
@@ -101033,16 +100915,13 @@
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dpx" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 1
-	},
 /obj/effect/landmark/start/medical_doctor,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 10
+	},
 /turf/open/floor/plasteel,
 /area/medical/medbay/central)
 "dpy" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 9
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
@@ -101793,6 +101672,7 @@
 /area/hallway/primary/aft)
 "dqU" = (
 /obj/effect/decal/cleanable/dirt,
+/obj/machinery/vending/assist,
 /turf/open/floor/plating{
 	icon_state = "panelscorched"
 	},
@@ -103853,12 +103733,12 @@
 /turf/open/floor/plating,
 /area/science/robotics/mechbay)
 "duU" = (
-/obj/machinery/recharge_station,
 /obj/effect/decal/cleanable/dirt,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
 /obj/effect/turf_decal/bot,
+/obj/effect/landmark/start/cyborg,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "duV" = (
@@ -103866,7 +103746,6 @@
 	icon_state = "1-2"
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/effect/landmark/start/cyborg,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -103882,20 +103761,9 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
-"duX" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 1
-	},
-/turf/open/floor/circuit/green,
-/area/science/robotics/mechbay)
 "duY" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/effect/turf_decal/stripes/line{
-	dir = 6
-	},
-/turf/open/floor/plating,
+/obj/machinery/recharge_station,
+/turf/open/floor/circuit/green,
 /area/science/robotics/mechbay)
 "duZ" = (
 /obj/effect/decal/cleanable/dirt,
@@ -107437,26 +107305,18 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/genetics)
 "dAX" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 1
-	},
 /obj/machinery/light,
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 8
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dAY" = (
-/obj/machinery/dna_scannernew,
 /obj/structure/extinguisher_cabinet{
 	pixel_y = -32
 	},
-/obj/effect/turf_decal/stripes/end{
-	dir = 4
-	},
+/obj/structure/table/reinforced,
 /turf/open/floor/plasteel,
 /area/medical/genetics)
 "dAZ" = (
@@ -109609,18 +109469,15 @@
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dEz" = (
-/obj/structure/table,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/decal/cleanable/dirt,
-/obj/item/crowbar,
-/obj/item/wrench,
-/obj/item/clothing/mask/gas,
 /obj/structure/extinguisher_cabinet{
 	pixel_x = 26
 	},
 /obj/effect/turf_decal/bot,
+/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "dEA" = (
@@ -112896,8 +112753,6 @@
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJT" = (
-/obj/structure/tank_dispenser,
-/obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "dJU" = (
@@ -125187,6 +125042,11 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/library)
+"eka" = (
+/obj/effect/turf_decal/bot,
+/obj/machinery/portable_atmospherics/canister,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "emA" = (
 /obj/effect/spawner/structure/window/reinforced,
 /obj/machinery/atmospherics/pipe/simple/green/visible{
@@ -125195,6 +125055,15 @@
 /obj/machinery/atmospherics/pipe/simple/cyan/visible,
 /turf/open/floor/plating,
 /area/engine/atmos)
+"esp" = (
+/obj/structure/cable{
+	icon_state = "0-4"
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 4
+	},
+/turf/open/floor/plating,
+/area/engine/engineering)
 "exE" = (
 /obj/machinery/air_sensor/atmos/toxins_mixing_tank,
 /turf/open/floor/engine/vacuum,
@@ -125933,6 +125802,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/medical/morgue)
+"jDf" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+	dir = 4
+	},
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "jOB" = (
 /obj/structure/disposalpipe/segment,
 /turf/closed/wall,
@@ -126077,6 +125953,11 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
+"kLw" = (
+/obj/effect/turf_decal/delivery,
+/obj/structure/table/reinforced,
+/turf/open/floor/plasteel,
+/area/science/robotics/lab)
 "kQS" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
@@ -126323,6 +126204,13 @@
 	},
 /turf/open/floor/plasteel,
 /area/maintenance/port/fore)
+"muV" = (
+/obj/machinery/status_display/evac{
+	pixel_x = 32
+	},
+/obj/structure/table/reinforced,
+/turf/open/floor/circuit/green,
+/area/science/xenobiology)
 "mvm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -126640,6 +126528,16 @@
 	},
 /turf/open/floor/plating,
 /area/science/research/abandoned)
+"pKZ" = (
+/obj/machinery/shieldgen,
+/obj/effect/decal/cleanable/dirt,
+/obj/effect/decal/cleanable/dirt,
+/obj/structure/sign/warning/nosmoking{
+	pixel_y = 32
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
 "pQm" = (
 /obj/effect/decal/cleanable/dirt,
 /obj/structure/cable/white{
@@ -126960,6 +126858,20 @@
 	},
 /turf/open/floor/plasteel/dark,
 /area/chapel/office)
+"ujx" = (
+/obj/machinery/power/tesla_coil,
+/obj/effect/decal/cleanable/dirt,
+/obj/machinery/camera{
+	c_tag = "Engineering - Secure Storage";
+	dir = 1;
+	name = "engineering camera"
+	},
+/obj/effect/turf_decal/bot,
+/turf/open/floor/plasteel,
+/area/engine/engineering)
+"ull" = (
+/turf/open/floor/plasteel,
+/area/science/robotics/mechbay)
 "upk" = (
 /obj/machinery/door/airlock/public/glass{
 	name = "Holodeck Access"
@@ -150841,7 +150753,7 @@ cdI
 cfC
 chu
 cje
-cje
+esp
 cje
 cjd
 cpa
@@ -150851,7 +150763,7 @@ ctp
 cuQ
 cjd
 cje
-cje
+esp
 cAK
 cCr
 cfC
@@ -151808,7 +151720,7 @@ anG
 amH
 amH
 amH
-ark
+bfe
 asp
 atN
 auW
@@ -154185,10 +154097,10 @@ car
 car
 car
 car
-cpj
-cqE
+cva
+jDf
 crX
-ctA
+cva
 cva
 cwo
 cxK
@@ -154699,11 +154611,11 @@ car
 ckK
 cmf
 car
-cpl
-cqF
+pKZ
+cqE
 crY
 ctC
-cvc
+ujx
 cwo
 cxM
 czy
@@ -159300,7 +159212,7 @@ ble
 ble
 ble
 bvA
-bwN
+cqF
 bar
 bzG
 bBr
@@ -159863,7 +159775,7 @@ cTV
 cVT
 cXm
 cZb
-cXm
+muV
 dcu
 ddV
 cMY
@@ -160146,7 +160058,7 @@ dHl
 dIA
 dJZ
 dKF
-dLZ
+eka
 dLZ
 dOo
 dOT
@@ -160328,7 +160240,7 @@ jwo
 bnj
 bnh
 bvB
-bwN
+cqF
 bar
 aYx
 bBr
@@ -160403,7 +160315,7 @@ dHm
 dIB
 dKa
 dKF
-dLZ
+eka
 dLZ
 dOo
 dOT
@@ -160917,7 +160829,7 @@ dHo
 dID
 dKc
 dKG
-dMa
+eka
 dNC
 dNC
 dOT
@@ -161174,7 +161086,7 @@ dHp
 dIE
 dKd
 dKH
-dMa
+eka
 dMa
 dMa
 dOT
@@ -164248,7 +164160,7 @@ dqN
 duW
 dwx
 dyd
-dzH
+kLw
 dAL
 dCr
 dDB
@@ -164429,7 +164341,7 @@ aLL
 aKz
 bcj
 bdJ
-bfe
+bdI
 bgs
 bhQ
 bjF
@@ -164502,7 +164414,7 @@ doZ
 dqO
 dsi
 dtx
-duX
+duY
 dwy
 dye
 dzI
@@ -164678,7 +164590,7 @@ aLL
 aNh
 aOK
 aQt
-aLL
+bfg
 aTI
 aVs
 aNh
@@ -164759,7 +164671,7 @@ dpa
 dqO
 dsj
 dtx
-dpa
+ull
 dwz
 dyd
 dzH
@@ -164943,7 +164855,7 @@ aLL
 aKA
 bcj
 bdJ
-bfg
+bdI
 bgu
 bhS
 bjF

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -5,9 +5,6 @@
 	pixel_x = 24
 	},
 /obj/structure/table,
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
 /obj/item/radio/intercom{
 	pixel_y = 25
 	},
@@ -1329,7 +1326,6 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
 "adk" = (
-/obj/machinery/recharger,
 /obj/structure/table/reinforced,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/main)
@@ -4789,7 +4785,6 @@
 /turf/open/floor/plating,
 /area/security/vacantoffice/b)
 "ajg" = (
-/obj/machinery/computer/secure_data,
 /obj/effect/turf_decal/bot,
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5719,6 +5714,7 @@
 	dir = 8
 	},
 /obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel,
 /area/security/main)
 "akT" = (
@@ -7762,14 +7758,7 @@
 /area/maintenance/fore/secondary)
 "apv" = (
 /obj/structure/table/reinforced,
-/obj/machinery/recharger{
-	pixel_x = -6;
-	pixel_y = 3
-	},
-/obj/machinery/recharger{
-	pixel_x = 6;
-	pixel_y = 3
-	},
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/showroomfloor,
 /area/security/warden)
 "apw" = (
@@ -16031,7 +16020,8 @@
 /area/chapel/office)
 "aJO" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aJP" = (
@@ -17813,8 +17803,8 @@
 /turf/open/floor/carpet,
 /area/library)
 "aOT" = (
-/obj/machinery/gibber,
-/turf/open/floor/plasteel/showroomfloor,
+/obj/structure/table,
+/turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aOU" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
@@ -17831,10 +17821,10 @@
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aOW" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/camera{
 	c_tag = "Hydroponics North"
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aOX" = (
@@ -18755,7 +18745,6 @@
 /obj/structure/sink/kitchen{
 	pixel_y = 28
 	},
-/obj/machinery/food_cart,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aRD" = (
@@ -18783,10 +18772,6 @@
 /area/crew_quarters/kitchen)
 "aRG" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /obj/machinery/airalarm{
 	pixel_y = 24
 	},
@@ -19861,7 +19846,6 @@
 /turf/open/floor/wood,
 /area/security/vacantoffice)
 "aUz" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/airalarm{
 	dir = 8;
 	pixel_x = 24
@@ -20399,10 +20383,10 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/starboard)
 "aVM" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 4
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "aVN" = (
@@ -21144,12 +21128,13 @@
 /area/crew_quarters/kitchen)
 "aXn" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
 /obj/machinery/requests_console{
 	department = "Kitchen";
 	departmentType = 2;
 	pixel_x = 30
 	},
+/obj/item/pestle,
+/obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "aXo" = (
@@ -24771,6 +24756,7 @@
 /obj/structure/disposalpipe/segment{
 	dir = 6
 	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bgQ" = (
@@ -24865,24 +24851,23 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhb" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhc" = (
 /obj/machinery/camera{
 	c_tag = "Chemistry"
 	},
-/obj/machinery/chem_heater,
+/obj/structure/closet/secure_closet/chemical,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhd" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -24890,6 +24875,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bhe" = (
@@ -25439,7 +25425,19 @@
 /obj/machinery/light{
 	dir = 8
 	},
-/obj/structure/closet/secure_closet/chemical,
+/obj/structure/table/glass,
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/storage/box/beakers{
+	pixel_x = 2;
+	pixel_y = 2
+	},
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/glass/beaker/large,
+/obj/item/reagent_containers/dropper,
+/obj/item/reagent_containers/dropper,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bip" = (
@@ -25572,21 +25570,9 @@
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
-"biG" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 2
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
-/turf/open/floor/plating,
-/area/science/robotics/mechbay)
 "biH" = (
 /obj/structure/cable{
 	icon_state = "1-2"
-	},
-/obj/structure/cable{
-	icon_state = "1-8"
 	},
 /obj/structure/cable{
 	icon_state = "1-4"
@@ -25594,12 +25580,12 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "biI" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
-/obj/structure/cable{
-	icon_state = "4-8"
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
 	},
-/turf/open/floor/circuit,
-/area/science/robotics/mechbay)
+/turf/open/floor/plasteel/white,
+/area/medical/medbay/central)
 "biJ" = (
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26071,10 +26057,10 @@
 /turf/open/floor/plasteel,
 /area/security/checkpoint/medical)
 "bjO" = (
-/obj/machinery/disposal/bin,
-/obj/structure/disposalpipe/trunk{
-	dir = 8
+/obj/structure/disposalpipe/segment{
+	dir = 4
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bjP" = (
@@ -26091,23 +26077,14 @@
 /turf/closed/wall,
 /area/medical/chemistry)
 "bjR" = (
-/obj/structure/table/glass,
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/storage/box/beakers{
-	pixel_x = 2;
-	pixel_y = 2
-	},
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/glass/beaker/large,
-/obj/item/reagent_containers/dropper,
-/obj/item/reagent_containers/dropper,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/disposalpipe/trunk{
+	dir = 8
+	},
+/obj/machinery/disposal/bin,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bjS" = (
@@ -26429,10 +26406,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bkL" = (
-/obj/structure/disposalpipe/segment,
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/obj/machinery/sleeper,
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "bkM" = (
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
@@ -26768,9 +26744,6 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/morgue)
 "bls" = (
-/obj/structure/table,
-/obj/item/storage/toolbox/mechanical,
-/obj/item/crowbar/large,
 /obj/machinery/camera{
 	c_tag = "Mech Bay";
 	dir = 1
@@ -26779,29 +26752,21 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blt" = (
-/obj/machinery/recharge_station,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden{
 	dir = 4
 	},
 /obj/structure/sign/poster/official/state_laws{
 	pixel_y = -32
 	},
-/obj/effect/landmark/start/cyborg,
+/obj/structure/table,
+/obj/item/crowbar/large,
+/obj/item/storage/toolbox/mechanical,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blu" = (
-/obj/machinery/computer/mech_bay_power_console{
-	dir = 4
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "blv" = (
-/obj/structure/cable{
-	icon_state = "1-8"
-	},
 /obj/structure/cable{
 	icon_state = "1-4"
 	},
@@ -27267,11 +27232,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmG" = (
-/obj/machinery/chem_dispenser,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmH" = (
@@ -27285,7 +27250,6 @@
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
 "bmI" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
@@ -27293,6 +27257,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/machinery/chem_dispenser,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bmJ" = (
@@ -27905,7 +27870,7 @@
 	},
 /obj/machinery/firealarm{
 	dir = 4;
-	pixel_x = -24
+	pixel_x = -26
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
@@ -28461,7 +28426,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bpu" = (
-/obj/structure/bed/roller,
 /obj/machinery/button/door{
 	desc = "A remote control switch for the medbay foyer.";
 	id = "MedbayFoyer";
@@ -28579,7 +28543,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bpI" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -28587,6 +28550,12 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
+/obj/structure/table/glass,
+/obj/item/paper_bin{
+	pixel_y = 6
+	},
+/obj/item/pen/fountain,
+/obj/item/pen/fountain,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bpJ" = (
@@ -28740,13 +28709,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
 "bqd" = (
-/obj/effect/turf_decal/stripes/line,
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "robo2"
-	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
-/area/science/robotics/lab)
+/area/science/storage)
 "bqe" = (
 /turf/closed/wall/r_wall,
 /area/science/explab)
@@ -29020,9 +28985,9 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bqP" = (
-/obj/structure/bed/roller,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/obj/structure/tank_dispenser,
+/turf/open/floor/plasteel,
+/area/science/storage)
 "bqQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
@@ -29139,9 +29104,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "brb" = (
-/obj/machinery/computer/scan_consolenew{
-	dir = 8
-	},
 /obj/effect/turf_decal/tile/blue,
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -29149,6 +29111,9 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/table/glass,
+/obj/item/folder/white,
+/obj/item/folder/white,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "brc" = (
@@ -30704,6 +30669,10 @@
 	dir = 4;
 	pixel_x = -22
 	},
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "buF" = (
@@ -31520,9 +31489,7 @@
 /turf/open/floor/plasteel/dark,
 /area/medical/sleeper)
 "bwD" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwE" = (
@@ -31532,14 +31499,7 @@
 /area/medical/sleeper)
 "bwF" = (
 /obj/structure/table/glass,
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
-/obj/item/reagent_containers/glass/beaker/cryoxadone{
-	pixel_x = 7;
-	pixel_y = 1
-	},
+/obj/item/storage/firstaid/regular,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bwG" = (
@@ -31816,9 +31776,6 @@
 /turf/open/floor/plating,
 /area/maintenance/aft)
 "bxi" = (
-/obj/machinery/computer/aifixer{
-	dir = 8
-	},
 /obj/machinery/requests_console{
 	announcementConsole = 1;
 	department = "Research Director's Desk";
@@ -31831,11 +31788,12 @@
 /obj/structure/window/reinforced{
 	dir = 4
 	},
+/obj/structure/table,
+/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxj" = (
 /obj/structure/table,
-/obj/machinery/computer/security/telescreen/rd,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/heads/hor)
 "bxk" = (
@@ -32125,17 +32083,9 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxS" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 4
-	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
-/area/medical/sleeper)
-"bxT" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
+/area/science/storage)
 "bxU" = (
 /obj/machinery/atmospherics/pipe/simple/general/visible{
 	dir = 10
@@ -32143,7 +32093,9 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxV" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible,
+/obj/machinery/atmospherics/pipe/simple/general/visible{
+	dir = 5
+	},
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bxW" = (
@@ -33267,18 +33219,12 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bAq" = (
-/obj/machinery/sleeper{
-	dir = 8
-	},
 /obj/machinery/camera{
 	c_tag = "Medbay Treatment Center";
 	dir = 8;
 	network = list("ss13","medbay")
 	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
-"bAr" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bAs" = (
@@ -34360,7 +34306,6 @@
 /obj/item/folder/white,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCH" = (
@@ -34442,13 +34387,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
 	},
-/turf/open/floor/plasteel/white,
-/area/medical/sleeper)
-"bCT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/bloodbankgen,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCU" = (
@@ -36715,10 +36653,6 @@
 /area/science/xenobiology)
 "bIi" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36737,8 +36671,6 @@
 /obj/machinery/light,
 /obj/item/reagent_containers/spray/cleaner,
 /obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
-/obj/item/clothing/glasses/hud/health,
 /obj/item/hand_labeler,
 /obj/item/stack/packageWrap,
 /obj/item/stack/packageWrap,
@@ -36746,10 +36678,6 @@
 /area/medical/sleeper)
 "bIk" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36764,10 +36692,6 @@
 /area/medical/sleeper)
 "bIl" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36787,10 +36711,6 @@
 /area/medical/sleeper)
 "bIn" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -37513,10 +37433,6 @@
 	pixel_y = -2
 	},
 /obj/structure/table/reinforced,
-/turf/open/floor/plasteel/white,
-/area/science/mixing)
-"bJY" = (
-/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bJZ" = (
@@ -52764,17 +52680,10 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/science/robotics/lab)
-"cHV" = (
-/obj/machinery/conveyor_switch/oneway{
-	id = "robo2"
-	},
-/turf/open/floor/plasteel/white,
-/area/science/robotics/lab)
 "cHW" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
-/obj/machinery/mecha_part_fabricator,
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
 "cHX" = (
@@ -52814,10 +52723,6 @@
 "cIb" = (
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
-	},
-/obj/machinery/conveyor{
-	dir = 4;
-	id = "robo2"
 	},
 /turf/open/floor/plasteel,
 /area/science/robotics/lab)
@@ -54698,9 +54603,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "fGf" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
 /obj/structure/table,
 /obj/item/radio/intercom{
 	pixel_y = 25
@@ -57686,10 +57588,10 @@
 /turf/open/floor/plating,
 /area/engine/engineering)
 "nGf" = (
-/obj/machinery/hydroponics/constructable,
 /obj/machinery/light{
 	dir = 1
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "nGt" = (
@@ -58956,11 +58858,11 @@
 /turf/open/floor/plasteel,
 /area/security/brig)
 "rdG" = (
-/obj/machinery/hydroponics/constructable,
 /obj/item/radio/intercom{
 	name = "Station Intercom (General)";
 	pixel_x = 29
 	},
+/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel/dark,
 /area/hydroponics)
 "reA" = (
@@ -59847,15 +59749,6 @@
 	},
 /turf/open/floor/engine,
 /area/engine/engineering)
-"sWR" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden{
-	dir = 4
-	},
-/obj/machinery/computer/bounty{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/quartermaster/office)
 "sXl" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
 	dir = 1
@@ -60220,11 +60113,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/closed/wall/r_wall,
 /area/engine/engineering)
-"tPT" = (
-/obj/machinery/chem_dispenser/drinks/beer,
-/obj/structure/table/wood,
-/turf/open/floor/wood,
-/area/maintenance/bar)
 "tQY" = (
 /obj/machinery/atmospherics/components/binary/valve/digital/on{
 	dir = 4;
@@ -83980,7 +83868,7 @@ bVG
 bHE
 bHE
 bCq
-tPT
+bcU
 tRF
 mrR
 dKP
@@ -84981,7 +84869,7 @@ bnG
 bnz
 bpA
 bbR
-sWR
+bkM
 jlm
 bud
 eyM
@@ -96541,7 +96429,7 @@ bhc
 bip
 bgP
 bjL
-bkL
+bjL
 bmT
 bnD
 bpM
@@ -97572,7 +97460,7 @@ wbE
 bmJ
 bof
 bpu
-bqP
+bhh
 bsy
 bEe
 bvh
@@ -98611,7 +98499,7 @@ bvj
 bvj
 bzW
 bDZ
-bCT
+bCJ
 bGR
 bIj
 bJC
@@ -98864,7 +98752,7 @@ bvh
 bwF
 bxQ
 bxQ
-bAr
+bxQ
 bvj
 bzV
 bDZ
@@ -99118,8 +99006,8 @@ bhh
 bsx
 btV
 bvj
-bwI
-bxT
+bkL
+bxQ
 bxQ
 bAt
 bvj
@@ -99376,7 +99264,7 @@ bsx
 btV
 bvh
 bwH
-bxS
+bxQ
 bzh
 bAs
 bvj
@@ -101154,7 +101042,7 @@ aJI
 aRG
 aSO
 aTO
-cCq
+aOT
 aVz
 aVz
 qus
@@ -101406,7 +101294,7 @@ aJI
 aJI
 aJI
 aNO
-aOT
+aMF
 aJI
 aRF
 aSN
@@ -101684,7 +101572,7 @@ biz
 bla
 bmY
 boq
-boq
+biI
 brj
 bpE
 btk
@@ -102178,12 +102066,12 @@ aKH
 aMI
 aIp
 aOV
-aOX
+aSR
 aOX
 aSR
 aUi
 aVJ
-aOX
+aSR
 aiJ
 bal
 bam
@@ -103462,7 +103350,7 @@ aIp
 aKL
 aMz
 aNQ
-aOX
+aSR
 aQm
 lva
 nUV
@@ -103747,7 +103635,7 @@ bon
 buG
 bvA
 bon
-tiF
+bAw
 bzg
 bLS
 bLS
@@ -103978,11 +103866,11 @@ aMN
 aNQ
 aOZ
 aOX
-aOX
+aSR
 rdG
 aUz
 aVM
-aOX
+aSR
 aYT
 bam
 iuR
@@ -104505,8 +104393,8 @@ bcj
 beC
 bfT
 cHF
-biG
-blw
+blu
+bnb
 blu
 bnb
 bfT
@@ -104762,9 +104650,9 @@ aXq
 bfU
 bhu
 cHG
-biI
 bkh
-biI
+bkh
+bkh
 cHQ
 bfT
 boE
@@ -106309,7 +106197,7 @@ bkm
 cHO
 blG
 biL
-cHV
+biL
 cIa
 biL
 box
@@ -106824,7 +106712,7 @@ cHP
 cHR
 bou
 bpT
-bqd
+cId
 biL
 box
 btS
@@ -107348,7 +107236,7 @@ bzD
 bxv
 bCc
 bDc
-bEo
+bqd
 bDj
 bDY
 bIA
@@ -107605,10 +107493,10 @@ bzC
 bAH
 bCb
 bDc
-bEo
+bqP
 bDf
 bEb
-bGY
+bxS
 bGY
 bJN
 bMp
@@ -110693,7 +110581,7 @@ bEy
 bFU
 bFT
 bFU
-bJY
+bFU
 bEC
 bMv
 bNv

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -3805,7 +3805,6 @@
 	dir = 4;
 	layer = 2.9
 	},
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /obj/effect/turf_decal/tile/neutral{
 	dir = 1
 	},
@@ -4299,11 +4298,11 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "ajq" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ajr" = (
@@ -4311,17 +4310,17 @@
 	dir = 1;
 	light_color = "#cee5d2"
 	},
-/obj/structure/tank_dispenser,
 /obj/effect/turf_decal/delivery,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/scrubber/huge,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ajs" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
 /obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
 	dir = 6
 	},
+/obj/machinery/portable_atmospherics/scrubber,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "ajt" = (
@@ -5959,7 +5958,6 @@
 /area/science/robotics/lab)
 "amC" = (
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/mecha_part_fabricator,
 /obj/effect/turf_decal/trimline/white/filled/corner{
 	dir = 1
 	},
@@ -6027,7 +6025,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "amK" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/structure/window/reinforced{
 	dir = 1;
 	layer = 2.9
@@ -6036,6 +6033,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "amL" = (
@@ -6624,7 +6622,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "anO" = (
-/obj/machinery/portable_atmospherics/scrubber,
 /obj/machinery/light{
 	dir = 4;
 	light_color = "#e8eaff"
@@ -6633,6 +6630,7 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/canister,
 /turf/open/floor/plasteel,
 /area/science/mixing)
 "anP" = (
@@ -8784,9 +8782,9 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "arg" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/effect/turf_decal/delivery,
 /obj/machinery/airalarm/directional/east,
+/obj/structure/tank_dispenser,
 /turf/open/floor/plasteel,
 /area/science/storage)
 "arh" = (
@@ -9766,7 +9764,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
-/obj/structure/chair/comfy/black,
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "asI" = (
@@ -10250,9 +10247,6 @@
 /obj/effect/turf_decal/stripes/line{
 	dir = 10
 	},
-/obj/machinery/computer/camera_advanced/xenobio{
-	dir = 1
-	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
 "atE" = (
@@ -10540,11 +10534,6 @@
 /obj/machinery/status_display{
 	pixel_y = 32
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
-"aub" = (
-/obj/machinery/recharge_station,
-/obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "auc" = (
@@ -11599,27 +11588,22 @@
 /turf/open/floor/circuit,
 /area/science/robotics/mechbay)
 "avR" = (
-/turf/open/floor/plasteel/recharge_floor,
+/turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "avS" = (
-/obj/machinery/mech_bay_recharge_port{
-	dir = 8
-	},
-/obj/structure/cable{
-	icon_state = "0-4"
-	},
+/obj/machinery/recharge_station,
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "avT" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
-/obj/structure/cable{
-	icon_state = "1-8"
+/obj/effect/turf_decal/tile/bar{
+	dir = 8
 	},
-/obj/structure/cable{
-	icon_state = "1-2"
+/obj/effect/turf_decal/tile/bar{
+	dir = 4
 	},
-/turf/open/floor/plasteel,
-/area/science/robotics/mechbay)
+/obj/machinery/processor,
+/turf/open/floor/plasteel/cafeteria,
+/area/crew_quarters/kitchen)
 "avU" = (
 /obj/effect/turf_decal/trimline/purple/filled/line,
 /turf/open/floor/plasteel/white,
@@ -16999,7 +16983,6 @@
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
 "aER" = (
-/obj/machinery/suit_storage_unit/security,
 /obj/effect/turf_decal/tile/red,
 /obj/effect/turf_decal/tile/red{
 	dir = 4
@@ -25205,9 +25188,6 @@
 /obj/machinery/light{
 	dir = 4
 	},
-/obj/machinery/chem_dispenser/drinks/beer{
-	dir = 8
-	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/crew_quarters/bar)
@@ -25838,9 +25818,6 @@
 	dir = 1;
 	name = "Station Intercom";
 	pixel_y = -28
-	},
-/obj/machinery/computer/bounty{
-	dir = 1
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -29285,7 +29262,7 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bbS" = (
-/obj/machinery/gibber,
+/obj/structure/closet/secure_closet/freezer/kitchen,
 /turf/open/floor/plasteel/freezer,
 /area/crew_quarters/kitchen/backroom)
 "bbT" = (
@@ -30881,7 +30858,6 @@
 /turf/open/floor/wood,
 /area/crew_quarters/bar)
 "bfj" = (
-/obj/machinery/reagentgrinder,
 /obj/structure/table,
 /obj/effect/turf_decal/trimline/green/filled/line,
 /turf/open/floor/plasteel,
@@ -30932,20 +30908,20 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bfr" = (
-/obj/machinery/computer/scan_consolenew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bfs" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
 /obj/structure/sign/warning/nosmoking{
 	pixel_y = 32
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bft" = (
@@ -33201,7 +33177,8 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/machinery/reagentgrinder,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bjV" = (
@@ -33841,7 +33818,6 @@
 	dir = 4
 	},
 /obj/structure/table,
-/obj/machinery/microwave,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = 24
@@ -34243,15 +34219,14 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "blF" = (
-/obj/effect/turf_decal/tile/bar{
-	dir = 8
+/obj/structure/cable/yellow{
+	icon_state = "0-4"
 	},
-/obj/effect/turf_decal/tile/bar{
-	dir = 4
+/obj/structure/cable{
+	icon_state = "1-2"
 	},
-/obj/machinery/processor,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "blG" = (
 /obj/effect/turf_decal/tile/bar{
 	dir = 8
@@ -36555,7 +36530,8 @@
 	pixel_x = -28
 	},
 /obj/structure/table,
-/obj/machinery/smartfridge/disks,
+/obj/item/reagent_containers/glass/mortar,
+/obj/item/pestle,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "bqu" = (
@@ -37881,10 +37857,6 @@
 	pixel_x = 1;
 	pixel_y = 2
 	},
-/obj/item/storage/firstaid/brute{
-	pixel_x = -3;
-	pixel_y = 4
-	},
 /obj/structure/table/reinforced,
 /obj/structure/window/reinforced{
 	dir = 8;
@@ -37903,10 +37875,6 @@
 /obj/item/storage/firstaid/fire{
 	pixel_x = 1;
 	pixel_y = 2
-	},
-/obj/item/storage/firstaid/fire{
-	pixel_x = -4;
-	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southleft{
@@ -37933,10 +37901,6 @@
 /obj/item/storage/firstaid/o2{
 	pixel_x = 1;
 	pixel_y = 2
-	},
-/obj/item/storage/firstaid/o2{
-	pixel_x = -4;
-	pixel_y = 4
 	},
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southright{
@@ -38000,7 +37964,6 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 5
 	},
-/obj/machinery/bloodbankgen,
 /obj/machinery/iv_drip,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
@@ -38701,10 +38664,6 @@
 	pixel_x = 1;
 	pixel_y = 2
 	},
-/obj/item/storage/firstaid/toxin{
-	pixel_x = -4;
-	pixel_y = 4
-	},
 /obj/machinery/status_display/ai{
 	pixel_y = 32
 	},
@@ -38780,10 +38739,6 @@
 /obj/item/storage/firstaid/regular{
 	pixel_x = 1;
 	pixel_y = 2
-	},
-/obj/item/storage/firstaid/regular{
-	pixel_x = -3;
-	pixel_y = 4
 	},
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 8
@@ -39607,12 +39562,11 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bwl" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
-	dir = 4
+/obj/structure/cable/yellow{
+	icon_state = "0-8"
 	},
-/obj/machinery/chem_heater,
-/turf/open/floor/plasteel/white,
-/area/medical/chemistry)
+/turf/open/floor/plating/airless,
+/area/engine/engineering)
 "bwm" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden/layer3{
 	dir = 10
@@ -39642,7 +39596,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/virology)
 "bws" = (
-/obj/machinery/chem_heater,
 /obj/machinery/light{
 	dir = 8;
 	light_color = "#e8eaff"
@@ -39770,7 +39723,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwD" = (
-/obj/machinery/atmospherics/components/unary/cryo_cell,
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
 	},
@@ -39984,7 +39936,7 @@
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
 "bxa" = (
-/obj/machinery/chem_master,
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxb" = (
@@ -39995,13 +39947,6 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
-"bxd" = (
-/obj/machinery/sleeper,
-/obj/effect/turf_decal/trimline/blue/filled/line{
-	dir = 1
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/cryo)
 "bxe" = (
 /obj/machinery/smartfridge/chemistry/preloaded,
 /turf/closed/wall,
@@ -40020,6 +39965,7 @@
 	name = "Station Intercom (Medbay)";
 	pixel_y = 30
 	},
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxg" = (
@@ -40073,9 +40019,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "bxq" = (
-/obj/machinery/atmospherics/pipe/simple/general/visible{
-	dir = 5
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
@@ -40085,12 +40028,10 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bxr" = (
-/obj/machinery/atmospherics/pipe/manifold/general/visible{
-	dir = 4
-	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
 	},
+/obj/machinery/atmospherics/pipe/simple/general/visible,
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bxs" = (
@@ -40109,13 +40050,13 @@
 /turf/open/floor/plasteel,
 /area/medical/cryo)
 "bxt" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/trimline/yellow/filled/line{
 	dir = 8
 	},
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 8
 	},
+/obj/structure/table/glass,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxu" = (
@@ -40125,6 +40066,7 @@
 /obj/effect/turf_decal/trimline/red/filled/line{
 	dir = 4
 	},
+/obj/machinery/chem_heater,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxv" = (
@@ -47532,7 +47474,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/surgery)
 "bLA" = (
-/obj/structure/closet/secure_closet/freezer/kitchen,
 /obj/machinery/atmospherics/pipe/simple/supply/hidden/layer1{
 	dir = 6
 	},
@@ -66908,7 +66849,6 @@
 /turf/open/floor/plasteel,
 /area/engine/storage_shared)
 "cyu" = (
-/obj/machinery/power/tesla_coil,
 /obj/structure/cable/yellow{
 	icon_state = "0-4"
 	},
@@ -67290,7 +67230,6 @@
 /turf/open/floor/plasteel,
 /area/engine/engineering)
 "czn" = (
-/obj/machinery/power/tesla_coil,
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
@@ -67378,7 +67317,6 @@
 /turf/open/floor/plating,
 /area/maintenance/starboard/aft)
 "czy" = (
-/obj/machinery/power/tesla_coil,
 /obj/structure/cable/yellow{
 	icon_state = "4-8"
 	},
@@ -70109,8 +70047,6 @@
 	},
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
 /obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
-/obj/item/reagent_containers/glass/beaker/cryoxadone,
 /turf/open/floor/plasteel/white,
 /area/medical/cryo)
 "cEC" = (
@@ -71690,10 +71626,6 @@
 	dir = 8
 	},
 /obj/structure/reagent_dispensers/watertank,
-/obj/item/extinguisher{
-	pixel_x = 4;
-	pixel_y = 3
-	},
 /obj/item/extinguisher,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
@@ -71704,6 +71636,8 @@
 /obj/effect/turf_decal/trimline/purple/filled/line{
 	dir = 10
 	},
+/obj/structure/reagent_dispensers/watertank,
+/obj/item/extinguisher,
 /turf/open/floor/plasteel/white,
 /area/science/xenobiology)
 "cHk" = (
@@ -76345,6 +76279,11 @@
 	dir = 4;
 	pixel_x = 24
 	},
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "cQp" = (
@@ -76684,7 +76623,6 @@
 /obj/effect/turf_decal/tile/bar{
 	dir = 4
 	},
-/obj/machinery/food_cart,
 /obj/structure/extinguisher_cabinet{
 	dir = 4;
 	pixel_x = 24
@@ -80751,7 +80689,6 @@
 /obj/structure/cable/yellow{
 	icon_state = "0-8"
 	},
-/obj/machinery/power/tesla_coil,
 /turf/open/floor/plating/airless,
 /area/engine/engineering)
 "ihw" = (
@@ -116846,9 +116783,9 @@ ajH
 aqs
 arB
 ath
-aub
+avR
 auX
-avT
+awM
 awM
 ayt
 axV
@@ -124622,7 +124559,7 @@ bsQ
 bsQ
 bxf
 btG
-bwl
+bwk
 bxa
 bzp
 bsQ
@@ -125106,7 +125043,7 @@ aWi
 aXj
 aYq
 aYq
-aYq
+aSX
 aYq
 aYq
 aSX
@@ -125877,7 +125814,7 @@ ebs
 aXl
 aYq
 aYq
-aYq
+aSX
 aYq
 aYq
 aSX
@@ -126648,7 +126585,7 @@ ebs
 aXn
 aYq
 aYq
-aYq
+aSX
 aYq
 aYq
 bfo
@@ -126912,8 +126849,8 @@ cAw
 bft
 vDt
 gMF
-blF
-hBS
+gMF
+avT
 hBS
 ehl
 nRc
@@ -127419,9 +127356,9 @@ aRO
 aRO
 aXp
 aZm
-aYq
-aYq
-aYq
+aSX
+aSX
+aSX
 cAw
 bgy
 vDt
@@ -128291,7 +128228,7 @@ ePb
 cws
 cxw
 tsA
-cxw
+blF
 tsA
 cxw
 rqY
@@ -128991,7 +128928,7 @@ bpC
 bpC
 bpC
 bvO
-bxd
+bxm
 bxp
 byB
 bzA
@@ -131375,7 +131312,7 @@ ePb
 cxv
 czo
 cwS
-czo
+bwl
 cwS
 czo
 cwS

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -3936,7 +3936,6 @@
 	pixel_x = 3;
 	pixel_y = 3
 	},
-/obj/item/storage/firstaid/regular,
 /obj/structure/table/glass,
 /obj/machinery/airalarm{
 	pixel_y = 22
@@ -5121,7 +5120,6 @@
 /area/security/warden)
 "amZ" = (
 /obj/structure/table,
-/obj/machinery/recharger,
 /obj/machinery/light/small{
 	dir = 4
 	},
@@ -5176,7 +5174,6 @@
 /area/security/main)
 "ane" = (
 /obj/structure/table/wood,
-/obj/machinery/recharger,
 /obj/structure/disposalpipe/segment,
 /turf/open/floor/plasteel,
 /area/security/main)
@@ -18765,7 +18762,6 @@
 	dir = 4;
 	pixel_x = -28
 	},
-/obj/machinery/hydroponics/constructable,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aSB" = (
@@ -18828,9 +18824,10 @@
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
 "aSJ" = (
-/obj/machinery/gibber,
+/obj/structure/table,
+/obj/machinery/recharger,
 /turf/open/floor/plasteel/showroomfloor,
-/area/crew_quarters/kitchen)
+/area/security/main)
 "aSK" = (
 /turf/open/floor/plasteel/showroomfloor,
 /area/crew_quarters/kitchen)
@@ -19812,7 +19809,8 @@
 /area/hydroponics)
 "aUW" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/item/pestle,
+/obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aUX" = (
@@ -19879,8 +19877,8 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aVg" = (
-/obj/machinery/chem_dispenser/drinks/beer,
 /obj/structure/table,
+/obj/machinery/chem_dispenser/drinks,
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "aVh" = (
@@ -21224,7 +21222,6 @@
 /turf/open/floor/plasteel,
 /area/hydroponics)
 "aXY" = (
-/obj/machinery/hydroponics/constructable,
 /obj/structure/sign/departments/botany{
 	pixel_y = 32
 	},
@@ -21933,9 +21930,11 @@
 /obj/machinery/status_display/supply{
 	pixel_x = -32
 	},
-/obj/machinery/computer/bounty{
-	dir = 4
-	},
+/obj/structure/table,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
+/obj/item/paper/bounty_printout,
 /turf/open/floor/plasteel,
 /area/quartermaster/office)
 "aZk" = (
@@ -22830,7 +22829,8 @@
 /area/crew_quarters/kitchen)
 "bbi" = (
 /obj/structure/table,
-/obj/machinery/reagentgrinder,
+/obj/item/pestle,
+/obj/item/reagent_containers/glass/mortar,
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bbl" = (
@@ -23200,10 +23200,6 @@
 /area/hydroponics)
 "bce" = (
 /obj/structure/table,
-/obj/machinery/microwave{
-	pixel_x = -3;
-	pixel_y = 6
-	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "bcf" = (
@@ -25309,9 +25305,6 @@
 	icon_state = "1-4"
 	},
 /obj/structure/cable{
-	icon_state = "2-4"
-	},
-/obj/structure/cable{
 	icon_state = "4-8"
 	},
 /obj/structure/disposalpipe/segment{
@@ -25588,17 +25581,36 @@
 /turf/open/floor/plasteel,
 /area/science/robotics/mechbay)
 "bhU" = (
-/obj/machinery/mech_bay_recharge_port,
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
-"bhV" = (
-/obj/machinery/computer/mech_bay_power_console{
+/obj/effect/turf_decal/tile/green{
 	dir = 1
 	},
-/obj/structure/cable,
-/turf/open/floor/plasteel/dark,
-/area/science/robotics/mechbay)
+/obj/effect/turf_decal/tile/green{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/hydroponics)
+"bhV" = (
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/atmospherics/components/unary/portables_connector/visible,
+/obj/structure/noticeboard{
+	pixel_y = 32
+	},
+/obj/machinery/light{
+	dir = 1
+	},
+/obj/effect/turf_decal/delivery,
+/obj/effect/turf_decal/tile/blue{
+	dir = 1
+	},
+/obj/effect/turf_decal/tile/blue,
+/obj/effect/turf_decal/tile/blue{
+	dir = 4
+	},
+/obj/effect/turf_decal/tile/blue{
+	dir = 8
+	},
+/turf/open/floor/plasteel,
+/area/medical/sleeper)
 "bib" = (
 /obj/structure/chair/comfy/beige{
 	dir = 4
@@ -29514,7 +29526,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "brj" = (
-/obj/machinery/chem_master,
 /obj/effect/turf_decal/tile/yellow{
 	dir = 1
 	},
@@ -29524,6 +29535,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brk" = (
@@ -29556,7 +29568,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brm" = (
-/obj/machinery/chem_master,
 /obj/machinery/requests_console{
 	department = "Chemistry";
 	departmentType = 2;
@@ -29570,6 +29581,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "brq" = (
@@ -30149,33 +30161,6 @@
 "bsD" = (
 /obj/machinery/portable_atmospherics/canister/oxygen,
 /obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/structure/noticeboard{
-	pixel_y = 32
-	},
-/obj/machinery/light{
-	dir = 1
-	},
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/tile/blue{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/blue,
-/obj/effect/turf_decal/tile/blue{
-	dir = 4
-	},
-/obj/effect/turf_decal/tile/blue{
-	dir = 8
-	},
-/turf/open/floor/plasteel,
-/area/medical/sleeper)
-"bsE" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/machinery/atmospherics/components/unary/portables_connector/visible,
-/obj/item/radio/intercom{
-	frequency = 1485;
-	name = "Station Intercom (Medbay)";
-	pixel_x = 28
-	},
 /obj/machinery/airalarm{
 	pixel_y = 22
 	},
@@ -30191,6 +30176,15 @@
 	dir = 8
 	},
 /turf/open/floor/plasteel,
+/area/medical/sleeper)
+"bsE" = (
+/obj/item/radio/intercom{
+	frequency = 1485;
+	name = "Station Intercom (Medbay)";
+	pixel_x = 28
+	},
+/obj/machinery/sleeper,
+/turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bsF" = (
 /obj/machinery/shower{
@@ -30257,8 +30251,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsL" = (
-/obj/item/storage/box/beakers,
-/obj/structure/table,
+/obj/machinery/chem_master,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bsM" = (
@@ -30801,6 +30794,7 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "buc" = (
+/obj/item/wrench/medical,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -30808,7 +30802,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bud" = (
-/obj/item/wrench/medical,
 /obj/machinery/atmospherics/pipe/manifold/general/visible,
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
@@ -31825,24 +31818,14 @@
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
-"bww" = (
-/obj/machinery/computer/scan_consolenew,
-/obj/effect/turf_decal/tile/purple{
-	dir = 1
-	},
-/obj/effect/turf_decal/tile/purple{
-	dir = 4
-	},
-/turf/open/floor/plasteel/white,
-/area/medical/genetics)
 "bwx" = (
-/obj/machinery/dna_scannernew,
 /obj/effect/turf_decal/tile/purple{
 	dir = 1
 	},
 /obj/effect/turf_decal/tile/purple{
 	dir = 4
 	},
+/obj/structure/table,
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
 "bwy" = (
@@ -31984,22 +31967,17 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bwO" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
+/obj/effect/turf_decal/stripes/line{
 	dir = 4
 	},
-/obj/structure/bed/roller,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/engine,
+/area/science/storage)
 "bwP" = (
-/obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
-	dir = 4
+/obj/effect/turf_decal/stripes/corner{
+	dir = 8
 	},
-/obj/structure/bed/roller,
-/obj/machinery/iv_drip,
-/obj/effect/turf_decal/tile/blue,
-/turf/open/floor/plasteel/white,
-/area/medical/medbay/central)
+/turf/open/floor/engine,
+/area/science/storage)
 "bwQ" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 9
@@ -32048,6 +32026,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 8
 	},
+/obj/item/storage/box/beakers,
 /turf/open/floor/plasteel/white,
 /area/medical/chemistry)
 "bxa" = (
@@ -33433,9 +33412,6 @@
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/zone3)
 "bzP" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 1
 	},
@@ -33452,6 +33428,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bzQ" = (
@@ -34323,13 +34301,11 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bBE" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery,
 /obj/machinery/light{
 	dir = 1
 	},
 /obj/effect/turf_decal/stripes/line{
-	dir = 4
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -34341,7 +34317,7 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bBG" = (
-/obj/machinery/portable_atmospherics/scrubber/huge,
+/obj/structure/tank_dispenser,
 /turf/open/floor/engine,
 /area/science/storage)
 "bBH" = (
@@ -34651,9 +34627,6 @@
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCj" = (
-/obj/machinery/sleeper{
-	dir = 4
-	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 1
 	},
@@ -34664,6 +34637,8 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/bed/roller,
+/obj/machinery/iv_drip,
 /turf/open/floor/plasteel,
 /area/medical/sleeper)
 "bCl" = (
@@ -34679,6 +34654,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/structure/bed/roller,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCm" = (
@@ -35049,14 +35025,6 @@
 "bCP" = (
 /obj/effect/spawner/structure/window/reinforced,
 /turf/open/floor/plating,
-/area/science/storage)
-"bCQ" = (
-/obj/machinery/portable_atmospherics/canister/toxins,
-/obj/effect/turf_decal/delivery,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
 /area/science/storage)
 "bCR" = (
 /turf/open/floor/engine,
@@ -35486,18 +35454,11 @@
 /obj/machinery/atmospherics/pipe/simple/supply/hidden,
 /turf/open/floor/engine,
 /area/science/storage)
-"bDN" = (
-/obj/machinery/portable_atmospherics/canister/oxygen,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/storage)
 "bDO" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
 	},
+/obj/effect/turf_decal/stripes/corner,
 /turf/open/floor/engine,
 /area/science/storage)
 "bDP" = (
@@ -35507,6 +35468,7 @@
 /obj/structure/cable{
 	icon_state = "2-4"
 	},
+/obj/effect/turf_decal/stripes/line,
 /turf/open/floor/engine,
 /area/science/storage)
 "bDQ" = (
@@ -35824,10 +35786,6 @@
 /area/medical/medbay/central)
 "bEw" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/brute{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/brute,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -35847,10 +35805,6 @@
 /area/medical/medbay/central)
 "bEx" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/fire{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/fire,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -35870,10 +35824,6 @@
 /area/medical/medbay/central)
 "bEy" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/toxin{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/toxin,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -35893,10 +35843,6 @@
 /area/medical/medbay/central)
 "bEz" = (
 /obj/structure/table,
-/obj/item/storage/firstaid/o2{
-	pixel_x = 3;
-	pixel_y = 3
-	},
 /obj/item/storage/firstaid/o2,
 /obj/item/storage/firstaid/regular{
 	pixel_x = -3;
@@ -36275,7 +36221,7 @@
 /area/hallway/primary/aft)
 "bFa" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine,
 /area/science/storage)
 "bFb" = (
@@ -36284,18 +36230,12 @@
 /obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
-"bFc" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
-/obj/effect/turf_decal/stripes/line{
-	dir = 4
-	},
-/turf/open/floor/engine,
-/area/science/storage)
 "bFd" = (
 /obj/structure/cable{
 	icon_state = "1-2"
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
 "bFf" = (
@@ -36348,7 +36288,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFl" = (
-/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bFm" = (
@@ -36730,8 +36669,8 @@
 /area/hallway/primary/aft)
 "bGf" = (
 /obj/effect/turf_decal/bot,
-/obj/machinery/portable_atmospherics/canister/nitrogen,
 /obj/effect/turf_decal/stripes/line,
+/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
 /turf/open/floor/engine,
 /area/science/storage)
 "bGg" = (
@@ -36742,10 +36681,8 @@
 /turf/open/floor/engine,
 /area/science/storage)
 "bGh" = (
-/obj/machinery/portable_atmospherics/canister/nitrous_oxide,
-/obj/effect/turf_decal/bot,
 /obj/effect/turf_decal/stripes/line{
-	dir = 6
+	dir = 8
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -36762,6 +36699,8 @@
 	dir = 8;
 	pixel_x = 28
 	},
+/obj/machinery/portable_atmospherics/canister/oxygen,
+/obj/effect/turf_decal/bot,
 /turf/open/floor/engine,
 /area/science/storage)
 "bGj" = (
@@ -36893,7 +36832,6 @@
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGr" = (
-/obj/structure/tank_dispenser,
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 4
 	},
@@ -36901,6 +36839,7 @@
 /obj/effect/turf_decal/tile/purple{
 	dir = 8
 	},
+/obj/machinery/portable_atmospherics/pump,
 /turf/open/floor/plasteel/white,
 /area/science/mixing)
 "bGs" = (
@@ -37438,6 +37377,9 @@
 	},
 /obj/structure/sign/poster/random{
 	pixel_x = 32
+	},
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
 	},
 /turf/open/floor/engine,
 /area/science/storage)
@@ -38017,7 +37959,6 @@
 	icon_state = "4-8"
 	},
 /obj/effect/turf_decal/stripes/line,
-/obj/machinery/pipedispenser,
 /turf/open/floor/engine,
 /area/science/storage)
 "bII" = (
@@ -38030,14 +37971,22 @@
 /obj/effect/turf_decal/stripes/corner{
 	dir = 1
 	},
-/obj/machinery/pipedispenser/disposal,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 9
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "bIJ" = (
 /obj/structure/cable{
 	icon_state = "1-8"
 	},
-/obj/machinery/pipedispenser/disposal/transit_tube,
+/obj/machinery/portable_atmospherics/canister/nitrogen,
+/obj/effect/turf_decal/bot,
+/obj/effect/turf_decal/stripes/line{
+	dir = 1
+	},
 /turf/open/floor/engine,
 /area/science/storage)
 "bIK" = (
@@ -42920,6 +42869,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/pipedispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTL" = (
@@ -42935,6 +42885,7 @@
 /obj/effect/turf_decal/tile/yellow{
 	dir = 4
 	},
+/obj/machinery/pipedispenser,
 /turf/open/floor/plasteel,
 /area/engine/atmos)
 "bTM" = (
@@ -46203,9 +46154,12 @@
 /turf/open/floor/plating,
 /area/maintenance/department/engine)
 "cbV" = (
-/obj/machinery/shieldgen,
-/turf/open/floor/plating,
-/area/engine/engineering)
+/obj/machinery/atmospherics/pipe/simple/scrubbers/visible{
+	dir = 4
+	},
+/obj/machinery/pipedispenser,
+/turf/open/floor/plasteel,
+/area/engine/atmos)
 "cbW" = (
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden{
 	dir = 6
@@ -49607,9 +49561,9 @@
 /turf/open/floor/plasteel/dark,
 /area/crew_quarters/bar)
 "cpu" = (
-/obj/machinery/deepfryer,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/obj/machinery/shieldgen,
+/turf/open/floor/plating,
+/area/engine/engineering)
 "cpv" = (
 /obj/machinery/atmospherics/components/unary/vent_scrubber/on{
 	dir = 4
@@ -49650,10 +49604,10 @@
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
 "cpy" = (
-/obj/machinery/atmospherics/pipe/simple/supply/hidden,
-/obj/machinery/food_cart,
-/turf/open/floor/plasteel/cafeteria,
-/area/crew_quarters/kitchen)
+/obj/structure/lattice,
+/obj/item/paper/bounty_printout,
+/turf/open/space/basic,
+/area/space/nearstation)
 "cpz" = (
 /obj/structure/rack,
 /obj/item/stack/packageWrap,
@@ -56189,9 +56143,6 @@
 /turf/open/floor/plasteel,
 /area/hallway/primary/central)
 "kEW" = (
-/obj/machinery/smartfridge/disks{
-	pixel_y = 2
-	},
 /obj/structure/table,
 /turf/open/floor/plasteel,
 /area/hydroponics)
@@ -56881,7 +56832,6 @@
 /turf/open/space/basic,
 /area/space)
 "mhl" = (
-/obj/machinery/power/emitter,
 /obj/machinery/light{
 	dir = 8
 	},
@@ -58519,12 +58469,6 @@
 	},
 /turf/open/floor/plasteel,
 /area/hallway/secondary/exit/departure_lounge)
-"pHo" = (
-/obj/machinery/computer/bounty{
-	dir = 1
-	},
-/turf/open/floor/wood,
-/area/crew_quarters/heads/hop)
 "pKd" = (
 /obj/effect/spawner/lootdrop/maintenance{
 	lootcount = 2;
@@ -86132,7 +86076,7 @@ bqW
 bsr
 btU
 bou
-bww
+bwx
 byg
 bzH
 bAR
@@ -86177,7 +86121,7 @@ ehM
 bDi
 dWk
 bBX
-aht
+cpy
 adR
 aaa
 aaa
@@ -86834,7 +86778,7 @@ aaa
 agQ
 ahd
 ahq
-ahq
+aSJ
 ahq
 ahd
 agP
@@ -87911,7 +87855,7 @@ aWP
 aXQ
 aYN
 aZR
-aYN
+bhU
 aYN
 aYN
 aXQ
@@ -88164,7 +88108,7 @@ aSB
 aTR
 aUT
 aRL
-aWQ
+aYO
 aXR
 aXS
 aZS
@@ -88686,7 +88630,7 @@ bbb
 bbZ
 bdk
 beh
-bfl
+bdj
 bdm
 aJI
 aDZ
@@ -88997,7 +88941,7 @@ sjC
 bXk
 mci
 cbX
-ceq
+cbX
 mhl
 ceq
 ceq
@@ -89213,7 +89157,7 @@ bld
 bld
 bpJ
 biY
-bsC
+bhV
 bud
 bvk
 bwH
@@ -89254,10 +89198,10 @@ cdI
 cri
 cbX
 cbX
-cbV
-cbV
-ceq
-ceq
+cbX
+cbX
+cpu
+cpu
 bXk
 aaa
 aaa
@@ -89471,7 +89415,7 @@ blf
 bpK
 biY
 bsD
-buc
+bue
 kQy
 bwI
 byo
@@ -89511,8 +89455,8 @@ ous
 bXk
 ccR
 cbX
-ccQ
-ccQ
+cbX
+cbX
 ccQ
 ccQ
 bXk
@@ -89728,7 +89672,7 @@ boD
 bpH
 biY
 bsE
-bue
+bzR
 tix
 cSJ
 bsA
@@ -90740,7 +90684,7 @@ aYR
 aYS
 aYS
 cpq
-cpu
+aYS
 cpw
 bfp
 bgk
@@ -90987,7 +90931,7 @@ aKT
 aPC
 aQP
 aRN
-aSJ
+aSK
 aSK
 aVa
 aVY
@@ -90999,7 +90943,7 @@ bbg
 cpr
 bcf
 beq
-cpy
+bcf
 bgl
 bhe
 aDZ
@@ -91272,7 +91216,7 @@ brh
 bjd
 cqm
 bvl
-bwO
+cqs
 byv
 bzZ
 bBg
@@ -91529,7 +91473,7 @@ bri
 bjd
 cqm
 bvl
-bwP
+cqs
 byu
 bAa
 bBh
@@ -91786,7 +91730,7 @@ bjd
 aay
 cqm
 bvl
-bwP
+cqs
 byv
 bAb
 bBi
@@ -95085,7 +95029,7 @@ aAG
 aBA
 aCQ
 aDS
-pHo
+aCS
 aAH
 aGu
 aHh
@@ -97975,7 +97919,7 @@ bPQ
 bPQ
 bQI
 bPQ
-bNc
+cbV
 bMf
 bMf
 hjk
@@ -99231,7 +99175,7 @@ biu
 bju
 bkt
 blI
-bmO
+bmM
 bnQ
 bnQ
 bqi
@@ -99997,7 +99941,7 @@ beI
 bfy
 bgH
 bhn
-bhU
+bfz
 biw
 biw
 bkt
@@ -100511,7 +100455,7 @@ beI
 bfA
 bgJ
 bhn
-bhV
+bfz
 beI
 aKq
 bkx
@@ -100528,9 +100472,9 @@ bxv
 byU
 bAA
 bBE
-bCQ
-bDN
-bFc
+bGh
+bGh
+bGh
 bGh
 bCR
 bIH
@@ -100787,9 +100731,9 @@ bAA
 bBF
 bCR
 bDO
-bCR
-bCR
-bCR
+bwO
+bwO
+bwP
 bII
 bHw
 bKY


### PR DESCRIPTION
kek lmao

## About The Pull Request
All stations other then kilo/omega - Kilo is out of rotation as is omega
have had their bugets cut! Leading to the horror of downsizing gear that can really quickly be replaced.
Sec wise - Some maps had 3 hard suits, this is no longer the case, and theirs a few less chargers around. Double medkits are also now solo
Medical - OH GOD LILLY WHY ARE YOU LIKE THIS WE USE THAT
One sleeper and one cryo tube, one set of gene messing as well.
Blood banks are also gone
One less of each type of kit in storage
1 less chem heater and chemmaster
Serest - LILLY NO
Half the microwaves
Gibber is now gone as is disk storage toaster  
Grinders are how hand grinders now!
Less hydro beds, oh nooooo
Booze-Dispender now must be made, meaning you got to now use your smarts to mix drinks and bottles - The vender is their for a reason...
Engi - 
In gernal just less emitters in storage, less anti-breach in storage, nothing really.
Sci - *dies*
Toxins has less plasma cans, less big scrubbers and the dispender is moved into storage.
Robotics now have to share fabs/mech chargers or build their own, what ever works!
Cargo - Lilly is the end of us!
Bounty consoles have been replace with 4 papers of the read outs of what bounters are, QM gets to keep his console
Command, really nothing here to take out other then HoPs spare bounty consoles/cargo consoles that are in his room
Half the xenobio consoles, meaning you just got to build a second one, not that hard.
## Why It's Good For The Game
Edit im dumb and forgot to fill this out

Theirs a lot of nodes that are nothing nodes in Rnd, such as consoles to a point when no one has a reason to build any of them unless bombs/meteors, or the blood bank never gets made do to already having one. This gives the whole crew something to do through a shift on upgrading their workplace and having to mingle with sci/engi for parts or even boards.

Hell you can prob be an assisant thats job is to upgrade things call yourself a handy man or something.

Gives use to some of the boards in tech storage for people other then theifs.


## Changelog
:cl:
tweak: All maps have been hit with a massive cut in supplies, meaning NT has removed a "few" this from work places, no need to panic sci can Rnd up the parts and boards needed for engis to replace them if wanted/needed
/:cl:
