### PR TITLE
Ashwalker den no longer spawns with a Malf upgrade and illegal tech

### DIFF
--- a/_maps/map_files/Mining/Lavaland.dmm
+++ b/_maps/map_files/Mining/Lavaland.dmm
@@ -1486,9 +1486,7 @@
 /obj/structure/stone_tile/cracked{
 	dir = 8
 	},
-/obj/item/malf_upgrade,
-/obj/item/disk/tech_disk/illegal,
-/obj/structure/safe,
+/obj/item/storage/firstaid/ancient,
 /turf/open/floor/plating/asteroid/basalt/lava_land_surface,
 /area/ruin/unpowered/ash_walkers)
 "pc" = (

--- a/code/modules/mining/lavaland/necropolis_chests.dm
+++ b/code/modules/mining/lavaland/necropolis_chests.dm
@@ -11,7 +11,7 @@
 	desc = "It's watching you suspiciously."
 
 /obj/structure/closet/crate/necropolis/tendril/PopulateContents()
-	var/loot = rand(1,28)
+	var/loot = rand(1,29)
 	switch(loot)
 		if(1)
 			new /obj/item/shared_storage/red(src)
@@ -77,6 +77,11 @@
 			new /obj/item/bedsheet/cult(src)
 		if(28)
 			new /obj/item/clothing/neck/necklace/memento_mori(src)
+		if(29)
+			if(prob(50))
+				new /obj/item/malf_upgrade
+			else
+				new /obj/item/disk/tech_disk/illegal
 
 //KA modkit design discs
 /obj/item/disk/design_disk/modkit_disc


### PR DESCRIPTION

## About The Pull Request
These items have been moved to tendrils so they are still obtainable.

## Why It's Good For The Game
the ashwalker base used to be a chance to spawn, and by extension, these items were a _chance_ to spawn, now that the ashwalker base is static this can be used for a 100% reliable doomsday. If traitors can't get nuke codes without admin intervention they also shouldn't be able to reliably doomsday.

## Changelog
:cl:
balance: malf disk and illegal tech disk moved from ashwalker base (guaranteed) to tendrils (chance based)
/:cl:
aka **this is why we can't have nice things.**