### PR TITLE
Removing duplicate total item attack force modifiers.

### DIFF
--- a/code/modules/mob/living/carbon/carbon_defense.dm
+++ b/code/modules/mob/living/carbon/carbon_defense.dm
@@ -78,12 +78,6 @@
 
 /mob/living/carbon/attacked_by(obj/item/I, mob/living/user)
 	var/totitemdamage = pre_attacked_by(I, user)
-	if(!(user.combat_flags & COMBAT_FLAG_COMBAT_ACTIVE))
-		totitemdamage *= 0.5
-	if(!CHECK_MOBILITY(user, MOBILITY_STAND))
-		totitemdamage *= 0.5
-	if(!(combat_flags & COMBAT_FLAG_COMBAT_ACTIVE))
-		totitemdamage *= 1.5
 	var/impacting_zone = (user == src)? check_zone(user.zone_selected) : ran_zone(user.zone_selected)
 	if((user != src) && (mob_run_block(I, totitemdamage, "the [I]", ATTACK_TYPE_MELEE, I.armour_penetration, user, impacting_zone, null) & BLOCK_SUCCESS))
 		return FALSE


### PR DESCRIPTION
## About The Pull Request
Title, this applies for monkeys and xenos, species code handles it for humans.

## Why It's Good For The Game
Stops xeno/monkeys from only receiving 0.25x/0.06125x the damage when the attacker is resting or/and not in combat mode.

## Changelog
:cl:
fix: Monkey/xeno fix for item attack damage.
/:cl:
