### PR TITLE
Lowers the slowdown on snow tiles

### DIFF
--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -157,7 +157,7 @@
 	planetary_atmos = TRUE
 	floor_tile = null
 	initial_gas_mix = FROZEN_ATMOS
-	slowdown = 1.3 //So digging it out paths are usefull.
+	slowdown = 1.5 //So digging it out paths are usefull.
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND

--- a/code/game/turfs/simulated/floor/fancy_floor.dm
+++ b/code/game/turfs/simulated/floor/fancy_floor.dm
@@ -157,7 +157,7 @@
 	planetary_atmos = TRUE
 	floor_tile = null
 	initial_gas_mix = FROZEN_ATMOS
-	slowdown = 2
+	slowdown = 1.3 //So digging it out paths are usefull.
 	bullet_sizzle = TRUE
 	footstep = FOOTSTEP_SAND
 	barefootstep = FOOTSTEP_SAND


### PR DESCRIPTION
## About The Pull Request

2 slowdown has been shifted to 1.5 making you only have to deal with a bit more then plasmamen slowdown

## Why It's Good For The Game
Makes mining and dealing with the snow tiles/mobs on tiles less of a hassle were you can perhaps maybe run away from things, or get some distance! 

## Changelog
:cl:
tweak: makes snow tiles no longer force you to go at slowdown 2, but slowdown 1.5 meaning your 50% faster then before on snow!
/:cl:
