### PR TITLE
Makes bloodsuckers unable to suck through thick clothing

### DIFF
--- a/code/modules/antagonists/bloodsucker/powers/feed.dm
+++ b/code/modules/antagonists/bloodsucker/powers/feed.dm
@@ -43,10 +43,19 @@
 				to_chat(owner, "<span class='warning'>Lesser beings require a tighter grip.</span>")
 			return FALSE
 		// Bloodsuckers:
-		else if(iscarbon(target) && target.mind && target.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER))
-			if(display_error)
-				to_chat(owner, "<span class='warning'>Other Bloodsuckers will not fall for your subtle approach.</span>")
-			return FALSE
+		else if(ishuman(target))
+			var/mob/living/carbon/human/H = target
+			var/arm_to_bite
+			if(prob(50))
+				arm_to_bite = BODY_ZONE_L_ARM
+			else
+				arm_to_bite = BODY_ZONE_R_ARM
+			if(!H.can_inject(owner, TRUE, arm_to_bite))
+				return FALSE
+			if(target.mind && target.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER))
+				if(display_error)
+					to_chat(owner, "<span class='warning'>Other Bloodsuckers will not fall for your subtle approach.</span>")
+				return FALSE
 	// Must have Target
 	if(!target)	 //  || !ismob(target)
 		if(display_error)
@@ -64,7 +73,6 @@
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
 		if(!H.can_inject(owner, TRUE, BODY_ZONE_HEAD)) //Cant suck through thick clothing.
-			to_chat(OWNER, "<span class='alert'>There is no exposed flesh or thin material [above_neck(target_zone) ? "on [p_their()] head" : "on [p_their()] body"].</span>")
 			return FALSE
 		if(NOBLOOD in H.dna.species.species_traits)// || owner.get_blood_id() != target.get_blood_id())
 			if(display_error)

--- a/code/modules/antagonists/bloodsucker/powers/feed.dm
+++ b/code/modules/antagonists/bloodsucker/powers/feed.dm
@@ -63,6 +63,9 @@
 		return FALSE
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
+		if(!H.can_inject(owner, TRUE, BODY_ZONE_HEAD)) //Cant suck through thick clothing.
+			to_chat(OWNER, "<span class='alert'>There is no exposed flesh or thin material [above_neck(target_zone) ? "on [p_their()] head" : "on [p_their()] body"].</span>")
+			return FALSE
 		if(NOBLOOD in H.dna.species.species_traits)// || owner.get_blood_id() != target.get_blood_id())
 			if(display_error)
 				to_chat(owner, "<span class='warning'>Your victim's blood is not suitable for you to take.</span>")

--- a/code/modules/antagonists/bloodsucker/powers/feed.dm
+++ b/code/modules/antagonists/bloodsucker/powers/feed.dm
@@ -45,12 +45,7 @@
 		// Bloodsuckers:
 		else if(ishuman(target))
 			var/mob/living/carbon/human/H = target
-			var/arm_to_bite
-			if(prob(50))
-				arm_to_bite = BODY_ZONE_L_ARM
-			else
-				arm_to_bite = BODY_ZONE_R_ARM
-			if(!H.can_inject(owner, TRUE, arm_to_bite))
+			if(!H.can_inject(owner, TRUE, BODY_ZONE_CHEST))
 				return FALSE
 			if(target.mind && target.mind.has_antag_datum(ANTAG_DATUM_BLOODSUCKER))
 				if(display_error)
@@ -72,7 +67,7 @@
 		return FALSE
 	if(ishuman(target))
 		var/mob/living/carbon/human/H = target
-		if(!H.can_inject(owner, TRUE, BODY_ZONE_HEAD)) //Cant suck through thick clothing.
+		if(!H.can_inject(owner, TRUE, BODY_ZONE_HEAD) && target == owner.pulling && owner.grab_state < GRAB_AGGRESSIVE)
 			return FALSE
 		if(NOBLOOD in H.dna.species.species_traits)// || owner.get_blood_id() != target.get_blood_id())
 			if(display_error)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Makes bloodsuckers unable to suck through hardsuit helmets or the such, if using aggresive sucking.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
It should be possible to protect against this, instead of their bites being able to pierce a solid hardsuit
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Bloodsuckers can no longer bite through hardsuits
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
