### PR TITLE
Fixes offstation-AI silicon access

### DIFF
--- a/code/modules/mob/living/silicon/ai/ai.dm
+++ b/code/modules/mob/living/silicon/ai/ai.dm
@@ -285,8 +285,6 @@
 	. = ..()
 	var/turf/ai = get_turf(src)
 	var/turf/target = get_turf(A)
-	if (.)
-		return
 
 	if(!target)
 		return


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
A whiile ago, AI got made so they could no longer interact with things off their z-level if they were not on the station z. Relatively recently though, silicon access code got refactored a bit (mainly the has_silicon_access_in_area thing)
Therefore, . may be true for a while, even if conditions exist that will trigger a FALSE / nonstandard return statement.
This removes the early return from the proc that checks if an AI can access things, which lead to it returning true even in cases where it shouldn't have.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Might be good to once again not have wars between onstation and offstation AIs.
See #8753 for the original change
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Offstation AIs can once again only interact with their z-level
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
