### PR TITLE
changes the inefficient attack message prefix and threshold.

### DIFF
--- a/code/__DEFINES/combat.dm
+++ b/code/__DEFINES/combat.dm
@@ -273,7 +273,7 @@ GLOBAL_LIST_INIT(shove_disarming_types, typecacheof(list(
   * should the current-attack-damage be lower than the item force multiplied by this value,
   * a "inefficiently" prefix will be added to the message.
   */
-#define INEFFICIENT_ATTACK_MSG_THRESHOLD 0.7
+#define FEEBLE_ATTACK_MSG_THRESHOLD 0.5
 
 
 //bullet_act() return values

--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -211,8 +211,8 @@
 	var/message_verb = "attacked"
 	if(I.attack_verb && I.attack_verb.len)
 		message_verb = "[pick(I.attack_verb)]"
-	if(current_force < I.force * INEFFICIENT_ATTACK_MSG_THRESHOLD)
-		message_verb = "inefficiently [message_verb]"
+	if(current_force < I.force * FEEBLE_ATTACK_MSG_THRESHOLD)
+		message_verb = "[pick("feebly", "limply", "saplessly")] [message_verb]"
 	else if(!I.force)
 		return
 	var/message_hit_area = ""


### PR DESCRIPTION
## About The Pull Request
Title. See code.

## Why It's Good For The Game
"Inefficiently" doesn't fit the context very well. Lowered the threshold so attacking mobs while prone alone won't prompt that funky prefix.

## Changelog
:cl:
tweak: changed the weak attack message prefix from "inefficiently" to "limply", "feebly" and "saplessly" and lowered the threshold.
/:cl:
