### PR TITLE
Reduces prices of basic things by 20% + rounding

### DIFF
--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -125,9 +125,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/scan_id = TRUE
 	var/obj/item/coin/coin
 	///Default price of items if not overridden
-	var/default_price = 20
+	var/default_price = 25
 	///Default price of premium items if not overridden
-	var/extra_price = 40
+	var/extra_price = 50
 	///cost multiplier per department or access
 	var/list/cost_multiplier_per_dept = list()
   	/**

--- a/code/modules/vending/_vending.dm
+++ b/code/modules/vending/_vending.dm
@@ -125,9 +125,9 @@ IF YOU MODIFY THE PRODUCTS LIST OF A MACHINE, MAKE SURE TO UPDATE ITS RESUPPLY C
 	var/scan_id = TRUE
 	var/obj/item/coin/coin
 	///Default price of items if not overridden
-	var/default_price = 25
+	var/default_price = 20
 	///Default price of premium items if not overridden
-	var/extra_price = 50
+	var/extra_price = 40
 	///cost multiplier per department or access
 	var/list/cost_multiplier_per_dept = list()
   	/**

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -19,8 +19,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/assist
 	resistance_flags = FIRE_PROOF
-	default_price = 50
-	extra_price = 100
+	default_price = 40
+	extra_price = 80
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/assist

--- a/code/modules/vending/assist.dm
+++ b/code/modules/vending/assist.dm
@@ -19,8 +19,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/assist
 	resistance_flags = FIRE_PROOF
-	default_price = 40
-	extra_price = 80
+	default_price = 50
+	extra_price = 100
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/assist

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -139,8 +139,8 @@
 					/obj/item/clothing/under/costume/drfreeze = 1)
 
 	refill_canister = /obj/item/vending_refill/autodrobe
-	default_price = 180
-	extra_price = 360
+	default_price = 140
+	extra_price = 280
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/autodrobe/Initialize()

--- a/code/modules/vending/autodrobe.dm
+++ b/code/modules/vending/autodrobe.dm
@@ -139,8 +139,8 @@
 					/obj/item/clothing/under/costume/drfreeze = 1)
 
 	refill_canister = /obj/item/vending_refill/autodrobe
-	default_price = 140
-	extra_price = 280
+	default_price = 180
+	extra_price = 360
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/autodrobe/Initialize()

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -40,8 +40,8 @@
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
 	refill_canister = /obj/item/vending_refill/boozeomat
-	default_price = 120
-	extra_price = 100
+	default_price = 100
+	extra_price = 80
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/boozeomat.dm
+++ b/code/modules/vending/boozeomat.dm
@@ -40,8 +40,8 @@
 	product_slogans = "I hope nobody asks me for a bloody cup o' tea...;Alcohol is humanity's friend. Would you abandon a friend?;Quite delighted to serve you!;Is nobody thirsty on this station?"
 	product_ads = "Drink up!;Booze is good for you!;Alcohol is humanity's best friend.;Quite delighted to serve you!;Care for a nice, cold beer?;Nothing cures you like booze!;Have a sip!;Have a drink!;Have a beer!;Beer is good for you!;Only the finest alcohol!;Best quality booze since 2053!;Award-winning wine!;Maximum alcohol!;Man loves beer.;A toast for progress!"
 	refill_canister = /obj/item/vending_refill/boozeomat
-	default_price = 100
-	extra_price = 80
+	default_price = 120
+	extra_price = 100
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -16,8 +16,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/cart
 	resistance_flags = FIRE_PROOF
-	default_price = 250
-	extra_price = 500
+	default_price = 200
+	extra_price = 400
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/cartridge.dm
+++ b/code/modules/vending/cartridge.dm
@@ -16,8 +16,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/cart
 	resistance_flags = FIRE_PROOF
-	default_price = 200
-	extra_price = 400
+	default_price = 250
+	extra_price = 500
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -20,8 +20,8 @@
 					/obj/item/storage/fancy/cigarettes/cigars/havana = 1,
 					/obj/item/storage/fancy/cigarettes/cigars/cohiba = 1)
 	refill_canister = /obj/item/vending_refill/cigarette
-	default_price = 60
-	extra_price = 200
+	default_price = 75
+	extra_price = 250
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/cigarette/syndicate

--- a/code/modules/vending/cigarette.dm
+++ b/code/modules/vending/cigarette.dm
@@ -20,8 +20,8 @@
 					/obj/item/storage/fancy/cigarettes/cigars/havana = 1,
 					/obj/item/storage/fancy/cigarettes/cigars/cohiba = 1)
 	refill_canister = /obj/item/vending_refill/cigarette
-	default_price = 75
-	extra_price = 250
+	default_price = 60
+	extra_price = 200
 	payment_department = ACCOUNT_SRV
 
 /obj/machinery/vending/cigarette/syndicate

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -173,8 +173,8 @@
 					/obj/item/clothing/suit/jacket/letterman_nanotrasen = 5,
 					/obj/item/clothing/suit/hooded/wintercoat/polychromic = 5)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = 60
-	extra_price = 120
+	default_price = 50
+	extra_price = 100
 	payment_department = NO_FREEBIES
 
 /obj/machinery/vending/clothing/canLoadItem(obj/item/I,mob/user)

--- a/code/modules/vending/clothesmate.dm
+++ b/code/modules/vending/clothesmate.dm
@@ -173,8 +173,8 @@
 					/obj/item/clothing/suit/jacket/letterman_nanotrasen = 5,
 					/obj/item/clothing/suit/hooded/wintercoat/polychromic = 5)
 	refill_canister = /obj/item/vending_refill/clothing
-	default_price = 50
-	extra_price = 100
+	default_price = 60
+	extra_price = 120
 	payment_department = NO_FREEBIES
 
 /obj/machinery/vending/clothing/canLoadItem(obj/item/I,mob/user)

--- a/code/modules/vending/coffee.dm
+++ b/code/modules/vending/coffee.dm
@@ -14,8 +14,8 @@
 					/obj/item/reagent_containers/food/condiment/sugar = 1)
 
 	refill_canister = /obj/item/vending_refill/coffee
-	default_price = 35
-	extra_price = 120
+	default_price = 45
+	extra_price = 150
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/coffee

--- a/code/modules/vending/coffee.dm
+++ b/code/modules/vending/coffee.dm
@@ -14,8 +14,8 @@
 					/obj/item/reagent_containers/food/condiment/sugar = 1)
 
 	refill_canister = /obj/item/vending_refill/coffee
-	default_price = 45
-	extra_price = 150
+	default_price = 35
+	extra_price = 120
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/coffee

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -21,8 +21,8 @@
 					/obj/item/reagent_containers/food/drinks/soda_cans/grey_bull = 1,
 					/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy = 1)
 	refill_canister = /obj/item/vending_refill/cola
-	default_price = 45
-	extra_price = 200
+	default_price = 35
+	extra_price = 160
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/cola

--- a/code/modules/vending/cola.dm
+++ b/code/modules/vending/cola.dm
@@ -21,8 +21,8 @@
 					/obj/item/reagent_containers/food/drinks/soda_cans/grey_bull = 1,
 					/obj/item/reagent_containers/food/drinks/soda_cans/monkey_energy = 1)
 	refill_canister = /obj/item/vending_refill/cola
-	default_price = 35
-	extra_price = 160
+	default_price = 45
+	extra_price = 200
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/cola

--- a/code/modules/vending/dinnerware.dm
+++ b/code/modules/vending/dinnerware.dm
@@ -27,8 +27,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/dinnerware
 	resistance_flags = FIRE_PROOF
-	default_price = 50
-	extra_price = 250
+	default_price = 40
+	extra_price = 200
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/dinnerware.dm
+++ b/code/modules/vending/dinnerware.dm
@@ -27,8 +27,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/dinnerware
 	resistance_flags = FIRE_PROOF
-	default_price = 40
-	extra_price = 200
+	default_price = 50
+	extra_price = 250
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -28,7 +28,7 @@
 					/obj/item/stock_parts/manipulator = 5)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 450
-	extra_price = 500
+	default_price = 350
+	extra_price = 400
 	payment_department = ACCOUNT_ENG
 	cost_multiplier_per_dept = list(ACCOUNT_ENG = 0)

--- a/code/modules/vending/engineering.dm
+++ b/code/modules/vending/engineering.dm
@@ -28,7 +28,7 @@
 					/obj/item/stock_parts/manipulator = 5)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 350
-	extra_price = 400
+	default_price = 450
+	extra_price = 500
 	payment_department = ACCOUNT_ENG
 	cost_multiplier_per_dept = list(ACCOUNT_ENG = 0)

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -29,8 +29,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/engivend
 	resistance_flags = FIRE_PROOF
-	default_price = 450
-	extra_price = 500
+	default_price = 350
+	extra_price = 400
 	payment_department = ACCOUNT_ENG
 	cost_multiplier_per_dept = list(ACCOUNT_ENG = 0)
 

--- a/code/modules/vending/engivend.dm
+++ b/code/modules/vending/engivend.dm
@@ -29,8 +29,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/engivend
 	resistance_flags = FIRE_PROOF
-	default_price = 350
-	extra_price = 400
+	default_price = 450
+	extra_price = 500
 	payment_department = ACCOUNT_ENG
 	cost_multiplier_per_dept = list(ACCOUNT_ENG = 0)
 

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -12,8 +12,8 @@
 	premium = list(/obj/item/melee/skateboard/pro = 3,
 					/obj/item/melee/skateboard/hoverboard = 1)
 	refill_canister = /obj/item/vending_refill/games
-	default_price = 50
-	extra_price = 250
+	default_price = 40
+	extra_price = 200
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/games.dm
+++ b/code/modules/vending/games.dm
@@ -12,8 +12,8 @@
 	premium = list(/obj/item/melee/skateboard/pro = 3,
 					/obj/item/melee/skateboard/hoverboard = 1)
 	refill_canister = /obj/item/vending_refill/games
-	default_price = 40
-	extra_price = 200
+	default_price = 50
+	extra_price = 250
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/kinkmate.dm
+++ b/code/modules/vending/kinkmate.dm
@@ -40,8 +40,8 @@
 				/obj/item/clothing/under/pants/chaps = 5
 				)
 	refill_canister = /obj/item/vending_refill/kink
-	default_price = 80
-	extra_price = 250
+	default_price = 60
+	extra_price = 200
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/kink

--- a/code/modules/vending/kinkmate.dm
+++ b/code/modules/vending/kinkmate.dm
@@ -40,8 +40,8 @@
 				/obj/item/clothing/under/pants/chaps = 5
 				)
 	refill_canister = /obj/item/vending_refill/kink
-	default_price = 60
-	extra_price = 200
+	default_price = 80
+	extra_price = 250
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/kink

--- a/code/modules/vending/liberation.dm
+++ b/code/modules/vending/liberation.dm
@@ -28,6 +28,6 @@
 					/obj/item/reagent_containers/food/snacks/burger/superbite = 3) //U S A
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 120
-	extra_price = 400
+	default_price = 150
+	extra_price = 500
 	payment_department = ACCOUNT_SEC

--- a/code/modules/vending/liberation.dm
+++ b/code/modules/vending/liberation.dm
@@ -28,6 +28,6 @@
 					/obj/item/reagent_containers/food/snacks/burger/superbite = 3) //U S A
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 150
-	extra_price = 500
+	default_price = 120
+	extra_price = 400
 	payment_department = ACCOUNT_SEC

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -25,8 +25,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/donksoft
-	default_price = 120
-	extra_price = 240
+	default_price = 150
+	extra_price = 300
 	payment_department = NO_FREEBIES
 
 /obj/machinery/vending/toyliberationstation/Initialize()

--- a/code/modules/vending/liberation_toy.dm
+++ b/code/modules/vending/liberation_toy.dm
@@ -25,8 +25,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/donksoft
-	default_price = 150
-	extra_price = 300
+	default_price = 120
+	extra_price = 240
 	payment_department = NO_FREEBIES
 
 /obj/machinery/vending/toyliberationstation/Initialize()

--- a/code/modules/vending/magivend.dm
+++ b/code/modules/vending/magivend.dm
@@ -16,6 +16,6 @@
 	contraband = list(/obj/item/reagent_containers/glass/bottle/wizarditis = 1)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "magic" = 100)
 	resistance_flags = FIRE_PROOF
-	default_price = 250
-	extra_price = 500
+	default_price = 200
+	extra_price = 400
 	payment_department = ACCOUNT_SRV

--- a/code/modules/vending/magivend.dm
+++ b/code/modules/vending/magivend.dm
@@ -16,6 +16,6 @@
 	contraband = list(/obj/item/reagent_containers/glass/bottle/wizarditis = 1)	//No one can get to the machine to hack it anyways; for the lulz - Microwave
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50, "magic" = 100)
 	resistance_flags = FIRE_PROOF
-	default_price = 200
-	extra_price = 400
+	default_price = 250
+	extra_price = 500
 	payment_department = ACCOUNT_SRV

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -46,8 +46,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical
-	default_price = 160
-	extra_price = 200
+	default_price = 200
+	extra_price = 250
 	payment_department = ACCOUNT_MED
 	cost_multiplier_per_dept = list(ACCOUNT_MED = 0)
 

--- a/code/modules/vending/medical.dm
+++ b/code/modules/vending/medical.dm
@@ -46,8 +46,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/medical
-	default_price = 200
-	extra_price = 250
+	default_price = 160
+	extra_price = 200
 	payment_department = ACCOUNT_MED
 	cost_multiplier_per_dept = list(ACCOUNT_MED = 0)
 

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -19,7 +19,7 @@
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed
 	default_price = 0
-	extra_price = 100
+	extra_price = 80
 	payment_department = ACCOUNT_MED
 	cost_multiplier_per_dept = list(ACCOUNT_MED = 0)
 

--- a/code/modules/vending/medical_wall.dm
+++ b/code/modules/vending/medical_wall.dm
@@ -19,7 +19,7 @@
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/wallmed
 	default_price = 0
-	extra_price = 80
+	extra_price = 100
 	payment_department = ACCOUNT_MED
 	cost_multiplier_per_dept = list(ACCOUNT_MED = 0)
 

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -58,8 +58,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/hydroseeds
 	resistance_flags = FIRE_PROOF
-	default_price = 80
-	extra_price = 280
+	default_price = 100
+	extra_price = 350
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/megaseed.dm
+++ b/code/modules/vending/megaseed.dm
@@ -58,8 +58,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/hydroseeds
 	resistance_flags = FIRE_PROOF
-	default_price = 100
-	extra_price = 350
+	default_price = 80
+	extra_price = 280
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -19,8 +19,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/hydronutrients
 	resistance_flags = FIRE_PROOF
-	default_price = 100
-	extra_price = 250
+	default_price = 80
+	extra_price = 200
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/nutrimax.dm
+++ b/code/modules/vending/nutrimax.dm
@@ -19,8 +19,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	refill_canister = /obj/item/vending_refill/hydronutrients
 	resistance_flags = FIRE_PROOF
-	default_price = 80
-	extra_price = 200
+	default_price = 100
+	extra_price = 250
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 

--- a/code/modules/vending/plasmaresearch.dm
+++ b/code/modules/vending/plasmaresearch.dm
@@ -11,7 +11,7 @@
 					/obj/item/assembly/prox_sensor = 6,
 					/obj/item/assembly/igniter = 6)
 	contraband = list(/obj/item/assembly/health = 3)
-	default_price = 400
-	extra_price = 600
+	default_price = 320
+	extra_price = 480
 	payment_department = ACCOUNT_SCI
 	cost_multiplier_per_dept = list(ACCOUNT_SCI = 0)

--- a/code/modules/vending/plasmaresearch.dm
+++ b/code/modules/vending/plasmaresearch.dm
@@ -11,7 +11,7 @@
 					/obj/item/assembly/prox_sensor = 6,
 					/obj/item/assembly/igniter = 6)
 	contraband = list(/obj/item/assembly/health = 3)
-	default_price = 320
-	extra_price = 480
+	default_price = 400
+	extra_price = 600
 	payment_department = ACCOUNT_SCI
 	cost_multiplier_per_dept = list(ACCOUNT_SCI = 0)

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -20,6 +20,6 @@
 					/obj/item/crowbar = 5)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 600
+	default_price = 480
 	payment_department = ACCOUNT_SCI
 	cost_multiplier_per_dept = list(ACCOUNT_SCI = 0)

--- a/code/modules/vending/robotics.dm
+++ b/code/modules/vending/robotics.dm
@@ -20,6 +20,6 @@
 					/obj/item/crowbar = 5)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 480
+	default_price = 600
 	payment_department = ACCOUNT_SCI
 	cost_multiplier_per_dept = list(ACCOUNT_SCI = 0)

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -25,8 +25,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/security
-	default_price = 650
-	extra_price = 700
+	default_price = 520
+	extra_price = 560
 	payment_department = ACCOUNT_SEC
 	cost_multiplier_per_dept = list(ACCOUNT_SEC = 0)
 

--- a/code/modules/vending/security.dm
+++ b/code/modules/vending/security.dm
@@ -25,8 +25,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/security
-	default_price = 520
-	extra_price = 560
+	default_price = 650
+	extra_price = 700
 	payment_department = ACCOUNT_SEC
 	cost_multiplier_per_dept = list(ACCOUNT_SEC = 0)
 

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -27,8 +27,8 @@
 
 	refill_canister = /obj/item/vending_refill/snack
 	canload_access_list = list(ACCESS_KITCHEN)
-	default_price = 60
-	extra_price = 160
+	default_price = 50
+	extra_price = 130
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 	input_display_header = "Chef's Food Selection"

--- a/code/modules/vending/snack.dm
+++ b/code/modules/vending/snack.dm
@@ -27,8 +27,8 @@
 
 	refill_canister = /obj/item/vending_refill/snack
 	canload_access_list = list(ACCESS_KITCHEN)
-	default_price = 50
-	extra_price = 130
+	default_price = 60
+	extra_price = 160
 	payment_department = ACCOUNT_SRV
 	cost_multiplier_per_dept = list(ACCOUNT_SRV = 0)
 	input_display_header = "Chef's Food Selection"

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -7,6 +7,6 @@
 	contraband = list(/obj/item/reagent_containers/food/drinks/drinkingglass/filled/cola = 20)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 1
-	extra_price = 1
+	default_price = 0
+	extra_price = 0
 	payment_department = NO_FREEBIES

--- a/code/modules/vending/sovietsoda.dm
+++ b/code/modules/vending/sovietsoda.dm
@@ -7,6 +7,6 @@
 	contraband = list(/obj/item/reagent_containers/food/drinks/drinkingglass/filled/cola = 20)
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
-	default_price = 0
-	extra_price = 0
+	default_price = 1
+	extra_price = 1
 	payment_department = NO_FREEBIES

--- a/code/modules/vending/sovietvend.dm
+++ b/code/modules/vending/sovietvend.dm
@@ -23,8 +23,8 @@
 	premium = list()
 
 	refill_canister = /obj/item/vending_refill/soviet
-	default_price = 0
-	extra_price = 0
+	default_price = 1
+	extra_price = 1
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/soviet

--- a/code/modules/vending/sovietvend.dm
+++ b/code/modules/vending/sovietvend.dm
@@ -23,8 +23,8 @@
 	premium = list()
 
 	refill_canister = /obj/item/vending_refill/soviet
-	default_price = 1
-	extra_price = 1
+	default_price = 0
+	extra_price = 0
 	payment_department = NO_FREEBIES
 
 /obj/item/vending_refill/soviet

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -25,8 +25,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/donksoft
-	default_price = 150
-	extra_price = 300
+	default_price = 120
+	extra_price = 240
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/donksoft

--- a/code/modules/vending/toys.dm
+++ b/code/modules/vending/toys.dm
@@ -25,8 +25,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 50)
 	resistance_flags = FIRE_PROOF
 	refill_canister = /obj/item/vending_refill/donksoft
-	default_price = 120
-	extra_price = 240
+	default_price = 150
+	extra_price = 300
 	payment_department = ACCOUNT_SRV
 
 /obj/item/vending_refill/donksoft

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -2,8 +2,8 @@
 	icon_state = "refill_clothes"
 
 /obj/machinery/vending/wardrobe
-	default_price = 280
-	extra_price = 320
+	default_price = 350
+	extra_price = 400
 	payment_department = NO_FREEBIES
 	input_display_header = "Returned Clothing"
 

--- a/code/modules/vending/wardrobes.dm
+++ b/code/modules/vending/wardrobes.dm
@@ -2,8 +2,8 @@
 	icon_state = "refill_clothes"
 
 /obj/machinery/vending/wardrobe
-	default_price = 350
-	extra_price = 400
+	default_price = 280
+	extra_price = 320
 	payment_department = NO_FREEBIES
 	input_display_header = "Returned Clothing"
 

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -22,8 +22,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	refill_canister = /obj/item/vending_refill/tool
 	resistance_flags = FIRE_PROOF
-	default_price = 50
-	extra_price = 300
+	default_price = 40
+	extra_price = 240
 	payment_department = ACCOUNT_ENG
 	cost_multiplier_per_dept = list(ACCOUNT_ENG = 0)
 

--- a/code/modules/vending/youtool.dm
+++ b/code/modules/vending/youtool.dm
@@ -22,8 +22,8 @@
 	armor = list("melee" = 100, "bullet" = 100, "laser" = 100, "energy" = 100, "bomb" = 0, "bio" = 0, "rad" = 0, "fire" = 100, "acid" = 70)
 	refill_canister = /obj/item/vending_refill/tool
 	resistance_flags = FIRE_PROOF
-	default_price = 40
-	extra_price = 240
+	default_price = 50
+	extra_price = 300
 	payment_department = ACCOUNT_ENG
 	cost_multiplier_per_dept = list(ACCOUNT_ENG = 0)
 


### PR DESCRIPTION

## About The Pull Request

Reduces prices of basic things by 20% + rounding, for vendors only

## Why It's Good For The Game

Makes being able to buy things as a graytide, much more easy on the wallet as well as makes additive costs of things less painfull on the lower-payed people such as a MD needing to buy something from tool-vender.

## Changelog
:cl:
tweak: Reduces prices of basic things by 20% + rounding for vendors only
/:cl:
