### PR TITLE
Powers Remembered: Chants

### DIFF
--- a/code/game/objects/effects/temporary_visuals/clockcult.dm
+++ b/code/game/objects/effects/temporary_visuals/clockcult.dm
@@ -123,14 +123,14 @@
 	for(var/mob/living/L in T)
 		if(is_servant_of_ratvar(L))
 			continue
-		var/obj/item/I = L.null_rod_check()
+		var/obj/item/I = L.anti_magic_check()
 		if(I)
 			L.visible_message("<span class='warning'>Strange energy flows into [L]'s [I.name]!</span>", \
 			"<span class='userdanger'>Your [I.name] shields you from [src]!</span>")
 			continue
 		L.visible_message("<span class='warning'>[L] is struck by a [name]!</span>", "<span class='userdanger'>You're struck by a [name]!</span>")
 		L.apply_damage(damage, BURN, "chest", L.run_armor_check("chest", "laser", "Your armor absorbs [src]!", "Your armor blocks part of [src]!", 0, "Your armor was penetrated by [src]!"))
-		add_logs(user, L, "struck with a volt blast")
+		log_combat(user, L, "struck with a volt blast")
 		hit_amount++
 	for(var/obj/mecha/M in T)
 		if(M.occupant)

--- a/code/game/objects/effects/temporary_visuals/clockcult.dm
+++ b/code/game/objects/effects/temporary_visuals/clockcult.dm
@@ -104,7 +104,7 @@
 	light_power = 2
 	light_color = LIGHT_COLOR_ORANGE
 	var/mob/user
-	var/damage = 25
+	var/damage = 18
 
 /obj/effect/temp_visual/ratvar/volt_hit/Initialize(mapload, caster)
 	. = ..()
@@ -117,7 +117,7 @@
 
 /obj/effect/temp_visual/ratvar/volt_hit/proc/volthit()
 	if(user)
-		Beam(get_turf(user), "volt_ray", time=duration, maxdistance=8, beam_type=/obj/effect/ebeam/volt_ray)
+		Beam(get_turf(user), "volt_ray", time=duration, maxdistance=6, beam_type=/obj/effect/ebeam/volt_ray)
 	var/hit_amount = 0
 	var/turf/T = get_turf(src)
 	for(var/mob/living/L in T)

--- a/code/game/objects/effects/temporary_visuals/clockcult.dm
+++ b/code/game/objects/effects/temporary_visuals/clockcult.dm
@@ -104,7 +104,7 @@
 	light_power = 2
 	light_color = LIGHT_COLOR_ORANGE
 	var/mob/user
-	var/damage = 18
+	var/damage = 20
 
 /obj/effect/temp_visual/ratvar/volt_hit/Initialize(mapload, caster)
 	. = ..()
@@ -117,7 +117,7 @@
 
 /obj/effect/temp_visual/ratvar/volt_hit/proc/volthit()
 	if(user)
-		Beam(get_turf(user), "volt_ray", time=duration, maxdistance=6, beam_type=/obj/effect/ebeam/volt_ray)
+		Beam(get_turf(user), "volt_ray", time=duration, maxdistance=8, beam_type=/obj/effect/ebeam/volt_ray)
 	var/hit_amount = 0
 	var/turf/T = get_turf(src)
 	for(var/mob/living/L in T)

--- a/code/game/objects/effects/temporary_visuals/clockcult.dm
+++ b/code/game/objects/effects/temporary_visuals/clockcult.dm
@@ -95,6 +95,56 @@
 	icon_state = "warden_gaze"
 	duration = 3
 
+/obj/effect/temp_visual/ratvar/volt_hit
+	name = "volt blast"
+	layer = ABOVE_MOB_LAYER
+	duration = 8
+	icon_state = "volt_hit"
+	light_range = 1.5
+	light_power = 2
+	light_color = LIGHT_COLOR_ORANGE
+	var/mob/user
+	var/damage = 25
+
+/obj/effect/temp_visual/ratvar/volt_hit/Initialize(mapload, caster)
+	. = ..()
+	user = caster
+	if(user)
+		var/matrix/M = new
+		M.Turn(Get_Angle(src, user))
+		transform = M
+	INVOKE_ASYNC(src, .proc/volthit)
+
+/obj/effect/temp_visual/ratvar/volt_hit/proc/volthit()
+	if(user)
+		Beam(get_turf(user), "volt_ray", time=duration, maxdistance=8, beam_type=/obj/effect/ebeam/volt_ray)
+	var/hit_amount = 0
+	var/turf/T = get_turf(src)
+	for(var/mob/living/L in T)
+		if(is_servant_of_ratvar(L))
+			continue
+		var/obj/item/I = L.null_rod_check()
+		if(I)
+			L.visible_message("<span class='warning'>Strange energy flows into [L]'s [I.name]!</span>", \
+			"<span class='userdanger'>Your [I.name] shields you from [src]!</span>")
+			continue
+		L.visible_message("<span class='warning'>[L] is struck by a [name]!</span>", "<span class='userdanger'>You're struck by a [name]!</span>")
+		L.apply_damage(damage, BURN, "chest", L.run_armor_check("chest", "laser", "Your armor absorbs [src]!", "Your armor blocks part of [src]!", 0, "Your armor was penetrated by [src]!"))
+		add_logs(user, L, "struck with a volt blast")
+		hit_amount++
+	for(var/obj/mecha/M in T)
+		if(M.occupant)
+			if(is_servant_of_ratvar(M.occupant))
+				continue
+			to_chat(M.occupant, "<span class='userdanger'>Your [M.name] is struck by a [name]!</span>")
+		M.visible_message("<span class='warning'>[M] is struck by a [name]!</span>")
+		M.take_damage(damage, BURN, 0, 0)
+		hit_amount++
+	if(hit_amount)
+		playsound(src, 'sound/machines/defib_zap.ogg', damage*hit_amount, 1, -1)
+	else
+		playsound(src, "sparks", 50, 1)
+
 /obj/effect/temp_visual/ratvar/ocular_warden/Initialize()
 	. = ..()
 	pixel_x = rand(-8, 8)

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -153,8 +153,10 @@
 		playsound(ranged_ability_user, 'sound/effects/light_flicker.ogg', 50, 1)
 		T = get_turf(target)
 		new/obj/effect/temp_visual/ratvar/volt_hit(T, ranged_ability_user)
-		add_logs(ranged_ability_user, T, "fired a volt ray")
+		log_combat(ranged_ability_user, T, "fired a volt ray")
 		remove_ranged_ability()
+
+	return TRUE
 
 //For the Kindle scripture; stuns and mutes a target non-servant.
 /obj/effect/proc_holder/slab/kindle

--- a/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/slab_abilities.dm
@@ -135,6 +135,27 @@
 
 	return TRUE
 
+//For the Volt Void scripture, fires a ray of energy at a target location
+/obj/effect/proc_holder/slab/volt
+	ranged_mousepointer = 'icons/effects/volt_target.dmi'
+
+/obj/effect/proc_holder/slab/volt/InterceptClickOn(mob/living/caller, params, atom/target)
+	if(target == slab || ..()) //we can't cancel
+		return TRUE
+
+	var/turf/T = ranged_ability_user.loc
+	if(!isturf(T))
+		return TRUE
+
+	if(target in view(7, get_turf(ranged_ability_user)))
+		successful = TRUE
+		ranged_ability_user.visible_message("<span class='warning'>[ranged_ability_user] fires a ray of energy at [target]!</span>", "<span class='nzcrentr'>You fire a volt ray at [target].</span>")
+		playsound(ranged_ability_user, 'sound/effects/light_flicker.ogg', 50, 1)
+		T = get_turf(target)
+		new/obj/effect/temp_visual/ratvar/volt_hit(T, ranged_ability_user)
+		add_logs(ranged_ability_user, T, "fired a volt ray")
+		remove_ranged_ability()
+
 //For the Kindle scripture; stuns and mutes a target non-servant.
 /obj/effect/proc_holder/slab/kindle
 	ranged_mousepointer = 'icons/effects/volt_target.dmi'

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -375,3 +375,48 @@
 	new /obj/effect/temp_visual/ratvar/mending_mantra(get_turf(invoker))
 	return TRUE
 
+//Volt Blaster: Channeled for up to five times over ten seconds to fire up to five rays of energy at target locations.
+/datum/clockwork_scripture/channeled/volt_blaster
+	descname = "Channeled, Targeted Energy Blasts"
+	name = "Volt Blaster"
+	desc = "Allows you to fire five energy rays at target locations. Channeled every fourth of a second for a maximum of ten seconds."
+	channel_time = 30
+	invocations = list("Amperage...", "...grant me your power!")
+	chant_invocations = list("Use charge to kill!", "Slay with power!", "Hunt with energy!")
+	chant_amount = 5
+	chant_interval = 4
+	power_cost = 200
+	usage_tip = "Though it requires you to stand still, this scripture can do massive damage."
+	tier = SCRIPTURE_SCRIPT
+	primary_component = HIEROPHANT_ANSIBLE
+	sort_priority = 10
+	quickbind = TRUE
+	quickbind_desc = "Allows you to fire energy rays at target locations.<br><b>Maximum 5 chants.</b>"
+	var/static/list/nzcrentr_insults = list("You're not very good at aiming.", "You hunt badly.", "What a waste of energy.", "Almost funny to watch.",
+	"Boss says </span><span class='heavy_brass'>\"Click something, you idiot!\"</span><span class='nzcrentr'>.", "Stop wasting components if you can't aim.")
+
+/datum/clockwork_scripture/channeled/volt_blaster/chant_effects(chant_number)
+	slab.busy = null
+	var/datum/clockwork_scripture/ranged_ability/volt_ray/ray = new
+	ray.slab = slab
+	ray.invoker = invoker
+	var/turf/T = get_turf(invoker)
+	if(!ray.run_scripture() && slab && invoker)
+		if(can_recite() && T == get_turf(invoker))
+			to_chat(invoker, "<span class='nzcrentr'>\"[text2ratvar(pick(nzcrentr_insults))]\"</span>")
+		else
+			return FALSE
+	return TRUE
+
+/obj/effect/ebeam/volt_ray
+	name = "volt_ray"
+	layer = LYING_MOB_LAYER
+
+/datum/clockwork_scripture/ranged_ability/volt_ray
+	name = "Volt Ray"
+	slab_icon = "volt"
+	allow_mobility = FALSE
+	ranged_type = /obj/effect/proc_holder/slab/volt
+	ranged_message = "<span class='nzcrentr_small'><i>You charge the clockwork slab with shocking might.</i>\n\
+	<b>Left-click a target to fire, quickly!</b></span>"
+	timeout_time = 20

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -263,3 +263,115 @@
 		duration = max(duration, 100)
 	return slab.procure_gateway(invoker, duration, portal_uses)
 
+
+//Mending Mantra: Channeled for up to ten times over twenty seconds to repair structures and heal allies
+/datum/clockwork_scripture/channeled/mending_mantra
+	descname = "Channeled, Area Healing and Repair"
+	name = "Mending Mantra"
+	desc = "Repairs nearby structures and constructs. Servants wearing clockwork armor will also be healed. Channeled every two seconds for a maximum of twenty seconds."
+	chant_invocations = list("Mend our dents!", "Heal our scratches!", "Repair our gears!")
+	chant_amount = 10
+	chant_interval = 20
+	power_cost = 400
+	usage_tip = "This is a very effective way to rapidly reinforce a base after an attack."
+	tier = SCRIPTURE_SCRIPT
+	primary_component = VANGUARD_COGWHEEL
+	sort_priority = 7
+	quickbind = TRUE
+	quickbind_desc = "Repairs nearby structures and constructs. Servants wearing clockwork armor will also be healed.<br><b>Maximum 10 chants.</b>"
+	var/heal_attempts = 4
+	var/heal_amount = 2.5
+	var/static/list/damage_heal_order = list(BRUTE, BURN, OXY)
+	var/static/list/heal_finish_messages = list("There, all mended!", "Try not to get too damaged.", "No more dents and scratches for you!", "Champions never die.", "All patched up.", \
+	"Ah, child, it's okay now.", "Pain is temporary.", "What you do for the Justiciar is eternal.", "Bear this for me.", "Be strong, child.", "Please, be careful!", \
+	"If you die, you will be remembered.")
+	var/static/list/heal_target_typecache = typecacheof(list(
+	/obj/structure/destructible/clockwork,
+	/obj/machinery/door/airlock/clockwork,
+	/obj/machinery/door/window/clockwork,
+	/obj/structure/window/reinforced/clockwork,
+	/obj/structure/table/reinforced/brass))
+	var/static/list/ratvarian_armor_typecache = typecacheof(list(
+	/obj/item/clothing/suit/armor/clockwork,
+	/obj/item/clothing/head/helmet/clockwork,
+	/obj/item/clothing/gloves/clockwork,
+	/obj/item/clothing/shoes/clockwork))
+
+/datum/clockwork_scripture/channeled/mending_mantra/chant_effects(chant_number)
+	var/turf/T
+	for(var/atom/movable/M in range(7, invoker))
+		if(isliving(M))
+			if(isclockmob(M) || istype(M, /mob/living/simple_animal/drone/cogscarab))
+				var/mob/living/simple_animal/S = M
+				if(S.health == S.maxHealth || S.stat == DEAD)
+					continue
+				T = get_turf(M)
+				for(var/i in 1 to heal_attempts)
+					if(S.health < S.maxHealth)
+						S.adjustHealth(-heal_amount)
+						new /obj/effect/temp_visual/heal(T, "#1E8CE1")
+						if(i == heal_attempts && S.health >= S.maxHealth) //we finished healing on the last tick, give them the message
+							to_chat(S, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
+							break
+					else
+						to_chat(S, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
+						break
+			else if(issilicon(M))
+				var/mob/living/silicon/S = M
+				if(S.health == S.maxHealth || S.stat == DEAD || !is_servant_of_ratvar(S))
+					continue
+				T = get_turf(M)
+				for(var/i in 1 to heal_attempts)
+					if(S.health < S.maxHealth)
+						S.heal_ordered_damage(heal_amount, damage_heal_order)
+						new /obj/effect/temp_visual/heal(T, "#1E8CE1")
+						if(i == heal_attempts && S.health >= S.maxHealth)
+							to_chat(S, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
+							break
+					else
+						to_chat(S, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
+						break
+			else if(ishuman(M))
+				var/mob/living/carbon/human/H = M
+				if(H.health == H.maxHealth || H.stat == DEAD || !is_servant_of_ratvar(H))
+					continue
+				T = get_turf(M)
+				var/heal_ticks = 0 //one heal tick for each piece of ratvarian armor worn
+				var/obj/item/I = H.get_item_by_slot(SLOT_WEAR_SUIT)
+				if(is_type_in_typecache(I, ratvarian_armor_typecache))
+					heal_ticks++
+				I = H.get_item_by_slot(SLOT_HEAD)
+				if(is_type_in_typecache(I, ratvarian_armor_typecache))
+					heal_ticks++
+				I = H.get_item_by_slot(SLOT_GLOVES)
+				if(is_type_in_typecache(I, ratvarian_armor_typecache))
+					heal_ticks++
+				I = H.get_item_by_slot(SLOT_SHOES)
+				if(is_type_in_typecache(I, ratvarian_armor_typecache))
+					heal_ticks++
+				if(heal_ticks)
+					for(var/i in 1 to heal_ticks)
+						if(H.health < H.maxHealth)
+							H.heal_ordered_damage(heal_amount, damage_heal_order)
+							new /obj/effect/temp_visual/heal(T, "#1E8CE1")
+							if(i == heal_ticks && H.health >= H.maxHealth)
+								to_chat(H, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
+								break
+						else
+							to_chat(H, "<span class='inathneq'>\"[text2ratvar(pick(heal_finish_messages))]\"</span>")
+							break
+		else if(is_type_in_typecache(M, heal_target_typecache))
+			var/obj/structure/destructible/clockwork/C = M
+			if(C.obj_integrity == C.max_integrity || (istype(C) && !C.can_be_repaired))
+				continue
+			T = get_turf(M)
+			for(var/i in 1 to heal_attempts)
+				if(C.obj_integrity < C.max_integrity)
+					C.obj_integrity = min(C.obj_integrity + 5, C.max_integrity)
+					C.update_icon()
+					new /obj/effect/temp_visual/heal(T, "#1E8CE1")
+				else
+					break
+	new /obj/effect/temp_visual/ratvar/mending_mantra(get_turf(invoker))
+	return TRUE
+

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -414,7 +414,7 @@
 
 /datum/clockwork_scripture/ranged_ability/volt_ray
 	name = "Volt Ray"
-	slab_icon = "volt"
+	slab_overlay = "volt"
 	allow_mobility = FALSE
 	ranged_type = /obj/effect/proc_holder/slab/volt
 	ranged_message = "<span class='nzcrentr_small'><i>You charge the clockwork slab with shocking might.</i>\n\

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -385,7 +385,7 @@
 	chant_invocations = list("Use charge to kill!", "Slay with power!", "Hunt with energy!")
 	chant_amount = 5
 	chant_interval = 4
-	power_cost = 200
+	power_cost = 500
 	usage_tip = "Though it requires you to stand still, this scripture can do massive damage."
 	tier = SCRIPTURE_SCRIPT
 	primary_component = HIEROPHANT_ANSIBLE
@@ -393,7 +393,7 @@
 	quickbind = TRUE
 	quickbind_desc = "Allows you to fire energy rays at target locations.<br><b>Maximum 5 chants.</b>"
 	var/static/list/nzcrentr_insults = list("You're not very good at aiming.", "You hunt badly.", "What a waste of energy.", "Almost funny to watch.",
-	"Boss says </span><span class='heavy_brass'>\"Click something, you idiot!\"</span><span class='nzcrentr'>.", "Stop wasting components if you can't aim.")
+	"Boss says </span><span class='heavy_brass'>\"Click something, you idiot!\"</span><span class='nzcrentr'>.", "Stop wasting power if you can't aim.")
 
 /datum/clockwork_scripture/channeled/volt_blaster/chant_effects(chant_number)
 	slab.busy = null


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
This PR restores two chants from Clockwork Cult's past, with some minor tweaks to numbers.
About Chants: Chants are special spells that require the invoker to stand still to constantly proc the effect of them. Moving, switching hands, getting stunned/shoved will stop the chant early, with the the remaining chants disappearing.

Mending Mantra: Standing still and chanting it in the middle of clockwork structures and armored allies will restore their integrity over time. Great for healing up after a long engagement, and for restoring base integrity in a pinch. Best used if you can actually afford to get all chants off, otherwise you will start to bleed power.

Volt Blaster: A somewhat slow charging ranged attack. Does not need to be aimed, but leaves the user wide open to attack while zeroing in. Inflicts 20 burn damage unarmored, with 5 shots per full cast, with a maximum 8 tile range, provided you have true Line of Sight where you are trying to strike. Best used to support your frontline warriors, be it fellow servants or marauders, or for picking away at invaders attempting to butt into your station base as a Chaplain of Ratvar. Cannot be used through camera console nor obtains the ability to fire through walls with Wraith Spectacles/Xray Mutation/Eye of God. 

A vast majority of the code is from much older versions of clockcult, I merely did some tidying up and fixing up to allow it to function in the modern era. Local tests didn't pop up with runtimes or any noticeable errors, so I'm relatively confident it will function fine.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Improves, at least somewhat, the options a Ratvarian Chaplain has to combat the station, and grants Ratvar's Faithful more powerful synergies with more abilities being restored; E.G. Volt Void (when it gets added) + Mending Mantra to sooth the constant burns of channeling the stations power unto themselves, as well as adding a decent triage option if there is no time to cast dozens of Sentinel's Compromises on the injured. Also adds a somewhat viable ranged option to Ratvar's Faithful, while not being straight up as powerful as Nar'sies Blood Beam.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Ratvar's Faithful have studied skirmishes of ages past, and have recollected some old battle chants.
add: Re-adds Mending Mantra and Volt Blaster, an offensive but slow charging bolt of energy, and a chant that repairs those clad in armor, as well as structures built.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
