### PR TITLE
Reducing prefilled hypospray kits availability.

### DIFF
--- a/code/game/objects/items/storage/boxes.dm
+++ b/code/game/objects/items/storage/boxes.dm
@@ -221,6 +221,13 @@
 	for(var/i in 1 to 7)
 		new /obj/item/reagent_containers/hypospray/medipen(src)
 
+/obj/item/storage/box/vials
+	name = "box of hypovials"
+
+/obj/item/storage/box/vials/PopulateContents()
+	for(var/i in 1 to 7)
+		new /obj/item/reagent_containers/glass/bottle/vial/small( src )
+
 /obj/item/storage/box/medipens/utility
 	name = "stimpack value kit"
 	desc = "A box with several stimpack medipens for the economical miner."

--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -444,6 +444,14 @@
 	/obj/item/hypospray/mkii,
 	/obj/item/reagent_containers/glass/bottle/vial))
 
+/// DIY variant found in the non-premium section of med vendors.
+/obj/item/storage/hypospraykit/starter
+
+/obj/item/storage/hypospraykit/starter/PopulateContents()
+	new /obj/item/hypospray/mkii(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/small(src)
+	new /obj/item/reagent_containers/glass/bottle/vial/small(src)
+
 /obj/item/storage/hypospraykit/regular
 	icon_state = "firstaid-mini"
 	desc = "A hypospray kit with general use vials."
@@ -470,6 +478,7 @@
 
 /obj/item/storage/hypospraykit/toxin
 	name = "toxin treatment hypospray kit"
+	desc = "A specialized hypospray kit for toxin treatments."
 	icon_state = "toxin-mini"
 	item_state = "firstaid-toxin"
 
@@ -482,6 +491,7 @@
 
 /obj/item/storage/hypospraykit/o2
 	name = "oxygen deprivation hypospray kit"
+	desc = "A specialized hypospray kit for oxygen deprivation."
 	icon_state = "oxy-mini"
 	item_state = "firstaid-o2"
 
@@ -494,6 +504,7 @@
 
 /obj/item/storage/hypospraykit/enlarge
 	name = "organomegaly trauma hypospray kit"
+	desc = "A specialized hypospray kit for a few specific organomegalies."
 	icon_state = "enlarge-mini"
 	item_state = "firstaid-brute"
 
@@ -510,6 +521,7 @@
 
 /obj/item/storage/hypospraykit/brute
 	name = "brute trauma hypospray kit"
+	desc = "A specialized hypospray kit for brute trauma."
 	icon_state = "brute-mini"
 	item_state = "firstaid-brute"
 
@@ -547,10 +559,3 @@
 	new /obj/item/reagent_containers/glass/bottle/vial/large/salglu(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/dexalin(src)
 	new /obj/item/reagent_containers/glass/bottle/vial/large/synthflesh(src)
-
-/obj/item/storage/box/vials
-	name = "box of hypovials"
-
-/obj/item/storage/box/vials/PopulateContents()
-	for(var/i in 1 to 7)
-		new /obj/item/reagent_containers/glass/bottle/vial/small( src )

--- a/code/modules/jobs/job_types/chemist.dm
+++ b/code/modules/jobs/job_types/chemist.dm
@@ -37,7 +37,7 @@
 	satchel = /obj/item/storage/backpack/satchel/chem
 	duffelbag = /obj/item/storage/backpack/duffelbag/med
 
-	backpack_contents = list(/obj/item/storage/hypospraykit/regular)
+	backpack_contents = list(/obj/item/storage/hypospraykit/starter)
 
 	chameleon_extras = /obj/item/gun/syringe
 

--- a/code/modules/reagents/chemistry/machinery/chem_master.dm
+++ b/code/modules/reagents/chemistry/machinery/chem_master.dm
@@ -278,7 +278,7 @@
 			else if (item_type == "condimentBottle")
 				vol_each_max = min(50, vol_each_max)
 			else if (item_type == "hypoVial")
-				vol_each_max = min(60, vol_each_max)
+				vol_each_max = min(30, vol_each_max)
 			else if (item_type == "smartDart")
 				vol_each_max = min(20, vol_each_max)
 			else
@@ -366,7 +366,7 @@
 					reagents.trans_to(P, vol_each)
 				return TRUE
 			if(item_type == "hypoVial")
-				var/obj/item/reagent_containers/glass/bottle/vial/small/P
+				var/obj/item/reagent_containers/glass/bottle/vial/tiny/P
 				for(var/i = 0; i < amount; i++)
 					P = new/obj/item/reagent_containers/glass/bottle/vial/small(drop_location())
 					P.name = trim("[name] hypovial")

--- a/code/modules/reagents/reagent_containers/hypospray.dm
+++ b/code/modules/reagents/reagent_containers/hypospray.dm
@@ -218,7 +218,7 @@
 	name = "hypospray mk.II"
 	icon_state = "hypo2"
 	icon = 'icons/obj/syringe.dmi'
-	desc = "A new development from DeForest Medical, this hypospray takes 30-unit vials as the drug supply for easy swapping."
+	desc = "A new development from DeForest Medical, this hypospray takes special vials as the drug supply for easy swapping."
 	w_class = WEIGHT_CLASS_TINY
 	var/list/allowed_containers = list(/obj/item/reagent_containers/glass/bottle/vial/tiny, /obj/item/reagent_containers/glass/bottle/vial/small)
 	var/mode = HYPO_INJECT

--- a/code/modules/reagents/reagent_containers/hypovial.dm
+++ b/code/modules/reagents/reagent_containers/hypovial.dm
@@ -5,7 +5,7 @@
 	desc = "A hypovial compatible with most hyposprays."
 	icon_state = "hypovial"
 	spillable = FALSE
-	volume = 10
+	volume = 30
 	possible_transfer_amounts = list(1,2,5,10)
 	container_flags = APTFT_VERB
 	obj_flags = UNIQUE_RENAME
@@ -19,6 +19,7 @@
 						"pink hypovial" = "hypovial-pink"
 						)
 	always_reskinnable = TRUE
+	custom_price = PRICE_PRETTY_CHEAP
 	cached_icon = "hypovial"
 
 /obj/item/reagent_containers/glass/bottle/vial/Initialize()
@@ -28,7 +29,7 @@
 /obj/item/reagent_containers/glass/bottle/vial/on_reagent_change()
 	update_icon()
 
-/obj/item/reagent_containers/glass/bottle/vial/tiny
+/obj/item/reagent_containers/glass/bottle/vial/tiny // Version printed by chem masters.
 	name = "small hypovial"
 	//Shouldn't be possible to get this without adminbuse
 

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -23,10 +23,7 @@
 					/obj/item/reagent_containers/glass/bottle/morphine = 4,
 					/obj/item/reagent_containers/glass/bottle/toxin = 3,
 					/obj/item/reagent_containers/syringe/antiviral = 6,
-					/obj/item/storage/hypospraykit/fire = 2,
-					/obj/item/storage/hypospraykit/toxin = 2,
-					/obj/item/storage/hypospraykit/o2 = 2,
-					/obj/item/storage/hypospraykit/brute = 2,
+					/obj/item/storage/hypospraykit/starter = 3,
 					/obj/item/storage/hypospraykit/enlarge = 2,
 					/obj/item/reagent_containers/glass/bottle/vial/small = 5,
 					/obj/item/storage/briefcase/medical = 2)
@@ -34,6 +31,10 @@
 					/obj/item/reagent_containers/pill/morphine = 4,
 					/obj/item/reagent_containers/pill/charcoal = 6)
 	premium = list(/obj/item/reagent_containers/medspray/synthflesh = 2,
+					/obj/item/storage/hypospraykit/fire = 1,
+					/obj/item/storage/hypospraykit/toxin = 1,
+					/obj/item/storage/hypospraykit/o2 = 1,
+					/obj/item/storage/hypospraykit/brute = 1,
 					/obj/item/storage/box/hug/medical = 1,
 					/obj/item/storage/pill_bottle/psicodine = 2,
 					/obj/item/reagent_containers/hypospray/medipen = 3,


### PR DESCRIPTION
## About The Pull Request
Title. Moved prefilled hypospray kits to the premium category of the med vendor, added DIY empty versions in their place. Replaced chemists trico hypo kits with the DIY variants.

## Why It's Good For The Game
Aiming to encourage players to use the healing mixes they made throughout the round instead of relying premade stuff.

## Changelog
:cl:
balance: Moved prefilled hypospray kits (save the organomaly one) to the premium category, replaced them with an DIY kit.
balance: The chemist job now starts with a DIY hypospray kit instead of a prefilled version.
balance: Reduced the capacity of chem-master printed hypovials from 60 to 30.
/:cl:
