### PR TITLE
Makes stealing hos gun beacon also count as stealing the hos gun

### DIFF
--- a/code/game/gamemodes/objective_items.dm
+++ b/code/game/gamemodes/objective_items.dm
@@ -36,7 +36,7 @@
 	targetitem = /obj/item/gun/energy/e_gun/hos
 	difficulty = 10
 	excludefromjob = list("Head Of Security")
-	altitems = list(/obj/item/gun/ballistic/revolver/mws)
+	altitems = list(/obj/item/gun/ballistic/revolver/mws, /obj/item/choice_beacon/hosgun) //We now look for eather the alt verson of the hos gun or the beacon picker.
 
 /datum/objective_item/steal/handtele
 	name = "a hand teleporter."


### PR DESCRIPTION
## About The Pull Request

Syndicats have relised stealing the becone itself is just as good as stealing one or the other gun

## Why It's Good For The Game

Consistency for one, your still basicly stealing the gun they want.
Second, so a traitor dosnt need to steal the becone and then pick a gun, like come-on its meant for hos to pick not just any old jolly that needs it shift start for a goal to later get it taken away when they get arrested
Third, wait a second, why is that destuctable?

## Changelog
:cl:
fix: The Syndicate has realised stealing the HoS gun beacon itself is just as good as stealing one gun or the other.
/:cl:
