### PR TITLE
Corrects shoes being unable to hold mini-guns

### DIFF
--- a/code/datums/components/storage/concrete/pockets.dm
+++ b/code/datums/components/storage/concrete/pockets.dm
@@ -57,7 +57,7 @@
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
 		/obj/item/firing_pin, /obj/item/gun/ballistic/automatic/pistol, /obj/item/gun/ballistic/automatic/magrifle/pistol,
-		/obj/item/toy/plush/snakeplushie
+		/obj/item/toy/plush/snakeplushie, /obj/item/gun/energy/e_gun/mini
 		))
 
 /datum/component/storage/concrete/pockets/shoes/clown/Initialize()
@@ -68,7 +68,7 @@
 		/obj/item/scalpel, /obj/item/reagent_containers/syringe, /obj/item/dnainjector,
 		/obj/item/reagent_containers/hypospray/medipen, /obj/item/reagent_containers/dropper,
 		/obj/item/implanter, /obj/item/screwdriver, /obj/item/weldingtool/mini,
-		/obj/item/firing_pin, /obj/item/bikehorn, /obj/item/gun/ballistic/automatic/pistol))
+		/obj/item/firing_pin, /obj/item/bikehorn, /obj/item/gun/ballistic/automatic/pistol, /obj/item/gun/energy/e_gun/mini))
 
 /datum/component/storage/concrete/pockets/pocketprotector
 	max_items = 3


### PR DESCRIPTION

## About The Pull Request

Shoes now can hold guns that are made small like a pistol that shoots laser beams

## Why It's Good For The Game

Consistency with gun size placements of what fits in boots.
Im sure this is just an oversight that they were not added to the list of boot-able guns tbh

## Changelog
:cl:
balance: Mini E-guns now like the mag pistol fits in boots
/:cl: