### PR TITLE
fixed coordinate converters in Integrated Electronics converters.dm

### DIFF
--- a/code/modules/integrated_electronics/subtypes/converters.dm
+++ b/code/modules/integrated_electronics/subtypes/converters.dm
@@ -426,7 +426,7 @@
 	activators = list("compute abs coordinates" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/converter/abs_to_rel_coords/do_work()
+/obj/item/integrated_circuit/converter/rel_to_abs_coords/do_work()
 	var/x1 = get_pin_data(IC_INPUT, 1)
 	var/y1 = get_pin_data(IC_INPUT, 2)
 
@@ -456,7 +456,7 @@
 	activators = list("compute abs coordinates" = IC_PINTYPE_PULSE_IN, "on convert" = IC_PINTYPE_PULSE_OUT)
 	spawn_flags = IC_SPAWN_DEFAULT|IC_SPAWN_RESEARCH
 
-/obj/item/integrated_circuit/converter/abs_to_rel_coords/do_work()
+/obj/item/integrated_circuit/converter/adv_rel_to_abs_coords/do_work()
 	var/turf/T = get_turf(src)
 
 	if(!T)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

There was an obvious lazy copypasta where the do_work() of abs_to_rel_coords was repeated twice where the rel_to_abs_coords/do_work() and adv_rel_to_abs_coords/do_work() should have been, breaking all of the coordinate converters.

**The effect of this was:**
The rel_to_abs and advanced abs converter wasn't doing anything. You can pulse the pins, but nothing ever happened and the outputs were always null no matter what you did, because there is no do_work() for these components to run.

The abs_to_rel converter was 'working' but was misbehaving. You could pulse the on_converted pin and get it to do things to other things. The output was also getting assigned values, but they were weird and weren't correct. Some wacky byond effect of having abs_to_rel_coords/do_work() getting defined 3 different ways in the same file is happening here.

## Why It's Good For The Game
Should fix the three coordinate converters in the circuits. Abs_to_rel, rel_to_abs, and advanced rel_to_abs. This helps circuits people make drones and stuff- as I was trying to make a drone remote control, but found the rel_to_abs coordinate converter literally couldn't even pulse its own pins.

## Changelog
:cl: ArbytheDragon
fix: the coordinate converter circuits should actually work now.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
