### PR TITLE
Removes cryofuild and monkey cubes from cook vender

### DIFF
--- a/code/modules/vending/dinnerware.dm
+++ b/code/modules/vending/dinnerware.dm
@@ -20,12 +20,10 @@
 					/obj/item/reagent_containers/food/condiment/saltshaker = 5,
 					/obj/item/reagent_containers/food/condiment/peppermill = 5)
 	contraband = list(
-					/obj/item/reagent_containers/food/snacks/cube/monkey= 1,
 					/obj/item/kitchen/knife/butcher = 2,
 					/obj/item/reagent_containers/syringe = 3)
 	premium = list(
-					/obj/item/reagent_containers/food/condiment/enzyme = 1,
-					/obj/item/reagent_containers/glass/bottle/cryoxadone = 2) // Bartender can literally make this with upgraded parts, or it gets stolen from medical.
+					/obj/item/reagent_containers/food/condiment/enzyme = 1)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/dinnerware
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION

## About The Pull Request
The 120u and monkey cube stored in the vender is gone

## Why It's Good For The Game

Makes cook need to interact with the crew to get meat and or cryo fuild when needed for their dishes just as barkeep has to now
## Changelog
:cl:
del: Cook vender has had buget cuts leading to no longer stocking cryofuild and money cubes
/:cl: