### PR TITLE
nuclear option - sets attackby() on mob to waitfor = FALSE to fix potential race conditions

### DIFF
--- a/code/_onclick/item_attack.dm
+++ b/code/_onclick/item_attack.dm
@@ -53,6 +53,7 @@
 	return ..() || ((obj_flags & CAN_BE_HIT) && I.attack_obj(src, user))
 
 /mob/living/attackby(obj/item/I, mob/living/user, params, attackchain_flags, damage_multiplier)
+	set waitfor = FALSE
 	if(..())
 		return TRUE
 	I.attack_delay_done = FALSE //Should be set TRUE in pre_attacked_by()


### PR DESCRIPTION
<!-- Write **BELOW** The Headers and **ABOVE** The comments else it may not be viewable. -->
<!-- You can view Contributing.MD for a detailed description of the pull request process. -->

Right I have no clue why multi attacks are happening.
Best bet at this point is make absolute sure every click processes the moment it goes through without sleeping.

## Changelog
:cl:
experimental: mob/living/attackby now is waitfor = FALSE
/:cl:

<!-- Both :cl:'s are required for the changelog to work! You can put your name to the right of the first :cl: if you want to overwrite your GitHub username as author ingame. -->
<!-- You can use multiple of the same prefix (they're only used for the icon ingame) and delete the unneeded ones. Despite some of the tags, changelogs should generally represent how a player might be affected by the changes rather than a summary of the PR's contents. -->
