### PR TITLE
plushmium: the fermichem that creates sentient plushies

### DIFF
--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -17,11 +17,11 @@
 	verb_ask = "squeaks inquisitively"
 	verb_exclaim = "squeaks intensely"
 	verb_yell = "squeaks intensely"
-	var/melee_damage_type = STAMINA
-	var/melee_damage_lower = 0
-	var/melee_damage_upper = 1
-	var/attack_verb_continuous = "squeaks"
-	var/attack_verb_simple = "squeak"
+	melee_damage_type = STAMINA
+	melee_damage_lower = 0
+	melee_damage_upper = 1
+	attack_verb_continuous = "squeaks"
+	attack_verb_simple = "squeak"
 	deathmessage = "lets out a faint squeak as the glint in its eyes disappears"
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -29,17 +29,14 @@
 	desc = "A plushie. Its eyes seem to be staring right back at you. Something isn't quite right."
 	icon = 'icons/obj/plushes.dmi'
 	icon_state = "debug"
-	var/next_ask //When you can next poll for ghosts to take over the plush
-	var/askDelay = 600 //1 minute cooldown on polling for ghosts
-	var/mob/living/brain/brainmob = null
 
 /obj/item/toy/plush/shell/Initialize()
 	next_ask = world.time
 
 //attacking yourself transfers your mind into the plush!
-/obj/item/toy/plush/shell/attack(mob/user, mob/M)
-	if(user == M) // make sure they're using it on themselves
-		var/safety = alert(user, "The plushie is staring back at you. This seems like a terrible idea.", "Are you sure about this?", "Hug the plushie", "Abort")
+/obj/item/toy/plush/shell/attack_self(mob/user)
+	if(user.mind)
+		var/safety = alert(user, "The plushie is staring back at you intensely.", "Are you sure?", "Hug it!", "Don't hug it.")
 		if(safety == "Abort" || !in_range(src, user))
 			return
 		to_chat(user, "<span class='userdanger'>You hug the strange plushie. You fool.</span>")
@@ -47,20 +44,5 @@
 		new_plushie.icon = src.icon
 		new_plushie.icon_state = src.icon_state
 		new_plushie.name = user.name
-		if(user.mind)
-			user.mind.transfer_to(new_plushie)
-			var/new_name = stripped_input(src, "Enter your name, or press \"Cancel\" to stick with Plushie.", "Name Change")
-			if(new_name)
-				to_chat(src, "<span class='notice'>Your name is now <b>\"new_name\"</b>!</span>")
-				name = new_name
-			qdel(src)
-	else
-		return ..()
-
-//using it in your hand polls ghosts to take over the plush instead!
-/obj/item/toy/plush/shell/attack_self(mob/user)
-	if(next_ask > world.time)
-		return ..()
-	to_chat(user, "You feel tense energy radiating from the plushie!")
-	next_ask = world.time + askDelay
-	notify_ghosts("Sentient plushie in [get_area(src)]!", ghost_sound = null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_POSIBRAIN, ignore_dnr_observers = TRUE)
+		user.mind.transfer_to(new_plushie)
+		qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -55,8 +55,9 @@
 		//setup what the mob drops when it dies (the original plushie, with the brain of the user inside)
 		var/obj/item/organ/brain/stored_brain = user.getorganslot(ORGAN_SLOT_BRAIN)
 		stored_brain.Remove()
-		stored_plush.stored_item = stored_brain
+		stored_plush.stuffed = FALSE
 		stored_brain.forceMove(stored_plush)
+		stored_plush.stored_item = stored_brain
 		new_plushie.corpse_plush = stored_plush
 		stored_plush.forceMove(new_plushie)
 

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -18,9 +18,10 @@
 	verb_yell = "squeaks intensely"
 	deathmessage = "lets out a faint squeak as the glint in its eyes disappears"
 	del_on_death = TRUE
-	var/obj/item/toy/plush/corpse_plush = null
 	attacked_sound = 'sound/items/toysqueak1.ogg'
 	death_sound = 'sound/items/toysqueak2.ogg'
+	footstep_type = FOOTSTEP_MOB_BAREFOOT
+	var/obj/item/toy/plush/corpse_plush = null //plushie that the mob is made from, dropped on death containing the brain of the user
 
 /mob/living/simple_animal/pet/plushie/ComponentInitialize()
 	. = ..()
@@ -70,7 +71,7 @@
 	..()
 
 //low regen over time
-/mob/living/simple_animal/pet/plush/Life()
+/mob/living/simple_animal/pet/plushie/Life()
 	if(stat)
 		return
 	if(health < maxHealth)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -1,0 +1,20 @@
+/mob/living/simple_animal/pet/plushie
+	name = "Plushie"
+	desc = "A living plushie!"
+	icon = 'icons/obj/plushes.dmi'
+	icon_state = "debug"
+	icon_living = "debug"
+	speak_emote = list("squeaks")
+	maxHealth = 50
+	health = 50
+	density = FALSE
+	movement_type = FLYING
+	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
+	mob_size = MOB_SIZE_TINY
+	mob_biotypes = MOB_ORGANIC
+	gold_core_spawnable = FRIENDLY_SPAWN
+	verb_say = "squeaks"
+	verb_ask = "squeaks inquisitively"
+	verb_exclaim = "squeaks intensely"
+	verb_yell = "squeaks intensely"
+	speak_chance = 1

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -38,7 +38,7 @@
 //attacking yourself transfers your mind into the plush!
 /obj/item/toy/plushie_shell/attack_self(mob/user)
 	if(user.mind)
-		var/safety = alert(user, "The plushie is staring back at you intensely, it seems cursed!", "Hugging this is a bad idea.", "Hug it!", "Cancel")
+		var/safety = alert(user, "The plushie is staring back at you intensely, it seems cursed! (Permanently become a plushie)", "Hugging this is a bad idea.", "Hug it!", "Cancel")
 		if(safety == "Cancel" || !in_range(src, user))
 			return
 		to_chat(user, "<span class='userdanger'>You hug the strange plushie. You fool.</span>")

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -17,6 +17,11 @@
 	verb_ask = "squeaks inquisitively"
 	verb_exclaim = "squeaks intensely"
 	verb_yell = "squeaks intensely"
+	var/melee_damage_type = STAMINA
+	var/melee_damage_lower = 0
+	var/melee_damage_upper = 1
+	var/attack_verb_continuous = "squeaks"
+	var/attack_verb_simple = "squeak"
 	deathmessage = "lets out a faint squeak as the glint in its eyes disappears"
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
 	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -12,37 +12,73 @@
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
 	mob_biotypes = MOB_ORGANIC
-	gold_core_spawnable = FRIENDLY_SPAWN
 	verb_say = "squeaks"
 	verb_ask = "squeaks inquisitively"
 	verb_exclaim = "squeaks intensely"
 	verb_yell = "squeaks intensely"
-	speak_chance = 1
+	deathmessage = "lets out a faint squeak as the glint in its eyes disappears"
+	del_on_death = TRUE
+	var/obj/item/toy/plush/corpse_plush = null
+	attacked_sound = 'sound/items/toysqueak1.ogg'
+	death_sound = 'sound/items/toysqueak2.ogg'
 
 /mob/living/simple_animal/pet/plushie/ComponentInitialize()
 	. = ..()
 	AddElement(/datum/element/mob_holder, "plushie")
 
 //shell that lets people turn into the plush or poll for ghosts
-/obj/item/toy/plush/shell
+/obj/item/toy/plushie_shell
 	name = "Plushie Shell"
 	desc = "A plushie. Its eyes seem to be staring right back at you. Something isn't quite right."
 	icon = 'icons/obj/plushes.dmi'
 	icon_state = "debug"
-
-/obj/item/toy/plush/shell/Initialize()
-	next_ask = world.time
+	var/obj/item/toy/plush/stored_plush = null
 
 //attacking yourself transfers your mind into the plush!
-/obj/item/toy/plush/shell/attack_self(mob/user)
+/obj/item/toy/plushie_shell/attack_self(mob/user)
 	if(user.mind)
-		var/safety = alert(user, "The plushie is staring back at you intensely.", "Are you sure?", "Hug it!", "Don't hug it.")
-		if(safety == "Abort" || !in_range(src, user))
+		var/safety = alert(user, "The plushie is staring back at you intensely, it seems cursed!", "Hugging this is a bad idea.", "Hug it!", "Cancel")
+		if(safety == "Cancel" || !in_range(src, user))
 			return
 		to_chat(user, "<span class='userdanger'>You hug the strange plushie. You fool.</span>")
-		var/mob/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
+
+		//setup the mob
+		var/mob/living/simple_animal/pet/plushie/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
 		new_plushie.icon = src.icon
 		new_plushie.icon_state = src.icon_state
 		new_plushie.name = user.name
-		user.mind.transfer_to(new_plushie)
+		if(length(stored_plush.squeak_override) > 0) //theres plush sounds set for the stored plush, so grab the first one and use it
+			new_plushie.attacked_sound = stored_plush.squeak_override[1]
+			new_plushie.death_sound = stored_plush.squeak_override[1]
+
+		//setup what the mob drops when it dies (the original plushie, with the brain of the user inside)
+		var/obj/item/organ/brain/stored_brain = user.getorganslot(ORGAN_SLOT_BRAIN)
+		stored_brain.Remove()
+		stored_plush.stored_item = stored_brain
+		stored_brain.forceMove(stored_plush)
+		new_plushie.corpse_plush = stored_plush
+		stored_plush.forceMove(new_plushie)
+
+		//take care of the user's mind, old body and the old shell
+		stored_brain.brainmob.mind.transfer_to(new_plushie)
+		user.dust(drop_items = TRUE)
 		qdel(src)
+
+//drop the plushie on death and then delete the mob (the stored plushie contains the user's brain!)
+/mob/living/simple_animal/pet/plushie/death()
+	corpse_plush.forceMove(src.loc)
+	..()
+
+//low regen over time
+/mob/living/simple_animal/pet/plush/Life()
+	if(stat)
+		return
+	if(health < maxHealth)
+		heal_overall_damage(2) //Slow life regen, they're not able to hurt anyone so this shouldn't be an issue (butterbear for reference has 10 regen)
+
+//play plushie noise whenever it attacks
+/mob/living/simple_animal/pet/plushie/attack_animal(mob/living/simple_animal/M)
+	playsound(attacked_sound,50,1,1)
+	..(M)
+
+

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -20,19 +20,48 @@
 	verb_yell = "squeaks intensely"
 	speak_chance = 1
 
+/mob/living/simple_animal/pet/plushie/ComponentInitialize()
+	. = ..()
+	AddElement(/datum/element/mob_holder, "plushie")
+
 //shell that lets people turn into the plush or poll for ghosts
 /obj/item/toy/plushie/shell
 	name = "Plushie Shell"
 	desc = "A plushie. Its eyes seem to be staring right back at you. Something isn't quite right."
 	icon = 'icons/obj/plushes.dmi'
 	icon_state = "debug"
+	var/next_ask //When you can next poll for ghosts to take over the plush
+	var/askDelay = 600 //1 minute cooldown on polling for ghosts
+	var/mob/living/brain/brainmob = null
+
+/obj/item/toy/plushie/shell/Initialize()
+	next_ask = world.time
 
 //attacking yourself transfers your mind into the plush!
+/obj/item/toy/plushie/shell/attack(mob/user, mob/M)
+	if(user == M) // make sure they're using it on themselves
+		var/safety = alert(user, "The plushie is staring back at you. This seems like a terrible idea.", "Are you sure about this?", "Hug the plushie", "Abort")
+		if(safety == "Abort" || !in_range(src, user))
+			return
+		to_chat(user, "<span class='userdanger'>You hug the strange plushie. You fool.</span>")
+		var/mob/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
+		new_plushie.icon = src.icon
+		new_plushie.icon_state = src.icon_state
+		new_plushie.name = user.name
+		if(user.mind)
+			user.mind.transfer_to(new_plushie)
+			var/new_name = stripped_input(src, "Enter your name, or press \"Cancel\" to stick with Plushie.", "Name Change")
+			if(new_name)
+				to_chat(src, "<span class='notice'>Your name is now <b>\"new_name\"</b>!</span>")
+				name = new_name
+			qdel(src)
+	else
+		return ..()
+
+//using it in your hand polls ghosts to take over the plush instead!
 /obj/item/toy/plushie/shell/attack_self(mob/user)
-	to_chat(user, "<span class='userdanger'>You hug the strange plushie. You fool.</span>")
-	var/mob/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
-	new_plushie.icon = src.icon
-	new_plushie.icon_state = src.icon_state
-	if(user.mind)
-		user.mind.transfer_to(new_plushie)
-	qdel(src)
+	if(next_ask > world.time)
+		return ..()
+	to_chat(user, "You feel tense energy radiating from the plushie!")
+	next_ask = world.time + askDelay
+	notify_ghosts("Sentient plushie in [get_area(src)]!", ghost_sound = null, enter_link = "<a href=?src=[REF(src)];activate=1>(Click to enter)</a>", source = src, action = NOTIFY_ATTACK, flashwindow = FALSE, ignore_key = POLL_IGNORE_POSIBRAIN, ignore_dnr_observers = TRUE)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -19,6 +19,9 @@
 	verb_yell = "squeaks intensely"
 	deathmessage = "lets out a faint squeak as the glint in its eyes disappears"
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
+	atmos_requirements = list("min_oxy" = 0, "max_oxy" = 0, "min_tox" = 0, "max_tox" = 0, "min_co2" = 0, "max_co2" = 0, "min_n2" = 0, "max_n2" = 0)
+	minbodytemp = 0
+	pressure_resistance = 200
 
 /mob/living/simple_animal/pet/plushie/ComponentInitialize()
 	. = ..()

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -9,7 +9,6 @@
 	maxHealth = 50
 	health = 50
 	density = FALSE
-	movement_type = FLYING
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
 	mob_biotypes = MOB_ORGANIC
@@ -34,7 +33,7 @@
 	var/askDelay = 600 //1 minute cooldown on polling for ghosts
 	var/mob/living/brain/brainmob = null
 
-/obj/item/toy/plushie/shell/Initialize()
+/obj/item/toy/plush/shell/Initialize()
 	next_ask = world.time
 
 //attacking yourself transfers your mind into the plush!

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -5,6 +5,7 @@
 	icon = 'icons/obj/plushes.dmi'
 	icon_state = "debug"
 	icon_living = "debug"
+	icon_dead = "debug"
 	speak_emote = list("squeaks")
 	maxHealth = 100
 	health = 100
@@ -42,7 +43,8 @@
 		//setup the mob
 		var/mob/living/simple_animal/pet/plushie/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
 		new_plushie.icon = src.icon
-		new_plushie.icon_dead = src.icon
+		new_plushie.icon_living = src.icon_state
+		new_plushie.icon_dead = src.icon_state
 		new_plushie.icon_state = src.icon_state
 		new_plushie.name = src.name
 

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -17,6 +17,8 @@
 	verb_ask = "squeaks inquisitively"
 	verb_exclaim = "squeaks intensely"
 	verb_yell = "squeaks intensely"
+	attack_sound = 'sound/items/toysqueak1.ogg'
+	attacked_sound = 'sound/items/toysqueak1.ogg'
 	melee_damage_type = STAMINA
 	melee_damage_lower = 0
 	melee_damage_upper = 1
@@ -64,9 +66,6 @@
 		if(length(stored_plush.squeak_override) > 0)
 			new_plushie.attack_sound = stored_plush.squeak_override[1]
 			new_plushie.attacked_sound = stored_plush.squeak_override[1]
-		else
-			new_plushie.attack_sound = 'sound/items/toysqueak1.ogg'
-			new_plushie.attacked_sound = 'sound/items/toysqueak1.ogg'
 
 		//take care of the user's old body and the old shell
 		user.dust(drop_items = TRUE)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -63,8 +63,10 @@
 		new_plushie.AddComponent(/datum/component/squeak, stored_plush.squeak_override)
 		if(length(stored_plush.squeak_override) > 0)
 			new_plushie.attack_sound = stored_plush.squeak_override[1]
+			new_plushie.attacked_sound = stored_plush.squeak_override[1]
 		else
 			new_plushie.attack_sound = 'sound/items/toysqueak1.ogg'
+			new_plushie.attacked_sound = 'sound/items/toysqueak1.ogg'
 
 		//take care of the user's old body and the old shell
 		user.dust(drop_items = TRUE)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -1,3 +1,4 @@
+//simplemob plushie that can be controlled by players
 /mob/living/simple_animal/pet/plushie
 	name = "Plushie"
 	desc = "A living plushie!"
@@ -18,3 +19,20 @@
 	verb_exclaim = "squeaks intensely"
 	verb_yell = "squeaks intensely"
 	speak_chance = 1
+
+//shell that lets people turn into the plush or poll for ghosts
+/obj/item/toy/plushie/shell
+	name = "Plushie Shell"
+	desc = "A plushie. Its eyes seem to be staring right back at you. Something isn't quite right."
+	icon = 'icons/obj/plushes.dmi'
+	icon_state = "debug"
+
+//attacking yourself transfers your mind into the plush!
+/obj/item/toy/plushie/shell/attack_self(mob/user)
+	to_chat(user, "<span class='userdanger'>You hug the strange plushie. You fool.</span>")
+	var/mob/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
+	new_plushie.icon = src.icon
+	new_plushie.icon_state = src.icon_state
+	if(user.mind)
+		user.mind.transfer_to(new_plushie)
+	qdel(src)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -6,8 +6,8 @@
 	icon_state = "debug"
 	icon_living = "debug"
 	speak_emote = list("squeaks")
-	maxHealth = 50
-	health = 50
+	maxHealth = 100
+	health = 100
 	density = FALSE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
@@ -17,11 +17,7 @@
 	verb_exclaim = "squeaks intensely"
 	verb_yell = "squeaks intensely"
 	deathmessage = "lets out a faint squeak as the glint in its eyes disappears"
-	del_on_death = TRUE
-	attacked_sound = 'sound/items/toysqueak1.ogg'
-	death_sound = 'sound/items/toysqueak2.ogg'
 	footstep_type = FOOTSTEP_MOB_BAREFOOT
-	var/obj/item/toy/plush/corpse_plush = null //plushie that the mob is made from, dropped on death containing the brain of the user
 
 /mob/living/simple_animal/pet/plushie/ComponentInitialize()
 	. = ..()
@@ -46,41 +42,23 @@
 		//setup the mob
 		var/mob/living/simple_animal/pet/plushie/new_plushie = new /mob/living/simple_animal/pet/plushie/(user.loc)
 		new_plushie.icon = src.icon
+		new_plushie.icon_dead = src.icon
 		new_plushie.icon_state = src.icon_state
-		new_plushie.name = user.name
-		if(length(stored_plush.squeak_override) > 0) //theres plush sounds set for the stored plush, so grab the first one and use it
-			new_plushie.attacked_sound = stored_plush.squeak_override[1]
-			new_plushie.death_sound = stored_plush.squeak_override[1]
+		new_plushie.name = src.name
 
-		//setup what the mob drops when it dies (the original plushie, with the brain of the user inside)
-		var/obj/item/organ/brain/stored_brain = user.getorganslot(ORGAN_SLOT_BRAIN)
-		stored_brain.Remove()
-		stored_plush.stuffed = FALSE
-		stored_brain.forceMove(stored_plush)
-		stored_plush.stored_item = stored_brain
-		new_plushie.corpse_plush = stored_plush
-		stored_plush.forceMove(new_plushie)
+		//make the mob sentient
+		user.mind.transfer_to(new_plushie)
 
-		//take care of the user's mind, old body and the old shell
-		stored_brain.brainmob.mind.transfer_to(new_plushie)
+		//add sounds to mob
+		new_plushie.AddComponent(/datum/component/squeak, stored_plush.squeak_override)
+
+		//take care of the user's old body and the old shell
 		user.dust(drop_items = TRUE)
 		qdel(src)
-
-//drop the plushie on death and then delete the mob (the stored plushie contains the user's brain!)
-/mob/living/simple_animal/pet/plushie/death()
-	corpse_plush.forceMove(src.loc)
-	..()
 
 //low regen over time
 /mob/living/simple_animal/pet/plushie/Life()
 	if(stat)
 		return
 	if(health < maxHealth)
-		heal_overall_damage(2) //Slow life regen, they're not able to hurt anyone so this shouldn't be an issue (butterbear for reference has 10 regen)
-
-//play plushie noise whenever it attacks
-/mob/living/simple_animal/pet/plushie/attack_animal(mob/living/simple_animal/M)
-	playsound(attacked_sound,50,1,1)
-	..(M)
-
-
+		heal_overall_damage(5) //Decent life regen, they're not able to hurt anyone so this shouldn't be an issue (butterbear for reference has 10 regen)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -7,8 +7,8 @@
 	icon_living = "debug"
 	icon_dead = "debug"
 	speak_emote = list("squeaks")
-	maxHealth = 100
-	health = 100
+	maxHealth = 50
+	health = 50
 	density = FALSE
 	pass_flags = PASSTABLE | PASSGRILLE | PASSMOB
 	mob_size = MOB_SIZE_TINY
@@ -56,6 +56,10 @@
 
 		//add sounds to mob
 		new_plushie.AddComponent(/datum/component/squeak, stored_plush.squeak_override)
+		if(length(stored_plush.squeak_override) > 0)
+			new_plushie.attack_sound = stored_plush.squeak_override[1]
+		else
+			new_plushie.attack_sound = 'sound/items/toysqueak1.ogg'
 
 		//take care of the user's old body and the old shell
 		user.dust(drop_items = TRUE)

--- a/code/modules/mob/living/simple_animal/friendly/plushie.dm
+++ b/code/modules/mob/living/simple_animal/friendly/plushie.dm
@@ -24,7 +24,7 @@
 	AddElement(/datum/element/mob_holder, "plushie")
 
 //shell that lets people turn into the plush or poll for ghosts
-/obj/item/toy/plushie/shell
+/obj/item/toy/plush/shell
 	name = "Plushie Shell"
 	desc = "A plushie. Its eyes seem to be staring right back at you. Something isn't quite right."
 	icon = 'icons/obj/plushes.dmi'
@@ -37,7 +37,7 @@
 	next_ask = world.time
 
 //attacking yourself transfers your mind into the plush!
-/obj/item/toy/plushie/shell/attack(mob/user, mob/M)
+/obj/item/toy/plush/shell/attack(mob/user, mob/M)
 	if(user == M) // make sure they're using it on themselves
 		var/safety = alert(user, "The plushie is staring back at you. This seems like a terrible idea.", "Are you sure about this?", "Hug the plushie", "Abort")
 		if(safety == "Abort" || !in_range(src, user))
@@ -58,7 +58,7 @@
 		return ..()
 
 //using it in your hand polls ghosts to take over the plush instead!
-/obj/item/toy/plushie/shell/attack_self(mob/user)
+/obj/item/toy/plush/shell/attack_self(mob/user)
 	if(next_ask > world.time)
 		return ..()
 	to_chat(user, "You feel tense energy radiating from the plushie!")

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -44,7 +44,7 @@
 		client.change_view(CONFIG_GET(string/default_view)) // Resets the client.view in case it was changed.
 
 		if(client.player_details && istype(client.player_details))
-			if(client.player_details.player_actions?.len)
+			if(client.player_details.player_actions.len)
 				for(var/datum/action/A in client.player_details.player_actions)
 					A.Grant(src)
 

--- a/code/modules/mob/login.dm
+++ b/code/modules/mob/login.dm
@@ -44,7 +44,7 @@
 		client.change_view(CONFIG_GET(string/default_view)) // Resets the client.view in case it was changed.
 
 		if(client.player_details && istype(client.player_details))
-			if(client.player_details.player_actions.len)
+			if(client.player_details.player_actions?.len)
 				for(var/datum/action/A in client.player_details.player_actions)
 					A.Grant(src)
 

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -183,6 +183,11 @@
 		new_shell.stored_plush = O
 		O.forceMove(new_shell)
 
+//Extra interaction for which spraying it on an existing sentient plushie aheals them, so they can be revived!
+/datum/reagent/fermi/plushmium/reaction_mob(mob/living/M, method=TOUCH, reac_volume)
+	if(istype(M, /mob/living/simple_animal/pet/plushie) && reac_volume >= 1)
+		M.revive(full_heal = 1, admin_revive = 1)
+
 ///////////////////////////////////////////////////////////////////////////////////////////////
 //Nanite removal
 //Writen by Trilby!! Embellsished a little by me.

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -175,7 +175,7 @@
 
 /datum/reagent/fermi/plushmium/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/item/toy/plush) && reac_volume >= 5)
-		O.loc.visible_message("<span class='warning'>The [O] seems to be staring back at you.</span>")
+		O.loc.visible_message("<span class='warning'>The plushie seems to be staring back at you.</span>")
 		var/obj/item/toy/plushie/shell/new_shell = new /obj/item/toy/plushie/shell(O.loc)
 		new_shell.name = O.name
 		new_shell.icon = O.icon

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -176,11 +176,12 @@
 /datum/reagent/fermi/plushmium/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/item/toy/plush) && reac_volume >= 5)
 		O.loc.visible_message("<span class='warning'>The plushie seems to be staring back at you.</span>")
-		var/obj/item/toy/plush/shell/new_shell = new /obj/item/toy/plush/shell(O.loc)
+		var/obj/item/toy/plushie_shell/new_shell = new /obj/item/toy/plushie_shell(O.loc)
 		new_shell.name = O.name
 		new_shell.icon = O.icon
 		new_shell.icon_state = O.icon_state
-		qdel(O)
+		new_shell.stored_plush = O
+		O.forceMove(new_shell)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////
 //Nanite removal

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -176,7 +176,7 @@
 /datum/reagent/fermi/plushmium/reaction_obj(obj/O, reac_volume)
 	if(istype(O, /obj/item/toy/plush) && reac_volume >= 5)
 		O.loc.visible_message("<span class='warning'>The plushie seems to be staring back at you.</span>")
-		var/obj/item/toy/plushie/shell/new_shell = new /obj/item/toy/plushie/shell(O.loc)
+		var/obj/item/toy/plush/shell/new_shell = new /obj/item/toy/plush/shell(O.loc)
 		new_shell.name = O.name
 		new_shell.icon = O.icon
 		new_shell.icon_state = O.icon_state

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -163,7 +163,7 @@
 //										PLUSHMIUM
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 //A chemical you can spray on plushies to turn them into a 'shell'
-//Using the shell in your hand polls ghosts to enter it, whereas using it on yourself turns yourself into the plushie.
+//Hugging the plushie turns yourself into the plushie!
 /datum/reagent/fermi/plushmium
 	name = "Plushmium"
 	description = "A strange chemical, seeming almost fluffy, if it were not for it being a liquid. Known to have a strange effect on plushies."

--- a/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/reagents/fermi_reagents.dm
@@ -159,6 +159,29 @@
 		log_reagent("FERMICHEM: [M] ckey: [M.key]'s tongue has been made permanent")
 
 
+////////////////////////////////////////////////////////////////////////////////////////////////////
+//										PLUSHMIUM
+///////////////////////////////////////////////////////////////////////////////////////////////////
+//A chemical you can spray on plushies to turn them into a 'shell'
+//Using the shell in your hand polls ghosts to enter it, whereas using it on yourself turns yourself into the plushie.
+/datum/reagent/fermi/plushmium
+	name = "Plushmium"
+	description = "A strange chemical, seeming almost fluffy, if it were not for it being a liquid. Known to have a strange effect on plushies."
+	color = "#fbcbd7"
+	taste_description = "the soft feeling of a plushie"
+	pH = 5
+	value = 50
+	can_synth = TRUE
+
+/datum/reagent/fermi/plushmium/reaction_obj(obj/O, reac_volume)
+	if(istype(O, /obj/item/toy/plush) && reac_volume >= 5)
+		O.loc.visible_message("<span class='warning'>The [O] seems to be staring back at you.</span>")
+		var/obj/item/toy/plushie/shell/new_shell = new /obj/item/toy/plushie/shell(O.loc)
+		new_shell.name = O.name
+		new_shell.icon = O.icon
+		new_shell.icon_state = O.icon_state
+		qdel(O)
+
 ///////////////////////////////////////////////////////////////////////////////////////////////
 //Nanite removal
 //Writen by Trilby!! Embellsished a little by me.

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -480,12 +480,41 @@
 	RateUpLim 		= 15
 	FermiChem 		= TRUE
 
+/datum/chemical_reaction/fermi/plushmium // done
+	name = "Plushification serum"
+	id = /datum/reagent/fermi/plushmium
+	results = list(/datum/reagent/fermi/plushmium = 5)
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 5, /datum/reagent/drug/happiness = 3, /datum/reagent/consumable/blood = 10, /datum/reagent/consumable/laughter = 5, /datum/reagent/toxin/bad_food = 6)
+	//mix_message = ""
+	//FermiChem vars:
+	OptimalTempMin 	= 400
+	OptimalTempMax 	= 666
+	ExplodeTemp 	= 800
+	OptimalpHMin 	= 2
+	OptimalpHMax 	= 5
+	ReactpHLim 		= 6
+	//CatalystFact 	= 0 //To do 1
+	CurveSharpT 	= 8
+	CurveSharppH 	= 0.5
+	ThermicConstant = -2
+	HIonRelease 	= -0.1
+	RateUpLim 		= 2
+	FermiChem 		= TRUE
+	FermiExplode 	= TRUE
+	PurityMin		= 0.6
+
+/datum/chemical_reaction/fermi/plushmium/FermiExplode(datum/reagents, var/atom/my_atom, volume, temp, pH)
+	var/obj/item/organ/genital/penis/P = new /obj/item/toy/plush/random(get_turf(my_atom))
+	my_atom.visible_message("<span class='warning'>The reaction suddenly zaps, creating a plushie!</b></span>")
+	my_atom.reagents.clear_reagents()
 
 /datum/chemical_reaction/fermi/basic_buffer/FermiFinish(datum/reagents/holder, atom/my_atom) //might need this
 	var/datum/reagent/fermi/basic_buffer/Fb = locate(/datum/reagent/fermi/basic_buffer) in my_atom.reagents.reagent_list
 	if(!Fb)
 		return
 	Fb.data = 14
+
+
 
 //secretcatchemcode, shh!! Of couse I hide it amongst cats. Though, I moved it with your requests.
 //I'm not trying to be sneaky, I'm trying to keep it a secret!

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -484,7 +484,7 @@
 	name = "Plushification serum"
 	id = /datum/reagent/fermi/plushmium
 	results = list(/datum/reagent/fermi/plushmium = 5)
-	required_reagents = list(/datum/reagent/medicine/strange_reagent = 5, /datum/reagent/drug/happiness = 3, /datum/reagent/consumable/blood = 10, /datum/reagent/consumable/laughter = 5, /datum/reagent/toxin/bad_food = 6)
+	required_reagents = list(/datum/reagent/medicine/strange_reagent = 5, /datum/reagent/drug/happiness = 3, /datum/reagent/blood = 10, /datum/reagent/consumable/laughter = 5, /datum/reagent/toxin/bad_food = 6)
 	//mix_message = ""
 	//FermiChem vars:
 	OptimalTempMin 	= 400
@@ -504,7 +504,7 @@
 	PurityMin		= 0.6
 
 /datum/chemical_reaction/fermi/plushmium/FermiExplode(datum/reagents, var/atom/my_atom, volume, temp, pH)
-	var/obj/item/organ/genital/penis/P = new /obj/item/toy/plush/random(get_turf(my_atom))
+	new /obj/item/toy/plush/random(get_turf(my_atom))
 	my_atom.visible_message("<span class='warning'>The reaction suddenly zaps, creating a plushie!</b></span>")
 	my_atom.reagents.clear_reagents()
 

--- a/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
+++ b/modular_citadel/code/modules/reagents/chemistry/recipes/fermi.dm
@@ -514,8 +514,6 @@
 		return
 	Fb.data = 14
 
-
-
 //secretcatchemcode, shh!! Of couse I hide it amongst cats. Though, I moved it with your requests.
 //I'm not trying to be sneaky, I'm trying to keep it a secret!
 //I don't know how to do hidden chems like Aurora

--- a/tgstation.dme
+++ b/tgstation.dme
@@ -2519,6 +2519,7 @@
 #include "code\modules\mob\living\simple_animal\friendly\panda.dm"
 #include "code\modules\mob\living\simple_animal\friendly\penguin.dm"
 #include "code\modules\mob\living\simple_animal\friendly\pet.dm"
+#include "code\modules\mob\living\simple_animal\friendly\plushie.dm"
 #include "code\modules\mob\living\simple_animal\friendly\sloth.dm"
 #include "code\modules\mob\living\simple_animal\friendly\snake.dm"
 #include "code\modules\mob\living\simple_animal\friendly\drone\_drone.dm"


### PR DESCRIPTION
## About The Pull Request
this adds in a new fermichem: plushmium
when 5+ units are sprayed on a plushie, it becomes a 'shell', and attempting to use it in your hands causes it to open a menu, selecting to hug it dusts you and drops your items, transferring your mind into the plush
when 1+ units are sprayed on a sentient plushie, the plushie gets a full aheal

sentient plushies cannot attack (edit now do 0 to 1 stamina damage so they make noises when they 'attack'), squeak when they speak, and make the regular plushie noise when stood on, and also have the mob holder element so they can be picked up!

they receive half the health regen that butter bear does, just so they don't die to something silly

the recipe is as follows, to create 5u of plushmium:
5u strange reagent, 3u happiness, 10u blood, 5u laughter, 6u bad food
optimal minimum temperature: 400
optimal maximum temperature: 666
explode temperature: 800
optimal minimum pH: 2
optimal maximum pH: 6

the explosion of the reaction creates a random plushie

## Why It's Good For The Game
it's a funny gimmicky thing, and you can't force it on people, as they have to use it in their hand themselves and select yes on a popup menu

small gimmicky things like this make the game fun

## Changelog
:cl:
add: adds a new fermichem, used for creating sentient plushies!
/:cl:
