### PR TITLE
New gun flag for dual wielding exclusion

### DIFF
--- a/code/__DEFINES/flags/guns.dm
+++ b/code/__DEFINES/flags/guns.dm
@@ -1,0 +1,3 @@
+// Flags for obj/item/gun/var/gun_flags
+/// Can not be part of dual wielding. Firing this gun will not trigger dual wielding, and dual wielding will not trigger this gun.
+#define GUN_FLAG_DUAL_WIELDING_EXCLUDED			(1<<0)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -17,6 +17,9 @@
 	force = 5
 	item_flags = NEEDS_PERMIT | NO_ATTACK_CHAIN_SOFT_STAMCRIT
 	attack_verb = list("struck", "hit", "bashed")
+	
+	/// See __DEFINES/flags/guns.dm
+	var/gun_flags = NONE
 
 	var/fire_sound = "gunshot"
 	var/suppressed = null					//whether or not a message is displayed when fired
@@ -212,15 +215,17 @@
 	var/loop_counter = 0
 
 	bonus_spread += getinaccuracy(user) //CIT CHANGE - adds bonus spread while not aiming
-	if(ishuman(user) && user.a_intent == INTENT_HARM)
-		var/mob/living/carbon/human/H = user
-		for(var/obj/item/gun/G in H.held_items)
-			if(G == src || G.weapon_weight >= WEAPON_MEDIUM)
-				continue
-			else if(G.can_trigger_gun(user))
-				bonus_spread += 24 * G.weapon_weight * G.dualwield_spread_mult
-				loop_counter++
-				addtimer(CALLBACK(G, /obj/item/gun.proc/process_fire, target, user, TRUE, params, null, bonus_spread), loop_counter)
+	
+	if(!(gun_flags & GUN_FLAG_DUAL_WIELDING_EXCLUDED))
+		if(ishuman(user) && user.a_intent == INTENT_HARM)
+			var/mob/living/carbon/human/H = user
+			for(var/obj/item/gun/G in H.held_items)
+				if((G == src) || (G.weapon_weight >= WEAPON_MEDIUM) || (G.gun_flags & GUN_FLAG_DUAL_WIELDING_EXCLUDED))
+					continue
+				else if(G.can_trigger_gun(user))
+					bonus_spread += 24 * G.weapon_weight * G.dualwield_spread_mult
+					loop_counter++
+					addtimer(CALLBACK(G, /obj/item/gun.proc/process_fire, target, user, TRUE, params, null, bonus_spread), loop_counter)
 
 	process_fire(target, user, TRUE, params, null, bonus_spread)
 

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -124,6 +124,7 @@
 #include "code\__DEFINES\dcs\helpers.dm"
 #include "code\__DEFINES\dcs\signals.dm"
 #include "code\__DEFINES\flags\shields.dm"
+#include "code\__DEFINES\flags\guns.dm"
 #include "code\__DEFINES\mapping\maploader.dm"
 #include "code\__DEFINES\material\worth.dm"
 #include "code\__DEFINES\misc\return_values.dm"


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

Title
Prevents a gun from being used as part of dual wielding (the loop skips over it without any effect) or being dual wielded (will not initiate the loop)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Better way to do this if you do not want to use WEAPON_HEAVY (which REQUIRES two free hands to use a gun.)
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
code: Gun flags have been added with a dual wielding exclusion flag.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
