### PR TITLE
Makes gun weight akimbo restrictions work the other way around.

### DIFF
--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -215,7 +215,7 @@
 	var/loop_counter = 0
 
 	bonus_spread += getinaccuracy(user) //CIT CHANGE - adds bonus spread while not aiming
-	if(ishuman(user) && user.a_intent == INTENT_HARM && G.weapon_weight <= WEAPON_LIGHT)
+	if(ishuman(user) && user.a_intent == INTENT_HARM && weapon_weight <= WEAPON_LIGHT)
 		var/mob/living/carbon/human/H = user
 		for(var/obj/item/gun/G in H.held_items)
 			if(G == src || G.weapon_weight >= WEAPON_MEDIUM)

--- a/code/modules/projectiles/gun.dm
+++ b/code/modules/projectiles/gun.dm
@@ -215,7 +215,7 @@
 	var/loop_counter = 0
 
 	bonus_spread += getinaccuracy(user) //CIT CHANGE - adds bonus spread while not aiming
-	if(ishuman(user) && user.a_intent == INTENT_HARM)
+	if(ishuman(user) && user.a_intent == INTENT_HARM && G.weapon_weight <= WEAPON_LIGHT)
 		var/mob/living/carbon/human/H = user
 		for(var/obj/item/gun/G in H.held_items)
 			if(G == src || G.weapon_weight >= WEAPON_MEDIUM)


### PR DESCRIPTION
## About The Pull Request
Yea, This means you can't barrage your three pistols while plinking mobs with a mag rifle should you have two extra arms somewhat... But this is probably for the best until I code in inaccuracity if firing bigger guns not wielded with both hands (two handed component), but that'll also mean moving other functions away from attack_self.

## Why It's Good For The Game
Simplier alternative to #12293.

## Changelog
:cl:
tweak: gun weight checks work the other way around when akimbo-ing.
/:cl:
