### PR TITLE
Massively buffs atmos firestoper backpacks

### DIFF
--- a/code/game/objects/items/tanks/watertank.dm
+++ b/code/game/objects/items/tanks/watertank.dm
@@ -210,6 +210,7 @@
 	power = 8
 	force = 10
 	precision = 1
+	total_mass = 0.2
 	cooling_power = 5
 	w_class = WEIGHT_CLASS_HUGE
 	item_flags = ABSTRACT  // don't put in storage


### PR DESCRIPTION

## About The Pull Request
The massive item no longer takes as much stam to use

## Why It's Good For The Game
QoL so atmos techs dont have to spend 20 mins clearing out resin do to no stam
## Changelog
:cl:
tweak: The Adv atmos fire nozzle is now light weight
/:cl:
