### PR TITLE
Brings back the syringe gun from dart gun

### DIFF
--- a/_maps/map_files/BoxStation/BoxStation.dmm
+++ b/_maps/map_files/BoxStation/BoxStation.dmm
@@ -34152,7 +34152,6 @@
 /obj/item/folder/white,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCH" = (
@@ -35954,7 +35953,7 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/neck/stethoscope,
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bGT" = (

--- a/_maps/map_files/CogStation/CogStation.dmm
+++ b/_maps/map_files/CogStation/CogStation.dmm
@@ -26716,7 +26716,6 @@
 "bgh" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 6
 	},
 /turf/open/space/basic,
@@ -32795,7 +32794,6 @@
 "bsz" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -32941,7 +32939,6 @@
 "bsT" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/space/basic,
@@ -36274,7 +36271,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/space/basic,
@@ -39590,7 +39586,6 @@
 /area/maintenance/solars/starboard/aft)
 "bHA" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/closed/wall/r_wall,
@@ -39748,7 +39743,6 @@
 /area/maintenance/solars/starboard/aft)
 "bHO" = (
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/closed/wall/r_wall,
@@ -42178,7 +42172,6 @@
 	icon_state = "1-2"
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/space/basic,
@@ -42302,7 +42295,6 @@
 	pixel_y = -32
 	},
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -43279,7 +43271,6 @@
 "bPh" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
@@ -43375,7 +43366,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 4
 	},
 /turf/open/space/basic,
@@ -43685,7 +43675,6 @@
 "bPX" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 9
 	},
 /turf/open/space/basic,
@@ -44428,7 +44417,6 @@
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -44441,7 +44429,6 @@
 "bRp" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/space/basic,
@@ -44811,6 +44798,7 @@
 	},
 /obj/item/storage/belt/medical,
 /obj/item/clothing/neck/stethoscope,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bRZ" = (
@@ -45604,7 +45592,6 @@
 "bTJ" = (
 /obj/structure/lattice,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -46231,7 +46218,6 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 10
 	},
 /turf/open/space/basic,
@@ -48949,7 +48935,6 @@
 /obj/structure/lattice,
 /obj/structure/disposalpipe/segment,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 5
 	},
 /turf/open/space/basic,
@@ -50432,7 +50417,6 @@
 	},
 /obj/machinery/atmospherics/pipe/simple/supplymain/visible,
 /obj/machinery/atmospherics/pipe/simple/violet/hidden{
-	icon_state = "pipe11-2";
 	dir = 8
 	},
 /turf/open/space/basic,
@@ -52880,7 +52864,6 @@
 /obj/effect/turf_decal/delivery,
 /obj/machinery/door/window/westleft{
 	name = "Science Desk";
-	req_access_txt = "0";
 	req_one_access_txt = "29;47"
 	},
 /obj/machinery/atmospherics/pipe/simple/orange/hidden{
@@ -57036,7 +57019,6 @@
 	},
 /obj/structure/noticeboard/qm{
 	dir = 4;
-	icon_state = "nboard00";
 	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
@@ -61071,7 +61053,6 @@
 	name = "Mining Conveyor Access";
 	pixel_x = 8;
 	pixel_y = -24;
-	req_access_txt = "0";
 	req_one_access_txt = "10;24;48"
 	},
 /turf/open/floor/plasteel,

--- a/_maps/map_files/Deltastation/DeltaStation2.dmm
+++ b/_maps/map_files/Deltastation/DeltaStation2.dmm
@@ -62765,7 +62765,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library - Aft";
-	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/wood,
@@ -63931,7 +63930,6 @@
 /area/library)
 "cel" = (
 /obj/structure/chair/sofa/right{
-	icon_state = "sofaend_right";
 	dir = 8
 	},
 /obj/structure/sign/painting/library{
@@ -89981,7 +89979,7 @@
 /obj/effect/turf_decal/tile/neutral{
 	dir = 4
 	},
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel,
 /area/medical/storage)
 "cWv" = (
@@ -126341,7 +126339,6 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Library - Aft";
-	dir = 2;
 	name = "library camera"
 	},
 /turf/open/floor/plasteel/grimy,
@@ -127251,7 +127248,6 @@
 /area/space)
 "yin" = (
 /obj/structure/chair/sofa/left{
-	icon_state = "sofaend_left";
 	dir = 8
 	},
 /turf/open/floor/wood,

--- a/_maps/map_files/IceBoxStation/IceBoxStation.dmm
+++ b/_maps/map_files/IceBoxStation/IceBoxStation.dmm
@@ -34305,7 +34305,6 @@
 /obj/item/folder/white,
 /obj/item/reagent_containers/dropper,
 /obj/item/soap/nanotrasen,
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bCH" = (
@@ -36106,7 +36105,7 @@
 	pixel_y = 2
 	},
 /obj/item/clothing/neck/stethoscope,
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/sleeper)
 "bGT" = (

--- a/_maps/map_files/KiloStation/KiloStation.dmm
+++ b/_maps/map_files/KiloStation/KiloStation.dmm
@@ -22311,7 +22311,7 @@
 /obj/machinery/light_switch{
 	pixel_y = 24
 	},
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/dark,
 /area/medical/storage)
 "aKZ" = (
@@ -62896,9 +62896,9 @@
 	pixel_x = 24
 	},
 /obj/machinery/button/electrochromatic{
+	id = "!interrogation_room";
 	pixel_x = 38;
-	pixel_y = -5;
-	id = "!interrogation_room"
+	pixel_y = -5
 	},
 /turf/open/floor/plasteel,
 /area/security/warden)

--- a/_maps/map_files/LambdaStation/lambda.dmm
+++ b/_maps/map_files/LambdaStation/lambda.dmm
@@ -37992,6 +37992,7 @@
 /obj/effect/turf_decal/trimline/blue/filled/line{
 	dir = 1
 	},
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "btd" = (

--- a/_maps/map_files/MetaStation/MetaStation.dmm
+++ b/_maps/map_files/MetaStation/MetaStation.dmm
@@ -53980,7 +53980,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/storage)
 "cds" = (
@@ -67172,8 +67172,7 @@
 	layer = 4;
 	name = "Test Chamber Telescreen";
 	network = list("toxins");
-	pixel_x = -32;
-	pixel_y = 0
+	pixel_x = -32
 	},
 /turf/open/floor/plasteel,
 /area/science/mixing)

--- a/_maps/map_files/OmegaStation/OmegaStation.dmm
+++ b/_maps/map_files/OmegaStation/OmegaStation.dmm
@@ -3043,7 +3043,6 @@
 	pixel_x = 26
 	},
 /obj/machinery/computer/card/minor/qm{
-	icon_state = "computer";
 	dir = 8
 	},
 /obj/effect/turf_decal/tile/brown{
@@ -9226,7 +9225,6 @@
 	},
 /obj/machinery/computer/security/telescreen/ce{
 	dir = 1;
-	icon_state = "telescreen";
 	pixel_y = -24
 	},
 /turf/open/floor/plasteel,
@@ -28429,7 +28427,7 @@
 /obj/item/storage/belt/medical,
 /obj/item/clothing/neck/stethoscope,
 /obj/item/clothing/neck/stethoscope,
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel,
 /area/medical/medbay/zone3)
 "aXR" = (

--- a/_maps/map_files/PubbyStation/PubbyStation.dmm
+++ b/_maps/map_files/PubbyStation/PubbyStation.dmm
@@ -37700,6 +37700,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "bIf" = (

--- a/_maps/map_files/Snaxi/Snaxi.dmm
+++ b/_maps/map_files/Snaxi/Snaxi.dmm
@@ -471,8 +471,8 @@
 "aiS" = (
 /obj/structure/closet/secure_closet/CMO,
 /obj/machinery/keycard_auth{
-	pixel_y = 4;
-	pixel_x = -24
+	pixel_x = -24;
+	pixel_y = 4
 	},
 /obj/effect/turf_decal/tile/blue{
 	dir = 4
@@ -819,7 +819,6 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/gun/syringe/dart,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "aoT" = (
@@ -1991,8 +1990,8 @@
 	dir = 4
 	},
 /obj/machinery/conveyor{
-	id = "packageSort2";
-	dir = 1
+	dir = 1;
+	id = "packageSort2"
 	},
 /obj/machinery/disposal/deliveryChute,
 /obj/structure/window/reinforced{
@@ -2905,9 +2904,9 @@
 /area/crew_quarters/dorms)
 "aNS" = (
 /obj/machinery/turnstile{
+	dir = 4;
 	name = "Genpop Entrance Turnstile";
-	req_access_txt = "69";
-	dir = 4
+	req_access_txt = "69"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "permacell1";
@@ -3390,9 +3389,9 @@
 /area/maintenance/solars/port/fore)
 "bcc" = (
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 1;
 	id = "Cell 2";
-	name = "Cell 2";
-	dir = 1
+	name = "Cell 2"
 	},
 /obj/effect/turf_decal/vg_decals/numbers/two,
 /obj/machinery/door/poddoor/preopen{
@@ -3519,8 +3518,8 @@
 	name = "supply dock loading door"
 	},
 /obj/machinery/conveyor{
-	id = "QMLoad2";
-	dir = 1
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -3867,9 +3866,9 @@
 "brE" = (
 /obj/machinery/atmospherics/pipe/manifold/scrubbers/hidden,
 /obj/machinery/door/window/southleft{
+	dir = 1;
 	name = "Court Cell";
-	req_access_txt = "2";
-	dir = 1
+	req_access_txt = "2"
 	},
 /obj/structure/window/reinforced{
 	dir = 8
@@ -4120,9 +4119,9 @@
 	dir = 1
 	},
 /obj/machinery/turnstile{
+	dir = 4;
 	name = "Genpop Entrance Turnstile";
-	req_access_txt = "69";
-	dir = 4
+	req_access_txt = "69"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -5800,9 +5799,9 @@
 	name = "west facing firelock"
 	},
 /obj/machinery/door/window/southleft{
+	dir = 8;
 	name = "Test Chamber";
-	req_access_txt = "55";
-	dir = 8
+	req_access_txt = "55"
 	},
 /obj/machinery/door/poddoor/preopen{
 	id = "xenobio2";
@@ -5818,9 +5817,9 @@
 	dir = 10
 	},
 /obj/machinery/door/window/southleft{
+	dir = 4;
 	name = "Test Chamber";
-	req_access_txt = "55";
-	dir = 4
+	req_access_txt = "55"
 	},
 /turf/open/floor/plasteel,
 /area/science/xenobiology)
@@ -5915,9 +5914,9 @@
 	dir = 4
 	},
 /obj/machinery/door/window/brigdoor{
+	dir = 1;
 	name = "Reception Desk";
-	req_access_txt = "63";
-	dir = 1
+	req_access_txt = "63"
 	},
 /obj/machinery/door/window/brigdoor{
 	dir = 8;
@@ -6318,8 +6317,8 @@
 	},
 /obj/structure/table/wood,
 /obj/machinery/recharger{
-	pixel_y = 4;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 4
 	},
 /obj/item/book/manual/wiki/security_space_law{
 	pixel_x = 6;
@@ -8155,8 +8154,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Medbay West";
-	network = list("ss13","medbay");
-	dir = 4
+	dir = 4;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
@@ -8273,9 +8272,9 @@
 	req_access_txt = "10"
 	},
 /obj/machinery/door/window/northright{
+	dir = 4;
 	name = "Engineering Delivery";
-	req_access_txt = "10";
-	dir = 4
+	req_access_txt = "10"
 	},
 /obj/effect/turf_decal/delivery,
 /turf/open/floor/plasteel/dark,
@@ -9259,8 +9258,8 @@
 	dir = 4
 	},
 /obj/machinery/shower{
-	pixel_y = 20;
-	pixel_x = 11
+	pixel_x = 11;
+	pixel_y = 20
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -9632,8 +9631,8 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 1;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 1
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
@@ -10099,9 +10098,9 @@
 	dir = 4
 	},
 /obj/machinery/turnstile{
+	dir = 8;
 	name = "Genpop Exit Turnstile";
-	req_access_txt = "70";
-	dir = 8
+	req_access_txt = "70"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -11074,8 +11073,8 @@
 /obj/machinery/atmospherics/pipe/simple/scrubbers/hidden,
 /obj/machinery/button/flasher{
 	id = "PCell 1";
-	pixel_y = 9;
-	pixel_x = -37
+	pixel_x = -37;
+	pixel_y = 9
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -11257,9 +11256,9 @@
 	dir = 4
 	},
 /obj/machinery/turnstile{
+	dir = 8;
 	name = "Genpop Exit Turnstile";
-	req_access_txt = "70";
-	dir = 8
+	req_access_txt = "70"
 	},
 /obj/effect/turf_decal/tile/red{
 	dir = 1
@@ -12366,8 +12365,8 @@
 /area/bridge/meeting_room)
 "eZU" = (
 /obj/machinery/conveyor{
-	id = "QMLoad2";
-	dir = 1
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -12448,9 +12447,9 @@
 	icon_state = "1-4"
 	},
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 8;
 	id = "Cell 1";
-	name = "Cell 1";
-	dir = 8
+	name = "Cell 1"
 	},
 /obj/effect/turf_decal/vg_decals/numbers/one,
 /obj/machinery/door/poddoor/preopen{
@@ -13314,8 +13313,8 @@
 	name = "Door Bolt Control";
 	normaldoorcontrol = 1;
 	pixel_x = 24;
-	specialfunctions = 4;
-	pixel_y = -5
+	pixel_y = -5;
+	specialfunctions = 4
 	},
 /obj/machinery/light/small{
 	dir = 8
@@ -13812,8 +13811,8 @@
 /obj/structure/table/wood,
 /obj/item/book/manual/wiki/security_space_law,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 1;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 1
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
@@ -14514,9 +14513,9 @@
 /obj/machinery/button/door{
 	id = "Secure Gate";
 	name = "Cell Shutters";
+	pixel_x = 3;
 	pixel_y = 24;
-	req_access_txt = "2";
-	pixel_x = 3
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/brig)
@@ -15839,9 +15838,9 @@
 /obj/machinery/button/door{
 	id = "kitchen";
 	name = "Kitchen Shutters Control";
-	req_access_txt = "28";
 	pixel_x = 24;
-	pixel_y = -4
+	pixel_y = -4;
+	req_access_txt = "28"
 	},
 /turf/open/floor/plasteel/cafeteria,
 /area/crew_quarters/kitchen)
@@ -16100,8 +16099,8 @@
 	dir = 8
 	},
 /obj/machinery/computer/monitor{
-	name = "bridge power monitoring console";
-	dir = 1
+	dir = 1;
+	name = "bridge power monitoring console"
 	},
 /obj/structure/cable{
 	icon_state = "0-2"
@@ -16264,8 +16263,8 @@
 /obj/item/folder/blue,
 /obj/item/stamp/law,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 1;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 1
 	},
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
@@ -17461,9 +17460,9 @@
 /area/engine/engineering)
 "hVH" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/siphon/on{
+	dir = 1;
 	external_pressure_bound = 120;
-	name = "killroom vent";
-	dir = 1
+	name = "killroom vent"
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
@@ -17501,8 +17500,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Surgery Observation";
-	network = list("ss13","medbay");
-	dir = 8
+	dir = 8;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/dark,
 /area/medical/surgery)
@@ -17651,8 +17650,8 @@
 /area/security/main)
 "iam" = (
 /obj/machinery/computer/slot_machine{
-	pixel_y = 2;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 2
 	},
 /turf/open/floor/wood,
 /area/maintenance/bar)
@@ -18842,8 +18841,8 @@
 /obj/machinery/button/door{
 	id = "hos";
 	name = "HoS Office Shutters";
-	pixel_y = -26;
-	pixel_x = -6
+	pixel_x = -6;
+	pixel_y = -26
 	},
 /turf/open/floor/carpet,
 /area/crew_quarters/heads/hos)
@@ -20450,8 +20449,8 @@
 	pixel_y = -22
 	},
 /obj/machinery/button/door/incinerator_vent_toxmix{
-	pixel_y = -22;
-	pixel_x = 9
+	pixel_x = 9;
+	pixel_y = -22
 	},
 /obj/machinery/meter,
 /turf/open/floor/plasteel/white,
@@ -21064,8 +21063,8 @@
 "kdM" = (
 /obj/effect/turf_decal/stripes,
 /obj/machinery/conveyor{
-	id = "QMLoad2";
-	dir = 1
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -23669,8 +23668,8 @@
 "lMF" = (
 /obj/machinery/camera{
 	c_tag = "Virology Module";
-	network = list("ss13","medbay");
-	dir = 1
+	dir = 1;
+	network = list("ss13","medbay")
 	},
 /obj/structure/disposalpipe/segment{
 	dir = 4
@@ -25125,8 +25124,8 @@
 /obj/machinery/button/door{
 	id = "engsm";
 	name = "Radiation Shutters Control";
-	req_access_txt = "10";
-	pixel_y = 25
+	pixel_y = 25;
+	req_access_txt = "10"
 	},
 /obj/machinery/atmospherics/pipe/manifold/cyan/visible,
 /obj/effect/turf_decal/stripes/line{
@@ -25272,9 +25271,9 @@
 	dir = 4
 	},
 /obj/machinery/turnstile{
+	dir = 8;
 	name = "Genpop Exit Turnstile";
-	req_access_txt = "70";
-	dir = 8
+	req_access_txt = "70"
 	},
 /obj/structure/cable{
 	icon_state = "4-8"
@@ -26769,8 +26768,8 @@
 /area/bridge)
 "nFM" = (
 /obj/machinery/atmospherics/components/binary/pump{
-	name = "Port Mix to Engine";
-	dir = 1
+	dir = 1;
+	name = "Port Mix to Engine"
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmos)
@@ -26919,9 +26918,9 @@
 "nJI" = (
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/southleft{
+	dir = 4;
 	name = "Reception Desk";
-	req_access_txt = "63";
-	dir = 4
+	req_access_txt = "63"
 	},
 /obj/structure/cable{
 	icon_state = "1-2"
@@ -27171,8 +27170,8 @@
 /area/engine/engineering)
 "nSX" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Gas to Cooling Loop";
-	dir = 1
+	dir = 1;
+	name = "Gas to Cooling Loop"
 	},
 /turf/open/floor/plating,
 /area/engine/atmospherics_engine)
@@ -29332,8 +29331,8 @@
 /area/quartermaster/storage)
 "pfb" = (
 /obj/machinery/atmospherics/components/binary/pump/on{
-	name = "Gas to Cooling Loop";
-	dir = 1
+	dir = 1;
+	name = "Gas to Cooling Loop"
 	},
 /obj/effect/turf_decal/stripes/line{
 	dir = 9
@@ -30047,10 +30046,10 @@
 /area/ai_monitored/security/armory)
 "pvY" = (
 /obj/machinery/atmospherics/components/unary/vent_pump/on{
+	dir = 1;
 	external_pressure_bound = 140;
 	name = "killroom vent";
-	pressure_checks = 0;
-	dir = 1
+	pressure_checks = 0
 	},
 /turf/open/floor/circuit/telecomms,
 /area/science/xenobiology)
@@ -30601,9 +30600,9 @@
 	dir = 4
 	},
 /obj/machinery/turnstile{
+	dir = 8;
 	name = "Genpop Exit Turnstile";
-	req_access_txt = "70";
-	dir = 8
+	req_access_txt = "70"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -31796,8 +31795,8 @@
 	},
 /obj/machinery/button/ignition{
 	id = "testigniter";
-	pixel_y = -30;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = -30
 	},
 /obj/structure/disposalpipe/trunk{
 	dir = 1
@@ -31988,9 +31987,9 @@
 /area/maintenance/bar)
 "qEz" = (
 /obj/machinery/door/window/brigdoor/security/cell{
+	dir = 1;
 	id = "Cell 3";
-	name = "Cell 3";
-	dir = 1
+	name = "Cell 3"
 	},
 /obj/effect/turf_decal/vg_decals/numbers/three,
 /obj/machinery/door/poddoor/preopen{
@@ -32070,8 +32069,8 @@
 /area/hallway/secondary/exit/departure_lounge)
 "qGt" = (
 /obj/structure/bodycontainer/crematorium{
-	id = "crematoriumChapel";
-	dir = 8
+	dir = 8;
+	id = "crematoriumChapel"
 	},
 /obj/machinery/button/crematorium{
 	id = "crematoriumChapel";
@@ -32812,7 +32811,7 @@
 /obj/effect/turf_decal/tile/blue{
 	dir = 8
 	},
-/obj/item/gun/syringe/dart,
+/obj/item/gun/syringe,
 /turf/open/floor/plasteel/white,
 /area/medical/medbay/central)
 "rck" = (
@@ -32919,8 +32918,8 @@
 "rgQ" = (
 /obj/machinery/camera{
 	c_tag = "Xenobiology Test Chamber";
-	network = list("xeno","rd");
-	dir = 4
+	dir = 4;
+	network = list("xeno","rd")
 	},
 /turf/open/floor/engine,
 /area/science/xenobiology)
@@ -33686,8 +33685,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "AI Chamber - Core";
-	network = list("aicore");
-	dir = 4
+	dir = 4;
+	network = list("aicore")
 	},
 /turf/open/floor/circuit/off,
 /area/ai_monitored/turret_protected/ai)
@@ -33806,9 +33805,9 @@
 	dir = 4
 	},
 /obj/machinery/turnstile{
+	dir = 8;
 	name = "Genpop Exit Turnstile";
-	req_access_txt = "70";
-	dir = 8
+	req_access_txt = "70"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 4;
@@ -36542,9 +36541,9 @@
 /obj/effect/turf_decal/delivery,
 /obj/structure/table/reinforced,
 /obj/machinery/door/window/eastleft{
+	dir = 8;
 	name = "Hydroponics Desk";
-	req_access_txt = "35";
-	dir = 8
+	req_access_txt = "35"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -37065,8 +37064,8 @@
 	},
 /obj/machinery/camera{
 	c_tag = "Genetics Research";
-	network = list("ss13","medbay");
-	dir = 8
+	dir = 8;
+	network = list("ss13","medbay")
 	},
 /turf/open/floor/plasteel/white,
 /area/medical/genetics)
@@ -37239,9 +37238,9 @@
 /obj/machinery/button/door{
 	id = "Secure Brig Control";
 	name = "Brig Control Shutters";
+	pixel_x = -6;
 	pixel_y = -3;
-	req_access_txt = "2";
-	pixel_x = -6
+	req_access_txt = "2"
 	},
 /turf/open/floor/plasteel/dark,
 /area/security/warden)
@@ -38361,8 +38360,8 @@
 "uuY" = (
 /obj/machinery/camera{
 	c_tag = "Toxins Lab West";
-	network = list("ss13","rd");
-	dir = 4
+	dir = 4;
+	network = list("ss13","rd")
 	},
 /obj/structure/table/reinforced,
 /obj/item/assembly/prox_sensor{
@@ -38753,9 +38752,9 @@
 	pixel_y = 23
 	},
 /obj/machinery/door/window/southright{
+	dir = 8;
 	name = "Bar Door";
-	req_one_access_txt = "25;28";
-	dir = 8
+	req_one_access_txt = "25;28"
 	},
 /obj/machinery/door/firedoor/border_only{
 	dir = 8;
@@ -38907,8 +38906,8 @@
 	dir = 4
 	},
 /obj/machinery/computer/security/telescreen/prison{
-	pixel_x = 29;
-	dir = 8
+	dir = 8;
+	pixel_x = 29
 	},
 /turf/open/floor/plasteel/cult,
 /area/lawoffice)
@@ -39211,8 +39210,8 @@
 	name = "supply dock loading door"
 	},
 /obj/machinery/conveyor{
-	id = "QMLoad2";
-	dir = 1
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/plating,
 /area/quartermaster/storage)
@@ -39315,8 +39314,8 @@
 	dir = 8
 	},
 /obj/structure/chair{
-	name = "Judge";
-	dir = 4
+	dir = 4;
+	name = "Judge"
 	},
 /turf/open/floor/wood,
 /area/security/courtroom)
@@ -39652,8 +39651,8 @@
 /area/security/checkpoint/supply)
 "vgX" = (
 /obj/machinery/conveyor{
-	id = "QMLoad2";
-	dir = 1
+	dir = 1;
+	id = "QMLoad2"
 	},
 /turf/open/floor/plasteel,
 /area/quartermaster/storage)
@@ -40033,8 +40032,8 @@
 	},
 /obj/machinery/button/ignition{
 	id = "Incinerator";
-	pixel_y = 35;
-	pixel_x = -1
+	pixel_x = -1;
+	pixel_y = 35
 	},
 /turf/open/floor/plasteel,
 /area/engine/atmospherics_engine)
@@ -41951,8 +41950,8 @@
 "wtt" = (
 /obj/structure/table/wood,
 /obj/item/flashlight/lamp/green{
-	pixel_y = 13;
-	pixel_x = -7
+	pixel_x = -7;
+	pixel_y = 13
 	},
 /obj/item/camera/detective,
 /obj/item/hand_labeler{
@@ -41960,8 +41959,8 @@
 	},
 /obj/item/storage/briefcase,
 /obj/item/storage/secure/safe{
-	pixel_y = 36;
-	pixel_x = 6
+	pixel_x = 6;
+	pixel_y = 36
 	},
 /turf/open/floor/carpet,
 /area/security/detectives_office)
@@ -44064,8 +44063,8 @@
 	areastring = "/area/engine/engineering";
 	dir = 8;
 	name = "Engineering APC";
-	pixel_y = -1;
-	pixel_x = -27
+	pixel_x = -27;
+	pixel_y = -1
 	},
 /obj/machinery/firealarm{
 	dir = 1;


### PR DESCRIPTION
## About The Pull Request

Brings back the syringe gun as a roundstart item on the map.

## Why It's Good For The Game

With the introduction of the economy, two dart guns can be obtained from every individual small NanoMed machine on the wall. The syringe gun can't actually be obtained in-game at all, only a rapid fire syringe gun can get researched, sometimes.

## Changelog
:cl:
balance: Replaces dart gun with the syringe gun as a map item.
/:cl: