### PR TITLE
Powers Reimagined : Void Volt

### DIFF
--- a/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
@@ -1,13 +1,14 @@
 //horrifying power drain proc made for clockcult's power drain in lieu of six istypes or six for(x in view) loops
-/atom/movable/proc/power_drain(clockcult_user, drain_weapons = FALSE) //This proc as of now is only in use for void volt.
+/atom/movable/proc/power_drain(clockcult_user, drain_weapons = FALSE) //This proc as of now is only in use for void volt
 	var/obj/item/stock_parts/cell/cell = get_cell()
 	if(cell)
 		return cell.power_drain(clockcult_user)
-	return 0 //Returns 0 instead of false to symbolise it returning the power amount in other cases, not TRUE aka 1
+	return 0 //Returns 0 instead of FALSE to symbolise it returning the power amount in other cases, not TRUE aka 1
 
 /obj/item/melee/baton/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
 	if(!drain_weapons)
 		return 0
+	message_admins("Succ successfully performed on [src], see next cell drain report for closer info.")
 	return ..()
 
 /obj/item/gun/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
@@ -25,7 +26,7 @@
 	if(cell && cell.charge)
 		playsound(src, "sparks", 50, 1)
 		flick("apc-spark", src)
-		. = min(cell.charge, MIN_CLOCKCULT_POWER*3)
+		. = min(cell.charge, MIN_CLOCKCULT_POWER*4)
 		cell.use(.) //Better than a power sink!
 		if(!cell.charge && !shorted)
 			shorted = 1
@@ -35,7 +36,7 @@
 
 /obj/machinery/power/smes/power_drain(clockcult_user, drain_weapons = FALSE)
 	if(charge)
-		. = min(charge, MIN_CLOCKCULT_POWER*3)
+		. = min(charge, MIN_CLOCKCULT_POWER*4)
 		charge -= . * 50
 		if(!charge && !panel_open)
 			panel_open = TRUE
@@ -46,8 +47,8 @@
 
 /obj/item/stock_parts/cell/power_drain(clockcult_user, drain_weapons = FALSE)
 	if(charge)
-		. = min(charge, MIN_CLOCKCULT_POWER * 4)
-		use(. * 10) //Usually cell-powered equipment that is not a gun has at least ten times the capacity of a gun / 5 times the amount of an APC. This adjusts the drain to account for that.
+		. = min(charge, MIN_CLOCKCULT_POWER * 4) //Done like this because normal cells are usually quite a bit bigger than the ones used in guns / APCs
+		use(min(charge, . * 10)) //Usually cell-powered equipment that is not a gun has at least ten times the capacity of a gun / 5 times the amount of an APC. This adjusts the drain to account for that.
 		update_icon()
 
 /mob/living/silicon/robot/power_drain(clockcult_user, drain_weapons = FALSE)

--- a/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
@@ -8,7 +8,6 @@
 /obj/item/melee/baton/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
 	if(!drain_weapons)
 		return 0
-	message_admins("Succ successfully performed on [src], see next cell drain report for closer info.")
 	return ..()
 
 /obj/item/gun/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes

--- a/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
+++ b/code/modules/antagonists/clockcult/clock_helpers/clock_powerdrain.dm
@@ -1,17 +1,27 @@
 //horrifying power drain proc made for clockcult's power drain in lieu of six istypes or six for(x in view) loops
-/atom/movable/proc/power_drain(clockcult_user)
+/atom/movable/proc/power_drain(clockcult_user, drain_weapons = FALSE) //This proc as of now is only in use for void volt.
 	var/obj/item/stock_parts/cell/cell = get_cell()
 	if(cell)
 		return cell.power_drain(clockcult_user)
-	return 0
+	return 0 //Returns 0 instead of false to symbolise it returning the power amount in other cases, not TRUE aka 1
 
-/obj/item/melee/baton/power_drain(clockcult_user)	//balance memes
-	return 0
+/obj/item/melee/baton/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
+	if(!drain_weapons)
+		return 0
+	return ..()
 
-/obj/item/gun/power_drain(clockcult_user)	//balance memes
-	return 0
+/obj/item/gun/power_drain(clockcult_user, drain_weapons = FALSE)	//balance memes
+	if(!drain_weapons)
+		return 0
+	var/obj/item/stock_parts/cell/cell = get_cell()
+	if(!cell)
+		return 0
+	if(cell.charge)
+		. = min(cell.charge, MIN_CLOCKCULT_POWER*4) //Done snowflakey because guns have far smaller cells than batons / other equipment
+		cell.use(.)
+		update_icon()
 
-/obj/machinery/power/apc/power_drain(clockcult_user)
+/obj/machinery/power/apc/power_drain(clockcult_user, drain_weapons = FALSE)
 	if(cell && cell.charge)
 		playsound(src, "sparks", 50, 1)
 		flick("apc-spark", src)
@@ -23,7 +33,7 @@
 		update()
 		update_icon()
 
-/obj/machinery/power/smes/power_drain(clockcult_user)
+/obj/machinery/power/smes/power_drain(clockcult_user, drain_weapons = FALSE)
 	if(charge)
 		. = min(charge, MIN_CLOCKCULT_POWER*3)
 		charge -= . * 50
@@ -34,19 +44,19 @@
 			visible_message("<span class='warning'>[src]'s panel flies open with a flurry of sparks!</span>")
 		update_icon()
 
-/obj/item/stock_parts/cell/power_drain(clockcult_user)
+/obj/item/stock_parts/cell/power_drain(clockcult_user, drain_weapons = FALSE)
 	if(charge)
-		. = min(charge, MIN_CLOCKCULT_POWER*3)
-		charge = use(.)
+		. = min(charge, MIN_CLOCKCULT_POWER * 4)
+		use(. * 10) //Usually cell-powered equipment that is not a gun has at least ten times the capacity of a gun / 5 times the amount of an APC. This adjusts the drain to account for that.
 		update_icon()
 
-/mob/living/silicon/robot/power_drain(clockcult_user)
+/mob/living/silicon/robot/power_drain(clockcult_user, drain_weapons = FALSE)
 	if((!clockcult_user || !is_servant_of_ratvar(src)) && cell && cell.charge)
 		. = min(cell.charge, MIN_CLOCKCULT_POWER*4)
 		cell.use(.)
 		spark_system.start()
 
-/obj/mecha/power_drain(clockcult_user)
+/obj/mecha/power_drain(clockcult_user, drain_weapons = FALSE)
 	if((!clockcult_user || (occupant && !is_servant_of_ratvar(occupant))) && cell && cell.charge)
 		. = min(cell.charge, MIN_CLOCKCULT_POWER*4)
 		cell.use(.)

--- a/code/modules/antagonists/clockcult/clock_scripture.dm
+++ b/code/modules/antagonists/clockcult/clock_scripture.dm
@@ -203,6 +203,10 @@ Applications: 8 servants, 3 caches, and 100 CV
 		if(!do_after(invoker, chant_interval, target = invoker, extra_checks = CALLBACK(src, .proc/can_recite)))
 			break
 		clockwork_say(invoker, text2ratvar(pick(chant_invocations)), whispered)
+		if(multiple_invokers_used)
+			for(var/mob/living/L in range(1, get_turf(invoker)))
+				if(can_recite_scripture(L) && L != invoker)
+					clockwork_say(L, text2ratvar(pick(chant_invocations)), whispered)
 		if(!chant_effects(i))
 			break
 	if(invoker && slab)

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -115,7 +115,7 @@
 	tier = SCRIPTURE_SCRIPT
 	space_allowed = TRUE
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 5
+	sort_priority = 6
 	quickbind = TRUE
 	quickbind_desc = "Creates a Ratvarian shield, which can absorb energy from attacks for use in powerful bashes."
 
@@ -131,7 +131,7 @@
 	usage_tip = "Throwing the spear at a mob will do massive damage and knock them down, but break the spear. You will need to wait for 30 seconds before resummoning it."
 	tier = SCRIPTURE_SCRIPT
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 6
+	sort_priority = 7
 	important = TRUE
 	quickbind = TRUE
 	quickbind_desc = "Permanently binds clockwork armor and a Ratvarian spear to you."
@@ -231,7 +231,7 @@
 	usage_tip = "This gateway is strictly one-way and will only allow things through the invoker's portal."
 	tier = SCRIPTURE_SCRIPT
 	primary_component = GEIS_CAPACITOR
-	sort_priority = 7
+	sort_priority = 9
 	quickbind = TRUE
 	quickbind_desc = "Allows you to create a one-way Spatial Gateway to a living Servant or Clockwork Obelisk."
 
@@ -276,7 +276,7 @@
 	usage_tip = "This is a very effective way to rapidly reinforce a base after an attack."
 	tier = SCRIPTURE_SCRIPT
 	primary_component = VANGUARD_COGWHEEL
-	sort_priority = 7
+	sort_priority = 8
 	quickbind = TRUE
 	quickbind_desc = "Repairs nearby structures and constructs. Servants wearing clockwork armor will also be healed.<br><b>Maximum 10 chants.</b>"
 	var/heal_attempts = 4
@@ -388,8 +388,8 @@
 	power_cost = 500
 	usage_tip = "Though it requires you to stand still, this scripture can do massive damage."
 	tier = SCRIPTURE_SCRIPT
-	primary_component = HIEROPHANT_ANSIBLE
-	sort_priority = 10
+	primary_component = BELLIGERENT_EYE
+	sort_priority = 5
 	quickbind = TRUE
 	quickbind_desc = "Allows you to fire energy rays at target locations.<br><b>Maximum 5 chants.</b>"
 	var/static/list/nzcrentr_insults = list("You're not very good at aiming.", "You hunt badly.", "What a waste of energy.", "Almost funny to watch.",
@@ -437,11 +437,15 @@
 	usage_tip = "It may be useful to end channelling early if the burning gets too much."
 	tier = SCRIPTURE_SCRIPT
 	primary_component = GEIS_CAPACITOR
-	sort_priority = 11
+	sort_priority = 10
 	quickbind = TRUE
 	quickbind_desc = "Quickly drains power in an area around the invoker, causing burns due to the high amount of energy channeled.<br><b>Maximum of 20 chants.</b>"
 
 /datum/clockwork_scripture/channeled/void_volt/scripture_effects()
+	invoker.light_power = 2
+	invoker.light_range = 2
+	invoker.light_color = LIGHT_COLOR_FIRE
+	invoker.update_light()
 	invoker.visible_message("<span class='warning'>[invoker] glows in a brilliant golden light!</span>")
 	invoker.add_atom_colour("#FFD700", ADMIN_COLOUR_PRIORITY) //#EC8A2D? #E2B007? TODO: Find a good color, maybe make them actually glow too and not just have the sigil effect do that
 	return ..()
@@ -476,6 +480,9 @@
 	return TRUE
 
 /datum/clockwork_scripture/channeled/void_volt/chant_end_effects()
+	invoker.light_power = 0
+	invoker.light_range = 0
+	invoker.update_light()
 	invoker.visible_message("<span class='warning'>[invoker] stops glowing...</span>")
 	invoker.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
 	return ..()

--- a/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
+++ b/code/modules/antagonists/clockcult/clock_scriptures/scripture_scripts.dm
@@ -420,3 +420,62 @@
 	ranged_message = "<span class='nzcrentr_small'><i>You charge the clockwork slab with shocking might.</i>\n\
 	<b>Left-click a target to fire, quickly!</b></span>"
 	timeout_time = 20
+
+/datum/clockwork_scripture/channeled/void_volt
+	descname = "Channeled, Power Drain"
+	name = "Void Volt"
+	desc = "A channled chant that quickly drains any powercells in a large radius, but burns the invoker. \
+	Can be channeled with more cultists to increase range and decrease damage in relation to power absorbed. \
+	Also charges clockwork power by a small percentage of the drained power, which can help offset the scriptures powercost."
+	chant_invocations = list("Make their lights fall dark!", "Their power shall fuel Engine!")
+	chant_amount = 20
+	chant_interval = 10 //100KW drain per pulse for guns / 1MW for other cells = 10 chants / 100ds / 10s to drain a charged weapon or a baton with a nonupgraded cell
+	channel_time = 50
+	power_cost = 300
+	multiple_invokers_used = TRUE
+	multiple_invokers_optional = TRUE
+	usage_tip = "It may be useful to end channelling early if the burning gets too much."
+	tier = SCRIPTURE_SCRIPT
+	primary_component = GEIS_CAPACITOR
+	sort_priority = 11
+	quickbind = TRUE
+	quickbind_desc = "Quickly drains power in an area around the invoker, causing burns due to the high amount of energy channeled.<br><b>Maximum of 20 chants.</b>"
+
+/datum/clockwork_scripture/channeled/void_volt/scripture_effects()
+	invoker.visible_message("<span class='warning'>[invoker] glows in a brilliant golden light!</span>")
+	invoker.add_atom_colour("#FFD700", ADMIN_COLOUR_PRIORITY) //#EC8A2D? #E2B007? TODO: Find a good color, maybe make them actually glow too and not just have the sigil effect do that
+	return ..()
+
+
+/datum/clockwork_scripture/channeled/void_volt/chant_effects(chant_number)
+	var/power_drained = 0
+	var/power_mod = 0.0035 //TODO: Find a well balanced powermod
+	var/drain_range = 8
+	var/additional_chanters = 0
+	var/list/chanters = list()
+	chanters += invoker
+	for(var/mob/living/L in range(1, invoker))
+		if(!L.stat && is_servant_of_ratvar(L))
+			additional_chanters++
+			chanters += L
+	drain_range = min(drain_range + 2 * additional_chanters, drain_range * 2) //s u c c
+	for(var/t in spiral_range_turfs(drain_range, invoker))
+		var/turf/T = t
+		for(var/M in T)
+			var/atom/movable/A = M
+			power_drained += A.power_drain(TRUE, TRUE) //Yes, this absolutely does drain weaponry TODO: At the moment, far too strong vs. guns / cells in general
+	new /obj/effect/temp_visual/ratvar/sigil/transgression(invoker.loc, 1 + (power_drained * power_mod))
+	var/datum/effect_system/spark_spread/S = new
+	S.set_up(round(1 + (power_drained * power_mod), 1),0,get_turf(invoker))
+	S.start()
+	adjust_clockwork_power(power_drained * power_mod) //TODO: Balance this too
+	for(var/mob/living/L in chanters)
+		L.adjustFireLoss(round(clamp(power_drained * power_mod / (1 + additional_chanters), 0.1, 20), 0.1)) //No you won't just immediately melt if you do this in a very power-rich area
+
+
+	return TRUE
+
+/datum/clockwork_scripture/channeled/void_volt/chant_end_effects()
+	invoker.visible_message("<span class='warning'>[invoker] stops glowing...</span>")
+	invoker.remove_atom_colour(ADMIN_COLOUR_PRIORITY)
+	return ..()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
Adds the Void Volt scripture to the scripture tier (tier two) of clockwork cultists.
It is a chanted scripture, which means it can be channeled for quite a bit of time for increased effects, or well, in this case, more 'pulses' of effects, to a maximum of _20_ per cast, with _1_ second of time between individual pulses after _5_ seconds of initial invocation time.
Every pulse, the chant drains power from any powered object within _8_ tiles of the invoker, draining _100KJ_ from guns such as cells and APCs, aswell as _1MJ_ from any other powered objects within range such as cells, mechs, borgs, etc., which is handled as _100KJ_ for power-feedback purposes.
After performing the drain pulse, the invoker suffers _0.005_ times the drained power amount as burn damage, leading to _0.5_ damage per drained object per pulse (in general). 15 times the suffered damage is then added to the clockwork cult's global power pool. Also, a maximum damage of 20 can be suffered by a singular pulse, to not have the chant be immediate suicide in powerrich areas. It takes about _10_ pulses to drain a gun or normal cell, and about _20_ - _40_ to drain a normal APC (depending on how well the powernet is working). APCs are shorted out of they end up empty after one of these pulses, though any other equipment suffers no ill effects aside from this.
This chant also allows for multiple (adjacent) cultists to chant together, giving the chant _2_ tiles of range increase per additional cultist involved, to a maximum of _2_ times the starting range, so _16_
When multiple cultists are chanting this chant together, the damage dealt is split evenly between all of them.

This PR also tweaks around the clockcult power-drain helper (which is used for nothing but void volt as of now), aswell as reordering scriptures of the scripture tier to be a bit more organised (with no gameplay effect), aswell as making additional cultists actually chant for multi-invoker chants.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Void Volt in the old design document looked like an interesting utility scripture to have in a cultists arsenal, and with this slightly modified implementation of it, it shoud provide an useful tool to cause localised power outages stationside, combat hostile mechs, or somewhat mitigate the effect of energy-weaponry being used in high amounts (though of course those can just be recharged).
All in all, an interesting, though somewhat situational, chant for clock cultists and ratvarian chaplains.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: Adds Void Volt to the tier two scriptures of clockies
tweak: Changed around the sorting of some clockwork spells (No actual gameplay impact)
tweak: Modifies the clockie power drain helper a bit, it was not being used prior to void volt anyway
tweak: Adds an interaction for chants being used with multiple casters
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
