### PR TITLE
Fix: Radiation Shutters

### DIFF
--- a/code/game/machinery/doors/shutters.dm
+++ b/code/game/machinery/doors/shutters.dm
@@ -53,7 +53,9 @@
 		if("opening")
 			rad_insulation = 1
 		if("closing")
-			rad_insulation = 0.2
+			rad_insulation = -0.5
+
+// A 3x3 N2 SM setup won't irradiate you if you're behind the shutter at -0.9 insulation. If it starts to delam, it'll start irradiating you slowly. Keep the value between -0.1 to -0.9
 
 /obj/machinery/door/poddoor/shutters/window
 	name = "windowed shutters"


### PR DESCRIPTION
## About The Pull Request
Changes rad_insulation from 0.2 to -0.5; this makes them actually do shit.
Don't worry, this is only really going to protect you from something like a N2 3x3 SM build if you're directly behind the shutter. Even then, you should take a few rads.

## Why It's Good For The Game
Makes radiation shutters go from being purely cosmetic to functional.
It stops people from being mislead into thinking the shutters actually work.

## Changelog
:cl:
fix: Fixes Radiation Shutters to actually start blocking radiation. Doesn't block all radiation, so don't think you're safe from a delaminating crystal.
/:cl: