### PR TITLE
Skewers no longer cause deadchat spam

### DIFF
--- a/code/modules/antagonists/clockcult/clock_structures/traps/brass_skewer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/traps/brass_skewer.dm
@@ -113,7 +113,7 @@
 		"<span class='danger'>You start tenderly lifting [skewee] off of [src]...</span>")
 		if(!do_after(user, 60, target = skewee))
 			skewee.visible_message("<span class='warning'>[skewee] painfully slides back down [src].</span>")
-			if(skewee.stat == DEAD)
+			if(skewee.stat >= UNCONSCIOUS)
 				return //by ratvar, no more spamming my deadchat, holy fuck
 			skewee.say("Oof, ouch owwie!!", forced = "fail brass skewer removal")
 			return

--- a/code/modules/antagonists/clockcult/clock_structures/traps/brass_skewer.dm
+++ b/code/modules/antagonists/clockcult/clock_structures/traps/brass_skewer.dm
@@ -113,6 +113,8 @@
 		"<span class='danger'>You start tenderly lifting [skewee] off of [src]...</span>")
 		if(!do_after(user, 60, target = skewee))
 			skewee.visible_message("<span class='warning'>[skewee] painfully slides back down [src].</span>")
+			if(skewee.stat == DEAD)
+				return //by ratvar, no more spamming my deadchat, holy fuck
 			skewee.say("Oof, ouch owwie!!", forced = "fail brass skewer removal")
 			return
 	skewee.visible_message("<span class='danger'>[skewee] comes free of [src] with a squelching pop!</span>", \


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
The forced speech from the skewer triggered even if the skewee was dead, causing immense amounts of deadchat spam if someone repeatedly failed lifting someone else of a skewer. This fixes that issue.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
.. do I really need to elaborate?
Fix man good.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Skewer-freeing-fail no longer forces speech if the skewee is dead.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
