### PR TITLE
Fix The X-01 Multiphase energy gun box

### DIFF
--- a/code/game/objects/items/storage/secure.dm
+++ b/code/game/objects/items/storage/secure.dm
@@ -174,7 +174,7 @@
 	name = "\improper X-01 Multiphase energy gun box"
 	desc = "A storage case for a high-tech energy firearm."
 
-/obj/item/storage/secure/briefcase/mws_pack_hos/PopulateContents()
+/obj/item/storage/secure/briefcase/hos/multiphase_box/PopulateContents()
 	new /obj/item/gun/energy/e_gun/hos(src)
 
 // -----------------------------


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Centcom mistakenly put pen and paper inside the Multiphase energy gun box as one of the personal weapon for hos,not anymore.

## Why It's Good For The Game
Bring back the Gun
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:

fix: fix the Multiphase energy gun box,it should have the gun in it now.

/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
