### PR TITLE
Emagged cleanbots now trip people up. Emagged cleanbots now sprint at people. Emagged cleanbots will now trip people up after ramming into them.

### DIFF
--- a/code/modules/mob/living/simple_animal/bot/cleanbot.dm
+++ b/code/modules/mob/living/simple_animal/bot/cleanbot.dm
@@ -191,6 +191,11 @@
 			else
 				shuffle = TRUE	//Shuffle the list the next time we scan so we dont both go the same way.
 			path = list()
+		
+		if(istype(target, /mob/living/carbon) && (emagged == 2))
+			base_speed = 5
+		else
+			base_speed = initial(base_speed)
 
 		if(!path || path.len == 0) //No path, need a new one
 			//Try to produce a path to the target, and ignore airlocks to which it has access.
@@ -305,6 +310,18 @@
 
 	else
 		..()
+
+/mob/living/simple_animal/bot/cleanbot/Crossed(atom/movable/AM)
+	if(ismob(AM) && on && ((emagged == 2) || prob(1)))
+		var/mob/living/carbon/C = AM
+		if(!istype(C))
+			return
+		C.visible_message("<span class='warning'>[src] trips [C] over!</span>", "<span class='warning'>[src] trips you over!</span>")
+		C.DefaultCombatKnockdown(10)
+		playsound(src, 'sound/misc/slip.ogg', 50, 1, -3)
+		sensor_blink()
+		return
+	return ..()
 
 /mob/living/simple_animal/bot/cleanbot/explode()
 	on = FALSE


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

5 tiles per second instead of 1 while chasing
Can now trip people up.

Oh and they have a 1% chance to trip people up anyways.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

Cleanbot
Makes 'em a bit more deadly since they're kinda pitiful rn.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
balance: Emagged cleanbots are now more deadly.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
