### PR TITLE
Makes bloodsuckers unguttable and undecappable

### DIFF
--- a/code/__DEFINES/traits.dm
+++ b/code/__DEFINES/traits.dm
@@ -147,6 +147,8 @@
 #define TRAIT_NORUNNING			"norunning"		// You walk!
 #define TRAIT_NOMARROW			"nomarrow"		// You don't make blood, with chemicals or nanites.
 #define TRAIT_NOPULSE			"nopulse"		// Your heart doesn't beat.
+#define TRAIT_NOGUT				"nogutting"		//Your chest cant be gutted of organs
+#define TRAIT_NODECAP			"nodecapping"	//Your head cant be cut off in combat
 #define TRAIT_EXEMPT_HEALTH_EVENTS	"exempt-health-events"
 #define TRAIT_NO_MIDROUND_ANTAG	"no-midround-antag" //can't be turned into an antag by random events
 #define TRAIT_PUGILIST	"pugilist" //This guy punches people for a living

--- a/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
+++ b/code/modules/antagonists/bloodsucker/datum_bloodsucker.dm
@@ -39,7 +39,7 @@
 	var/passive_blood_drain = -0.1        //The amount of blood we loose each bloodsucker life() tick
 	// LISTS
 	var/static/list/defaultTraits = list (TRAIT_STABLEHEART, TRAIT_NOBREATH, TRAIT_SLEEPIMMUNE, TRAIT_NOCRITDAMAGE, TRAIT_RESISTCOLD, TRAIT_RADIMMUNE, TRAIT_NIGHT_VISION, \
-										  TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_AGEUSIA, TRAIT_COLDBLOODED, TRAIT_NONATURALHEAL, TRAIT_NOMARROW, TRAIT_NOPULSE, TRAIT_VIRUSIMMUNE)
+										  TRAIT_NOSOFTCRIT, TRAIT_NOHARDCRIT, TRAIT_AGEUSIA, TRAIT_COLDBLOODED, TRAIT_NONATURALHEAL, TRAIT_NOMARROW, TRAIT_NOPULSE, TRAIT_VIRUSIMMUNE, TRAIT_NODECAP, TRAIT_NOGUT)
 
 /datum/antagonist/bloodsucker/on_gain()
 	SSticker.mode.bloodsuckers |= owner // Add if not already in here (and you might be, if you were picked at round start)

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -44,7 +44,7 @@
 	return TRUE
 
 /obj/item/bodypart/head/dismember()
-	if(HAS_TRAIT(C, TRAIT_NODECAP))
+	if(HAS_TRAIT(owner, TRAIT_NODECAP))
 		return FALSE
 	..()
 
@@ -56,7 +56,7 @@
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
 		return FALSE
-	if(HAS_TRAIT(C. TRAIT_NOGUT)) //Just for not allowing gutting
+	if(HAS_TRAIT(C, TRAIT_NOGUT)) //Just for not allowing gutting
 		return FALSE
 	. = list()
 	var/organ_spilled = 0

--- a/code/modules/surgery/bodyparts/dismemberment.dm
+++ b/code/modules/surgery/bodyparts/dismemberment.dm
@@ -14,7 +14,6 @@
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
 		return FALSE
-
 	var/obj/item/bodypart/affecting = C.get_bodypart(BODY_ZONE_CHEST)
 	affecting.receive_damage(clamp(brute_dam/2 * affecting.body_damage_coeff, 15, 50), clamp(burn_dam/2 * affecting.body_damage_coeff, 0, 50)) //Damage the chest based on limb's existing damage
 	C.visible_message("<span class='danger'><B>[C]'s [src.name] has been violently dismembered!</B></span>")
@@ -44,6 +43,10 @@
 	throw_at(target_turf, throw_range, throw_speed)
 	return TRUE
 
+/obj/item/bodypart/head/dismember()
+	if(HAS_TRAIT(C, TRAIT_NODECAP))
+		return FALSE
+	..()
 
 /obj/item/bodypart/chest/dismember()
 	if(!owner)
@@ -52,6 +55,8 @@
 	if(!dismemberable)
 		return FALSE
 	if(HAS_TRAIT(C, TRAIT_NODISMEMBER))
+		return FALSE
+	if(HAS_TRAIT(C. TRAIT_NOGUT)) //Just for not allowing gutting
 		return FALSE
 	. = list()
 	var/organ_spilled = 0


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR adds a few traits that allow for bloodsuckers to not be gutted and beheaded, as to allow for stakes to be somehow usefull, and so that they cant be killed instantly on the spot, the reason i dont use the no dismember trait is because i want it to be possible to take their limbs off still.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Whats the point of having stakes if you can just kill bloodsuckers with any kind of knife?
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
tweak: Cant behead or gut bloodsuckers anymore.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
I considered making them able to regenerate these parts but that would be a bit too similar to a changeling
This will make confirming kills neccesary, as before people would often simply gut them and instantly kill them.