### PR TITLE
[s] Fixes a major HTML injection vulnerability

### DIFF
--- a/code/datums/elements/flavor_text.dm
+++ b/code/datums/elements/flavor_text.dm
@@ -117,9 +117,9 @@ GLOBAL_LIST_EMPTY(mobs_with_editable_flavor_text) //et tu, hacky code
 		return FALSE
 
 	var/lower_name = lowertext(flavor_name)
-	var/new_text = stripped_multiline_input(user, "Set the [lower_name] displayed on 'examine'. [addendum]", flavor_name, texts_by_atom[usr], max_len, TRUE)
+	var/new_text = stripped_multiline_input(user, "Set the [lower_name] displayed on 'examine'. [addendum]", flavor_name, html_decode(texts_by_atom[usr]), max_len, TRUE)
 	if(!isnull(new_text) && (user in texts_by_atom))
-		texts_by_atom[user] = html_decode(new_text)
+		texts_by_atom[user] = new_text
 		to_chat(src, "Your [lower_name] has been updated.")
 		return TRUE
 	return FALSE

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -1638,19 +1638,19 @@ GLOBAL_LIST_EMPTY(preferences_datums)
 						age = max(min( round(text2num(new_age)), AGE_MAX),AGE_MIN)
 
 				if("flavor_text")
-					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", features["flavor_text"], MAX_FLAVOR_LEN, TRUE)
+					var/msg = stripped_multiline_input(usr, "Set the flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Flavor Text", html_decode(features["flavor_text"]), MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
-						features["flavor_text"] = html_decode(msg)
+						features["flavor_text"] = msg
 
 				if("silicon_flavor_text")
-					var/msg = stripped_multiline_input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", features["silicon_flavor_text"], MAX_FLAVOR_LEN, TRUE)
+					var/msg = stripped_multiline_input(usr, "Set the silicon flavor text in your 'examine' verb. This can also be used for OOC notes and preferences!", "Silicon Flavor Text", html_decode(features["silicon_flavor_text"]), MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
-						features["silicon_flavor_text"] = html_decode(msg)
+						features["silicon_flavor_text"] = msg
 
 				if("ooc_notes")
-					var/msg = stripped_multiline_input(usr, "Set always-visible OOC notes related to content preferences. THIS IS NOT FOR CHARACTER DESCRIPTIONS!", "OOC notes", features["ooc_notes"], MAX_FLAVOR_LEN, TRUE)
+					var/msg = stripped_multiline_input(usr, "Set always-visible OOC notes related to content preferences. THIS IS NOT FOR CHARACTER DESCRIPTIONS!", "OOC notes", html_decode(features["ooc_notes"]), MAX_FLAVOR_LEN, TRUE)
 					if(!isnull(msg))
-						features["ooc_notes"] = html_decode(msg)
+						features["ooc_notes"] = msg
 
 				if("hair")
 					var/new_hair = input(user, "Choose your character's hair colour:", "Character Preference","#"+hair_color) as color|null

--- a/code/modules/client/preferences_savefile.dm
+++ b/code/modules/client/preferences_savefile.dm
@@ -5,7 +5,7 @@
 //	You do not need to raise this if you are adding new values that have sane defaults.
 //	Only raise this value when changing the meaning/format/name/layout of an existing value
 //	where you would want the updater procs below to run
-#define SAVEFILE_VERSION_MAX	32
+#define SAVEFILE_VERSION_MAX	33
 
 /*
 SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Carn
@@ -194,6 +194,11 @@ SAVEFILE UPDATING/VERSIONING - 'Simplified', or rather, more coder-friendly ~Car
 	if(current_version < 31)
 		S["wing_color"]			>> features["wings_color"]
 		S["horn_color"]			>> features["horns_color"]
+	
+	if(current_version < 33)
+		features["flavor_text"] = html_encode(features["flavor_text"])
+		features["silicon_flavor_text"] = html_encode(features["silicon_flavor_text"])
+		features["ooc_notes"] = html_encode(features["ooc_notes"])
 
 /datum/preferences/proc/load_path(ckey,filename="preferences.sav")
 	if(!ckey)


### PR DESCRIPTION
Title. Does as it says on the tin. This PR makes it so that what you type into the flavortext box is *exactly* what you get, instead of how it currently works where the flavortext box just lets you write raw html because it html_decode()s and just blindly saves and displays that. The only place flavortext gets html_decode()'d with this PR is when you try to modify it, where it's used to make sure the flavortext appears exactly as you wrote it from top to bottom.

## Changelog
:cl: Bhijn
fix: raw HTML can no longer be used in flavortext
/:cl:
