### PR TITLE
Moves decal painting from BEPIS into venders

### DIFF
--- a/code/modules/research/bepis.dm
+++ b/code/modules/research/bepis.dm
@@ -33,8 +33,8 @@
 	var/inaccuracy_percentage = 1.5
 	var/positive_cash_offset = 0
 	var/negative_cash_offset = 0
-	var/minor_rewards = list(/obj/item/stack/circuit_stack/full,	//To add a new minor reward, add it here.
-					/obj/item/airlock_painter/decal,
+	var/minor_rewards = list(/obj/item/stack/circuit_stack/full, //To add a new minor reward, add it here.
+					/obj/item/flashlight/flashdark,
 					/obj/item/pen/survival,
 					/obj/item/circuitboard/machine/sleeper/party,
 					/obj/item/toy/sprayoncan)

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -14,7 +14,8 @@
 					/obj/item/stock_parts/cell/upgraded = 2)
 	premium = list(/obj/item/stock_parts/cell/upgraded/plus = 2,
 					/obj/item/flashlight/lantern = 2,
-					/obj/item/beacon = 2)
+					/obj/item/beacon = 2,
+					/obj/item/airlock_painter/decal = 5)
 	product_ads = "Only the finest!;Have some tools.;The most robust equipment.;The finest gear in space!"
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/assist

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -15,6 +15,7 @@
 					/obj/item/electronics/airalarm = 10,
 					/obj/item/electronics/firealarm = 10,
 					/obj/item/electronics/firelock = 10,
+					/obj/item/airlock_painter/decal = 5,
 					/obj/item/rcd_ammo = 3
 					)
 	contraband = list(/obj/item/stock_parts/cell/potato = 3,

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -18,7 +18,8 @@
 					/obj/item/clothing/gloves/color/fyellow = 4,
 					/obj/item/multitool = 2)
 	premium = list(/obj/item/clothing/gloves/color/yellow = 2,
-					/obj/item/weldingtool/hugetank = 2)
+					/obj/item/weldingtool/hugetank = 2,
+					/obj/item/airlock_painter/decal = 3)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	refill_canister = /obj/item/vending_refill/tool
 	resistance_flags = FIRE_PROOF


### PR DESCRIPTION

## About The Pull Request

Decal painter only gotton via bepis has been replaced by a flashdark
moving the painter into venders.

## Why It's Good For The Game
Helps us and others remake the station after bombing or the like, as well as helps starving art makers waste more of their money on a paint gun basicly then food and drinks

## Changelog
:cl:
tweak: BEPIS decal painter has been moved to venders, replacing it being the flashdark
/:cl:
