### PR TITLE
Adds Pride Month as a holiday!

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -18,6 +18,7 @@
 #define VALENTINES				"Valentine's Day"
 #define APRIL_FOOLS				"April Fool's Day"
 #define EASTER					"Easter"
+#define PRIDE_MONTH				"Pride Month"
 #define HALLOWEEN				"Halloween"
 #define CHRISTMAS				"Christmas"
 #define FESTIVE_SEASON			"Festive Season"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -694,21 +694,12 @@
 	..()
 	var/suited = !preference_source || preference_source.prefs.jumpsuit_style == PREF_SUIT
 	if (CONFIG_GET(flag/grey_assistants))
-		if(suited)
-			uniform = /obj/item/clothing/under/color/grey
-		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/grey
+		uniform = suited ? /obj/item/clothing/under/color/grey : /obj/item/clothing/under/color/jumpskirt/grey
 	else
 		if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH])
-			if(suited)
-				uniform = /obj/item/clothing/under/color/rainbow
-			else
-				uniform = /obj/item/clothing/under/color/jumpskirt/rainbow
+			uniform = suited ? /obj/item/clothing/under/color/rainbow : /obj/item/clothing/under/color/jumpskirt/rainbow
 		else
-			if(suited)
-				uniform = /obj/item/clothing/under/color/random
-			else
-				uniform = /obj/item/clothing/under/color/jumpskirt/random
+			uniform = suited ? /obj/item/clothing/under/color/random : /obj/item/clothing/under/color/jumpskirt/random
 
 /obj/item/storage/box/syndie_kit/chameleon/ghostcafe
 	name = "ghost cafe costuming kit"

--- a/code/game/objects/structures/ghost_role_spawners.dm
+++ b/code/game/objects/structures/ghost_role_spawners.dm
@@ -699,10 +699,16 @@
 		else
 			uniform = /obj/item/clothing/under/color/jumpskirt/grey
 	else
-		if(suited)
-			uniform = /obj/item/clothing/under/color/random
+		if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH])
+			if(suited)
+				uniform = /obj/item/clothing/under/color/rainbow
+			else
+				uniform = /obj/item/clothing/under/color/jumpskirt/rainbow
 		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/random
+			if(suited)
+				uniform = /obj/item/clothing/under/color/random
+			else
+				uniform = /obj/item/clothing/under/color/jumpskirt/random
 
 /obj/item/storage/box/syndie_kit/chameleon/ghostcafe
 	name = "ghost cafe costuming kit"

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -412,6 +412,15 @@
 	begin_month = JUNE
 	begin_weekday = SUNDAY
 
+/datum/holiday/pride
+	name = PRIDE_MONTH
+	begin_day = 1
+	begin_month = JUNE
+	end_day = 30
+
+/datum/holiday/pride/getStationPrefix()
+	return pick("Pride", "Gay", "Bi", "Trans", "Lesbian", "Ace", "Aro", "Agender", pick("Enby", "Enbie"), "Pan", "Intersex", "Demi", "Poly", "Closeted", "Genderfluid")
+
 /datum/holiday/moth
 	name = "Moth Week"
 

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -40,7 +40,13 @@ Assistant
 		else
 			uniform = /obj/item/clothing/under/color/jumpskirt/grey
 	else
-		if(suited)
-			uniform = /obj/item/clothing/under/color/random
+		if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH])
+			if(suited)
+				uniform = /obj/item/clothing/under/color/rainbow
+			else
+				uniform = /obj/item/clothing/under/color/jumpskirt/rainbow
 		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/random
+			if(suited)
+				uniform = /obj/item/clothing/under/color/random
+			else
+				uniform = /obj/item/clothing/under/color/jumpskirt/random

--- a/code/modules/jobs/job_types/assistant.dm
+++ b/code/modules/jobs/job_types/assistant.dm
@@ -35,18 +35,9 @@ Assistant
 	..()
 	var/suited = !preference_source || preference_source.prefs.jumpsuit_style == PREF_SUIT
 	if (CONFIG_GET(flag/grey_assistants))
-		if(suited)
-			uniform = /obj/item/clothing/under/color/grey
-		else
-			uniform = /obj/item/clothing/under/color/jumpskirt/grey
+		uniform = suited ? /obj/item/clothing/under/color/grey : /obj/item/clothing/under/color/jumpskirt/grey
 	else
 		if(SSevents.holidays && SSevents.holidays[PRIDE_MONTH])
-			if(suited)
-				uniform = /obj/item/clothing/under/color/rainbow
-			else
-				uniform = /obj/item/clothing/under/color/jumpskirt/rainbow
+			uniform = suited ? /obj/item/clothing/under/color/rainbow : /obj/item/clothing/under/color/jumpskirt/rainbow
 		else
-			if(suited)
-				uniform = /obj/item/clothing/under/color/random
-			else
-				uniform = /obj/item/clothing/under/color/jumpskirt/random
+			uniform = suited ? /obj/item/clothing/under/color/random : /obj/item/clothing/under/color/jumpskirt/random


### PR DESCRIPTION
Title. Does exactly as it says on the tin! As an added bonus, assistants during pride month will spawn with rainbow jumpsuits/jumpskirts by default (though this does not take priority over loadouts or the grey jumpsuit config option)
Since I happen to be omnisexual, panromantic, bigender, and intersex (yeah, it's a lot of boxes ticked, I know!), I figured I'm probably someone that would be able to treat this holiday with the proper respect that it deserves. I was thinking of adding more LGBT-related holidays, such as Asexual Awareness Week, National Coming Out Day, Intersex Awareness Day, the Stonewall Riot Anniversary, Transgender Day of Remembrance, or Transgender Awareness week, but I figured it'd probably be best to stick with the most recognizable and most widely-celebrated holiday for the sake of portability (for codebases interested in porting), along with avoiding stirring the pot *too* much (There are a *lot* of channers and other assorted edgelords in the SS13 community, so I don't want to spark any massive riots, lol)

## Changelog
:cl: Bhijn
add: Pride month has been added as a holiday!
/:cl:
