### PR TITLE
poplocks hijack/glorious death

### DIFF
--- a/code/modules/antagonists/traitor/classes/hijack.dm
+++ b/code/modules/antagonists/traitor/classes/hijack.dm
@@ -4,6 +4,7 @@
 	weight = 3
 	chaos = 5
 	threat = 3
+	min_players = 35
 	uplink_filters = list(/datum/uplink_item/stealthy_weapons/romerol_kit)
 
 /datum/traitor_class/human/hijack/forge_objectives(datum/antagonist/traitor/T)

--- a/code/modules/antagonists/traitor/classes/hijack.dm
+++ b/code/modules/antagonists/traitor/classes/hijack.dm
@@ -4,7 +4,7 @@
 	weight = 3
 	chaos = 5
 	threat = 3
-	min_players = 35
+	min_players = 25
 	uplink_filters = list(/datum/uplink_item/stealthy_weapons/romerol_kit)
 
 /datum/traitor_class/human/hijack/forge_objectives(datum/antagonist/traitor/T)

--- a/code/modules/antagonists/traitor/classes/martyr.dm
+++ b/code/modules/antagonists/traitor/classes/martyr.dm
@@ -4,6 +4,7 @@
 	weight = 2
 	chaos = 5
 	threat = 5
+	min_players = 25
 	uplink_filters = list(/datum/uplink_item/stealthy_weapons/romerol_kit,/datum/uplink_item/bundles_TC/contract_kit)
 
 /datum/traitor_class/human/martyr/forge_objectives(datum/antagonist/traitor/T)

--- a/code/modules/antagonists/traitor/classes/martyr.dm
+++ b/code/modules/antagonists/traitor/classes/martyr.dm
@@ -4,7 +4,7 @@
 	weight = 2
 	chaos = 5
 	threat = 5
-	min_players = 25
+	min_players = 20
 	uplink_filters = list(/datum/uplink_item/stealthy_weapons/romerol_kit,/datum/uplink_item/bundles_TC/contract_kit)
 
 /datum/traitor_class/human/martyr/forge_objectives(datum/antagonist/traitor/T)

--- a/code/modules/antagonists/traitor/classes/traitor_class.dm
+++ b/code/modules/antagonists/traitor/classes/traitor_class.dm
@@ -7,6 +7,8 @@ GLOBAL_LIST_EMPTY(traitor_classes)
 	var/chaos = 0
 	var/threat = 0
 	var/TC = 20
+	/// Minimum players for this to randomly roll via get_random_traitor_class().
+	var/min_players = 0
 	var/list/uplink_filters
 
 /datum/traitor_class/New()

--- a/code/modules/antagonists/traitor/datum_traitor.dm
+++ b/code/modules/antagonists/traitor/datum_traitor.dm
@@ -47,6 +47,8 @@
 	for(var/C in GLOB.traitor_classes)
 		if(!(C in blacklist))
 			var/datum/traitor_class/class = GLOB.traitor_classes[C]
+			if(class.min_players > length(GLOB.joined_player_list))
+				continue
 			var/weight = LOGISTIC_FUNCTION(1.5*class.weight,chaos_weight,class.chaos,0)
 			weights[C] = weight * 1000
 	var/choice = pickweight(weights, 0)


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

""bandaid"" patch that's not really a bandaid because this is necessary.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

no one wants to play lowpop hijack/glorious death it's cbt for all involved
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
add: traitor classes can now be poplocked. hijack/glorious death are now locked to 25/20 respectively.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
