### PR TITLE
fixes dumb blueprint bug to do with noteleport

### DIFF
--- a/code/__HELPERS/areas.dm
+++ b/code/__HELPERS/areas.dm
@@ -170,6 +170,7 @@ GLOBAL_LIST_INIT(typecache_powerfailure_safe_areas, typecacheof(/area/engine/eng
 		newA.setup(str)
 		newA.set_dynamic_lighting()
 		newA.has_gravity = oldA.has_gravity
+		newA.noteleport = oldA.noteleport
 	else
 		newA = area_choice
 


### PR DESCRIPTION
## About The Pull Request
newly created areas using blueprints now maintain the previous areas noteleport value
this means you can't use them to teleport out of places you shouldn't be able to

## Why It's Good For The Game
fixes a bug (closes #11599)

## Changelog
:cl:
fix: newly created areas using blueprints now maintain the previous areas noteleport value
/:cl:
