### PR TITLE
Slight simple mob boss improvements.

### DIFF
--- a/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
@@ -2,15 +2,16 @@
 	name = "A Perfectly Generic Boss Placeholder"
 	desc = ""
 	threat = 10
-	robust_searching = 1
+	robust_searching = TRUE
 	stat_attack = UNCONSCIOUS
-	status_flags = 0
+	status_flags = NONE
 	a_intent = INTENT_HARM
 	gender = NEUTER
 	has_field_of_vision = FALSE //You are a frikkin boss
 	var/list/boss_abilities = list() //list of /datum/action/boss
 	var/datum/boss_active_timed_battle/atb
-	var/point_regen_delay = 1
+	var/point_regen_delay = 20
+	var/point_regen_amount = 1
 
 
 /mob/living/simple_animal/hostile/boss/Initialize()
@@ -18,6 +19,7 @@
 
 	atb = new()
 	atb.point_regen_delay = point_regen_delay
+	atb.point_regen_amount = point_regen_amount
 	atb.boss = src
 
 	for(var/ab in boss_abilities)
@@ -40,6 +42,7 @@
 	required_mobility_flags = NONE
 	var/boss_cost = 100 //Cost of usage for the boss' AI 1-100
 	var/usage_probability = 100
+	var/list/req_statuses //If set, will only trigger if the mob AI status is present in this list.
 	var/mob/living/simple_animal/hostile/boss/boss
 	var/boss_type = /mob/living/simple_animal/hostile/boss
 	var/needs_target = TRUE //Does the boss need to have a target? (Only matters for the AI)
@@ -57,7 +60,7 @@
 	. = ..()
 	boss = null
 
-/datum/action/boss/Trigger()
+/datum/action/boss/IsAvailable(silent = FALSE)
 	. = ..()
 	if(!.)
 		return
@@ -69,6 +72,11 @@
 		return FALSE
 	if(!boss.client && needs_target && !boss.target)
 		return FALSE
+
+/datum/action/boss/Trigger()
+	. = ..()
+	if(!.)
+		return
 	if(!boss.atb.spend(boss_cost))
 		return FALSE
 	if(say_when_triggered)
@@ -85,7 +93,8 @@
 //Designed for boss mobs only
 /datum/boss_active_timed_battle
 	var/list/abilities //a list of /datum/action/boss owned by a boss mob
-	var/point_regen_delay = 5
+	var/point_regen_delay = 20
+	var/point_regen_amount = 1
 	var/max_points = 100
 	var/points = 50 //start with 50 so we can use some abilities but not insta-buttfug somebody
 	var/next_point_time = 0
@@ -93,48 +102,45 @@
 	var/highest_cost = 0
 	var/mob/living/simple_animal/hostile/boss/boss
 
-
 /datum/boss_active_timed_battle/New()
 	..()
 	START_PROCESSING(SSobj, src)
 
-
 /datum/boss_active_timed_battle/proc/assign_abilities(list/L)
 	if(!L)
-		return 0
+		return FALSE
 	abilities = L
 	for(var/ab in abilities)
 		var/datum/action/boss/AB = ab
 		if(AB.boss_cost > highest_cost)
 			highest_cost = AB.boss_cost
 
-
 /datum/boss_active_timed_battle/proc/spend(cost)
 	if(cost <= points)
-		points = max(0,points-cost)
+		points -= cost
 		return TRUE
 	return FALSE
-
 
 /datum/boss_active_timed_battle/proc/refund(cost)
 	points = min(points+cost, max_points)
 
-
 /datum/boss_active_timed_battle/process()
 	if(world.time >= next_point_time && points < max_points)
 		next_point_time = world.time + point_regen_delay
-		points = min(max_points, ++points) //has to be out of 100
+		points = min(max_points, points + point_regen_amount)
 
-	if(abilities)
-		chance_to_hold_onto_points = highest_cost*0.5
-		if(points != max_points && prob(chance_to_hold_onto_points))
-			return //Let's save our points for a better ability (unless we're at max points, in which case we can't save anymore!)
-		if(!boss.client)
-			abilities = shuffle(abilities)
-			for(var/ab in abilities)
-				var/datum/action/boss/AB = ab
-				if(prob(AB.usage_probability) && AB.Trigger())
-					break
+	if(!abilities)
+		return
+	chance_to_hold_onto_points = highest_cost*0.5
+	if(points != max_points && prob(chance_to_hold_onto_points))
+		return //Let's save our points for a better ability (unless we're at max points, in which case we can't save anymore!)
+	if(!boss.client)
+		abilities = shuffle(abilities)
+	for(var/ab in abilities)
+		var/datum/action/boss/AB = ab
+		if(!boss.client && (!AB.req_statuses || (boss.AIstatus in AB.req_statuses)) && prob(AB.usage_probability) && AB.Trigger())
+			break
+		AB.UpdateButtonIcon(TRUE)
 
 
 /datum/boss_active_timed_battle/Destroy()

--- a/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/boss.dm
@@ -138,7 +138,7 @@
 		abilities = shuffle(abilities)
 	for(var/ab in abilities)
 		var/datum/action/boss/AB = ab
-		if(!boss.client && (!AB.req_statuses || (boss.AIstatus in AB.req_statuses)) && prob(AB.usage_probability) && AB.Trigger())
+		if(!boss.client && (!AB.req_statuses || (boss.AIStatus in AB.req_statuses)) && prob(AB.usage_probability) && AB.Trigger())
 			break
 		AB.UpdateButtonIcon(TRUE)
 

--- a/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
+++ b/code/modules/mob/living/simple_animal/hostile/bosses/paperwizard.dm
@@ -36,6 +36,7 @@
 	boss_cost = 30
 	boss_type = /mob/living/simple_animal/hostile/boss/paper_wizard
 	needs_target = FALSE
+	req_statuses = list(AI_ON)
 	say_when_triggered = "Rise, my creations! Jump off your pages and into this realm!"
 	var/list/summoned_minions = list()
 	var/maximum_stickmen = 6
@@ -85,6 +86,7 @@
 	usage_probability = 30
 	boss_cost = 40
 	boss_type = /mob/living/simple_animal/hostile/boss/paper_wizard
+	req_statuses = list(AI_ON)
 	say_when_triggered = ""
 
 /datum/action/boss/wizard_mimic/Trigger()


### PR DESCRIPTION
## About The Pull Request
Title. Paper wiz abilities are only triggered when the mob AIStatus is on. Added atb regen amount variables, and made the default regen delay match the SSobj wait time since it can't go any faster.
Moved a few `datum/action/boss` `Trigger()` checks to `IsAvailable()` and made their icons update each process.

## Why It's Good For The Game
Improving the old boss archetype object.

## Changelog
:cl:
code: Slight simple mob boss (not to confused with megafauna or lavaland elite) improvements.
/:cl:
