### PR TITLE
Allows police batons to be used in combat in none-lethal ways

### DIFF
--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -243,6 +243,14 @@
 		return
 	return
 
+/obj/item/melee/classic_baton/examine(mob/user)
+	. = ..()
+		. += "<span class='notice'>[src] can be alt clicked to swap from brute damage to stamina damage or vis versa.</span>"
+	if(damtype == "brute")
+		. += "<span class='notice'>[src] is being used in a lethal manner.</span>"
+	if(damtype == STAMINA)
+		. += "<span class='notice'>[src] is being used in a non-lethal manner.</span>"
+
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()
 	return

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -235,20 +235,20 @@
 	. = ..()
 	if(damtype == "brute")
 		damtype = STAMINA
-		user.visible_message("<span class='notice'>[user] welds the [src] is a non-lethal way.</span>")
+		user.visible_message("<span class='notice'>[user] wields the [src] is a non-lethal way.</span>")
 		return
 	if(damtype == STAMINA)
 		damtype = "brute"
-		user.visible_message("<span class='warning'>[user] welds the [src] is a lethal way!</span>")
+		user.visible_message("<span class='warning'>[user] wields the [src] is a lethal way!</span>")
 		return
 	return
 
 /obj/item/melee/classic_baton/examine(mob/user)
 	. = ..()
 	if(damtype == "brute")
-		. += "<span class='notice'>[src] is being used in a lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vis versa.</span>"
+		. += "<span class='notice'>[src] is being used in a lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vice versa.</span>"
 	if(damtype == STAMINA)
-		. += "<span class='notice'>[src] is being used in a non-lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vis versa.</span>"
+		. += "<span class='notice'>[src] is being used in a non-lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vice versa.</span>"
 
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -230,6 +230,19 @@
 /obj/item/melee/classic_baton/Initialize()
 	. = ..()
 
+// For when we want to swap from Brute damage to Staminda and vise versa
+/obj/item/melee/classic_baton/AltClick(mob/user)
+	. = ..()
+	if(damtype == "brute")
+		damtype = STAMINA
+		user.visible_message("<span class='notice'>[user] welds the [src] is a non-lethal way.</span>")
+		return
+	if(damtype == STAMINA)
+		damtype = "brute"
+		user.visible_message("<span class='warning'>[user] welds the [src] is a lethal way!</span>")
+		return
+	return
+
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()
 	return

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -235,11 +235,11 @@
 	. = ..()
 	if(damtype == "brute")
 		damtype = STAMINA
-		user.visible_message("<span class='notice'>[user] wields the [src] is a non-lethal way.</span>")
+		user.visible_message("<span class='notice'>[user] wields the [src] in a non-lethal way.</span>")
 		return
 	if(damtype == STAMINA)
 		damtype = "brute"
-		user.visible_message("<span class='warning'>[user] wields the [src] is a lethal way!</span>")
+		user.visible_message("<span class='warning'>[user] wields the [src] in a lethal way!</span>")
 		return
 	return
 
@@ -248,7 +248,7 @@
 	if(damtype == "brute")
 		. += "<span class='notice'>[src] is being used in a lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vice versa.</span>"
 	if(damtype == STAMINA)
-		. += "<span class='notice'>[src] is being used in a non-lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vice versa.</span>"
+		. += "<span class='notice'>[src] is being used in a non-lethal manner. [src] can be alt clicked to swap from stamina damage to brute damage or vice versa.</span>"
 
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -230,7 +230,7 @@
 /obj/item/melee/classic_baton/Initialize()
 	. = ..()
 
-// For when we want to swap from Brute damage to Staminda and vise versa
+// For when we want to swap from Brute damage to Stamina and vise versa
 /obj/item/melee/classic_baton/AltClick(mob/user)
 	. = ..()
 	if(damtype == "brute")

--- a/code/game/objects/items/melee/misc.dm
+++ b/code/game/objects/items/melee/misc.dm
@@ -245,11 +245,10 @@
 
 /obj/item/melee/classic_baton/examine(mob/user)
 	. = ..()
-		. += "<span class='notice'>[src] can be alt clicked to swap from brute damage to stamina damage or vis versa.</span>"
 	if(damtype == "brute")
-		. += "<span class='notice'>[src] is being used in a lethal manner.</span>"
+		. += "<span class='notice'>[src] is being used in a lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vis versa.</span>"
 	if(damtype == STAMINA)
-		. += "<span class='notice'>[src] is being used in a non-lethal manner.</span>"
+		. += "<span class='notice'>[src] is being used in a non-lethal manner. [src] can be alt clicked to swap from brute damage to stamina damage or vis versa.</span>"
 
 // Description for trying to stun when still on cooldown.
 /obj/item/melee/classic_baton/proc/get_wait_description()


### PR DESCRIPTION
## About The Pull Request
You can now alt click a police baton to go from brute damage to stamina damage and vis versa

## Why It's Good For The Game

Adds more to the combat system then just waiting for your non-lethal cool down to reset, helps with non-escalation force and more!

## Changelog
:cl:
add: Alt clicking police and telescoping batons swap from stamina damage to brute and vis versa in melee combat
/:cl:
