### PR TITLE
fixes an oversight that bricks atmos under specific conditions.

### DIFF
--- a/code/controllers/subsystem/air.dm
+++ b/code/controllers/subsystem/air.dm
@@ -76,6 +76,8 @@ SUBSYSTEM_DEF(air)
 		var/list/pipenet_rebuilds = pipenets_needing_rebuilt
 		for(var/thing in pipenet_rebuilds)
 			var/obj/machinery/atmospherics/AT = thing
+			if(!istype(AT))
+				continue
 			AT.build_network()
 		cost_rebuilds = MC_AVERAGE(cost_rebuilds, TICK_DELTA_TO_MS(TICK_USAGE_REAL - timer))
 		pipenets_needing_rebuilt.Cut()


### PR DESCRIPTION
title. So over here, atmos can be bricked under very specific user-triggerable conditions. But downstream, the way bluespace pipes are coded results in this oversight bricking atmos whenever they're spawned. Thanks to Etheo for letting me know what was needed to find this oversight and patch it out

## Changelog
:cl: Bhijn
fix: Atmos can no longer become completely bricked
/:cl:
