### PR TITLE
[WIP] Combat Modernisation Rework

### DIFF
--- a/code/__DEFINES/citadel_defines.dm
+++ b/code/__DEFINES/citadel_defines.dm
@@ -117,8 +117,6 @@
 #define TOGGLES_CITADEL (EATING_NOISES|DIGESTION_NOISES|BREAST_ENLARGEMENT|PENIS_ENLARGEMENT)
 
 //component stuff
-#define COMSIG_COMBAT_TOGGLED "combatmode_toggled" //called by combat mode toggle on all equipped items. args: (mob/user, combatmode)
-
 #define COMSIG_VORE_TOGGLED "voremode_toggled" // totally not copypasta
 
 //belly sound pref things


### PR DESCRIPTION
## About The Pull Request
No changes so far in this WIP PR, a number of players I spoke to asked for this however so I'm now asking for feedback from maintainers whether this would be accepted first as it has some pretty significant changes. 

Citadel made the switch from stun to stamina combat before /tg/ did which helped the combat meta substantially, however /tg/ learned from other servers' implementations and today the state of their stamina combat system is more fluid and fun than Citadel's. This PR aims to replace stamina combat with tg's version. 

**The changes would include:**
- Removal of combat mode (and debuffs removed so you'll always do and take normal damage, shoot accurately etc)
- Removal of sprint toggle
- Base run speed increased slightly (slower than current sprint)
- Attacking doesn't drain stamina
- Disarm intent click now a shove 
- Stamina regenerates to full instantly after about 8 seconds with no stamina damage
- Soft stamcrit removed, hard stamcrit immobilises you completely until you regenerate out of it

## Why It's Good For The Game
Combat more fluid and enjoyable. 

## Changelog
:cl:
del: Combat mode
add: More dynamic stamina combat
/:cl: