### PR TITLE
Adds more LGBTQIA+ related holidays

### DIFF
--- a/code/__DEFINES/time.dm
+++ b/code/__DEFINES/time.dm
@@ -39,6 +39,8 @@ When using time2text(), please use "DDD" to find the weekday. Refrain from using
 #define SATURDAY	"Sat"
 #define SUNDAY		"Sun"
 
+#define WEEKDAY2NUM(D) (D == SUNDAY ? 1 : D == MONDAY ? 2 : D == TUESDAY ? 3 : D == WEDNESDAY ? 4 : D == THURSDAY ? 5 : D == FRIDAY ? 6 : 7) //this looks ugly, but switch statements can't be used as vars, so *shrug
+
 #define SECONDS *10
 
 #define MINUTES SECONDS*60

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -212,6 +212,14 @@
 /datum/holiday/bee/getStationPrefix()
 	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")
 
+/datum/holiday/lesbianvisibility
+	name = "Lesbian Visibility Day"
+	begin_day = 24
+	begin_month = MAY
+
+/datum/holiday/lesbianvisibility/greet()
+	return "Today is Lesbian Visibility Day!"
+
 /datum/holiday/summersolstice
 	name = "Summer Solstice"
 	begin_day = 21
@@ -292,6 +300,14 @@
 /datum/holiday/programmers/getStationPrefix()
 	return pick("span>","DEBUG: ","null","/list","EVENT PREFIX NOT FOUND") //Portability
 
+/datum/holiday/bivisibility
+	name = "Bisexual Visibility Day"
+	begin_day = 23
+	begin_month = SEPTEMBER
+
+/datum/holiday/bivisibility/greet()
+	return "Today is Bisexual Visibility Day!"
+
 /datum/holiday/questions
 	name = "Stupid-Questions Day"
 	begin_day = 28
@@ -314,11 +330,24 @@
 	begin_month = OCTOBER
 	drone_hat = /obj/item/clothing/head/papersack/smiley
 
+/datum/holiday/comingoutday
+	name = "Coming Out Day"
+	begin_day = 11
+	begin_month = OCTOBER
+
 /datum/holiday/boss
 	name = "Boss' Day"
 	begin_day = 16
 	begin_month = OCTOBER
 	drone_hat = /obj/item/clothing/head/that
+
+/datum/holiday/intersexawareness
+	name = "Intersex Awareness Day"
+	begin_day = 26
+	begin_month = OCTOBER
+
+/datum/holiday/intersexawareness/greet()
+	return "Today is Intersex Awareness Day! It has been [text2num(time2text(world.timeofday, "YYYY")) - 1996] years since the first public protest speaking out against the human rights issues faced by intersex people."
 
 /datum/holiday/halloween
 	name = HALLOWEEN
@@ -359,6 +388,23 @@
 	begin_month = NOVEMBER
 	drone_hat = /obj/item/reagent_containers/food/snacks/grown/moonflower
 
+/datum/holiday/transawareness
+	name = "Transgender Awareness Week"
+	begin_day = 13
+	begin_month = NOVEMBER
+	end_day = 19
+
+/datum/holiday/transawareness/greet()
+	return "This week is Transgender Awareness Week!"
+
+/datum/holiday/transremembrance
+	name = "Transgender Day of Remembrance"
+	begin_day = 20
+	begin_month = NOVEMBER
+
+/datum/holiday/transremembrance/greet()
+	return "Today is the Transgender Day of Remembrance."
+
 /datum/holiday/hello
 	name = "Saying-'Hello' Day"
 	begin_day = 21
@@ -397,6 +443,26 @@
 	begin_month = OCTOBER
 	begin_weekday = MONDAY
 
+/datum/holiday/aceawareness
+	name = "Asexual Awareness Week"
+	begin_month = OCTOBER
+
+/datum/holiday/aceawareness/greet()
+	return "This week is Asexual Awareness Week!"
+
+/datum/holiday/aceawareness/shouldCelebrate(dd, mm, yy, ww, ddd) //Ace awareness week falls on the last full week of October.
+	if(mm != begin_month)
+		return FALSE //it's not even the right month
+	var/daypointer = world.timeofday - ((WEEKDAY2NUM(ddd) - 1) * 24 HOURS)
+	if(text2num(time2text(daypointer, "MM")) != mm)
+		return FALSE //it's the beginning of the month and it isn't even a full week
+	daypointer += (24 HOURS * 6)
+	if(text2num(time2text(daypointer, "MM")) != mm)
+		return FALSE //this is the end of the month, and it is not a full week.
+	daypointer += (24 HOURS * 7)
+	if(text2num(time2text(daypointer, "MM")) != mm)
+		return TRUE //the end of next week falls on a different month, meaning that the current week is the last full week
+
 /datum/holiday/mother
 	name = "Mother's Day"
 	begin_week = 2
@@ -421,11 +487,30 @@
 /datum/holiday/pride/getStationPrefix()
 	return pick("Pride", "Gay", "Bi", "Trans", "Lesbian", "Ace", "Aro", "Agender", pick("Enby", "Enbie"), "Pan", "Intersex", "Demi", "Poly", "Closeted", "Genderfluid")
 
+/datum/holiday/stonewall
+	name = "Stonewall Riots Anniversary"
+	begin_day = 28
+	begin_month = JUNE
+
+/datum/holiday/stonewall/greet() //Not gonna lie, I was fairly tempted to make this use the IC year instead of the IRL year, but I was worried that it would have caused too much confusion.
+	return "Today marks the [text2num(time2text(world.timeofday, "YYYY")) - 1969]\th anniversary of the riots at the Stonewall Inn!"
+
 /datum/holiday/moth
 	name = "Moth Week"
+	begin_month = JULY
 
 /datum/holiday/moth/shouldCelebrate(dd, mm, yy, ww, ddd) //National Moth Week falls on the last full week of July
-	return mm == JULY && (ww == 4 || (ww == 5 && ddd == SUNDAY))
+	if(mm != begin_month)
+		return FALSE //it's not even the right month
+	var/daypointer = world.timeofday - ((WEEKDAY2NUM(ddd) - 1) * 24 HOURS)
+	if(text2num(time2text(daypointer, "MM")) != mm)
+		return FALSE //it's the beginning of the month and it isn't even a full week
+	daypointer += (24 HOURS * 6)
+	if(text2num(time2text(daypointer, "MM")) != mm)
+		return FALSE //this is the end of the month, and it is not a full week.
+	daypointer += (24 HOURS * 7)
+	if(text2num(time2text(daypointer, "MM")) != mm)
+		return TRUE //the end of next week falls on a different month, meaning that the current week is the last full week
 
 /datum/holiday/moth/getStationPrefix()
 	return pick("Mothball","Lepidopteran","Lightbulb","Moth","Giant Atlas","Twin-spotted Sphynx","Madagascan Sunset","Luna","Death's Head","Emperor Gum","Polyphenus","Oleander Hawk","Io","Rosy Maple","Cecropia","Noctuidae","Giant Leopard","Dysphania Militaris","Garden Tiger")

--- a/code/modules/holiday/holidays.dm
+++ b/code/modules/holiday/holidays.dm
@@ -189,6 +189,14 @@
 	begin_day = 22
 	begin_month = APRIL
 
+/datum/holiday/lesbianvisibility
+	name = "Lesbian Visibility Day"
+	begin_day = 26
+	begin_month = APRIL
+
+/datum/holiday/lesbianvisibility/greet()
+	return "Today is Lesbian Visibility Day!"
+
 /datum/holiday/labor
 	name = "Labor Day"
 	begin_day = 1
@@ -211,14 +219,6 @@
 
 /datum/holiday/bee/getStationPrefix()
 	return pick("Bee","Honey","Hive","Africanized","Mead","Buzz")
-
-/datum/holiday/lesbianvisibility
-	name = "Lesbian Visibility Day"
-	begin_day = 24
-	begin_month = MAY
-
-/datum/holiday/lesbianvisibility/greet()
-	return "Today is Lesbian Visibility Day!"
 
 /datum/holiday/summersolstice
 	name = "Summer Solstice"


### PR DESCRIPTION
This PR does exactly as it says on the tin, it adds more LGBTQIA+ holidays to cover more than just pride month! List of holidays added are in the changelog. The majority of holidays included in this PR are awareness periods, meaning that even though they fall under the holiday classification in the code, they aren't really celebrated, but rather, used for awareness. As such, the greet text for each one is overridden to convey a slightly more serious tone in contrast with other holidays. None of these holidays have any effects beyond showing roundstart text (No station prefixes, etc). This is fairly minor representation overall, but with the vast majority of our server's playerbase falling under the general LGBTQIA+ label (i mean cmon, it's the furry community, straight folks are extremely rare around these parts), it makes sense to have some level of direct representation of the more marginalized members of the LGBTQIA+ community in the code to go alongside pride month, even if it's something as small as this!

Also, the way holidays are sorted is an absolute mess. Grmbl grmbl.

## Changelog
:cl: Bhijn
add: Added Lesbian Visibility Day (April 26th)
add: Added Bisexual Visibility Day (September 23rd)
add: Added Coming Out Day! (October 11th)
add: Added Intersex Awareness Day (October 26th)
add: Added Transgender Awareness Week (November 13th - 19th)
add: Added the Transgender Day of Remembrance (November 20th)
add: Added Asexual Awareness Week (Last full week of October, this year it'll be Oct. 25-31)
add: Added the Stonewall Riot Anniversary (June 28)
fix: Moth week is now *actually* the last full week of July, instead of the 4th of every weekday + the 5th Sunday.
/:cl:
