### PR TITLE
the abstract idea of shadows can no longer be radioactive

### DIFF
--- a/code/modules/lighting/emissive_blocker.dm
+++ b/code/modules/lighting/emissive_blocker.dm
@@ -11,6 +11,7 @@
 	plane = EMISSIVE_BLOCKER_PLANE
 	layer = EMISSIVE_BLOCKER_LAYER
 	mouse_opacity = MOUSE_OPACITY_TRANSPARENT
+	rad_flags = RAD_NO_CONTAMINATE | RAD_PROTECT_CONTENTS
 	//Why?
 	//render_targets copy the transform of the target as well, but vis_contents also applies the transform
 	//to what's in it. Applying RESET_TRANSFORM here makes vis_contents not apply the transform.


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

## About The Pull Request

everyone has something called an emissive blocker, added to their visual contents.
the better fix is to move it out of contents but someone else can do that. this fix works because there's no POSSIBLE reason you would want it to be radioactive in the first place.
<!-- Describe The Pull Request. Please be sure every change is documented or this can delay review and even discourage maintainers from merging your PR! -->

## Why It's Good For The Game

invisible radiation is bad.
<!-- Please add a short description of why you think these changes would benefit the game. If you can't justify it in words, it might not be worth adding. -->

## Changelog
:cl: kevinz000
fix: emissive blockers can no longer be radioactive.
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
