### PR TITLE
[potentially hugbox as shit] poplocks loneops to 15 players

### DIFF
--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -3,7 +3,7 @@
 	typepath = /datum/round_event/ghost_role/operative
 	weight = 0 //Admin only
 	max_occurrences = 1
-	min_players = 25
+	min_players = 15
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1

--- a/code/modules/events/operative.dm
+++ b/code/modules/events/operative.dm
@@ -3,6 +3,7 @@
 	typepath = /datum/round_event/ghost_role/operative
 	weight = 0 //Admin only
 	max_occurrences = 1
+	min_players = 25
 
 /datum/round_event/ghost_role/operative
 	minimum_required = 1


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Same reasoning as the hijack PR.
While I agree with the station getting punished for not securing the disk, there's nothing to gain by lowpop rounds getting nuked by this when there's barely even anyone around able to secure the disk.

<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: loneops are now poplocked to 15.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
