### PR TITLE
[s] xenobio golems can no longer be used to exploit eldritch affairs mechanics

### DIFF
--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -330,15 +330,19 @@
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)
-	if(iscultist(creator))
+	if(iscultist(creator, TRUE))
 		SSticker.mode.add_cultist(src)
+	else if(iscultist(creator))
+		src.add_antag_datum(/datum/antagonist/cult/neutered/traitor)
 
 	else if(is_revolutionary(creator))
 		var/datum/antagonist/rev/converter = creator.mind.has_antag_datum(/datum/antagonist/rev,TRUE)
 		converter.add_revolutionary(src,FALSE)
 
-	else if(is_servant_of_ratvar(creator))
+	else if(is_servant_of_ratvar(creator, TRUE))
 		add_servant_of_ratvar(current)
+	else if(is_servant_of_ratvar(creator))
+		add_servant_of_ratvar(current, FALSE, FALSE, /datum/antagonist/clockcult/neutered/traitor)
 
 	else if(is_nuclear_operative(creator))
 		var/datum/antagonist/nukeop/converter = creator.mind.has_antag_datum(/datum/antagonist/nukeop,TRUE)

--- a/code/datums/mind.dm
+++ b/code/datums/mind.dm
@@ -330,19 +330,21 @@
 //Link a new mobs mind to the creator of said mob. They will join any team they are currently on, and will only switch teams when their creator does.
 
 /datum/mind/proc/enslave_mind_to_creator(mob/living/creator)
-	if(iscultist(creator, TRUE))
-		SSticker.mode.add_cultist(src)
-	else if(iscultist(creator))
-		src.add_antag_datum(/datum/antagonist/cult/neutered/traitor)
+	if(iscultist(creator))
+		if(iscultist(creator, TRUE))
+			SSticker.mode.add_cultist(src)
+		else
+			src.add_antag_datum(/datum/antagonist/cult/neutered/traitor)
 
 	else if(is_revolutionary(creator))
 		var/datum/antagonist/rev/converter = creator.mind.has_antag_datum(/datum/antagonist/rev,TRUE)
 		converter.add_revolutionary(src,FALSE)
 
-	else if(is_servant_of_ratvar(creator, TRUE))
-		add_servant_of_ratvar(current)
 	else if(is_servant_of_ratvar(creator))
-		add_servant_of_ratvar(current, FALSE, FALSE, /datum/antagonist/clockcult/neutered/traitor)
+		if(is_servant_of_ratvar(creator, TRUE))
+			add_servant_of_ratvar(current)
+		else
+			add_servant_of_ratvar(current, FALSE, FALSE, /datum/antagonist/clockcult/neutered/traitor)
 
 	else if(is_nuclear_operative(creator))
 		var/datum/antagonist/nukeop/converter = creator.mind.has_antag_datum(/datum/antagonist/nukeop,TRUE)

--- a/code/world.dm
+++ b/code/world.dm
@@ -12,4 +12,3 @@
 #ifdef FIND_REF_NO_CHECK_TICK
 	loop_checks = FALSE
 #endif
-mind

--- a/code/world.dm
+++ b/code/world.dm
@@ -12,3 +12,4 @@
 #ifdef FIND_REF_NO_CHECK_TICK
 	loop_checks = FALSE
 #endif
+mind


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request
As of now, people could create golems as an traitor cultist, which became actual full-on cultists, allowing for skipping any and all inbuilt restrictions of eldritch affairs. This fixes that so the golems are neutered too. (Done via neutered/traitor so they don't show up on the endround screen either.)
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game
Maaybe having golems / simillar be able to fully circumvent all restrictions set by eldritch affairs aiiin't the best idea..
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl:
fix: Golems / simillar now inherit the neutered antag datum if the creator is neutered.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
