### PR TITLE
Adds clown hardsuit to clown node

### DIFF
--- a/code/modules/research/designs/equipment_designs.dm
+++ b/code/modules/research/designs/equipment_designs.dm
@@ -32,6 +32,17 @@
 	category = list("Misc")
 	departmental_flags = DEPARTMENTAL_FLAG_ENGINEERING */
 
+/datum/design/clown_hardsuit
+	name = "Comedic Hardsuit"
+	desc = "A colourfull hardsuit, designed for EVA comedy and hazardous joke delivery"
+	id = "clown_hardsuit"
+	build_type = PROTOLATHE
+	build_path = /obj/item/clothing/suit/space/hardsuit/clown
+	materials = list(/datum/material/iron=28000, /datum/material/glass = 10000,  /datum/material/bananium = 8000, /datum/material/gold = 3000, /datum/material/silver = 3000, /datum/material/titanium = 12000)
+	construction_time = 100
+	category = list("Misc")
+	departmental_flags = DEPARTMENTAL_FLAG_ALL	//HONK!
+
 /datum/design/constructionhardsuit
 	name = "Construction Hardsuit"
 	desc = "A hardsuit, designed for EVA construction and hazardous material transportation"

--- a/code/modules/research/techweb/nodes/misc_nodes.dm
+++ b/code/modules/research/techweb/nodes/misc_nodes.dm
@@ -64,5 +64,5 @@
 	description = "Honk?!"
 	prereq_ids = list("base")
 	design_ids = list("air_horn", "honker_main", "honker_peri", "honker_targ", "honk_chassis", "honk_head", "honk_torso", "honk_left_arm", "honk_right_arm",
-	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown")
+	"honk_left_leg", "honk_right_leg", "mech_banana_mortar", "mech_mousetrap_mortar", "mech_honker", "mech_punching_face", "implant_trombone", "borg_transform_clown", "clown_hardsuit")
 	research_costs = list(TECHWEB_POINT_TYPE_GENERIC = 2500)


### PR DESCRIPTION

## About The Pull Request

Honk! The clown hardsuit has been added to clown node, costing bananium to get this clown trait only suit just for you!

## Why It's Good For The Game

Its funny, and maybe a clown and miner(Xenobio rainbow slime maker) can work with one a other to get a clown hardsuit for them, its not even that well armored

## Changelog
:cl:
add: Clown hardsuit has been blueprinted in the clown tech node
/:cl: