### PR TITLE
Fixing some blindness stuff and visible messages.

### DIFF
--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -197,34 +197,32 @@ SLIME SCANNER
 			var/obj/item/organ/O = organ
 
 			//EYES
-			if(istype(O, /obj/item/organ/eyes))
+			if(istype(O, /obj/item/organ/eyes) && advanced)
 				var/obj/item/organ/eyes/eyes = O
-				if(advanced)
-					if(HAS_TRAIT(C, TRAIT_BLIND))
-						temp_message += " <span class='alert'>Subject is blind.</span>"
-					if(HAS_TRAIT(C, TRAIT_NEARSIGHT))
-						temp_message += " <span class='alert'>Subject is nearsighted.</span>"
-					if(eyes.damage > 30)
-						damage_message += " <span class='alert'>Subject has severe eye damage.</span>"
-					else if(eyes.damage > 20)
-						damage_message += " <span class='alert'>Subject has significant eye damage.</span>"
-					else if(eyes.damage)
-						damage_message += " <span class='alert'>Subject has minor eye damage.</span>"
+				if(HAS_TRAIT_NOT_FROM(C, TRAIT_BLIND, EYES_COVERED))
+					temp_message += " <span class='alert'>Subject is blind.</span>"
+				if(HAS_TRAIT_NOT_FROM(C, TRAIT_NEARSIGHT, EYES_COVERED))
+					temp_message += " <span class='alert'>Subject is nearsighted.</span>"
+				if(eyes.damage > 30)
+					damage_message += " <span class='alert'>Subject has severe eye damage.</span>"
+				else if(eyes.damage > 20)
+					damage_message += " <span class='alert'>Subject has significant eye damage.</span>"
+				else if(eyes.damage)
+					damage_message += " <span class='alert'>Subject has minor eye damage.</span>"
 
 
 			//EARS
-			else if(istype(O, /obj/item/organ/ears))
+			else if(istype(O, /obj/item/organ/ears) && advanced)
 				var/obj/item/organ/ears/ears = O
-				if(advanced)
-					if(HAS_TRAIT_FROM(C, TRAIT_DEAF, GENETIC_MUTATION))
-						temp_message += " <span class='alert'>Subject is genetically deaf.</span>"
-					else if(HAS_TRAIT(C, TRAIT_DEAF))
-						temp_message += " <span class='alert'>Subject is deaf.</span>"
-					else
-						if(ears.damage)
-							damage_message += " <span class='alert'>Subject has [ears.damage > ears.maxHealth ? "permanent ": "temporary "]hearing damage.</span>"
-						if(ears.deaf)
-							damage_message += " <span class='alert'>Subject is [ears.damage > ears.maxHealth ? "permanently ": "temporarily "] deaf.</span>"
+				if(HAS_TRAIT_FROM(C, TRAIT_DEAF, GENETIC_MUTATION))
+					temp_message += " <span class='alert'>Subject is genetically deaf.</span>"
+				else if(HAS_TRAIT(C, TRAIT_DEAF))
+					temp_message += " <span class='alert'>Subject is deaf.</span>"
+				else
+					if(ears.damage)
+						damage_message += " <span class='alert'>Subject has [ears.damage > ears.maxHealth ? "permanent ": "temporary "]hearing damage.</span>"
+					if(ears.deaf)
+						damage_message += " <span class='alert'>Subject is [ears.damage > ears.maxHealth ? "permanently ": "temporarily "] deaf.</span>"
 
 
 			//BRAIN

--- a/code/game/objects/items/devices/scanners.dm
+++ b/code/game/objects/items/devices/scanners.dm
@@ -197,32 +197,34 @@ SLIME SCANNER
 			var/obj/item/organ/O = organ
 
 			//EYES
-			if(istype(O, /obj/item/organ/eyes) && advanced)
+			if(istype(O, /obj/item/organ/eyes))
 				var/obj/item/organ/eyes/eyes = O
-				if(HAS_TRAIT_NOT_FROM(C, TRAIT_BLIND, EYES_COVERED))
-					temp_message += " <span class='alert'>Subject is blind.</span>"
-				if(HAS_TRAIT_NOT_FROM(C, TRAIT_NEARSIGHT, EYES_COVERED))
-					temp_message += " <span class='alert'>Subject is nearsighted.</span>"
-				if(eyes.damage > 30)
-					damage_message += " <span class='alert'>Subject has severe eye damage.</span>"
-				else if(eyes.damage > 20)
-					damage_message += " <span class='alert'>Subject has significant eye damage.</span>"
-				else if(eyes.damage)
-					damage_message += " <span class='alert'>Subject has minor eye damage.</span>"
+				if(advanced)
+					if(HAS_TRAIT(C, TRAIT_BLIND))
+						temp_message += " <span class='alert'>Subject is blind.</span>"
+					if(HAS_TRAIT(C, TRAIT_NEARSIGHT))
+						temp_message += " <span class='alert'>Subject is nearsighted.</span>"
+					if(eyes.damage > 30)
+						damage_message += " <span class='alert'>Subject has severe eye damage.</span>"
+					else if(eyes.damage > 20)
+						damage_message += " <span class='alert'>Subject has significant eye damage.</span>"
+					else if(eyes.damage)
+						damage_message += " <span class='alert'>Subject has minor eye damage.</span>"
 
 
 			//EARS
-			else if(istype(O, /obj/item/organ/ears) && advanced)
+			else if(istype(O, /obj/item/organ/ears))
 				var/obj/item/organ/ears/ears = O
-				if(HAS_TRAIT_FROM(C, TRAIT_DEAF, GENETIC_MUTATION))
-					temp_message += " <span class='alert'>Subject is genetically deaf.</span>"
-				else if(HAS_TRAIT(C, TRAIT_DEAF))
-					temp_message += " <span class='alert'>Subject is deaf.</span>"
-				else
-					if(ears.damage)
-						damage_message += " <span class='alert'>Subject has [ears.damage > ears.maxHealth ? "permanent ": "temporary "]hearing damage.</span>"
-					if(ears.deaf)
-						damage_message += " <span class='alert'>Subject is [ears.damage > ears.maxHealth ? "permanently ": "temporarily "] deaf.</span>"
+				if(advanced)
+					if(HAS_TRAIT_FROM(C, TRAIT_DEAF, GENETIC_MUTATION))
+						temp_message += " <span class='alert'>Subject is genetically deaf.</span>"
+					else if(HAS_TRAIT(C, TRAIT_DEAF))
+						temp_message += " <span class='alert'>Subject is deaf.</span>"
+					else
+						if(ears.damage)
+							damage_message += " <span class='alert'>Subject has [ears.damage > ears.maxHealth ? "permanent ": "temporary "]hearing damage.</span>"
+						if(ears.deaf)
+							damage_message += " <span class='alert'>Subject is [ears.damage > ears.maxHealth ? "permanently ": "temporarily "] deaf.</span>"
 
 
 			//BRAIN

--- a/code/modules/mob/living/carbon/alien/larva/life.dm
+++ b/code/modules/mob/living/carbon/alien/larva/life.dm
@@ -24,12 +24,12 @@
 				if(!eye_blind)
 					blind_eyes(1)
 				update_mobility()
-		else
-			if(stat == UNCONSCIOUS)
-				stat = CONSCIOUS
-				if(!(combat_flags & COMBAT_FLAG_HARD_STAMCRIT))
-					set_resting(FALSE, TRUE)
+		else if(stat == UNCONSCIOUS)
+			stat = CONSCIOUS
+			if(!(combat_flags & COMBAT_FLAG_HARD_STAMCRIT))
+				set_resting(FALSE, TRUE)
+			if(eye_blind <= 1)
 				adjust_blindness(-1)
-				update_mobility()
+			update_mobility()
 	update_damage_hud()
 	update_health_hud()

--- a/code/modules/mob/living/carbon/carbon.dm
+++ b/code/modules/mob/living/carbon/carbon.dm
@@ -837,7 +837,8 @@
 				disable_intentional_combat_mode(FALSE, FALSE)
 			else
 				stat = CONSCIOUS
-			adjust_blindness(-1)
+			if(eye_blind <= 1)
+				adjust_blindness(-1)
 		update_mobility()
 	update_damage_hud()
 	update_health_hud()

--- a/code/modules/mob/living/status_procs.dm
+++ b/code/modules/mob/living/status_procs.dm
@@ -571,12 +571,13 @@
 /mob/living/proc/cure_blind(source)
 	REMOVE_TRAIT(src, TRAIT_BLIND, source)
 	if(!HAS_TRAIT(src, TRAIT_BLIND))
-		update_blindness()
+		if(eye_blind <= 1) //little hack now that we don't actively check for trait and unconsciousness on update_blindness.
+			adjust_blindness(-1)
 
 /mob/living/proc/become_blind(source)
 	if(!HAS_TRAIT(src, TRAIT_BLIND)) // not blind already, add trait then overlay
 		ADD_TRAIT(src, TRAIT_BLIND, source)
-		update_blindness()
+		blind_eyes(1)
 	else
 		ADD_TRAIT(src, TRAIT_BLIND, source)
 

--- a/code/modules/mob/mob.dm
+++ b/code/modules/mob/mob.dm
@@ -128,15 +128,13 @@
   * * target (optional) is the other mob involved with the visible message. For example, the attacker in many combat messages.
   * * target_message (optional) is what the target mob will see e.g. "[src] does something to you!"
   */
-/atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, list/ignored_mobs, mob/target, target_message)
+/atom/proc/visible_message(message, self_message, blind_message, vision_distance = DEFAULT_MESSAGE_RANGE, ignored_mobs, mob/target, target_message)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
 	var/list/hearers = get_hearers_in_view(vision_distance, src) //caches the hearers and then removes ignored mobs.
 	if(!length(hearers))
 		return
-	if(!islist(ignored_mobs))
-		ignored_mobs = list(ignored_mobs)
 	hearers -= ignored_mobs
 
 	if(target_message && target && istype(target) && target.client)
@@ -150,7 +148,7 @@
 			msg = blind_message
 		if(msg)
 			target.show_message(msg, MSG_VISUAL,blind_message, MSG_AUDIBLE)
-	else if(self_message)
+	if(self_message)
 		hearers -= src
 	for(var/mob/M in hearers)
 		if(!M.client)
@@ -185,15 +183,13 @@ mob/visible_message(message, self_message, blind_message, vision_distance = DEFA
   * * hearing_distance (optional) is the range, how many tiles away the message can be heard.
   * * ignored_mobs (optional) doesn't show any message to any given mob in the list.
   */
-/atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, list/ignored_mobs)
+/atom/proc/audible_message(message, deaf_message, hearing_distance = DEFAULT_MESSAGE_RANGE, self_message, ignored_mobs)
 	var/turf/T = get_turf(src)
 	if(!T)
 		return
 	var/list/hearers = get_hearers_in_view(hearing_distance, src)
 	if(!length(hearers))
 		return
-	if(!islist(ignored_mobs))
-		ignored_mobs = list(ignored_mobs)
 	hearers -= ignored_mobs
 	if(self_message)
 		hearers -= src

--- a/code/modules/mob/status_procs.dm
+++ b/code/modules/mob/status_procs.dm
@@ -23,9 +23,9 @@
   * Sets a mob's blindness to an amount if it was not above it already, similar to how status effects work
   */
 /mob/proc/blind_eyes(amount)
-	var/old_blind = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
-	eye_blind = max(eye_blind, amount)
-	var/new_blind = eye_blind || HAS_TRAIT(src, TRAIT_BLIND)
+	var/old_blind = eye_blind
+	eye_blind = max((!eye_blind && stat == UNCONSCIOUS || HAS_TRAIT(src, TRAIT_BLIND)) ? 1 : eye_blind , amount)
+	var/new_blind = eye_blind
 	if(old_blind != new_blind)
 		update_blindness()
 
@@ -36,21 +36,21 @@
   */
 /mob/proc/adjust_blindness(amount)
 	var/old_eye_blind = eye_blind
-	eye_blind = max(0, eye_blind + amount)
-	if(!old_eye_blind || !eye_blind && !HAS_TRAIT(src, TRAIT_BLIND))
+	eye_blind = max((stat == UNCONSCIOUS || HAS_TRAIT(src, TRAIT_BLIND)) ? 1 : 0, eye_blind + amount)
+	if(!old_eye_blind || !eye_blind)
 		update_blindness()
 /**
   * Force set the blindness of a mob to some level
   */
 /mob/proc/set_blindness(amount)
 	var/old_eye_blind = eye_blind
-	eye_blind = max(amount, 0)
-	if(!old_eye_blind || !eye_blind && !HAS_TRAIT(src, TRAIT_BLIND))
+	eye_blind = max(amount, (stat == UNCONSCIOUS || HAS_TRAIT(src, TRAIT_BLIND)) ? 1 : 0)
+	if(!old_eye_blind || !eye_blind)
 		update_blindness()
 
 /// proc that adds and removes blindness overlays when necessary
 /mob/proc/update_blindness()
-	if(stat == UNCONSCIOUS || HAS_TRAIT(src, TRAIT_BLIND) || eye_blind) // UNCONSCIOUS or has blind trait, or has temporary blindness
+	if(eye_blind) // UNCONSCIOUS or has blind trait, or has temporary blindness
 		if(stat == CONSCIOUS || stat == SOFT_CRIT)
 			throw_alert("blind", /obj/screen/alert/blind)
 		overlay_fullscreen("blind", /obj/screen/fullscreen/blind)


### PR DESCRIPTION
## About The Pull Request
When kevinz tried to fix blindness edge cases, I knew they didn't fix the several eye_blind and is_blind() checks, yet I were too cynic to tell him, also knowing they'd added unconsciousness and blindness trait checks to the `is_blind` proc, which I frankly believe is a more inefficient solution.

Also removed an `else` statement from `visible_message()` which caused `src` to received both `self_message` and `message` for several mob to mob interaction messages.

## Why It's Good For The Game
Fixing some stuff. This will close #11735.

## Changelog
:cl:
fix: Fixing some blindness stuff and visible messages.
/:cl:
