### PR TITLE
Fixing an issue with the wooden barricades / wood sheets interaction

### DIFF
--- a/code/game/machinery/deployable.dm
+++ b/code/game/machinery/deployable.dm
@@ -70,14 +70,13 @@
 		if(W.amount < 5)
 			to_chat(user, "<span class='warning'>You need at least five wooden planks to make a wall!</span>")
 			return
-		else
-			to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
-			if(do_after(user, 50, target=src))
-				W.use(5)
-				var/turf/T = get_turf(src)
-				T.PlaceOnTop(/turf/closed/wall/mineral/wood/nonmetal)
-				qdel(src)
-				return
+		to_chat(user, "<span class='notice'>You start adding [I] to [src]...</span>")
+		if(do_after(user, 50, target=src))
+			W.use(5)
+			var/turf/T = get_turf(src)
+			T.PlaceOnTop(/turf/closed/wall/mineral/wood/nonmetal)
+			qdel(src)
+		return
 	return ..()
 
 


### PR DESCRIPTION
## About The Pull Request
Moving the return line for trying to make a wood wall on a wooden barricade one tab left so it doesn't end up actually attacking the wood barricade if the do_after sequence fails.

## Why It's Good For The Game
Fixing a little issue.

## Changelog
:cl:
fix: Fixing an issue with the wooden barricades / wood sheets interaction.
/:cl:
