### PR TITLE
Stores unused bad mood skill modifiers in a static list instead of deleting them everytime.

### DIFF
--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -221,7 +221,7 @@
 					master.mind.add_skill_modifier(malus.identifier)
 				else
 					malus.RegisterSignal(master, COMSIG_MOB_ON_NEW_MIND, /datum/skill_modifier.proc/on_mob_new_mind, TRUE)
-			malus.value_mod = 1 - (sanity_level - 3) * MOOD_INSANITY_MALUS
+			malus.value_mod = malus.level_mod = 1 - (sanity_level - 3) * MOOD_INSANITY_MALUS
 		else if(malus)
 			if(master.mind)
 				master.mind.remove_skill_modifier(malus.identifier)

--- a/code/datums/components/mood.dm
+++ b/code/datums/components/mood.dm
@@ -213,14 +213,15 @@
 
 	if(sanity_level != old_sanity_level)
 		if(sanity_level >= 4)
-			if(!length(free_maluses))
-				ADD_SKILL_MODIFIER_BODY(/datum/skill_modifier/bad_mood, malus_id++, master, malus)
-			else
-				malus = pick_n_take(free_maluses)
-				if(master.mind)
-					master.mind.add_skill_modifier(malus.identifier)
+			if(!malus)
+				if(!length(free_maluses))
+					ADD_SKILL_MODIFIER_BODY(/datum/skill_modifier/bad_mood, malus_id++, master, malus)
 				else
-					malus.RegisterSignal(master, COMSIG_MOB_ON_NEW_MIND, /datum/skill_modifier.proc/on_mob_new_mind, TRUE)
+					malus = pick_n_take(free_maluses)
+					if(master.mind)
+						master.mind.add_skill_modifier(malus.identifier)
+					else
+						malus.RegisterSignal(master, COMSIG_MOB_ON_NEW_MIND, /datum/skill_modifier.proc/on_mob_new_mind, TRUE)
 			malus.value_mod = malus.level_mod = 1 - (sanity_level - 3) * MOOD_INSANITY_MALUS
 		else if(malus)
 			if(master.mind)
@@ -237,7 +238,7 @@
 		return
 
 	var/mob/living/L = parent
-	if(newval <= ECSTATIC_SANITY_PEN)
+	if(newval == ECSTATIC_SANITY_PEN && !bonus)
 		ADD_SKILL_MODIFIER_BODY(/datum/skill_modifier/great_mood, null, L, bonus)
 	else if(bonus)
 		REMOVE_SKILL_MODIFIER_BODY(/datum/skill_modifier/great_mood, null, L)


### PR DESCRIPTION
## About The Pull Request
I have been told constant creation and deletion of mood skill modifiers puts quite a lot of stress on the gc.
For bonus modifier, the pre-existing global list works fine since it's a hardset 1.2x affinity multiplier.
For the malus, I had to snowflake things a little considering the modifier varies withe the insanity of the owner. (also fixing a little mistake I did with it only updating when the effect level changed)

## Why It's Good For The Game
Skill modifiers are quite expensive around stuff such as mood sanity which tends to oscillate around fairly often. Performance improvement.

## Changelog
Nope.