### PR TITLE
New fermi chem Zeolites!

### DIFF
--- a/code/modules/reagents/reagent_containers/bottle.dm
+++ b/code/modules/reagents/reagent_containers/bottle.dm
@@ -8,7 +8,6 @@
 	possible_transfer_amounts = list(5,10,15,25,30)
 	volume = 30
 
-
 /obj/item/reagent_containers/glass/bottle/Initialize()
 	. = ..()
 	if(!icon_state)
@@ -39,7 +38,6 @@
 				filling.icon_state = "[cached_icon]100"
 
 		. += filling
-
 
 /obj/item/reagent_containers/glass/bottle/epinephrine
 	name = "epinephrine bottle"
@@ -227,6 +225,13 @@
 	name = "atropine bottle"
 	desc = "A small bottle of atropine."
 	list_reagents = list(/datum/reagent/medicine/atropine = 30)
+
+/obj/item/reagent_containers/glass/bottle/zeolites
+	name = "Zeolites bottle"
+	desc = "A small bottle of lab made Zeolite, which removes radiation from people quickly as well as contamination on items."
+	list_reagents = list(/datum/reagent/fermi/zeolites = 30)
+
+// Viro bottles
 
 /obj/item/reagent_containers/glass/bottle/romerol
 	name = "romerol bottle"

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -197,3 +197,25 @@
 		M.stat = DEAD
 		M.visible_message("The synthetic tissue degrades off [M]'s wounds as they collapse to the floor.")
 //NEEDS ON_MOB_DEAD()
+
+/datum/reagent/fermi/zeolites
+	name = "Artificial Zeolites"
+	description = "Lab made Zeolite, used to clear radiation form people and items alike! Splashing just a small amounts(5u) onto any item can clear away large amouts of contamination."
+	pH = 8
+	color = "#FFDADA"
+	metabolization_rate = 8 * REAGENTS_METABOLISM //Lastes not long in body but heals a lot!
+	value = REAGENT_VALUE_COMMON
+
+/datum/reagent/fermi/zeolites/on_mob_life(mob/living/carbon/M)
+	var/datum/component/radioactive/contamination = M.GetComponent(/datum/component/radioactive)
+	if(M.radiation > 0)
+		M.radiation -= min(M.radiation, 180)
+	if(contamination.strength > 0)
+		contamination.strength -= min(contamination.strength, 400)
+	..()
+
+/datum/reagent/fermi/zeolites/reaction_obj(obj/O, reac_volume)
+	var/datum/component/radioactive/contamination = O.GetComponent(/datum/component/radioactive)
+	if(contamination && reac_volume >= 5)
+		qdel(contamination)
+		return

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/healing.dm
@@ -209,9 +209,9 @@
 /datum/reagent/fermi/zeolites/on_mob_life(mob/living/carbon/M)
 	var/datum/component/radioactive/contamination = M.GetComponent(/datum/component/radioactive)
 	if(M.radiation > 0)
-		M.radiation -= min(M.radiation, 180)
+		M.radiation -= min(M.radiation, 60)
 	if(contamination.strength > 0)
-		contamination.strength -= min(contamination.strength, 400)
+		contamination.strength -= min(contamination.strength, 100)
 	..()
 
 /datum/reagent/fermi/zeolites/reaction_obj(obj/O, reac_volume)

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -561,3 +561,23 @@
 	HIonRelease 	= 0.1
 	RateUpLim 		= 2
 	FermiChem 		= TRUE
+
+/datum/chemical_reaction/fermi/zeolites
+	name = "Zeolites"
+	id = /datum/reagent/fermi/zeolites
+	results = list(/datum/reagent/fermi/zeolites = 5) //We make a lot!
+	required_reagents = list(/datum/reagent/medicine/potass_iodide = 1, /datum/reagent/aluminium = 1, /datum/reagent/silicon = 1, /datum/reagent/oxygen = 1)
+	//FermiChem vars:
+	OptimalTempMin 	= 300
+	OptimalTempMax 	= 900
+	ExplodeTemp 	= 1000 //check to see overflow doesn't happen!
+	OptimalpHMin 	= 4.0
+	OptimalpHMax 	= 6.0
+	ReactpHLim 		= 4
+	//CatalystFact 	= 0
+	CurveSharpT 	= 4
+	CurveSharppH 	= 0
+	ThermicConstant = 0
+	HIonRelease 	= 0.01
+	RateUpLim 		= 15
+	FermiChem 		= TRUE


### PR DESCRIPTION
## About The Pull Request
This new hard* to make chem is meant to clear out radiation and contamination!
Its made with heat, Potassium Iodide, O2, Aluminium, and Silicon.
Is made in 5 parts form 5 chems!
Splashing this chem on an object will clear it of radiation contamination well drinking it will lower yours as well as radiation.
Notes:
hard - to people that would not know how to make it or the way to have it be made the best possable way
## Why It's Good For The Game

More robust ways to clear out meltdowns and people gone nukie are wanted/requested all the time, this is just one chem that does that for clearing the large contamination items/people get that can not be cleared by showers/normal chems, forcing them to be shoved legit into a burn chamber and cleaned that way (Thats really fucked up)!

## Changelog
:cl: Putnam for helping me code the contamination clearing on people
add: Lab made Zeolites have been remade anew and more affective now that they refined the best possable way to mix and make a supper Zeolite capable of clearing contamination form not only people but items!
/:cl:
