### PR TITLE
Makes Spears rational.

### DIFF
--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -582,7 +582,7 @@
 	force_wielded = 18
 	throwforce = 20
 	throw_speed = 4
-	embedding = list("embedded_impact_pain_multiplier" = 1.5, "embed_chance" = 65)
+	embedding = getEmbeddingBehavior(embed_chance = 65, embedded_pain_multiplier = 1.5)
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -582,7 +582,7 @@
 	force_wielded = 18
 	throwforce = 20
 	throw_speed = 4
-	embedding = list("embedded_impact_pain_multiplier" = 3, "embed_chance" = 90)
+	embedding = list("embedded_impact_pain_multiplier" = 1.5, "embed_chance" = 65)
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'
@@ -667,6 +667,7 @@
 		force_wielded = 19
 		force_unwielded = 11
 		throwforce = 21
+		embedding = list("embedded_impact_pain_multiplier" = 1.5, "embed_chance" = 75) //plasmaglass spears are sharper
 		icon_prefix = "spearplasma"
 	qdel(tip)
 	var/obj/item/twohanded/spear/S = locate() in parts_list
@@ -681,6 +682,7 @@
 	if(G)
 		explosive = G
 		name = "explosive lance"
+		embedding = list("embedded_impact_pain_multiplier" = 1, "embed_chance" = 0)//elances should not be embeddable
 		desc = "A makeshift spear with [G] attached to it."
 	update_icon()
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -582,7 +582,7 @@
 	force_wielded = 18
 	throwforce = 20
 	throw_speed = 4
-	embedding = getEmbeddingBehavior(embed_chance = 65, embedded_pain_multiplier = 1.5)
+	embedding = list("embedded_impact_pain_multiplier" = 1.5, "embed_chance" = 65)
 	armour_penetration = 10
 	custom_materials = list(/datum/material/iron=1150, /datum/material/glass=2075)
 	hitsound = 'sound/weapons/bladeslice.ogg'

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -682,7 +682,7 @@
 	if(G)
 		explosive = G
 		name = "explosive lance"
-		embedding = list("embedded_impact_pain_multiplier" = 1, "embed_chance" = 0)//elances should not be embeddable
+		embedding = getEmbeddingBehavior(embed_chance = 0, embedded_pain_multiplier = 1)//elances should not be embeddable
 		desc = "A makeshift spear with [G] attached to it."
 	update_icon()
 

--- a/code/game/objects/items/twohanded.dm
+++ b/code/game/objects/items/twohanded.dm
@@ -667,7 +667,7 @@
 		force_wielded = 19
 		force_unwielded = 11
 		throwforce = 21
-		embedding = list("embedded_impact_pain_multiplier" = 1.5, "embed_chance" = 75) //plasmaglass spears are sharper
+		embedding = getEmbeddingBehavior(embed_chance = 75, embedded_pain_multiplier = 1.5) //plasmaglass spears are sharper
 		icon_prefix = "spearplasma"
 	qdel(tip)
 	var/obj/item/twohanded/spear/S = locate() in parts_list


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Drops the spear from 90% embed FLAT across it (and its subtypes) to 65% for the spear, 75% for the plasmatipped one, and 0% for the elance

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
hello yes funny spear 1hit kills you if it embeds, and elance spear that gibs you! 
Fuck 1 hit gib weapons
Also lowered the pain multiplier so it will no longer 1 hit crit you to the chest if it actually does embed.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Rebalanced spears etc to be less dumb in combat, dropped embed rates to 65/75/0, and the pain multiplier from 3.0 to 1.5
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
