### PR TITLE
pill bottles volumetric storage.

### DIFF
--- a/code/game/objects/items/storage/firstaid.dm
+++ b/code/game/objects/items/storage/firstaid.dm
@@ -223,6 +223,8 @@
 /obj/item/storage/pill_bottle/ComponentInitialize()
 	. = ..()
 	var/datum/component/storage/STR = GetComponent(/datum/component/storage)
+	STR.storage_flags = STORAGE_FLAGS_VOLUME_DEFAULT
+	STR.max_volume = 14
 	STR.allow_quick_gather = TRUE
 	STR.click_gather = TRUE
 	STR.can_hold = typecacheof(list(/obj/item/reagent_containers/pill, /obj/item/dice))
@@ -244,7 +246,7 @@
 	desc = "Contains pills used to counter radiation poisoning."
 
 /obj/item/storage/pill_bottle/anitrad/PopulateContents()
-	for(var/i in 1 to 5)
+	for(var/i in 1 to 4)
 		new /obj/item/reagent_containers/pill/antirad(src)
 
 /obj/item/storage/pill_bottle/epinephrine
@@ -276,7 +278,7 @@
 	desc = "Guaranteed to give you that extra burst of energy during a long shift!"
 
 /obj/item/storage/pill_bottle/stimulant/PopulateContents()
-	for(var/i in 1 to 5)
+	for(var/i in 1 to 4)
 		new /obj/item/reagent_containers/pill/stimulant(src)
 
 /obj/item/storage/pill_bottle/mining

--- a/code/modules/reagents/reagent_containers/pill.dm
+++ b/code/modules/reagents/reagent_containers/pill.dm
@@ -22,10 +22,17 @@
 	if(reagents.total_volume && roundstart)
 		name += " ([reagents.total_volume]u)"
 
-
 /obj/item/reagent_containers/pill/attack_self(mob/user)
 	return
 
+/obj/item/reagent_containers/pill/get_w_volume()
+	switch(reagents.total_volume)
+		if(0 to 9.5)
+			return 1
+		if(9.5 to 25)
+			return DEFAULT_VOLUME_TINY
+		else
+			return DEFAULT_VOLUME_SMALL
 
 /obj/item/reagent_containers/pill/attack(mob/M, mob/user, def_zone)
 	if(!canconsume(M, user))
@@ -137,14 +144,14 @@
 	name = "mannitol pill"
 	desc = "Used to treat brain damage."
 	icon_state = "pill17"
-	list_reagents = list(/datum/reagent/medicine/mannitol = 50)
+	list_reagents = list(/datum/reagent/medicine/mannitol = 25)
 	roundstart = 1
 
 /obj/item/reagent_containers/pill/mutadone
 	name = "mutadone pill"
 	desc = "Used to treat genetic damage."
 	icon_state = "pill20"
-	list_reagents = list(/datum/reagent/medicine/mutadone = 50)
+	list_reagents = list(/datum/reagent/medicine/mutadone = 25)
 	roundstart = 1
 
 /obj/item/reagent_containers/pill/salicyclic
@@ -186,14 +193,14 @@
 	name = "prussian blue pill"
 	desc = "Used to treat heavy radition poisoning."
 	icon_state = "prussian_blue"
-	list_reagents = list(/datum/reagent/medicine/prussian_blue = 25, /datum/reagent/water = 10)
+	list_reagents = list(/datum/reagent/medicine/prussian_blue = 25)
 	roundstart = 1
 
 /obj/item/reagent_containers/pill/mutarad
 	name = "radiation treatment deluxe pill"
 	desc = "Used to treat heavy radition poisoning and genetic defects."
 	icon_state = "anit_rad_fixgene"
-	list_reagents = list(/datum/reagent/medicine/prussian_blue = 15, /datum/reagent/medicine/potass_iodide = 15, /datum/reagent/medicine/mutadone = 15, /datum/reagent/water = 5)
+	list_reagents = list(/datum/reagent/medicine/prussian_blue = 10, /datum/reagent/medicine/potass_iodide = 10, /datum/reagent/medicine/mutadone = 5)
 	roundstart = 1
 
 ///////////////////////////////////////// this pill is used only in a legion mob drop
@@ -216,7 +223,7 @@
 
 /obj/item/reagent_containers/pill/lsd
 	name = "hallucinogen pill"
-	list_reagents = list(/datum/reagent/drug/mushroomhallucinogen = 15, /datum/reagent/toxin/mindbreaker = 15)
+	list_reagents = list(/datum/reagent/drug/mushroomhallucinogen = 12.5, /datum/reagent/toxin/mindbreaker = 12.5)
 
 
 /obj/item/reagent_containers/pill/aranesp


### PR DESCRIPTION
## About The Pull Request
Title. This means pill bottles will be able to fit as many as 14 9.5u pills and as few as 4 50u and 1 25u ones.

Adjusted most pills to fit within the 25u limit for their standard volume size (Pretty trivial, most of those pills contained easy reagents such as mannitol and mutadone). Otherwise reduced their numbers in a few pill bottles.

Patches are also affected by this because it turns out they are pill subtypes.

## Why It's Good For The Game
Tiny pill bottle tweak.

## Changelog
:cl:
add: Pill bottles now use volumetric storage.
balance: Pills and patches storage volume now varies with the amount of reagents they contain.
balance: Lowered the reagent amounts of a few pills so they can fit their respective pill bottles.
/:cl:
