### PR TITLE
Much better looking lava land ruins!

### DIFF
--- a/_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
@@ -28,28 +28,31 @@
 /obj/structure/fans/tiny/invisible,
 /turf/open/floor/engine/cult,
 /area/ruin/unpowered)
+"G" = (
+/turf/closed/wall/rust,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
+G
+G
+G
+G
+G
+G
 b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
+G
+G
+G
+G
+G
+G
+G
+G
 "}
 (2,1,1) = {"
 a
-b
+G
 d
 f
 f
@@ -63,11 +66,11 @@ d
 f
 f
 d
-b
+G
 "}
 (3,1,1) = {"
-b
-b
+G
+G
 e
 g
 f
@@ -81,10 +84,10 @@ g
 f
 g
 f
-b
+G
 "}
 (4,1,1) = {"
-b
+G
 c
 f
 f
@@ -102,8 +105,8 @@ f
 h
 "}
 (5,1,1) = {"
-b
-b
+G
+G
 e
 f
 f
@@ -117,11 +120,11 @@ f
 f
 f
 f
-b
+G
 "}
 (6,1,1) = {"
 a
-b
+G
 d
 g
 f
@@ -135,23 +138,23 @@ d
 f
 g
 d
-b
+G
 "}
 (7,1,1) = {"
 a
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
-b
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
+G
 "}

--- a/_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
+++ b/_maps/RandomRuins/AnywhereRuins/fountain_hall.dmm
@@ -2,34 +2,47 @@
 "a" = (
 /turf/template_noop,
 /area/template_noop)
-"b" = (
-/turf/closed/wall/mineral/cult,
-/area/ruin/unpowered)
 "c" = (
 /obj/structure/healingfountain,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/purple,
 /area/ruin/unpowered)
 "d" = (
 /obj/structure/fluff/divine/conduit,
-/turf/open/floor/engine/cult,
+/turf/open/floor/mineral/plasma,
 /area/ruin/unpowered)
 "e" = (
 /obj/structure/sacrificealtar,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/purple,
 /area/ruin/unpowered)
 "f" = (
-/turf/open/floor/engine/cult,
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/carpet/purple,
 /area/ruin/unpowered)
 "g" = (
 /mob/living/simple_animal/butterfly,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/red,
 /area/ruin/unpowered)
 "h" = (
 /obj/structure/fans/tiny/invisible,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/red,
+/area/ruin/unpowered)
+"u" = (
+/turf/open/floor/carpet/purple,
 /area/ruin/unpowered)
 "G" = (
-/turf/closed/wall/rust,
+/turf/closed/wall/mineral/cult{
+	sheet_amount = 0
+	},
+/area/ruin/unpowered)
+"J" = (
+/mob/living/simple_animal/butterfly,
+/turf/open/floor/carpet/royalblack,
+/area/ruin/unpowered)
+"T" = (
+/turf/open/floor/carpet/royalblack,
+/area/ruin/unpowered)
+"U" = (
+/turf/open/floor/carpet/red,
 /area/ruin/unpowered)
 
 (1,1,1) = {"
@@ -40,7 +53,7 @@ G
 G
 G
 G
-b
+G
 G
 G
 G
@@ -54,17 +67,17 @@ G
 a
 G
 d
-f
-f
-d
-f
-f
-d
-f
-f
-d
-f
-f
+U
+T
+T
+T
+J
+T
+T
+T
+T
+T
+T
 d
 G
 "}
@@ -73,70 +86,70 @@ G
 G
 e
 g
-f
-f
+U
+d
 g
-f
-f
-f
-f
-g
-f
-g
-f
+U
+d
+U
+U
+d
+U
+U
+u
 G
 "}
 (4,1,1) = {"
 G
 c
 f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
-f
+U
+T
+u
+T
+T
+u
+T
+T
+u
+T
+T
+T
 h
 "}
 (5,1,1) = {"
 G
 G
 e
-f
-f
-f
-f
 g
-f
-f
-f
-f
-f
-f
-f
+U
+d
+g
+U
+d
+U
+U
+d
+U
+U
+u
 G
 "}
 (6,1,1) = {"
 a
 G
 d
-g
-f
-d
-f
-f
-d
-f
-f
-d
-f
-g
+U
+T
+T
+T
+J
+T
+T
+T
+T
+T
+T
 d
 G
 "}

--- a/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_biodome_beach.dmm
@@ -42,6 +42,10 @@
 "ak" = (
 /obj/structure/toilet,
 /obj/effect/turf_decal/sand,
+/obj/item/reagent_containers/food/drinks/beer/light{
+	pixel_x = 9
+	},
+/obj/effect/decal/cleanable/vomit/old,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "al" = (
@@ -191,7 +195,9 @@
 /turf/open/floor/plasteel,
 /area/ruin/powered/beach)
 "aM" = (
-/obj/structure/reagent_dispensers/beerkeg,
+/obj/structure/reagent_dispensers/beerkeg{
+	reagent_id = /datum/reagent/consumable/ethanol/beer/light
+	},
 /turf/open/floor/wood,
 /area/ruin/powered/beach)
 "aN" = (
@@ -371,7 +377,7 @@
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "bP" = (
-/obj/item/reagent_containers/food/drinks/beer,
+/obj/item/reagent_containers/food/drinks/beer/light,
 /turf/open/floor/plating/beach/sand,
 /area/ruin/powered/beach)
 "bQ" = (
@@ -463,6 +469,7 @@
 /obj/item/storage/box/drinkingglasses,
 /obj/item/storage/box/beakers,
 /obj/item/storage/box/donkpockets,
+/obj/item/soap,
 /turf/open/floor/plating,
 /area/ruin/powered/beach)
 "hY" = (
@@ -537,6 +544,14 @@
 	},
 /turf/open/floor/pod/light,
 /area/ruin/powered/beach)
+"rV" = (
+/obj/effect/turf_decal/sand,
+/obj/item/reagent_containers/food/drinks/beer/light{
+	pixel_y = -3;
+	pixel_x = -9
+	},
+/turf/open/floor/plating,
+/area/ruin/powered/beach)
 "sy" = (
 /obj/effect/turf_decal/caution{
 	dir = 4
@@ -589,6 +604,11 @@
 "Gc" = (
 /obj/effect/turf_decal/sand,
 /turf/open/floor/pod/light,
+/area/ruin/powered/beach)
+"Gu" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/beer/light,
+/turf/open/floor/wood,
 /area/ruin/powered/beach)
 "HC" = (
 /obj/structure/rack,
@@ -964,7 +984,7 @@ ar
 ar
 ar
 ar
-ar
+bP
 ar
 bR
 bT
@@ -984,7 +1004,7 @@ as
 aw
 aC
 aC
-aP
+Gu
 aW
 aK
 Ga
@@ -1108,7 +1128,7 @@ aa
 aa
 bW
 ak
-au
+rV
 aj
 aE
 aC

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_alien_nest.dmm
@@ -219,6 +219,7 @@
 /obj/structure/alien/weeds,
 /obj/effect/decal/cleanable/blood/gibs,
 /mob/living/simple_animal/hostile/alien/drone,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "aZ" = (
@@ -535,6 +536,11 @@
 /obj/effect/mob_spawn/alien/corpse/humanoid/queen,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
+"wA" = (
+/obj/structure/alien/weeds,
+/obj/structure/alien/weeds/node,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/xenonest)
 "yf" = (
 /obj/structure/alien/weeds/node,
 /mob/living/simple_animal/hostile/alien/sentinel,
@@ -549,6 +555,12 @@
 "JM" = (
 /obj/structure/alien/weeds/node,
 /obj/effect/mob_spawn/alien/corpse/humanoid/drone,
+/turf/open/floor/plating/asteroid/basalt/lava_land_surface,
+/area/ruin/unpowered/xenonest)
+"QG" = (
+/obj/structure/alien/weeds,
+/obj/structure/bed/nest,
+/obj/structure/alien/weeds/node,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/xenonest)
 "Uh" = (
@@ -683,7 +695,7 @@ ac
 ac
 aj
 ac
-am
+QG
 ac
 ac
 ac
@@ -800,7 +812,7 @@ ac
 ac
 ac
 ac
-ag
+wA
 ag
 ag
 ar
@@ -884,7 +896,7 @@ aa
 (7,1,1) = {"
 ab
 ac
-ag
+wA
 ag
 ag
 ag
@@ -917,7 +929,7 @@ ac
 ac
 ZT
 ac
-ag
+wA
 ag
 ac
 ab
@@ -1349,7 +1361,7 @@ ar
 lG
 ag
 ag
-ag
+wA
 ad
 ag
 ag
@@ -1555,7 +1567,7 @@ ag
 ac
 aF
 ag
-ag
+ar
 ag
 ag
 ar
@@ -1603,7 +1615,7 @@ ao
 ah
 ac
 ag
-ag
+wA
 ag
 ag
 pE
@@ -1742,7 +1754,7 @@ ag
 ag
 ag
 ag
-ac
+aw
 ar
 ag
 bD
@@ -1791,9 +1803,9 @@ ac
 ac
 ac
 ac
+wA
 ag
-ag
-ac
+aw
 ar
 ag
 bD
@@ -1828,7 +1840,7 @@ ac
 ac
 ag
 Uh
-ag
+wA
 aZ
 be
 bo

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_biodome_winter.dmm
@@ -203,6 +203,12 @@
 /area/ruin/powered/snow_biodome)
 "aR" = (
 /obj/structure/flora/tree/pine/xmas,
+/obj/item/a_gift{
+	pixel_y = -5
+	},
+/obj/item/a_gift{
+	pixel_x = 6
+	},
 /turf/open/floor/plating/asteroid/snow{
 	initial_gas_mix = "o2=22;n2=82;TEMP=180"
 	},
@@ -295,6 +301,12 @@
 	},
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
+"gy" = (
+/obj/item/toy/snowball,
+/turf/open/floor/plating/asteroid/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
+/area/ruin/powered/snow_biodome)
 "gz" = (
 /obj/structure/chair/stool,
 /turf/open/floor/pod/dark,
@@ -315,6 +327,13 @@
 	dir = 8
 	},
 /turf/open/floor/pod/dark,
+/area/ruin/powered/snow_biodome)
+"rl" = (
+/obj/structure/flora/bush,
+/obj/item/toy/snowball,
+/turf/open/floor/plating/asteroid/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
 /area/ruin/powered/snow_biodome)
 "tb" = (
 /obj/effect/mapping_helpers/no_lava,
@@ -361,6 +380,11 @@
 /obj/structure/closet/secure_closet/freezer/fridge,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
+"IQ" = (
+/obj/structure/table/wood,
+/obj/item/reagent_containers/food/drinks/mug,
+/turf/open/floor/wood,
+/area/ruin/powered/snow_biodome)
 "JZ" = (
 /obj/structure/table,
 /obj/machinery/microwave,
@@ -380,6 +404,7 @@
 /area/ruin/powered/snow_biodome)
 "Oj" = (
 /obj/structure/table,
+/obj/item/reagent_containers/food/drinks/mug,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "PD" = (
@@ -407,6 +432,7 @@
 "QK" = (
 /obj/structure/table,
 /obj/item/storage/fancy/cigarettes/cigpack_carp,
+/obj/item/reagent_containers/food/drinks/mug,
 /turf/open/floor/pod/dark,
 /area/ruin/powered/snow_biodome)
 "QN" = (
@@ -416,6 +442,13 @@
 "Sj" = (
 /obj/effect/decal/cleanable/oil,
 /turf/open/floor/pod/dark,
+/area/ruin/powered/snow_biodome)
+"SL" = (
+/obj/structure/flora/grass/both,
+/obj/item/toy/snowball,
+/turf/open/floor/plating/asteroid/snow{
+	initial_gas_mix = "o2=22;n2=82;TEMP=180"
+	},
 /area/ruin/powered/snow_biodome)
 "Ub" = (
 /obj/structure/filingcabinet,
@@ -577,7 +610,7 @@ aB
 ak
 ak
 ak
-aI
+rl
 by
 ak
 ak
@@ -740,7 +773,7 @@ aI
 az
 ak
 ak
-ak
+gy
 ak
 ak
 aI
@@ -916,7 +949,7 @@ Wg
 ag
 ah
 as
-aw
+IQ
 aA
 aA
 at
@@ -924,7 +957,7 @@ aM
 aP
 ak
 ak
-aQ
+SL
 ak
 ak
 az
@@ -1077,7 +1110,7 @@ Wg
 an
 Wg
 ay
-ak
+gy
 ak
 ak
 ak
@@ -1114,6 +1147,7 @@ aI
 ak
 ap
 ak
+gy
 ak
 ak
 ak
@@ -1121,8 +1155,7 @@ ak
 ak
 ak
 ak
-ak
-ak
+gy
 ak
 aI
 ak
@@ -1240,7 +1273,7 @@ ak
 ak
 az
 ak
-ak
+gy
 ak
 bB
 ak

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_envy.dmm
@@ -11,7 +11,7 @@
 "d" = (
 /turf/closed/wall/rust,
 /area/ruin/unpowered)
-"e" = (
+"f" = (
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
@@ -21,17 +21,6 @@
 /obj/item/clothing/suit/hooded/bloated_human,
 /obj/effect/decal/cleanable/blood,
 /turf/open/floor/plating,
-/area/ruin/unpowered)
-"f" = (
-/obj/structure/mirror{
-	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
-	icon_state = "mirror_broke";
-	pixel_x = 28;
-	broken = 1
-	},
-/turf/open/floor/plating{
-	icon_state = "panelscorched"
-	},
 /area/ruin/unpowered)
 "g" = (
 /obj/effect/decal/cleanable/blood/tracks,
@@ -58,11 +47,12 @@
 /obj/structure/mirror{
 	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
 	icon_state = "mirror_broke";
-	pixel_y = 28;
+	pixel_x = 28;
 	broken = 1
 	},
-/obj/item/kitchen/knife/envy,
-/turf/open/floor/plating,
+/turf/open/floor/plating{
+	icon_state = "panelscorched"
+	},
 /area/ruin/unpowered)
 "l" = (
 /obj/structure/mirror{
@@ -106,6 +96,16 @@
 /obj/effect/mapping_helpers/no_lava,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
+"T" = (
+/obj/structure/mirror{
+	desc = "This mirror has been shattered. It looks like the bad luck energies spilling from it are taking immediate effect on your surroundings!";
+	icon_state = "mirror_broke";
+	pixel_y = 28;
+	broken = 1
+	},
+/obj/item/kitchen/knife/envy,
+/turf/open/floor/plating,
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -125,14 +125,8 @@ a
 a
 a
 a
-a
-a
-a
 "}
 (2,1,1) = {"
-a
-a
-c
 c
 c
 c
@@ -167,9 +161,6 @@ d
 d
 d
 d
-d
-d
-d
 c
 a
 "}
@@ -178,13 +169,10 @@ c
 c
 d
 d
-d
-e
+f
 g
 g
 g
-m
-m
 m
 m
 m
@@ -201,11 +189,8 @@ d
 d
 d
 d
-d
 h
 h
-i
-i
 i
 i
 i
@@ -224,10 +209,7 @@ d
 d
 d
 d
-d
-k
-i
-i
+T
 i
 i
 i
@@ -245,11 +227,8 @@ d
 d
 d
 d
-d
 i
 i
-i
-j
 i
 n
 i
@@ -266,11 +245,8 @@ c
 c
 d
 d
-d
-f
+k
 j
-l
-l
 l
 l
 l
@@ -299,18 +275,12 @@ d
 d
 d
 d
-d
-d
-d
 c
 a
 "}
 (10,1,1) = {"
 b
 b
-c
-c
-c
 c
 c
 c

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_gluttony.dmm
@@ -20,7 +20,7 @@
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
 "h" = (
-/obj/item/veilrender/vealrender,
+/obj/item/trash/boritos,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
 "i" = (
@@ -65,6 +65,7 @@
 /obj/machinery/light/small{
 	dir = 1
 	},
+/obj/item/trash/plate/alt,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
 "v" = (
@@ -84,12 +85,38 @@
 	},
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
+"B" = (
+/obj/item/veilrender/vealrender,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
+"E" = (
+/obj/machinery/light/small,
+/obj/item/trash/cheesie,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
+"G" = (
+/obj/item/trash/waffles,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
+"L" = (
+/obj/machinery/light/small,
+/obj/item/trash/plate/alt,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
+"N" = (
+/obj/item/trash/cheesie,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
 "R" = (
 /turf/closed/indestructible/riveted/uranium,
 /area/ruin/powered/gluttony)
 "S" = (
 /obj/machinery/door/airlock/uranium,
 /obj/structure/fans/tiny/invisible,
+/turf/open/floor/plasteel/freezer,
+/area/ruin/powered/gluttony)
+"Z" = (
+/obj/item/trash/plate/alt,
 /turf/open/floor/plasteel/freezer,
 /area/ruin/powered/gluttony)
 
@@ -191,7 +218,7 @@ b
 b
 c
 R
-h
+j
 i
 o
 R
@@ -213,9 +240,9 @@ b
 b
 c
 R
-i
-i
-v
+h
+G
+L
 R
 c
 b
@@ -258,7 +285,7 @@ c
 c
 R
 t
-i
+N
 m
 R
 c
@@ -305,10 +332,10 @@ g
 g
 i
 p
-i
+G
 z
 l
-i
+Z
 R
 c
 b
@@ -324,10 +351,10 @@ g
 g
 g
 g
+B
 n
 i
-i
-i
+h
 i
 i
 i
@@ -346,12 +373,12 @@ r
 g
 g
 g
-i
+N
 g
 i
 l
 A
-i
+Z
 q
 R
 c
@@ -368,7 +395,7 @@ R
 R
 R
 g
-i
+h
 v
 R
 R
@@ -391,7 +418,7 @@ c
 R
 r
 i
-i
+q
 R
 c
 c
@@ -435,7 +462,7 @@ c
 R
 j
 i
-v
+E
 R
 c
 b

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -124,7 +124,9 @@
 /turf/open/floor/carpet/purple,
 /area/ruin/powered/greed)
 "W" = (
-/turf/closed/wall/mineral/titanium/survival/nodiagonal,
+/turf/closed/wall/mineral/cult{
+	sheet_amount = 0
+	},
 /area/ruin/powered/greed)
 
 (1,1,1) = {"

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_greed.dmm
@@ -20,9 +20,7 @@
 /area/ruin/powered/greed)
 "f" = (
 /obj/structure/cursed_slot_machine,
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
+/turf/open/floor/carpet/black,
 /area/ruin/powered/greed)
 "g" = (
 /obj/structure/table/wood/poker,
@@ -41,11 +39,6 @@
 	icon_state = "carpetsymbol"
 	},
 /area/ruin/powered/greed)
-"i" = (
-/turf/open/floor/carpet{
-	icon_state = "carpetsymbol"
-	},
-/area/ruin/powered/greed)
 "j" = (
 /obj/structure/table/wood/poker,
 /obj/item/coin/adamantine,
@@ -57,28 +50,28 @@
 /obj/machinery/computer/arcade/battle{
 	set_obj_flags = "EMAGGED"
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/black,
 /area/ruin/powered/greed)
 "l" = (
 /obj/item/coin/gold,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/black,
 /area/ruin/powered/greed)
 "m" = (
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/black,
 /area/ruin/powered/greed)
 "n" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c1000,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "o" = (
 /obj/item/storage/bag/money,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/black,
 /area/ruin/powered/greed)
 "p" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/ore/gold,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "q" = (
 /obj/structure/table/wood/poker,
@@ -88,19 +81,19 @@
 	brightness = 3;
 	dir = 8
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "r" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c500,
 /obj/item/stack/spacecash/c100,
 /obj/item/stack/spacecash/c1000,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "s" = (
 /obj/structure/table/wood/poker,
 /obj/item/stack/spacecash/c200,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "u" = (
 /obj/structure/table/wood/poker,
@@ -110,25 +103,28 @@
 /obj/machinery/light/small{
 	dir = 4
 	},
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet,
 /area/ruin/powered/greed)
 "v" = (
 /obj/item/coin/gold,
 /obj/machinery/light/small,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/black,
 /area/ruin/powered/greed)
 "w" = (
 /obj/item/storage/bag/money,
 /obj/machinery/light/small,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/black,
+/area/ruin/powered/greed)
+"H" = (
+/turf/open/floor/carpet/purple,
 /area/ruin/powered/greed)
 "J" = (
 /obj/machinery/door/airlock/gold,
 /obj/structure/fans/tiny/invisible,
-/turf/open/floor/engine/cult,
+/turf/open/floor/carpet/purple,
 /area/ruin/powered/greed)
 "W" = (
-/turf/closed/wall/mineral/cult,
+/turf/closed/wall/mineral/titanium/survival/nodiagonal,
 /area/ruin/powered/greed)
 
 (1,1,1) = {"
@@ -337,7 +333,7 @@ a
 c
 W
 f
-i
+m
 m
 l
 m
@@ -345,7 +341,7 @@ o
 m
 m
 m
-m
+H
 J
 a
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pizzaparty.dmm
@@ -21,6 +21,7 @@
 "f" = (
 /obj/structure/table/wood,
 /obj/item/storage/box/cups,
+/obj/item/reagent_containers/food/snacks/lollipop,
 /turf/open/floor/wood{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -181,11 +182,19 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
+"B" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/trash/candy,
+/turf/open/floor/wood{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/unpowered)
 "C" = (
 /obj/structure/chair/wood/wings{
 	dir = 4
 	},
 /obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/candy,
 /turf/open/floor/plating{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -214,6 +223,7 @@
 /area/ruin/unpowered)
 "G" = (
 /obj/structure/table/wood,
+/obj/item/reagent_containers/food/snacks/lollipop,
 /turf/open/floor/wood{
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
@@ -288,6 +298,35 @@
 	initial_gas_mix = "o2=14;n2=23;TEMP=300"
 	},
 /area/ruin/unpowered)
+"R" = (
+/obj/structure/table/wood,
+/obj/effect/spawner/lootdrop/pizzaparty,
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/candy,
+/turf/open/floor/wood{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/unpowered)
+"V" = (
+/obj/item/reagent_containers/food/snacks/gumball,
+/turf/open/floor/wood{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/unpowered)
+"X" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/toy/snappop,
+/turf/open/floor/wood{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/unpowered)
+"Z" = (
+/obj/effect/decal/cleanable/dirt,
+/obj/item/reagent_containers/food/snacks/gumball,
+/turf/open/floor/wood{
+	initial_gas_mix = "o2=14;n2=23;TEMP=300"
+	},
+/area/ruin/unpowered)
 
 (1,1,1) = {"
 a
@@ -359,8 +398,8 @@ b
 c
 c
 e
-h
-h
+B
+Z
 e
 Q
 e
@@ -397,8 +436,8 @@ b
 d
 f
 n
-h
-h
+M
+X
 c
 e
 M
@@ -417,7 +456,7 @@ b
 d
 g
 o
-h
+B
 h
 C
 J
@@ -435,7 +474,7 @@ b
 b
 b
 e
-h
+Z
 p
 q
 x
@@ -461,7 +500,7 @@ r
 y
 E
 h
-h
+X
 c
 b
 b
@@ -496,7 +535,7 @@ b
 b
 e
 e
-h
+X
 t
 A
 G
@@ -515,12 +554,12 @@ b
 b
 b
 d
-k
+R
 h
 s
 s
 H
-h
+B
 O
 d
 b
@@ -536,9 +575,9 @@ b
 b
 d
 k
-h
+M
 u
-s
+V
 s
 o
 n

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -3,8 +3,9 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "b" = (
-/turf/closed/mineral/volcanic/lava_land_surface,
-/area/lavaland/surface/outdoors)
+/obj/structure/falsewall/silver,
+/turf/closed/wall/mineral/diamond,
+/area/ruin/powered/pride)
 "c" = (
 /turf/open/lava/smooth/lava_land_surface,
 /area/lavaland/surface/outdoors)
@@ -23,6 +24,10 @@
 "g" = (
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
+"i" = (
+/obj/item/clothing/gloves/ring,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
 "j" = (
 /obj/structure/mirror{
 	pixel_x = -32
@@ -33,13 +38,8 @@
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "k" = (
-/obj/structure/mirror{
-	pixel_x = 32
-	},
-/obj/machinery/light/small{
-	dir = 1
-	},
-/turf/open/floor/mineral/silver,
+/obj/structure/mirror/magic/pride,
+/turf/closed/wall/mineral/diamond,
 /area/ruin/powered/pride)
 "l" = (
 /obj/structure/mirror{
@@ -60,29 +60,71 @@
 	},
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
+"o" = (
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/item/lipstick/random,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"q" = (
+/obj/structure/mirror{
+	pixel_x = -32
+	},
+/obj/item/clothing/gloves/ring/silver,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
 "r" = (
 /obj/machinery/light/small,
 /turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
+"u" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/item/lipstick/random,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"D" = (
+/obj/item/clothing/head/wig/random,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
 "G" = (
-/turf/closed/wall/mineral/diamond,
+/turf/closed/mineral/volcanic/lava_land_surface,
+/area/lavaland/surface/outdoors)
+"I" = (
+/obj/item/clothing/gloves/ring/silver,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"J" = (
+/obj/structure/mirror{
+	pixel_x = 32
+	},
+/obj/machinery/light/small{
+	dir = 1
+	},
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"L" = (
+/obj/item/lipstick/random,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "O" = (
-/obj/structure/mirror/magic/pride,
-/turf/closed/wall/mineral/diamond,
+/obj/item/clothing/gloves/ring/diamond,
+/turf/open/floor/mineral/silver,
+/area/ruin/powered/pride)
+"V" = (
+/obj/item/clothing/head/wig,
+/turf/open/floor/mineral/silver,
 /area/ruin/powered/pride)
 "Y" = (
-/obj/machinery/door/airlock/diamond,
+/obj/machinery/door/airlock/silver/glass,
 /turf/open/floor/mineral/silver{
 	blocks_air = 1
 	},
 /area/ruin/powered/pride)
 
 (1,1,1) = {"
-a
-a
-a
-a
 a
 a
 a
@@ -116,91 +158,71 @@ c
 c
 c
 c
-c
-c
-c
-c
 a
 "}
 (3,1,1) = {"
+G
+c
+c
 b
-c
-c
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
+b
+b
+b
+b
+b
+b
+b
+b
+b
+b
 c
 a
 "}
 (4,1,1) = {"
 c
 c
-G
-G
-G
+b
+b
 j
-e
-e
-l
-e
+q
 e
 l
 e
 e
 l
 e
-e
-G
+o
+b
 c
 a
 "}
 (5,1,1) = {"
 c
-G
-G
-G
-G
-G
+b
+b
 g
 g
 g
+L
 g
+V
 g
-g
-g
-g
-g
-g
+L
+i
 r
-G
+b
 a
 a
 "}
 (6,1,1) = {"
 c
-G
-G
-G
-G
-G
+b
 O
 g
+k
 g
 g
-g
-g
+I
 g
 g
 g
@@ -212,77 +234,61 @@ a
 "}
 (7,1,1) = {"
 c
-G
-G
-G
-G
-G
+b
+b
 g
 g
+L
+D
 g
+L
+i
 g
-g
-g
-g
-g
-g
-g
+D
 r
-G
-c
+b
+a
 a
 "}
 (8,1,1) = {"
 c
 c
-G
-G
-G
-k
+b
+b
+J
 f
 f
 m
 f
 f
 m
+u
 f
-f
-m
-f
-f
-G
+b
 c
 a
 "}
 (9,1,1) = {"
+G
+c
+c
 b
-c
-c
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
-G
+b
+b
+b
+b
+b
+b
+b
+b
+b
+b
 c
 a
 "}
 (10,1,1) = {"
-b
-b
-c
-c
-c
-c
+G
+G
 c
 c
 c

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_pride.dmm
@@ -3,7 +3,6 @@
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/lavaland/surface/outdoors)
 "b" = (
-/obj/structure/falsewall/silver,
 /turf/closed/wall/mineral/diamond,
 /area/ruin/powered/pride)
 "c" = (

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -19,15 +19,23 @@
 	},
 /area/ruin/unpowered)
 "e" = (
-/obj/machinery/door/airlock/wood,
-/turf/open/floor/sepia{
-	blocks_air = 0;
-	slowdown = 10
-	},
+/obj/structure/sign/poster/official/fruit_bowl,
+/turf/closed/indestructible/riveted,
 /area/ruin/unpowered)
 "f" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
+/obj/item/reagent_containers/glass/bowl,
+/obj/item/reagent_containers/food/snacks/grown/grapes{
+	pixel_y = 10;
+	pixel_x = 10
+	},
+/obj/item/reagent_containers/food/snacks/grown/apple{
+	pixel_y = 8;
+	pixel_x = -8
+	},
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange{
+	pixel_y = 8
+	},
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
@@ -36,6 +44,13 @@
 "g" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
+/turf/open/floor/sepia{
+	blocks_air = 0;
+	slowdown = 10
+	},
+/area/ruin/unpowered)
+"j" = (
+/obj/machinery/door/airlock/wood,
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
@@ -93,7 +108,7 @@ a
 (5,1,1) = {"
 a
 b
-a
+e
 d
 d
 d
@@ -344,299 +359,11 @@ a
 "}
 (26,1,1) = {"
 a
-b
 a
-d
 a
 a
-a
-a
-b
-a
-"}
-(27,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(28,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(29,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(30,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(31,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(32,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(33,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(34,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(35,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(36,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(37,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(38,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(39,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(40,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(41,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(42,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(43,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(44,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(45,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(46,1,1) = {"
-a
-b
-a
-d
-a
-a
-a
-a
-b
-a
-"}
-(47,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(48,1,1) = {"
-a
-b
-a
-a
-a
-a
-d
-a
-b
-a
-"}
-(49,1,1) = {"
-a
-b
-a
-d
-d
-d
-d
-a
-b
-a
-"}
-(50,1,1) = {"
-a
-a
-a
-a
-e
-e
+j
+j
 a
 a
 a

--- a/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
+++ b/_maps/RandomRuins/LavaRuins/lavaland_surface_sloth.dmm
@@ -19,23 +19,15 @@
 	},
 /area/ruin/unpowered)
 "e" = (
-/obj/structure/sign/poster/official/fruit_bowl,
-/turf/closed/indestructible/riveted,
+/obj/machinery/door/airlock/wood,
+/turf/open/floor/sepia{
+	blocks_air = 0;
+	slowdown = 10
+	},
 /area/ruin/unpowered)
 "f" = (
 /obj/structure/table/wood,
-/obj/item/reagent_containers/glass/bowl,
-/obj/item/reagent_containers/food/snacks/grown/grapes{
-	pixel_y = 10;
-	pixel_x = 10
-	},
-/obj/item/reagent_containers/food/snacks/grown/apple{
-	pixel_y = 8;
-	pixel_x = -8
-	},
-/obj/item/reagent_containers/food/snacks/grown/citrus/orange{
-	pixel_y = 8
-	},
+/obj/item/reagent_containers/food/snacks/grown/citrus/orange,
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
@@ -44,13 +36,6 @@
 "g" = (
 /obj/structure/bed,
 /obj/item/bedsheet/brown,
-/turf/open/floor/sepia{
-	blocks_air = 0;
-	slowdown = 10
-	},
-/area/ruin/unpowered)
-"j" = (
-/obj/machinery/door/airlock/wood,
 /turf/open/floor/sepia{
 	blocks_air = 0;
 	slowdown = 10
@@ -108,7 +93,7 @@ a
 (5,1,1) = {"
 a
 b
-e
+a
 d
 d
 d
@@ -359,11 +344,299 @@ a
 "}
 (26,1,1) = {"
 a
+b
+a
+d
 a
 a
 a
-j
-j
+a
+b
+a
+"}
+(27,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(28,1,1) = {"
+a
+b
+a
+a
+a
+a
+d
+a
+b
+a
+"}
+(29,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(30,1,1) = {"
+a
+b
+a
+d
+a
+a
+a
+a
+b
+a
+"}
+(31,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(32,1,1) = {"
+a
+b
+a
+a
+a
+a
+d
+a
+b
+a
+"}
+(33,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(34,1,1) = {"
+a
+b
+a
+d
+a
+a
+a
+a
+b
+a
+"}
+(35,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(36,1,1) = {"
+a
+b
+a
+a
+a
+a
+d
+a
+b
+a
+"}
+(37,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(38,1,1) = {"
+a
+b
+a
+d
+a
+a
+a
+a
+b
+a
+"}
+(39,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(40,1,1) = {"
+a
+b
+a
+a
+a
+a
+d
+a
+b
+a
+"}
+(41,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(42,1,1) = {"
+a
+b
+a
+d
+a
+a
+a
+a
+b
+a
+"}
+(43,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(44,1,1) = {"
+a
+b
+a
+a
+a
+a
+d
+a
+b
+a
+"}
+(45,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(46,1,1) = {"
+a
+b
+a
+d
+a
+a
+a
+a
+b
+a
+"}
+(47,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(48,1,1) = {"
+a
+b
+a
+a
+a
+a
+d
+a
+b
+a
+"}
+(49,1,1) = {"
+a
+b
+a
+d
+d
+d
+d
+a
+b
+a
+"}
+(50,1,1) = {"
+a
+a
+a
+a
+e
+e
 a
 a
 a


### PR DESCRIPTION
## About The Pull Request

Makes pride and envy ruin a bit smaller!
Pride now has rings, lipstick wigs and silver walls/door making a nice and polished look then cyan blue walls.
Adds more trash and better dagger placement on food ruin
Snowboim now has snowballs and toy gifts for the two skeles daw!
Beach boim now has carp light branding beer, as well as soap!
Greed ruin now uses nice slick walls and carpet!
Founten ruin to a dark god being now uses carpets and other nice looking tiles, but no longer gives cult metal
Alien nest has a bit more glowy floors of resin looking a bit more lived in by the drones. As well as the "door" now being see through resin rather then the thicker stuff that you cant see through
Pizza party has a few more gifts, some candy and snap pops yay!
Sloth ruin is about 15~ tiles shorter, has and has more fruit for a bowl. How lazy!

## Why It's Good For The Game

Makes these old ruins just a bit nicer and more well-lived in feel adding in fluff and other fun little things, well not making things to much more overly powerfull. From trash to just more toys these changes do not really affect or do much for a miner other then add to the feel of the ruin!

## Changelog
:cl:
tweak: Makes pride and envy ruin a bit smaller!
add: Pride now has rings, lipstick wigs and silver walls/door making a nice and polished look then cyan blue walls.
add: more trash and better dagger placement on food ruin
add: Snowboim now has snowballs and toy gifts for the two skeles daw!
tweak: Beach boim now has carp light branding beer, as well as soap!
tweak: Greed ruin now uses nice slick walls and carpet!
tweak: Founten ruin looks a lot better with its carpets and well maintained fluff things, but walls suffered and no longer can salvage ruined metal...
add: Alien nest has a bit more glowy floors of resin looking a bit more lived in by the drones. As well as the "door" now being see through resin rather then the thicker stuff that you cant see through
add: Pizza party has a few more gifts, some candy and snap pops yay!
balance: Sloth ruin is about 15~ tiles shorter, has and has more fruit for a bowl. How lazy!
/:cl:
