### PR TITLE
Prevent surgery tools and items from being rad contaminatable 

### DIFF
--- a/code/modules/mob/living/silicon/robot/robot_modules.dm
+++ b/code/modules/mob/living/silicon/robot/robot_modules.dm
@@ -93,6 +93,7 @@
 	return new storage_type(src)
 
 /obj/item/robot_module/proc/add_module(obj/item/I, nonstandard, requires_rebuild)
+	rad_flags |= RAD_NO_CONTAMINATE
 	if(istype(I, /obj/item/stack))
 		var/obj/item/stack/S = I
 

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -6,7 +6,6 @@
 	custom_materials = list(/datum/material/iron=6000, /datum/material/glass=3000)
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
-	rad_flags = RAD_NO_CONTAMINATE
 	w_class = WEIGHT_CLASS_TINY
 	tool_behaviour = TOOL_RETRACTOR
 	toolspeed = 1
@@ -51,7 +50,6 @@
 	custom_materials = list(/datum/material/iron=5000, /datum/material/glass=2500)
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
-	rad_flags = RAD_NO_CONTAMINATE
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("attacked", "pinched")
 	tool_behaviour = TOOL_HEMOSTAT
@@ -76,7 +74,6 @@
 	custom_materials = list(/datum/material/iron=2500, /datum/material/glass=750)
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
-	rad_flags = RAD_NO_CONTAMINATE
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("burnt")
 	tool_behaviour = TOOL_CAUTERY
@@ -103,7 +100,6 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	custom_materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
 	item_flags = SURGICAL_TOOL
-	rad_flags = RAD_NO_CONTAMINATE
 	flags_1 = CONDUCT_1
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
@@ -158,7 +154,6 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	flags_1 = CONDUCT_1
-	rad_flags = RAD_NO_CONTAMINATE
 	force = 10
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5
@@ -242,7 +237,6 @@
 	throwhitsound =  'sound/weapons/pierce.ogg'
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
-	rad_flags = RAD_NO_CONTAMINATE
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 9
@@ -283,7 +277,6 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "surgical_drapes"
 	w_class = WEIGHT_CLASS_TINY
-	rad_flags = RAD_NO_CONTAMINATE
 	attack_verb = list("slapped")
 
 /obj/item/surgical_drapes/attack(mob/living/M, mob/user)
@@ -315,7 +308,6 @@
 	desc = "A container for holding body parts."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "evidenceobj"
-	rad_flags = RAD_NO_CONTAMINATE
 	item_flags = SURGICAL_TOOL
 
 /obj/item/organ_storage/afterattack(obj/item/I, mob/user, proximity)
@@ -363,7 +355,6 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
 	item_flags = NOBLUDGEON
-	rad_flags = RAD_NO_CONTAMINATE
 	var/list/advanced_surgeries = list()
 
 /obj/item/surgical_processor/afterattack(obj/item/O, mob/user, proximity)

--- a/code/modules/surgery/tools.dm
+++ b/code/modules/surgery/tools.dm
@@ -6,6 +6,7 @@
 	custom_materials = list(/datum/material/iron=6000, /datum/material/glass=3000)
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
+	rad_flags = RAD_NO_CONTAMINATE
 	w_class = WEIGHT_CLASS_TINY
 	tool_behaviour = TOOL_RETRACTOR
 	toolspeed = 1
@@ -50,6 +51,7 @@
 	custom_materials = list(/datum/material/iron=5000, /datum/material/glass=2500)
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
+	rad_flags = RAD_NO_CONTAMINATE
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("attacked", "pinched")
 	tool_behaviour = TOOL_HEMOSTAT
@@ -66,7 +68,6 @@
 	toolspeed = 0.5
 	attack_verb = list("attacked", "pinched")
 
-
 /obj/item/cautery
 	name = "cautery"
 	desc = "This stops bleeding."
@@ -75,6 +76,7 @@
 	custom_materials = list(/datum/material/iron=2500, /datum/material/glass=750)
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
+	rad_flags = RAD_NO_CONTAMINATE
 	w_class = WEIGHT_CLASS_TINY
 	attack_verb = list("burnt")
 	tool_behaviour = TOOL_CAUTERY
@@ -91,7 +93,6 @@
 	toolspeed = 0.5
 	attack_verb = list("burnt")
 
-
 /obj/item/surgicaldrill
 	name = "surgical drill"
 	desc = "You can drill using this item. You dig?"
@@ -102,6 +103,7 @@
 	hitsound = 'sound/weapons/circsawhit.ogg'
 	custom_materials = list(/datum/material/iron=10000, /datum/material/glass=6000)
 	item_flags = SURGICAL_TOOL
+	rad_flags = RAD_NO_CONTAMINATE
 	flags_1 = CONDUCT_1
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
@@ -148,7 +150,6 @@
 	toolspeed = 0.5
 	attack_verb = list("drilled")
 
-
 /obj/item/scalpel
 	name = "scalpel"
 	desc = "Cut, cut, and once more cut."
@@ -157,6 +158,7 @@
 	lefthand_file = 'icons/mob/inhands/equipment/medical_lefthand.dmi'
 	righthand_file = 'icons/mob/inhands/equipment/medical_righthand.dmi'
 	flags_1 = CONDUCT_1
+	rad_flags = RAD_NO_CONTAMINATE
 	force = 10
 	w_class = WEIGHT_CLASS_TINY
 	throwforce = 5
@@ -229,7 +231,6 @@
 	user.visible_message("<span class='suicide'>[user] is slitting [user.p_their()] [pick("wrists", "throat", "stomach")] with [src]! It looks like [user.p_theyre()] trying to commit suicide!</span>")
 	return (BRUTELOSS)
 
-
 /obj/item/circular_saw
 	name = "circular saw"
 	desc = "For heavy duty cutting."
@@ -241,6 +242,7 @@
 	throwhitsound =  'sound/weapons/pierce.ogg'
 	item_flags = SURGICAL_TOOL
 	flags_1 = CONDUCT_1
+	rad_flags = RAD_NO_CONTAMINATE
 	force = 15
 	w_class = WEIGHT_CLASS_NORMAL
 	throwforce = 9
@@ -281,6 +283,7 @@
 	icon = 'icons/obj/surgery.dmi'
 	icon_state = "surgical_drapes"
 	w_class = WEIGHT_CLASS_TINY
+	rad_flags = RAD_NO_CONTAMINATE
 	attack_verb = list("slapped")
 
 /obj/item/surgical_drapes/attack(mob/living/M, mob/user)
@@ -312,6 +315,7 @@
 	desc = "A container for holding body parts."
 	icon = 'icons/obj/storage.dmi'
 	icon_state = "evidenceobj"
+	rad_flags = RAD_NO_CONTAMINATE
 	item_flags = SURGICAL_TOOL
 
 /obj/item/organ_storage/afterattack(obj/item/I, mob/user, proximity)
@@ -359,6 +363,7 @@
 	icon = 'icons/obj/device.dmi'
 	icon_state = "spectrometer"
 	item_flags = NOBLUDGEON
+	rad_flags = RAD_NO_CONTAMINATE
 	var/list/advanced_surgeries = list()
 
 /obj/item/surgical_processor/afterattack(obj/item/O, mob/user, proximity)


### PR DESCRIPTION

## About The Pull Request

All surgery tools and items for borgs can no longer become contaminated

## Why It's Good For The Game

Helps make surgery borgs, and persons not become walking/dragged hot spots as they work to save someones life using sugery or life saving meds

## Changelog
:cl:
tweak: All surgery tools and borg based items now are lined with rad proof metals, what joy!
/:cl:
