### PR TITLE
Fixing cards states and mob-less projectiles checking mean armor values.

### DIFF
--- a/code/game/objects/items/toys.dm
+++ b/code/game/objects/items/toys.dm
@@ -835,11 +835,11 @@
 
 /obj/item/toy/cards/deck/update_icon_state()
 	switch(cards.len)
-		if(INFINITY to original_size/2)
+		if(original_size*0.5 to INFINITY)
 			icon_state = "deck_[deckstyle]_full"
-		if(original_size/2 to  original_size/4)
+		if(original_size*0.25 to original_size*0.5)
 			icon_state = "deck_[deckstyle]_half"
-		if(original_size/4 to 1)
+		if(1 to original_size*0.25)
 			icon_state = "deck_[deckstyle]_low"
 		else
 			icon_state = "deck_[deckstyle]_empty"

--- a/code/modules/projectiles/projectile.dm
+++ b/code/modules/projectiles/projectile.dm
@@ -272,7 +272,7 @@
 			return TRUE
 
 	var/distance = get_dist(T, starting) // Get the distance between the turf shot from and the mob we hit and use that for the calculations.
-	if(check_zone(def_zone) != BODY_ZONE_CHEST)
+	if(def_zone && check_zone(def_zone) != BODY_ZONE_CHEST)
 		def_zone = ran_zone(def_zone, max(100-(7*distance), 5) * zone_accuracy_factor) //Lower accurancy/longer range tradeoff. 7 is a balanced number to use.
 
 	if(isturf(A) && hitsound_wall)


### PR DESCRIPTION
## About The Pull Request
Title. the projectiles will likely hit the chest, but there is a chance limbs are hit instead, depending on the distance.

## Why It's Good For The Game
Fixing stuff. This will close #12398, and close #12396.

## Changelog
:cl:
fix: Fixing projectiles fired by non-mobs sources checking the mean armor value and not the hitzone's
fix: Fixing deck of cards icon states.
/:cl:
