### PR TITLE
Disposal rides now hurt a little.

### DIFF
--- a/code/modules/recycling/disposal/pipe.dm
+++ b/code/modules/recycling/disposal/pipe.dm
@@ -81,6 +81,9 @@
 		H.forceMove(P)
 		if(P.canclank == TRUE || (P.canclank == IFFY && P.dpdir != 3 && P.dpdir != 12))
 			playsound(P, H.hasmob ? "clang" : "clangsmall", H.hasmob ? 50 : 25, 1)
+			if(H.hasmob && prob(33))
+				for(var/mob/living/L in H.contents)
+					L.take_bodypart_damage(rand(1, 3))
 		return P
 	else			// if wasn't a pipe, then they're now in our turf
 		H.forceMove(get_turf(src))


### PR DESCRIPTION
## About The Pull Request
Saw this fine change on a downstream and decided to add something similar here too (with mean damage of 0.66 brute per turn instead of 0.33, both are still very low because I'm sure kevinz doesn't like these sort of bay features). Credits to jjpark-kb and Azarak I guess.

## Why It's Good For The Game
The game could use some workplace hazards and dangers, they are impromptu transit tubes all.

## Changelog
:cl:
add: Disposal rides now hurt a little.
/:cl:
